### PR TITLE
Update translation files

### DIFF
--- a/neodb/locale/da_DK/LC_MESSAGES/django.po
+++ b/neodb/locale/da_DK/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neodb-test\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-23 15:40-0400\n"
+"POT-Creation-Date: 2026-09-06 20:04-0400\n"
 "PO-Revision-Date: 2026-08-09 06:31+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Danish <https://hosted.weblate.org/projects/neodb/neodb/da/>\n"
@@ -18,171 +18,171 @@ msgstr ""
 "X-Crowdin-File: neo__django.po\n"
 "X-Crowdin-File-ID: 2\n"
 
-#: boofilsic/settings.py:472 common/models/lang.py:230
+#: boofilsic/settings.py:501 common/models/lang.py:232
 msgid "English"
 msgstr "Engelsk"
 
-#: boofilsic/settings.py:473 common/models/lang.py:77
+#: boofilsic/settings.py:502 common/models/lang.py:79
 msgid "Danish"
 msgstr "Dansk"
 
-#: boofilsic/settings.py:474 common/models/lang.py:78
+#: boofilsic/settings.py:503 common/models/lang.py:80
 msgid "German"
 msgstr "Tysk"
 
-#: boofilsic/settings.py:475 common/models/lang.py:183
+#: boofilsic/settings.py:504 common/models/lang.py:185
 msgid "Spanish"
 msgstr "Spansk"
 
-#: boofilsic/settings.py:476 common/models/lang.py:87
+#: boofilsic/settings.py:505 common/models/lang.py:89
 msgid "French"
 msgstr "Fransk"
 
-#: boofilsic/settings.py:477 common/models/lang.py:112
+#: boofilsic/settings.py:506 common/models/lang.py:114
 msgid "Italian"
 msgstr "Italiensk"
 
-#: boofilsic/settings.py:478 common/models/lang.py:166
-#: common/models/lang.py:305
+#: boofilsic/settings.py:507 common/models/lang.py:168
+#: common/models/lang.py:307
 msgid "Portuguese"
 msgstr "Portugisisk"
 
-#: boofilsic/settings.py:479
+#: boofilsic/settings.py:508
 #, fuzzy
 #| msgid "Portuguese"
 msgid "Brazilian Portuguese"
 msgstr "Portugisisk"
 
-#: boofilsic/settings.py:480 common/models/lang.py:316
+#: boofilsic/settings.py:509 common/models/lang.py:318
 msgid "Simplified Chinese"
 msgstr "Forenklet kinesisk"
 
-#: boofilsic/settings.py:481 common/models/lang.py:317
+#: boofilsic/settings.py:510 common/models/lang.py:319
 msgid "Traditional Chinese"
 msgstr "Traditionelt kinesisk"
 
-#: catalog/forms.py:35 catalog/models/item.py:291
+#: catalog/forms.py:35 catalog/models/item.py:307
 msgid "Primary ID Type"
 msgstr "Primær ID-type"
 
-#: catalog/forms.py:40 catalog/models/item.py:294
+#: catalog/forms.py:40 catalog/models/item.py:310
 msgid "Primary ID Value"
 msgstr "Primær ID-værdi"
 
-#: catalog/forms.py:181
+#: catalog/forms.py:176
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
-#: catalog/models/book.py:139 catalog/models/book.py:158
-#: catalog/models/common.py:280 catalog/models/common.py:298
+#: catalog/models/book.py:141 catalog/models/book.py:160
+#: catalog/models/common.py:279 catalog/models/common.py:297
 msgid "locale"
 msgstr "sprogindstilling"
 
-#: catalog/models/book.py:142 catalog/models/book.py:161
-#: catalog/models/common.py:283 catalog/models/common.py:303
+#: catalog/models/book.py:144 catalog/models/book.py:163
+#: catalog/models/common.py:282 catalog/models/common.py:302
 msgid "text content"
 msgstr "tekstindhold"
 
-#: catalog/models/book.py:177
+#: catalog/models/book.py:179
 msgid "Paperback"
 msgstr ""
 
-#: catalog/models/book.py:178
+#: catalog/models/book.py:180
 #, fuzzy
 #| msgid "cover"
 msgid "Hardcover"
 msgstr "omslag"
 
-#: catalog/models/book.py:179
+#: catalog/models/book.py:181
 #, fuzzy
 #| msgid "Book"
 msgid "eBook"
 msgstr "Bog"
 
-#: catalog/models/book.py:180
+#: catalog/models/book.py:182
 #, fuzzy
 #| msgid "Add books"
 msgid "Audiobook"
 msgstr "Tilføj bøger"
 
-#: catalog/models/book.py:182
+#: catalog/models/book.py:184
 #, fuzzy
 #| msgid "Verification"
 msgid "Web Fiction"
 msgstr "Bekræftelse"
 
-#: catalog/models/book.py:183 catalog/models/game.py:38
+#: catalog/models/book.py:185 catalog/models/game.py:38
 msgid "Other"
 msgstr "Anden udgivelse"
 
-#: catalog/models/book.py:260
+#: catalog/models/book.py:262
 msgid "subtitle"
 msgstr "undertitel"
 
-#: catalog/models/book.py:270 catalog/models/movie.py:120
-#: catalog/models/performance.py:385 catalog/models/tv.py:211
-#: catalog/models/tv.py:437
+#: catalog/models/book.py:272 catalog/models/movie.py:120
+#: catalog/models/performance.py:385 catalog/models/tv.py:213
+#: catalog/models/tv.py:439
 msgid "original title"
 msgstr "oprindelig titel"
 
-#: catalog/models/book.py:274
+#: catalog/models/book.py:276
 msgid "other title"
 msgstr "anden titel"
 
-#: catalog/models/book.py:280 catalog/models/book.py:564
-#: catalog/models/item.py:123
+#: catalog/models/book.py:282 catalog/models/book.py:566
+#: catalog/models/item.py:119
 msgid "author"
 msgstr "forfatter"
 
-#: catalog/models/book.py:287 catalog/models/item.py:124
+#: catalog/models/book.py:289 catalog/models/item.py:120
 msgid "translator"
 msgstr "oversætter"
 
-#: catalog/models/book.py:294 catalog/templates/edition.html:26
+#: catalog/models/book.py:296 catalog/templates/edition.html:26
 #, fuzzy
 #| msgid "books to read"
 msgid "book format"
 msgstr "bøger der skal læses"
 
-#: catalog/models/book.py:301 catalog/models/game.py:135
-#: catalog/models/item.py:138 catalog/models/music.py:142
+#: catalog/models/book.py:303 catalog/models/game.py:135
+#: catalog/models/item.py:134 catalog/models/music.py:142
 msgid "publisher"
 msgstr "forlag"
 
-#: catalog/models/book.py:308
+#: catalog/models/book.py:310
 msgid "publication year"
 msgstr "udgivelsesår"
 
-#: catalog/models/book.py:314
+#: catalog/models/book.py:316
 msgid "publication month"
 msgstr "udgivelsesmåned"
 
-#: catalog/models/book.py:319
+#: catalog/models/book.py:321
 msgid "binding"
 msgstr "indbinding"
 
-#: catalog/models/book.py:320
+#: catalog/models/book.py:322
 msgid "pages"
 msgstr "sider"
 
-#: catalog/models/book.py:321 catalog/templates/edition.html:45
+#: catalog/models/book.py:323 catalog/templates/edition.html:45
 msgid "series"
 msgstr "serie"
 
-#: catalog/models/book.py:322 catalog/templates/edition.html:65
+#: catalog/models/book.py:324 catalog/templates/edition.html:65
 msgid "contents"
 msgstr "indhold"
 
-#: catalog/models/book.py:323 catalog/templates/edition.html:51
+#: catalog/models/book.py:325 catalog/templates/edition.html:51
 msgid "price"
 msgstr "pris"
 
-#: catalog/models/book.py:324 catalog/models/item.py:149
+#: catalog/models/book.py:326 catalog/models/item.py:145
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr "kolofon"
 
-#: catalog/models/common.py:26 common/models/lang.py:256
+#: catalog/models/common.py:26 common/models/lang.py:258
 msgid "Unknown"
 msgstr "Ukendt"
 
@@ -190,11 +190,11 @@ msgstr "Ukendt"
 msgid "Douban"
 msgstr "Douban"
 
-#: catalog/models/common.py:28 catalog/models/common.py:79
+#: catalog/models/common.py:28 catalog/models/common.py:81
 msgid "Goodreads"
 msgstr "Goodreads"
 
-#: catalog/models/common.py:29 catalog/models/common.py:81
+#: catalog/models/common.py:29 catalog/models/common.py:83
 msgid "Google Books"
 msgstr "Google Bøger"
 
@@ -202,16 +202,16 @@ msgstr "Google Bøger"
 msgid "BooksTW"
 msgstr "BooksTW"
 
-#: catalog/models/common.py:31 catalog/models/common.py:91
-#: catalog/models/common.py:93
+#: catalog/models/common.py:31 catalog/models/common.py:93
+#: catalog/models/common.py:95
 msgid "Bibliotek.dk"
 msgstr ""
 
-#: catalog/models/common.py:32 catalog/models/common.py:92
+#: catalog/models/common.py:32 catalog/models/common.py:94
 msgid "eReolen.dk"
 msgstr ""
 
-#: catalog/models/common.py:33 catalog/models/common.py:74
+#: catalog/models/common.py:33 catalog/models/common.py:76
 #: catalog/templates/movie.html:41 catalog/templates/people.html:37
 #: catalog/templates/tvseason.html:58 catalog/templates/tvshow.html:53
 msgid "IMDb"
@@ -221,7 +221,7 @@ msgstr "IMDb"
 msgid "TMDB"
 msgstr "TMDB"
 
-#: catalog/models/common.py:35 catalog/models/common.py:94
+#: catalog/models/common.py:35 catalog/models/common.py:96
 msgid "Bandcamp"
 msgstr "Bandcamp"
 
@@ -237,11 +237,11 @@ msgstr "IGDB"
 msgid "Steam"
 msgstr "Steam"
 
-#: catalog/models/common.py:39 catalog/models/common.py:114
+#: catalog/models/common.py:39 catalog/models/common.py:116
 msgid "itch.io"
 msgstr ""
 
-#: catalog/models/common.py:40 catalog/models/common.py:115
+#: catalog/models/common.py:40 catalog/models/common.py:117
 msgid "Bangumi"
 msgstr "Bangumi"
 
@@ -249,7 +249,7 @@ msgstr "Bangumi"
 msgid "BGG"
 msgstr "BGG"
 
-#: catalog/models/common.py:42 catalog/models/common.py:116
+#: catalog/models/common.py:42 catalog/models/common.py:118
 msgid "Apple Podcast"
 msgstr "Apple podcast"
 
@@ -261,35 +261,35 @@ msgstr "RSS"
 msgid "Discogs"
 msgstr "Discogs"
 
-#: catalog/models/common.py:45 catalog/models/common.py:117
+#: catalog/models/common.py:45 catalog/models/common.py:119
 msgid "Apple Music"
 msgstr "Apple Musik"
 
-#: catalog/models/common.py:46 catalog/models/common.py:119
+#: catalog/models/common.py:46 catalog/models/common.py:121
 msgid "Fediverse"
 msgstr "Fødivers"
 
-#: catalog/models/common.py:47 catalog/models/common.py:120
+#: catalog/models/common.py:47 catalog/models/common.py:122
 msgid "Qidian"
 msgstr ""
 
-#: catalog/models/common.py:48 catalog/models/common.py:121
+#: catalog/models/common.py:48 catalog/models/common.py:123
 msgid "Ypshuo"
 msgstr ""
 
-#: catalog/models/common.py:49 catalog/models/common.py:122
+#: catalog/models/common.py:49 catalog/models/common.py:124
 msgid "Archive of Our Own"
 msgstr ""
 
-#: catalog/models/common.py:50 catalog/models/common.py:123
+#: catalog/models/common.py:50 catalog/models/common.py:125
 msgid "JinJiang"
 msgstr ""
 
-#: catalog/models/common.py:51 catalog/models/common.py:64
+#: catalog/models/common.py:51 catalog/models/common.py:66
 msgid "WikiData"
 msgstr "WikiData"
 
-#: catalog/models/common.py:52 catalog/models/common.py:124
+#: catalog/models/common.py:52 catalog/models/common.py:126
 msgid "Open Library"
 msgstr ""
 
@@ -303,17 +303,17 @@ msgstr "MusicBrainz ID"
 msgid "WorldCat"
 msgstr ""
 
-#: catalog/models/common.py:55 catalog/models/common.py:126
+#: catalog/models/common.py:55 catalog/models/common.py:128
 #, fuzzy
 #| msgid "Game"
 msgid "MobyGames"
 msgstr "Spil"
 
-#: catalog/models/common.py:56 catalog/models/common.py:127
+#: catalog/models/common.py:56 catalog/models/common.py:129
 msgid "StoryGraph"
 msgstr ""
 
-#: catalog/models/common.py:57 catalog/models/common.py:118
+#: catalog/models/common.py:57 catalog/models/common.py:120
 #, fuzzy
 #| msgid "Douban Music"
 msgid "YouTube Music"
@@ -331,363 +331,374 @@ msgstr ""
 msgid "Readmoo"
 msgstr ""
 
-#: catalog/models/common.py:65
+#: catalog/models/common.py:61
+msgid "MyAnimeList"
+msgstr ""
+
+#: catalog/models/common.py:62 catalog/models/common.py:140
+#, fuzzy
+#| msgid "Update"
+msgid "MangaUpdates"
+msgstr "Opdatering"
+
+#: catalog/models/common.py:67
 msgid "ISBN10"
 msgstr "ISBN10"
 
-#: catalog/models/common.py:66 catalog/templates/edition.html:19
+#: catalog/models/common.py:68 catalog/templates/edition.html:19
 msgid "ISBN"
 msgstr "ISBN"
 
-#: catalog/models/common.py:67
+#: catalog/models/common.py:69
 msgid "ASIN"
 msgstr "ASIN"
 
-#: catalog/models/common.py:68
+#: catalog/models/common.py:70
 msgid "ISSN"
 msgstr "ISSN"
 
-#: catalog/models/common.py:69
+#: catalog/models/common.py:71
 msgid "CUBN"
 msgstr "CUBN"
 
-#: catalog/models/common.py:70
+#: catalog/models/common.py:72
 msgid "ISRC"
 msgstr "ISRC"
 
-#: catalog/models/common.py:71
+#: catalog/models/common.py:73
 msgid "GTIN UPC EAN"
 msgstr "GTIN UPC EAN"
 
-#: catalog/models/common.py:72
+#: catalog/models/common.py:74
 msgid "OCLC Number"
 msgstr ""
 
-#: catalog/models/common.py:73
+#: catalog/models/common.py:75
 msgid "RSS Feed URL"
 msgstr "RSS-feed URL"
 
-#: catalog/models/common.py:75
+#: catalog/models/common.py:77
 #, fuzzy
 #| msgid "TMDB TV Serie"
 msgid "TMDB TV Series"
 msgstr "TMDB TV-serie"
 
-#: catalog/models/common.py:76
+#: catalog/models/common.py:78
 msgid "TMDB TV Season"
 msgstr "TMDB TV sæson"
 
-#: catalog/models/common.py:77
+#: catalog/models/common.py:79
 msgid "TMDB TV Episode"
 msgstr "TMDB TV afsnit"
 
-#: catalog/models/common.py:78
+#: catalog/models/common.py:80
 msgid "TMDB Movie"
 msgstr "TMDB film"
 
-#: catalog/models/common.py:80
+#: catalog/models/common.py:82
 msgid "Goodreads Work"
 msgstr "Goodreads værk"
 
-#: catalog/models/common.py:82
+#: catalog/models/common.py:84
 msgid "Douban Book"
 msgstr "Douban bog"
 
-#: catalog/models/common.py:83
+#: catalog/models/common.py:85
 msgid "Douban Book Work"
 msgstr "Douban bogværk"
 
-#: catalog/models/common.py:84
+#: catalog/models/common.py:86
 msgid "Douban Movie"
 msgstr "Douban film"
 
-#: catalog/models/common.py:85
+#: catalog/models/common.py:87
 msgid "Douban Music"
 msgstr "Douban musik"
 
-#: catalog/models/common.py:86
+#: catalog/models/common.py:88
 msgid "Douban Game"
 msgstr "Douban spil"
 
-#: catalog/models/common.py:87
+#: catalog/models/common.py:89
 msgid "Douban Drama"
 msgstr "Douban drama"
 
-#: catalog/models/common.py:88
+#: catalog/models/common.py:90
 msgid "Douban Drama Version"
 msgstr "Douban dramaudgave"
 
-#: catalog/models/common.py:89
+#: catalog/models/common.py:91
 msgid "BooksTW Book"
 msgstr "BooksTW bog"
 
-#: catalog/models/common.py:90
+#: catalog/models/common.py:92
 msgid "Readmoo Book"
 msgstr ""
 
-#: catalog/models/common.py:95
+#: catalog/models/common.py:97
 msgid "Spotify Album"
 msgstr "Spotify album"
 
-#: catalog/models/common.py:96
+#: catalog/models/common.py:98
 msgid "Spotify Podcast"
 msgstr "Spotify podcast"
 
-#: catalog/models/common.py:97
+#: catalog/models/common.py:99
 msgid "Discogs Release"
 msgstr "Discogs udgivelse"
 
-#: catalog/models/common.py:98
+#: catalog/models/common.py:100
 msgid "Discogs Master"
 msgstr "Discogs originalversion"
 
-#: catalog/models/common.py:101
+#: catalog/models/common.py:103
 #, fuzzy
 #| msgid "MusicBrainz ID"
 msgid "MusicBrainz Release Group"
 msgstr "MusicBrainz ID"
 
-#: catalog/models/common.py:103
+#: catalog/models/common.py:105
 #, fuzzy
 #| msgid "MusicBrainz ID"
 msgid "MusicBrainz Release"
 msgstr "MusicBrainz ID"
 
-#: catalog/models/common.py:104
+#: catalog/models/common.py:106
 #, fuzzy
 #| msgid "MusicBrainz ID"
 msgid "MusicBrainz Artist"
 msgstr "MusicBrainz ID"
 
-#: catalog/models/common.py:105
+#: catalog/models/common.py:107
 #, fuzzy
 #| msgid "Douban Game"
 msgid "Douban Personage"
 msgstr "Douban spil"
 
-#: catalog/models/common.py:106
+#: catalog/models/common.py:108
 #, fuzzy
 #| msgid "Goodreads Work"
 msgid "Goodreads Author"
 msgstr "Goodreads værk"
 
-#: catalog/models/common.py:107
+#: catalog/models/common.py:109
 #, fuzzy
 #| msgid "Spotify Podcast"
 msgid "Spotify Artist"
 msgstr "Spotify podcast"
 
-#: catalog/models/common.py:108
+#: catalog/models/common.py:110
 #, fuzzy
 #| msgid "TMDB TV Season"
 msgid "TMDB Person"
 msgstr "TMDB TV sæson"
 
-#: catalog/models/common.py:109
+#: catalog/models/common.py:111
 msgid "Open Library Author"
 msgstr ""
 
-#: catalog/models/common.py:110
+#: catalog/models/common.py:112
 msgid "IGDB Company"
 msgstr ""
 
-#: catalog/models/common.py:111
+#: catalog/models/common.py:113
 msgid "IGDB Game"
 msgstr "IGDB spil"
 
-#: catalog/models/common.py:112
+#: catalog/models/common.py:114
 msgid "BGG Boardgame"
 msgstr "BGG brætspil"
 
-#: catalog/models/common.py:113
+#: catalog/models/common.py:115
 msgid "Steam Game"
 msgstr "Steam spil"
 
-#: catalog/models/common.py:125
+#: catalog/models/common.py:127
 msgid "Open Library Work"
 msgstr ""
 
-#: catalog/models/common.py:128
+#: catalog/models/common.py:130
 msgid "RateYourMusic Release"
 msgstr ""
 
-#: catalog/models/common.py:132
+#: catalog/models/common.py:134
 msgid "AniList Anime"
 msgstr ""
 
-#: catalog/models/common.py:133
+#: catalog/models/common.py:135
 msgid "AniList Manga"
 msgstr ""
 
-#: catalog/models/common.py:134
+#: catalog/models/common.py:136
 msgid "MyAnimeList Anime"
 msgstr ""
 
-#: catalog/models/common.py:135
+#: catalog/models/common.py:137
 msgid "MyAnimeList Manga"
 msgstr ""
 
-#: catalog/models/common.py:156
+#: catalog/models/common.py:161
 #, fuzzy
 #| msgid "Editions"
 msgid "Edition"
 msgstr "Udgaver"
 
-#: catalog/models/common.py:157 catalog/templates/_sidebar_edit.html:286
+#: catalog/models/common.py:162 catalog/templates/_sidebar_edit.html:289
 msgid "Work"
 msgstr "Værk"
 
-#: catalog/models/common.py:158
+#: catalog/models/common.py:163
 #, fuzzy
 #| msgid "TV Serie"
 msgid "TV Series"
 msgstr "Tv-serie"
 
-#: catalog/models/common.py:159 catalog/templates/_sidebar_edit.html:207
+#: catalog/models/common.py:164 catalog/templates/_sidebar_edit.html:202
+#: catalog/views/edit.py:385
 msgid "TV Season"
 msgstr "TV sæson"
 
-#: catalog/models/common.py:160
+#: catalog/models/common.py:165
 msgid "TV Episode"
 msgstr "TV afsnit"
 
-#: catalog/models/common.py:161 catalog/models/common.py:177
-#: catalog/models/common.py:191 catalog/templates/_sidebar_edit.html:200
-#: journal/templates/_sidebar_user_mark_list.html:35
+#: catalog/models/common.py:166 catalog/models/common.py:182
+#: catalog/models/common.py:196 catalog/templates/_sidebar_edit.html:196
+#: catalog/views/edit.py:384 journal/templates/_sidebar_user_mark_list.html:35
 #: journal/templates/_sidebar_user_tag_filter.html:27
 msgid "Movie"
 msgstr "Film"
 
-#: catalog/models/common.py:162
+#: catalog/models/common.py:167
 msgid "Album"
 msgstr "Album"
 
-#: catalog/models/common.py:163 catalog/models/common.py:180
-#: catalog/models/common.py:194 common/templates/_header.html:43
+#: catalog/models/common.py:168 catalog/models/common.py:185
+#: catalog/models/common.py:199 common/templates/_header.html:53
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
 msgstr "Spil"
 
-#: catalog/models/common.py:164
+#: catalog/models/common.py:169
 msgid "Podcast Program"
 msgstr "Podcast-program"
 
-#: catalog/models/common.py:165
+#: catalog/models/common.py:170
 msgid "Podcast Episode"
 msgstr "Podcast-afsnit"
 
-#: catalog/models/common.py:166 catalog/models/common.py:182
-#: catalog/models/common.py:196 common/templates/_header.html:47
+#: catalog/models/common.py:171 catalog/models/common.py:187
+#: catalog/models/common.py:201 common/templates/_header.html:57
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
 msgstr "Forestilling"
 
-#: catalog/models/common.py:167
+#: catalog/models/common.py:172
 msgid "Production"
 msgstr "Produktion"
 
-#: catalog/models/common.py:168
+#: catalog/models/common.py:173
 msgid "Exhibition"
 msgstr "Udstilling"
 
-#: catalog/models/common.py:169 catalog/models/common.py:186
+#: catalog/models/common.py:174 catalog/models/common.py:191
 #: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr "Samling"
 
-#: catalog/models/common.py:172 catalog/models/common.py:185
+#: catalog/models/common.py:177 catalog/models/common.py:190
 msgid "Person / Organization"
 msgstr ""
 
-#: catalog/models/common.py:176 catalog/models/common.py:190
-#: common/templates/_header.html:27
+#: catalog/models/common.py:181 catalog/models/common.py:195
+#: common/templates/_header.html:37
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
 msgstr "Bog"
 
-#: catalog/models/common.py:178 catalog/models/common.py:192
+#: catalog/models/common.py:183 catalog/models/common.py:197
 #: journal/templates/_sidebar_user_mark_list.html:38
 #: journal/templates/_sidebar_user_tag_filter.html:30
 msgid "TV"
 msgstr "TV"
 
-#: catalog/models/common.py:179 catalog/models/common.py:193
-#: common/templates/_header.html:39
+#: catalog/models/common.py:184 catalog/models/common.py:198
+#: common/templates/_header.html:49
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr "Musik"
 
-#: catalog/models/common.py:181 catalog/models/common.py:195
-#: catalog/templates/_sidebar_edit.html:219 common/templates/_header.html:35
+#: catalog/models/common.py:186 catalog/models/common.py:200
+#: catalog/templates/_sidebar_edit.html:213 common/templates/_header.html:45
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
 msgstr "Podcast"
 
-#: catalog/models/common.py:346 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:345 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr "genre"
 
-#: catalog/models/common.py:384
+#: catalog/models/common.py:383
 #, fuzzy
 #| msgid "original creator"
 msgid "origin country"
 msgstr "oprindelig ophavsmand"
 
-#: catalog/models/common.py:413 catalog/templates/album.html:33
+#: catalog/models/common.py:412 catalog/templates/album.html:33
 msgid "album type"
 msgstr "albumtype"
 
-#: catalog/models/common.py:417 catalog/templates/_platform_list.html:5
+#: catalog/models/common.py:416 catalog/templates/_platform_list.html:5
 msgid "platform"
 msgstr "platform"
 
-#: catalog/models/common.py:421
+#: catalog/models/common.py:420
 #, fuzzy
 #| msgid "media type"
 msgid "media format"
 msgstr "medietype"
 
-#: catalog/models/common.py:426 catalog/templates/_language_list.html:5
-#: users/models/user.py:142
+#: catalog/models/common.py:425 catalog/templates/_language_list.html:5
+#: users/models/user.py:144
 msgid "language"
 msgstr "sprog"
 
-#: catalog/models/creator.py:24
+#: catalog/models/creator.py:26
 #, fuzzy
 #| msgid "Pending"
 msgid "pending"
 msgstr "Afventende"
 
-#: catalog/models/creator.py:25
+#: catalog/models/creator.py:27
 msgid "verified"
 msgstr ""
 
-#: catalog/models/creator.py:26
+#: catalog/models/creator.py:28
 #, fuzzy
 #| msgid "Failed"
 msgid "failed"
 msgstr "Mislykket"
 
-#: catalog/models/creator.py:29
+#: catalog/models/creator.py:31
 msgid "no feed url available for this item"
 msgstr ""
 
-#: catalog/models/creator.py:30
+#: catalog/models/creator.py:32
 msgid "unable to fetch or parse the feed"
 msgstr ""
 
-#: catalog/models/creator.py:31
+#: catalog/models/creator.py:33
 msgid "no audio episode found in the feed"
 msgstr ""
 
-#: catalog/models/creator.py:34
+#: catalog/models/creator.py:36
 msgid "no matching identity found in the feed or its linked website"
 msgstr ""
 
@@ -723,16 +734,16 @@ msgstr "Nyfortolkning"
 msgid "Special Edition"
 msgstr "Særlig udgave"
 
-#: catalog/models/game.py:111 catalog/models/item.py:130
+#: catalog/models/game.py:111 catalog/models/item.py:126
 msgid "designer"
 msgstr "designer"
 
-#: catalog/models/game.py:119 catalog/models/item.py:129
+#: catalog/models/game.py:119 catalog/models/item.py:125
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr "kunstner"
 
-#: catalog/models/game.py:127 catalog/models/item.py:139
+#: catalog/models/game.py:127 catalog/models/item.py:135
 msgid "developer"
 msgstr "udvikler"
 
@@ -741,8 +752,8 @@ msgid "date of publication"
 msgstr "udgivelsesdato"
 
 #: catalog/models/game.py:147 catalog/models/movie.py:156
-#: catalog/models/music.py:128 catalog/models/tv.py:247
-#: catalog/models/tv.py:473
+#: catalog/models/music.py:128 catalog/models/tv.py:249
+#: catalog/models/tv.py:475
 msgid "YYYY, YYYY-MM or YYYY-MM-DD"
 msgstr ""
 
@@ -753,7 +764,7 @@ msgstr "udgivelsestype"
 #: catalog/models/game.py:180 catalog/models/movie.py:158
 #: catalog/models/people.py:178 catalog/models/performance.py:258
 #: catalog/models/performance.py:465 catalog/models/podcast.py:89
-#: catalog/models/tv.py:249 catalog/models/tv.py:476
+#: catalog/models/tv.py:251 catalog/models/tv.py:478
 #: catalog/templates/game.html:33 catalog/templates/movie.html:48
 #: catalog/templates/people.html:44 catalog/templates/performance.html:35
 #: catalog/templates/performanceproduction.html:35
@@ -762,152 +773,152 @@ msgstr "udgivelsestype"
 msgid "website"
 msgstr "websted"
 
-#: catalog/models/item.py:125 catalog/models/movie.py:123
+#: catalog/models/item.py:121 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
-#: catalog/models/tv.py:214 catalog/models/tv.py:440
+#: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr "instruktør"
 
-#: catalog/models/item.py:126 catalog/models/movie.py:130
+#: catalog/models/item.py:122 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
-#: catalog/models/tv.py:221 catalog/models/tv.py:447
+#: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr "skuespilforfatter"
 
-#: catalog/models/item.py:127 catalog/models/movie.py:137
+#: catalog/models/item.py:123 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
-#: catalog/models/tv.py:228 catalog/models/tv.py:454
+#: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr "skuespiller"
 
-#: catalog/models/item.py:128 catalog/models/movie.py:144
-#: catalog/models/tv.py:235 catalog/models/tv.py:461
+#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/tv.py:237 catalog/models/tv.py:463
 #, fuzzy
 #| msgid "production"
 msgid "producer"
 msgstr "produktion"
 
-#: catalog/models/item.py:131 catalog/models/performance.py:203
+#: catalog/models/item.py:127 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr "komponist"
 
-#: catalog/models/item.py:132 catalog/models/performance.py:210
+#: catalog/models/item.py:128 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr "koreograf"
 
-#: catalog/models/item.py:133 catalog/models/performance.py:224
+#: catalog/models/item.py:129 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr "udøvende kunstner"
 
-#: catalog/models/item.py:134 catalog/models/podcast.py:80
+#: catalog/models/item.py:130 catalog/models/podcast.py:80
 msgid "host"
 msgstr "vært"
 
-#: catalog/models/item.py:135 catalog/models/performance.py:196
+#: catalog/models/item.py:131 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr "oprindelig ophavsmand"
 
-#: catalog/models/item.py:136 catalog/models/performance.py:238
+#: catalog/models/item.py:132 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr "produktionshold"
 
-#: catalog/models/item.py:140
+#: catalog/models/item.py:136
 #, fuzzy
 #| msgid "production"
 msgid "production company"
 msgstr "produktion"
 
-#: catalog/models/item.py:141
+#: catalog/models/item.py:137
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:142
+#: catalog/models/item.py:138
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:139
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:144 catalog/models/performance.py:231
+#: catalog/models/item.py:140 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr "trup"
 
-#: catalog/models/item.py:147
+#: catalog/models/item.py:143
 #, fuzzy
 #| msgid "director"
 msgid "voice actor"
 msgstr "instruktør"
 
-#: catalog/models/item.py:148 catalog/templates/edition.html:30
+#: catalog/models/item.py:144 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr "forlag"
 
-#: catalog/models/item.py:173 catalog/models/people.py:476
+#: catalog/models/item.py:169 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr "rolle"
 
-#: catalog/models/item.py:174 catalog/models/people.py:155
+#: catalog/models/item.py:170 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr "navn"
 
-#: catalog/models/item.py:176 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:288 catalog/models/item.py:320
-#: journal/models/collection.py:96
+#: catalog/models/item.py:304 catalog/models/item.py:336
+#: journal/models/collection.py:100
 msgid "title"
 msgstr "titel"
 
-#: catalog/models/item.py:289 catalog/models/item.py:328
-#: journal/models/collection.py:97
+#: catalog/models/item.py:305 catalog/models/item.py:344
+#: journal/models/collection.py:101
 msgid "description"
 msgstr "beskrivelse"
 
-#: catalog/models/item.py:300 catalog/models/people.py:484
+#: catalog/models/item.py:316 catalog/models/people.py:484
 msgid "metadata"
 msgstr "metadata"
 
-#: catalog/models/item.py:302 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
 msgid "cover"
 msgstr "omslag"
 
-#: catalog/models/item.py:1485
+#: catalog/models/item.py:1526
 msgid "source site"
 msgstr "kilde-site"
 
-#: catalog/models/item.py:1487
+#: catalog/models/item.py:1528
 msgid "ID on source site"
 msgstr "ID på kilde-site"
 
-#: catalog/models/item.py:1489
+#: catalog/models/item.py:1530
 msgid "source url"
 msgstr "kilde url"
 
-#: catalog/models/item.py:1505
+#: catalog/models/item.py:1546
 msgid "IdType of the source site"
 msgstr "IdType for kilde-sitet"
 
-#: catalog/models/item.py:1511
+#: catalog/models/item.py:1552
 msgid "Primary Id on the source site"
 msgstr "Primært ID på kilde-sitet"
 
-#: catalog/models/item.py:1514
+#: catalog/models/item.py:1555
 msgid "url to the resource"
 msgstr "url til ressourcen"
 
 #: catalog/models/movie.py:152 catalog/models/music.py:124
-#: catalog/models/tv.py:243 catalog/models/tv.py:469
+#: catalog/models/tv.py:245 catalog/models/tv.py:471
 #: catalog/templates/_item_card_metadata_album.html:16
 #: catalog/templates/album.html:17 catalog/templates/game.html:22
 #: catalog/templates/movie.html:36 catalog/templates/tvseason.html:53
@@ -922,7 +933,7 @@ msgid "length"
 msgstr "længde"
 
 #: catalog/models/movie.py:162 catalog/models/music.py:131
-#: catalog/models/tv.py:259 catalog/models/tv.py:486
+#: catalog/models/tv.py:261 catalog/models/tv.py:488
 #, fuzzy
 #| msgid "milliseconds"
 msgid "seconds"
@@ -1130,45 +1141,98 @@ msgstr "premieredato"
 msgid "closing date"
 msgstr "afslutningsdato"
 
-#: catalog/models/tv.py:186 catalog/templates/tvseason.html:38
+#: catalog/models/tv.py:188 catalog/templates/tvseason.html:38
 #: catalog/templates/tvshow.html:33
 msgid "number of seasons"
 msgstr "antal sæsoner"
 
-#: catalog/models/tv.py:189 catalog/models/tv.py:415
+#: catalog/models/tv.py:191 catalog/models/tv.py:417
 #: catalog/templates/tvseason.html:43 catalog/templates/tvshow.html:38
 msgid "number of episodes"
 msgstr "antal afsnit"
 
-#: catalog/models/tv.py:256 catalog/models/tv.py:483
+#: catalog/models/tv.py:258 catalog/models/tv.py:485
 msgid "episode length"
 msgstr "afsnitslængde"
 
-#: catalog/models/tv.py:412 catalog/templates/tvseason.html:33
+#: catalog/models/tv.py:414 catalog/templates/tvseason.html:33
 msgid "season number"
 msgstr "sæsonnummer"
 
-#: catalog/models/tv.py:530
+#: catalog/models/tv.py:532
 #, python-brace-format
 msgid "{show_title} Season {season_number}"
 msgstr "{show_title} sæson {season_number}"
 
-#: catalog/models/tv.py:684
+#: catalog/models/tv.py:686
 #, python-brace-format
 msgid "{season_title} E{episode_number}"
 msgstr "{season_title} A{episode_number}"
+
+#: catalog/templates/_catalog_confirm_item.html:7
+#: catalog/templates/catalog_edit.html:62
+msgid "Item has been deleted."
+msgstr "Elementet er blevet slettet."
+
+#: catalog/templates/_catalog_confirm_item.html:12
+#: catalog/templates/catalog_edit.html:65
+msgid "Item contains sub-items."
+msgstr "Elementet indeholder underelementer."
+
+#: catalog/templates/_catalog_confirm_item.html:17
+msgid "Item has been merged to another item."
+msgstr "Element er blevet flettet til et andet element."
+
+#: catalog/templates/_catalog_confirm_item.html:22
+msgid "Item has been marked by users."
+msgstr "Element er blevet markeret af brugere."
+
+#: catalog/templates/_catalog_edit_preview.html:11
+#, fuzzy
+#| msgid "Confirm and save"
+msgid "Confirm changes"
+msgstr "Bekræft og gem"
+
+#: catalog/templates/_catalog_edit_preview.html:16
+msgid "Please correct the errors below."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:24
+msgid "Field"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:25
+msgid "From"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:26
+msgid "To"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:45
+#, fuzzy
+#| msgid "Tag deleted."
+msgid "No changes detected."
+msgstr "Tag slettet."
+
+#: catalog/templates/_catalog_edit_preview.html:54
+#: users/templates/users/register.html:104
+msgid "Confirm and save"
+msgstr "Bekræft og gem"
+
+#: catalog/templates/_catalog_edit_preview.html:57
+#, fuzzy
+#| msgid "back to item"
+msgid "Back to editing"
+msgstr "tilbage til element"
 
 #: catalog/templates/_country_list.html:5
 msgid "region"
 msgstr "område"
 
 #: catalog/templates/_fetch_failed.html:4
-msgid ""
-"Unable to fetch from the link, please check again. Some sites may require "
-"login for certain links, please manually create them here."
-msgstr ""
-"Kan ikke hente fra linket, tjek venligst igen. Nogle websteder kræver "
-"muligvis login for visse links. Opret dem manuelt her."
+msgid "Unable to fetch from the link, please check again. Some sites may require login for certain links, please manually create them here."
+msgstr "Kan ikke hente fra linket, tjek venligst igen. Nogle websteder kræver muligvis login for visse links. Opret dem manuelt her."
 
 #: catalog/templates/_item_card_metadata_album.html:7
 #: catalog/templates/_item_card_metadata_edition.html:7
@@ -1227,7 +1291,7 @@ msgstr "vis mere"
 #: journal/templates/profile_posts.html:21
 #: journal/templates/user_follow_list_items.html:63
 #: journal/templates/user_post_list_items.html:24
-#: social/templates/events.html:43 social/templates/feed_events.html:28
+#: social/templates/events.html:43 social/templates/feed_events.html:27
 msgid "nothing more."
 msgstr "ikke mere."
 
@@ -1326,7 +1390,7 @@ msgid "Add note"
 msgstr "Tilføj film"
 
 #: catalog/templates/_item_user_pieces.html:83
-#: common/templates/_sidebar.html:196 journal/templates/profile_items.html:46
+#: common/templates/_sidebar.html:195 journal/templates/profile_items.html:46
 #, fuzzy
 #| msgid "Sync in progress."
 msgid "Set progress"
@@ -1355,6 +1419,12 @@ msgstr "min samling"
 #: catalog/templates/_item_user_pieces.html:214
 msgid "mark history"
 msgstr "markeringshistorik"
+
+#: catalog/templates/_search_suggest.html:2
+#, fuzzy
+#| msgid "Suggest Edits"
+msgid "Suggestions"
+msgstr "Foreslå ændringer"
 
 #: catalog/templates/_sidebar_edit.html:8
 msgid "edit"
@@ -1385,15 +1455,15 @@ msgid "Edit Options"
 msgstr "Rediger Indstillinger"
 
 #: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
-#: catalog/views/edit.py:82 catalog/views/edit.py:143 catalog/views/edit.py:197
-#: catalog/views/edit.py:218 catalog/views/edit.py:259
-#: catalog/views/edit.py:328 catalog/views/edit.py:332
-#: catalog/views/edit.py:351 catalog/views/edit.py:400
-#: catalog/views/edit.py:425 catalog/views/edit.py:440
-#: catalog/views/edit.py:480 catalog/views/edit.py:490
-#: catalog/views/edit.py:517 catalog/views/edit.py:582
-#: catalog/views/edit.py:637 catalog/views/edit.py:659
-#: catalog/views/search.py:367
+#: catalog/views/edit.py:160 catalog/views/edit.py:221
+#: catalog/views/edit.py:288 catalog/views/edit.py:309
+#: catalog/views/edit.py:364 catalog/views/edit.py:471
+#: catalog/views/edit.py:475 catalog/views/edit.py:509
+#: catalog/views/edit.py:576 catalog/views/edit.py:601
+#: catalog/views/edit.py:624 catalog/views/edit.py:664
+#: catalog/views/edit.py:674 catalog/views/edit.py:703
+#: catalog/views/edit.py:782 catalog/views/edit.py:837
+#: catalog/views/edit.py:859 catalog/views/search.py:418
 #, fuzzy
 #| msgid "Edit this item"
 msgid "Editing this item is restricted."
@@ -1431,7 +1501,7 @@ msgstr "Element er blevet markeret af brugere."
 msgid "The following items are merged into this item"
 msgstr "Følgende elementer er lagt sammen med dette element"
 
-#: catalog/templates/_sidebar_edit.html:70
+#: catalog/templates/_sidebar_edit.html:70 catalog/views/edit.py:456
 msgid "External website"
 msgstr "Eksternt websted"
 
@@ -1451,39 +1521,35 @@ msgstr "Eksisterende metadata kan blive overskrevet, sikker på at fortsætte?"
 msgid "Fetch again"
 msgstr "Hent igen"
 
-#: catalog/templates/_sidebar_edit.html:97
-msgid "You may not be able to undo this operation, sure to remove?"
-msgstr "Du kan måske ikke fortryde denne operation, sikker på at fjerne?"
-
-#: catalog/templates/_sidebar_edit.html:102
+#: catalog/templates/_sidebar_edit.html:100
 msgid "Remove link to site"
 msgstr "Fjern link til websted"
 
-#: catalog/templates/_sidebar_edit.html:110
+#: catalog/templates/_sidebar_edit.html:108
 #, fuzzy
 #| msgid "Discover"
 msgid "Choose cover"
 msgstr "Udforsk"
 
-#: catalog/templates/_sidebar_edit.html:119
+#: catalog/templates/_sidebar_edit.html:117
+#: catalog/templates/_sidebar_edit.html:118
 #: catalog/templates/_sidebar_edit.html:120
-#: catalog/templates/_sidebar_edit.html:122
 #, fuzzy
 #| msgid "Current Targets"
 msgid "Current cover"
 msgstr "Aktuelle Mål"
 
-#: catalog/templates/_sidebar_edit.html:139
+#: catalog/templates/_sidebar_edit.html:137
 msgid "Select an image to use as the cover of this item."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:140
-#: catalog/templates/catalog_edit.html:65
-#: common/templates/manage/settings.html:136
+#: catalog/templates/_sidebar_edit.html:138
+#: catalog/templates/catalog_edit.html:78
+#: common/templates/manage/settings.html:19
 #: journal/templates/add_to_collection.html:43
 #: journal/templates/article_edit.html:60
 #: journal/templates/collection_edit.html:39 journal/templates/comment.html:41
-#: journal/templates/mark.html:134 journal/templates/note.html:65
+#: journal/templates/mark.html:138 journal/templates/note.html:65
 #: journal/templates/post_compose.html:103
 #: journal/templates/review_edit.html:46 journal/templates/tag_edit.html:51
 #: users/templates/users/_pref_device.html:37
@@ -1492,198 +1558,162 @@ msgstr ""
 msgid "Save"
 msgstr "Gem"
 
-#: catalog/templates/_sidebar_edit.html:147
+#: catalog/templates/_sidebar_edit.html:145
 msgid "Edit sub-items"
 msgstr "Rediger underelementer"
 
-#: catalog/templates/_sidebar_edit.html:160
+#: catalog/templates/_sidebar_edit.html:158
 msgid "create"
 msgstr "opret"
 
-#: catalog/templates/_sidebar_edit.html:166
+#: catalog/templates/_sidebar_edit.html:164
 msgid "Fetch all episodes"
 msgstr "Hent alle afsnit"
 
-#: catalog/templates/_sidebar_edit.html:171
+#: catalog/templates/_sidebar_edit.html:169
 msgid "Fetch all"
 msgstr "Hent alle"
 
-#: catalog/templates/_sidebar_edit.html:172
-msgid ""
-"Due to differences in how Douban, IMDB, and TMDB handle season data, a small "
-"number of TV shows and animations may not return correct results. Please "
-"manually verify and clean up after updating."
-msgstr ""
-"På grund af forskelle i hvordan Douban, IMDB og TMDB håndterer sæsondata, "
-"vil et lille antal tv-shows og animationer muligvis ikke returnere korrekte "
-"resultater. Bekræft venligst og ryd op manuelt efter opdatering."
+#: catalog/templates/_sidebar_edit.html:170
+msgid "Due to differences in how Douban, IMDB, and TMDB handle season data, a small number of TV shows and animations may not return correct results. Please manually verify and clean up after updating."
+msgstr "På grund af forskelle i hvordan Douban, IMDB og TMDB håndterer sæsondata, vil et lille antal tv-shows og animationer muligvis ikke returnere korrekte resultater. Bekræft venligst og ryd op manuelt efter opdatering."
 
-#: catalog/templates/_sidebar_edit.html:173
+#: catalog/templates/_sidebar_edit.html:171
 msgid "Up to 250 episodes will be fetched for a season."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:176
-msgid ""
-"To fetch all episodes, season numbers and IMDB information are required. If "
-"filling this out is inconvenient, you can also manually create sub-entries."
-msgstr ""
-"For at hente alle afsnit, sæsonnumre og IMDB, er information påkrævet. Hvis "
-"dette er ubelejligt, kan du også manuelt oprette underelementer."
+#: catalog/templates/_sidebar_edit.html:174
+msgid "To fetch all episodes, season numbers and IMDB information are required. If filling this out is inconvenient, you can also manually create sub-entries."
+msgstr "For at hente alle afsnit, sæsonnumre og IMDB, er information påkrævet. Hvis dette er ubelejligt, kan du også manuelt oprette underelementer."
 
-#: catalog/templates/_sidebar_edit.html:182
-#: catalog/templates/_sidebar_edit.html:194
-#: catalog/templates/_sidebar_edit.html:213
+#: catalog/templates/_sidebar_edit.html:180
+#: catalog/templates/_sidebar_edit.html:191
+#: catalog/templates/_sidebar_edit.html:208
 msgid "switch category"
 msgstr "skift kategori"
 
-#: catalog/templates/_sidebar_edit.html:185
-msgid "Switching may remove some metadata. Sure to proceed?"
-msgstr "Skift kan fjerne nogle metadata. Vil du fortsætte?"
-
-#: catalog/templates/_sidebar_edit.html:188
+#: catalog/templates/_sidebar_edit.html:185 catalog/views/edit.py:383
 msgid "TV Show"
 msgstr "TV-serie"
 
-#: catalog/templates/_sidebar_edit.html:227
+#: catalog/templates/_sidebar_edit.html:221
 msgid "Link to parent item"
 msgstr "Link til overordnet element"
 
 #: catalog/templates/_sidebar_edit.html:230
-msgid "Sure to link?"
-msgstr "Vil du linke?"
-
-#: catalog/templates/_sidebar_edit.html:237
 msgid "Update link"
 msgstr "Opdatér link"
 
-#: catalog/templates/_sidebar_edit.html:243
+#: catalog/templates/_sidebar_edit.html:236
 msgid "Cleanup seasons"
 msgstr "Oprydning af sæsoner"
 
-#: catalog/templates/_sidebar_edit.html:246
-#: catalog/templates/catalog_delete.html:45
-msgid "This operation cannot be undone. Sure to delete?"
-msgstr "Denne handling kan ikke fortrydes. Vil du slette?"
-
-#: catalog/templates/_sidebar_edit.html:250
+#: catalog/templates/_sidebar_edit.html:242
 msgid "remove seasons not marked"
 msgstr "fjern sæsoner ikke markeret"
 
-#: catalog/templates/_sidebar_edit.html:256
-#: catalog/templates/catalog_merge.html:12
+#: catalog/templates/_sidebar_edit.html:248
 msgid "Merge"
 msgstr "Læg sammen"
 
-#: catalog/templates/_sidebar_edit.html:262
+#: catalog/templates/_sidebar_edit.html:254
 msgid "URL of target item, or empty if undo merge"
 msgstr "URL for målobjekt, eller tom for at fortryde sammenlægning"
 
-#: catalog/templates/_sidebar_edit.html:268
-#: catalog/templates/_sidebar_edit.html:348
+#: catalog/templates/_sidebar_edit.html:260
+#: catalog/templates/_sidebar_edit.html:350
 msgid "merge to another item"
 msgstr "flet til et andet element"
 
-#: catalog/templates/_sidebar_edit.html:273
-#: catalog/templates/_sidebar_edit.html:277
-#: catalog/templates/catalog_delete.html:12
+#: catalog/templates/_sidebar_edit.html:265
+#: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
 #: journal/templates/article.html:199 journal/templates/collection.html:188
-#: journal/templates/mark.html:149 journal/templates/note.html:82
+#: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
 #: users/templates/users/account.html:254
 msgid "Delete"
 msgstr "Slet"
 
-#: catalog/templates/_sidebar_edit.html:287
+#: catalog/templates/_sidebar_edit.html:275
+#: catalog/templates/_sidebar_edit.html:279
+#, fuzzy
+#| msgid "Tag deleted."
+msgid "Undo delete"
+msgstr "Tag slettet."
+
+#: catalog/templates/_sidebar_edit.html:280
+msgid "Links to external sites and parent item were removed on delete and will not be restored."
+msgstr ""
+
+#: catalog/templates/_sidebar_edit.html:290
 msgid "This edition belongs to the following work"
 msgstr "Denne udgave tilhører følgende værk"
 
-#: catalog/templates/_sidebar_edit.html:292
-msgid "Sure to unlink?"
-msgstr "Vil du fjerne linket?"
-
-#: catalog/templates/_sidebar_edit.html:298
+#: catalog/templates/_sidebar_edit.html:300
 msgid "Unlink from work"
 msgstr "Fjern link fra værk"
 
-#: catalog/templates/_sidebar_edit.html:304
+#: catalog/templates/_sidebar_edit.html:306
 msgid "Link"
 msgstr "Link"
 
-#: catalog/templates/_sidebar_edit.html:315
+#: catalog/templates/_sidebar_edit.html:317
 msgid "Link to another edition from same work"
 msgstr "Link til en anden udgave fra samme værk"
 
-#: catalog/templates/_sidebar_edit.html:324
+#: catalog/templates/_sidebar_edit.html:326
 #, fuzzy
 #| msgid "description"
 msgid "Restriction"
 msgstr "beskrivelse"
 
-#: catalog/templates/_sidebar_edit.html:337
+#: catalog/templates/_sidebar_edit.html:339
 #: journal/templates/collection_update_item_note.html:4
 msgid "Update"
 msgstr "Opdatering"
 
-#: catalog/templates/_sidebar_edit.html:342
+#: catalog/templates/_sidebar_edit.html:344
 msgid "Suggest Edits"
 msgstr "Foreslå ændringer"
 
-#: catalog/templates/_sidebar_edit.html:347
+#: catalog/templates/_sidebar_edit.html:349
 msgid "proposed action"
 msgstr "foreslået handling"
 
-#: catalog/templates/_sidebar_edit.html:349
+#: catalog/templates/_sidebar_edit.html:351
 msgid "link to another item"
 msgstr "link til et andet element"
 
-#: catalog/templates/_sidebar_edit.html:350
+#: catalog/templates/_sidebar_edit.html:352
 msgid "change item category"
 msgstr "ændre kategori for element"
 
-#: catalog/templates/_sidebar_edit.html:351
+#: catalog/templates/_sidebar_edit.html:353
 msgid "change item metadata"
 msgstr "ændre metadata for element"
 
-#: catalog/templates/_sidebar_edit.html:352
+#: catalog/templates/_sidebar_edit.html:354
 msgid "remove item"
 msgstr "fjern element"
 
-#: catalog/templates/_sidebar_edit.html:353
+#: catalog/templates/_sidebar_edit.html:355
 msgid "other"
 msgstr "øvrige"
 
-#: catalog/templates/_sidebar_edit.html:357
-msgid ""
-"To suggest merging or association, please include the URL of the target item"
-msgstr ""
-"For at foreslå sammenlægning eller associering, bedes du inkludere URL'en "
-"for målelementet"
+#: catalog/templates/_sidebar_edit.html:359
+msgid "To suggest merging or association, please include the URL of the target item"
+msgstr "For at foreslå sammenlægning eller associering, bedes du inkludere URL'en for målelementet"
 
-#: catalog/templates/_sidebar_edit.html:358
+#: catalog/templates/_sidebar_edit.html:360
 #: catalog/templates/catalog_verify.html:116
 msgid "submit"
 msgstr "send"
 
-#: catalog/templates/_sidebar_edit.html:359
-msgid ""
-"As a user of this community, you may edit some metadata of items on this "
-"site. If you are unsure whether your edits are appropriate or are unable to "
-"make a certain change, you can make suggestions here. Moderators will "
-"consider each suggestion, although there is no guarantee that they will "
-"always be fully adopted; suggestions may also be viewed or discussed by "
-"other community users. If you have suggestions that are not related to a "
-"specific item, please contact us. Thank you for your support and "
-"contribution."
-msgstr ""
-"Som bruger i dette fællesskab kan du redigere metadata for elementer på "
-"sitet. Hvis du er usikker på om dine ændringer er ok, eller hvis du ikke kan "
-"lave en bestemt ændring, kan du i stedet foreslå ændringer her. Moderatorer "
-"vil så overveje dit forslag, men der er ingen garanti for at ændringerne "
-"bliver gennemført. Forslag kan ses og diskuteres af andre brugere. Hvis du "
-"har forslag som ikke relaterer til et bestemt element, så kontakt os "
-"venligst. Tak for din støtte og dit bidrag."
+#: catalog/templates/_sidebar_edit.html:361
+msgid "As a user of this community, you may edit some metadata of items on this site. If you are unsure whether your edits are appropriate or are unable to make a certain change, you can make suggestions here. Moderators will consider each suggestion, although there is no guarantee that they will always be fully adopted; suggestions may also be viewed or discussed by other community users. If you have suggestions that are not related to a specific item, please contact us. Thank you for your support and contribution."
+msgstr "Som bruger i dette fællesskab kan du redigere metadata for elementer på sitet. Hvis du er usikker på om dine ændringer er ok, eller hvis du ikke kan lave en bestemt ændring, kan du i stedet foreslå ændringer her. Moderatorer vil så overveje dit forslag, men der er ingen garanti for at ændringerne bliver gennemført. Forslag kan ses og diskuteres af andre brugere. Hvis du har forslag som ikke relaterer til et bestemt element, så kontakt os venligst. Tak for din støtte og dit bidrag."
 
 #: catalog/templates/_sidebar_search.html:5
 #: journal/templates/_sidebar_search_journal.html:4
@@ -1786,9 +1816,7 @@ msgid "matched"
 msgstr "så"
 
 #: catalog/templates/_verify_status.html:21
-msgid ""
-"Sure to remove your creator verification? Anyone will be able to edit this "
-"item again."
+msgid "Sure to remove your creator verification? Anyone will be able to edit this item again."
 msgstr ""
 
 #: catalog/templates/_verify_status.html:26
@@ -1797,7 +1825,7 @@ msgstr ""
 msgid "Remove my verification"
 msgstr "Fjern fra samling"
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:309
+#: catalog/templates/_verify_status.html:31 users/views/account.py:311
 #, fuzzy
 #| msgid "Verification"
 msgid "Verification failed"
@@ -1840,43 +1868,11 @@ msgstr "stregkode"
 msgid "album media"
 msgstr "album media"
 
-#: catalog/templates/catalog_delete.html:19
-msgid "Are you sure to delete?"
-msgstr "Er du sikker på du vil slette?"
-
-#: catalog/templates/catalog_delete.html:24
-#: catalog/templates/catalog_edit.html:52
-#: catalog/templates/catalog_merge.html:36
-#: catalog/templates/catalog_merge.html:64
-msgid "Item has been deleted."
-msgstr "Elementet er blevet slettet."
-
-#: catalog/templates/catalog_delete.html:29
-#: catalog/templates/catalog_edit.html:55
-#: catalog/templates/catalog_merge.html:41
-#: catalog/templates/catalog_merge.html:69
-msgid "Item contains sub-items."
-msgstr "Elementet indeholder underelementer."
-
-#: catalog/templates/catalog_delete.html:34
-#: catalog/templates/catalog_merge.html:46
-#: catalog/templates/catalog_merge.html:74
-msgid "Item has been merged to another item."
-msgstr "Element er blevet flettet til et andet element."
-
-#: catalog/templates/catalog_delete.html:39
-#: catalog/templates/catalog_merge.html:51
-#: catalog/templates/catalog_merge.html:79
-msgid "Item has been marked by users."
-msgstr "Element er blevet markeret af brugere."
-
-#: catalog/templates/catalog_delete.html:48
-#: catalog/templates/catalog_merge.html:92 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:55 common/views_manage.py:139
 msgid "Yes"
 msgstr "Ja"
 
-#: catalog/templates/catalog_delete.html:49
-#: catalog/templates/catalog_merge.html:93 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:56 common/views_manage.py:139
 msgid "No"
 msgstr "Nej"
 
@@ -1885,36 +1881,18 @@ msgstr "Nej"
 msgid "Create"
 msgstr "Opret"
 
-#: catalog/templates/catalog_edit.html:68
+#: catalog/templates/catalog_edit.html:81
 #: journal/templates/collection_update_item_note.html:8
 #: journal/templates/piece_delete.html:38
 msgid "Cancel"
 msgstr "Annuller"
 
-#: catalog/templates/catalog_edit.html:104
+#: catalog/templates/catalog_edit.html:118
 msgid "open linked people page"
 msgstr ""
 
-#: catalog/templates/catalog_merge.html:22
-msgid "Are you sure to merge?"
-msgstr "Er du sikker på at du vil sammenlægge?"
-
-#: catalog/templates/catalog_merge.html:24
-msgid "Are you sure to cancel merge?"
-msgstr "Er du sikker på at du vil annullere sammenlægningen?"
-
-#: catalog/templates/catalog_merge.html:27
-msgid "Are you sure to link?"
-msgstr "Er du sikker på at du vil linke?"
-
-#: catalog/templates/catalog_merge.html:86
-msgid "This operation cannot be undone. Sure to merge?"
-msgstr "Denne handling kan ikke fortrydes. Vil du sammenlægge?"
-
 #: catalog/templates/catalog_verify.html:21
-msgid ""
-"If you are a creator of this podcast, you may verify the ownership, so that "
-"only you (and other verified creators) can edit its metadata on this site."
+msgid "If you are a creator of this podcast, you may verify the ownership, so that only you (and other verified creators) can edit its metadata on this site."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:22
@@ -1922,9 +1900,7 @@ msgid "Your recent episodes may also occasionally be featured in discovery."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:24
-msgid ""
-"To verify, prove you control one of the following identifiers of your "
-"account (click to copy):"
+msgid "To verify, prove you control one of the following identifiers of your account (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:30
@@ -1935,18 +1911,11 @@ msgid "copied"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:35
-msgid ""
-"You can prove this in a few ways, then start verification: add one of the "
-"identifiers above to the podcast feed's description; add a <code>rel=\"me\"</"
-"code> link back to one of them on the web page your feed links to (the link "
-"verification Mastodon uses); or point your feed's website at your Bluesky "
-"handle's own domain."
+msgid "You can prove this in a few ways, then start verification: add one of the identifiers above to the podcast feed's description; add a <code>rel=\"me\"</code> link back to one of them on the web page your feed links to (the link verification Mastodon uses); or point your feed's website at your Bluesky handle's own domain."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:44
-msgid ""
-"For example, add this rel=me link to the web page your feed links to (click "
-"to copy):"
+msgid "For example, add this rel=me link to the web page your feed links to (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:50
@@ -1954,9 +1923,7 @@ msgid "or, in the page's head:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:57
-msgid ""
-"Can't edit the website? Just add a line like this to your feed's description "
-"instead (click to copy):"
+msgid "Can't edit the website? Just add a line like this to your feed's description instead (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:62
@@ -1964,10 +1931,7 @@ msgid "Welcome to follow me on the Fediverse:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:66
-msgid ""
-"NeoDB does not re-check this periodically at the moment, but we recommend "
-"you keep it so that your audience can discover and connect with you in "
-"distributed social media."
+msgid "NeoDB does not re-check this periodically at the moment, but we recommend you keep it so that your audience can discover and connect with you in distributed social media."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:72
@@ -1997,12 +1961,11 @@ msgid "Send feedback"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:115
-msgid ""
-"Questions or issues with creator verification? Let the site moderators know."
+msgid "Questions or issues with creator verification? Let the site moderators know."
 msgstr ""
 
-#: catalog/templates/discover.html:28 common/views_manage.py:145
-#: common/views_manage.py:353 users/templates/users/preferences.html:34
+#: catalog/templates/discover.html:28 common/views_manage.py:35
+#: common/views_manage.py:431 users/templates/users/preferences.html:34
 msgid "Discover"
 msgstr "Udforsk"
 
@@ -2040,17 +2003,17 @@ msgstr "vis"
 msgid "hide"
 msgstr "skjul"
 
-#: catalog/templates/discover.html:206 common/templates/_sidebar.html:14
+#: catalog/templates/discover.html:206 common/templates/_sidebar.html:13
 msgid "Unread Announcements"
 msgstr "Ulæste Meddelelser"
 
-#: catalog/templates/discover.html:212 common/templates/_sidebar.html:20
+#: catalog/templates/discover.html:212 common/templates/_sidebar.html:19
 #: social/templates/notification.html:67
 msgid "mark all as read"
 msgstr "marker alle som læst"
 
 #: catalog/templates/discover.html:222
-#: common/templates/_sidebar_anonymous.html:55
+#: common/templates/_sidebar_anonymous.html:54
 msgid "Popular Tags"
 msgstr "Populære tags"
 
@@ -2061,9 +2024,9 @@ msgstr "Populære tags"
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
 #: catalog/templates/user_verified_works.html:23
-#: common/templates/_sidebar.html:127
-#: common/templates/_sidebar_anonymous.html:46
-#: common/templates/_sidebar_anonymous.html:62 journal/templates/posts.html:8
+#: common/templates/_sidebar.html:126
+#: common/templates/_sidebar_anonymous.html:45
+#: common/templates/_sidebar_anonymous.html:61 journal/templates/posts.html:7
 #: journal/templates/profile_articles.html:24
 #: journal/templates/profile_articles.html:26
 #: journal/templates/profile_items.html:65
@@ -2079,7 +2042,7 @@ msgstr "Populære tags"
 msgid "nothing so far."
 msgstr "intet indtil videre."
 
-#: catalog/templates/discover.html:239 common/templates/_sidebar.html:269
+#: catalog/templates/discover.html:239 common/templates/_sidebar.html:268
 msgid "Recent Posts"
 msgstr "Seneste indlæg"
 
@@ -2108,15 +2071,9 @@ msgstr "Lån eller køb"
 
 #: catalog/templates/external_search_results.html:10
 #, fuzzy
-#| msgid ""
-#| "System will search other websites and instances, click title of the item "
-#| "to save them locally. "
-msgid ""
-"Some items were found from other websites and instances, click their title "
-"to save them locally."
-msgstr ""
-"Systemet vil søge andre hjemmesider og instanser, klik på titlen på "
-"elementet for at gemme dem lokalt. "
+#| msgid "System will search other websites and instances, click title of the item to save them locally. "
+msgid "Some items were found from other websites and instances, click their title to save them locally."
+msgstr "Systemet vil søge andre hjemmesider og instanser, klik på titlen på elementet for at gemme dem lokalt. "
 
 #: catalog/templates/fetch_pending.html:13
 msgid "Search results"
@@ -2142,9 +2099,7 @@ msgstr "marker, kommenter og indsaml"
 
 #: catalog/templates/item_base.html:142
 msgid "Login or register to review or add this item to your collection."
-msgstr ""
-"Log ind eller registrer dig for at anmelde eller tilføje dette element til "
-"din samling."
+msgstr "Log ind eller registrer dig for at anmelde eller tilføje dette element til din samling."
 
 #: catalog/templates/item_base.html:151
 msgid "Related Collections"
@@ -2219,14 +2174,14 @@ msgstr "antal sæsoner"
 msgid "number of Episodes"
 msgstr "antal afsnit"
 
-#: catalog/templates/people.html:13 common/templates/_sidebar.html:77
-#: common/templates/_sidebar.html:84 journal/models/shelf.py:326
+#: catalog/templates/people.html:13 common/templates/_sidebar.html:76
+#: common/templates/_sidebar.html:83 journal/models/shelf.py:328
 #, fuzzy
 #| msgid "following you"
 msgid "following"
 msgstr "følger dig"
 
-#: catalog/templates/people.html:15 journal/models/shelf.py:324
+#: catalog/templates/people.html:15 journal/models/shelf.py:326
 #: social/templates/notification.html:60
 msgid "follow"
 msgstr "følg"
@@ -2245,7 +2200,6 @@ msgstr ""
 #: journal/templates/_sidebar_collection_filter.html:14
 #: journal/templates/_sidebar_collection_filter.html:28
 #: journal/templates/_sidebar_user_mark_list.html:56
-#: social/templates/feed.html:42 social/templates/feed.html:44
 #: social/templates/notification.html:56
 msgid "all"
 msgstr "alle"
@@ -2273,7 +2227,7 @@ msgstr "Fuldført"
 msgid "production"
 msgstr "produktion"
 
-#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:54
+#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:53
 #, fuzzy
 #| msgid "original creator"
 msgid "verified creator"
@@ -2360,14 +2314,8 @@ msgid "No items matching your search query."
 msgstr "Ingen elementer matcher din søgeforespørgsel."
 
 #: catalog/templates/search_results.html:34
-msgid ""
-"If you have URL from one of these sites, please put the full URL (e.g. "
-"<code>https://www.imdb.com/title/tt2513074/</code>) to the search box and "
-"press Enter."
-msgstr ""
-"Hvis du har en URL fra et af disse websteder, så angiv venligst den fulde "
-"URL (f.eks. <code>https://www. mdb.com/title/tt2513074/</code>) i "
-"søgefeltet, og tryk på Enter."
+msgid "If you have URL from one of these sites, please put the full URL (e.g. <code>https://www.imdb.com/title/tt2513074/</code>) to the search box and press Enter."
+msgstr "Hvis du har en URL fra et af disse websteder, så angiv venligst den fulde URL (f.eks. <code>https://www. mdb.com/title/tt2513074/</code>) i søgefeltet, og tryk på Enter."
 
 #: catalog/templates/search_results.html:48
 msgid "Searching from other sites"
@@ -2405,102 +2353,192 @@ msgstr ""
 msgid "Editions"
 msgstr "Udgaver"
 
-#: catalog/views/edit.py:202 catalog/views/edit.py:205
-#: catalog/views/edit.py:306 catalog/views/edit.py:309
-#: catalog/views/verify.py:197 journal/views/collection.py:77
-#: journal/views/collection.py:102 journal/views/collection.py:556
-#: journal/views/collection.py:651 journal/views/common.py:221
-#: journal/views/mark.py:196 journal/views/post.py:117
-#: journal/views/post.py:119 journal/views/post.py:166
-#: journal/views/post.py:185 journal/views/post.py:187
-#: journal/views/post.py:228 journal/views/post.py:241
+#: catalog/views/edit.py:293 catalog/views/edit.py:296
+#: catalog/views/edit.py:440 catalog/views/edit.py:443
+#: catalog/views/verify.py:197 journal/views/collection.py:75
+#: journal/views/collection.py:100 journal/views/collection.py:538
+#: journal/views/collection.py:634 journal/views/common.py:231
+#: journal/views/mark.py:244 journal/views/post.py:119
+#: journal/views/post.py:121 journal/views/post.py:168
+#: journal/views/post.py:187 journal/views/post.py:189
+#: journal/views/post.py:230 journal/views/post.py:243
 #: journal/views/review.py:154 journal/views/review.py:158
-#: users/views/actions.py:179
+#: users/views/actions.py:178
 msgid "Invalid parameter"
 msgstr "Ugyldig parameter"
 
-#: catalog/views/edit.py:220
+#: catalog/views/edit.py:313
 msgid "Item in use."
 msgstr "Element i brug."
 
-#: catalog/views/edit.py:222
+#: catalog/views/edit.py:315
 msgid "Item cannot be deleted."
 msgstr "Elementet kan ikke slettes."
 
-#: catalog/views/edit.py:247 catalog/views/edit.py:303
-#: catalog/views/edit.py:427 catalog/views/edit.py:519
-#: catalog/views/edit.py:552 catalog/views/verify.py:158
+#: catalog/views/edit.py:319 catalog/views/edit.py:515
+msgid "Are you sure to delete?"
+msgstr "Er du sikker på du vil slette?"
+
+#: catalog/views/edit.py:323 catalog/views/edit.py:518
+#: catalog/views/edit.py:617
+#, fuzzy
+#| msgid "This operation cannot be undone. Sure to merge?"
+msgid "This operation cannot be undone."
+msgstr "Denne handling kan ikke fortrydes. Vil du sammenlægge?"
+
+#: catalog/views/edit.py:344 catalog/views/edit.py:437
+#: catalog/views/edit.py:603 catalog/views/edit.py:705
+#: catalog/views/edit.py:752 catalog/views/verify.py:158
 #: catalog/views/verify.py:206 journal/views/article.py:44
 #: journal/views/article.py:133 journal/views/article.py:153
 #: journal/views/collection.py:248 journal/views/collection.py:341
-#: journal/views/collection.py:360 journal/views/collection.py:384
-#: journal/views/collection.py:457 journal/views/collection.py:500
-#: journal/views/collection.py:539 journal/views/collection.py:551
-#: journal/views/collection.py:576 journal/views/collection.py:613
-#: journal/views/common.py:300 journal/views/mark.py:281
-#: journal/views/post.py:58 journal/views/post.py:78 journal/views/post.py:100
-#: journal/views/post.py:170 journal/views/post.py:199
-#: journal/views/post.py:272 journal/views/post.py:287
-#: journal/views/post.py:394 journal/views/post.py:549
+#: journal/views/collection.py:354 journal/views/collection.py:372
+#: journal/views/collection.py:439 journal/views/collection.py:482
+#: journal/views/collection.py:521 journal/views/collection.py:533
+#: journal/views/collection.py:558 journal/views/collection.py:595
+#: journal/views/common.py:304 journal/views/mark.py:317
+#: journal/views/post.py:60 journal/views/post.py:80 journal/views/post.py:102
+#: journal/views/post.py:172 journal/views/post.py:201
+#: journal/views/post.py:274 journal/views/post.py:289
+#: journal/views/post.py:390 journal/views/post.py:539
 #: journal/views/review.py:64 journal/views/review.py:81
 #: journal/views/review.py:106
 msgid "Insufficient permission"
 msgstr "Utilstrækkelig tilladelse"
 
-#: catalog/views/edit.py:374
+#: catalog/views/edit.py:346
+#, fuzzy
+#| msgid "Item has been deleted."
+msgid "Item is not deleted"
+msgstr "Elementet er blevet slettet."
+
+#: catalog/views/edit.py:389
+#, fuzzy
+#| msgid "Switching may remove some metadata. Sure to proceed?"
+msgid "Switching may remove some metadata."
+msgstr "Skift kan fjerne nogle metadata. Vil du fortsætte?"
+
+#: catalog/views/edit.py:395
+#, fuzzy
+#| msgid "The following items are merged into this item"
+msgid "The following seasons will be detached from this show"
+msgstr "Følgende elementer er lagt sammen med dette element"
+
+#: catalog/views/edit.py:400
+msgid "Links to IMDB and TMDB will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:403
+#, fuzzy
+#| msgid "Are you sure to merge?"
+msgid "Are you sure to switch category?"
+msgstr "Er du sikker på at du vil sammenlægge?"
+
+#: catalog/views/edit.py:451
+#, fuzzy
+#| msgid "Are you sure to delete this post?"
+msgid "Are you sure to remove the link to this site?"
+msgstr "Er du sikker på at du vil slette dette indlæg?"
+
+#: catalog/views/edit.py:457
+#, fuzzy
+#| msgid "You may not be able to undo this operation, sure to remove?"
+msgid "You may not be able to undo this operation."
+msgstr "Du kan måske ikke fortryde denne operation, sikker på at fjerne?"
+
+#: catalog/views/edit.py:483
+#, fuzzy
+#| msgid "Link to parent item"
+msgid "Current parent item"
+msgstr "Link til overordnet element"
+
+#: catalog/views/edit.py:487
+msgid "The link to the parent item will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:490 catalog/views/edit.py:680
+msgid "Are you sure to link?"
+msgstr "Er du sikker på at du vil linke?"
+
+#: catalog/views/edit.py:521
+msgid "The following seasons will be deleted"
+msgstr ""
+
+#: catalog/views/edit.py:525
+msgid "The following seasons will be kept"
+msgstr ""
+
+#: catalog/views/edit.py:550
 msgid "TV Season with IMDB id and season number required."
 msgstr "TV-sæson med IMDB id og sæsonnummer kræves."
 
-#: catalog/views/edit.py:380
+#: catalog/views/edit.py:556
 msgid "Updating episodes"
 msgstr "Opdaterer afsnit"
 
-#: catalog/views/edit.py:405
+#: catalog/views/edit.py:581
 msgid "This person has no supported source to fetch works from."
 msgstr ""
 
-#: catalog/views/edit.py:412
+#: catalog/views/edit.py:588
 msgid "Already pulling works for this person, try again later."
 msgstr ""
 
-#: catalog/views/edit.py:416
+#: catalog/views/edit.py:592
 msgid "Pulling works in background."
 msgstr ""
 
-#: catalog/views/edit.py:438
-msgid "Cannot be merged to an item already deleted or merged"
-msgstr ""
-"Kan ikke lægges sammen med et element, som allerede er slettet eller "
-"sammenlagt"
+#: catalog/views/edit.py:609
+msgid "Are you sure to merge?"
+msgstr "Er du sikker på at du vil sammenlægge?"
 
-#: catalog/views/edit.py:443
+#: catalog/views/edit.py:611
+msgid "Are you sure to cancel merge?"
+msgstr "Er du sikker på at du vil annullere sammenlægningen?"
+
+#: catalog/views/edit.py:622
+msgid "Cannot be merged to an item already deleted or merged"
+msgstr "Kan ikke lægges sammen med et element, som allerede er slettet eller sammenlagt"
+
+#: catalog/views/edit.py:627
 msgid "Cannot merge items in different categories"
 msgstr "Kan ikke sammenlægge elementer i forskellige kategorier"
 
-#: catalog/views/edit.py:447
+#: catalog/views/edit.py:631
 #, fuzzy
 #| msgid "Cannot merge items in different categories"
 msgid "Cannot merge an item to itself"
 msgstr "Kan ikke sammenlægge elementer i forskellige kategorier"
 
-#: catalog/views/edit.py:488
+#: catalog/views/edit.py:672
 msgid "Cannot be linked to an item already deleted or merged"
-msgstr ""
-"Kan ikke linkes til et element som allerede er slettet eller sammenlagt"
+msgstr "Kan ikke linkes til et element som allerede er slettet eller sammenlagt"
 
-#: catalog/views/edit.py:492
+#: catalog/views/edit.py:676
 msgid "Cannot link items other than editions"
 msgstr "Kan ikke linke andre elementer end udgaver"
 
-#: catalog/views/search.py:96
+#: catalog/views/edit.py:710
+#, fuzzy
+#| msgid "Are you sure to link?"
+msgid "Are you sure to unlink?"
+msgstr "Er du sikker på at du vil linke?"
+
+#: catalog/views/edit.py:715
+#, fuzzy
+#| msgid "This edition belongs to the following work"
+msgid "This edition will be unlinked from the following work"
+msgstr "Denne udgave tilhører følgende værk"
+
+#: catalog/views/search.py:113
 msgid "the internet"
 msgstr ""
 
-#: catalog/views/search.py:359
+#: catalog/views/search.py:410
 msgid "Invalid URL"
 msgstr "Ugyldig URL"
 
-#: catalog/views/search.py:362
+#: catalog/views/search.py:413
 #, fuzzy
 #| msgid "Unsupported item type."
 msgid "Unsupported URL"
@@ -2526,9 +2564,9 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:122 common/utils.py:163
+#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
 #: journal/views/article.py:186 journal/views/review.py:182
-#: users/views/actions.py:45 users/views/actions.py:131
+#: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
 msgstr "Bruger ikke fundet"
 
@@ -2542,15 +2580,15 @@ msgstr ""
 msgid "Creator verification removed."
 msgstr "Send bekræftelseskode"
 
-#: catalog/views/view.py:74 catalog/views/view.py:99
+#: catalog/views/view.py:77 catalog/views/view.py:102
 msgid "Item not found"
 msgstr "Element ikke fundet"
 
-#: catalog/views/view.py:78 catalog/views/view.py:107 catalog/views/view.py:190
+#: catalog/views/view.py:81 catalog/views/view.py:110 catalog/views/view.py:193
 msgid "Item no longer exists"
 msgstr "Elementet findes ikke længere"
 
-#: catalog/views/view.py:187
+#: catalog/views/view.py:190
 #, fuzzy
 #| msgid "Invalid file."
 msgid "Invalid role"
@@ -3098,761 +3136,761 @@ msgctxt "genre"
 msgid "Health"
 msgstr ""
 
-#: common/models/lang.py:54
+#: common/models/lang.py:56
 msgid "Afar"
 msgstr "Afar"
 
-#: common/models/lang.py:55
+#: common/models/lang.py:57
 msgid "Afrikaans"
 msgstr "Afrikaans"
 
-#: common/models/lang.py:56
+#: common/models/lang.py:58
 msgid "Akan"
 msgstr "Akansk"
 
-#: common/models/lang.py:57
+#: common/models/lang.py:59
 msgid "Aragonese"
 msgstr "Aragonesisk"
 
-#: common/models/lang.py:58
+#: common/models/lang.py:60
 msgid "Assamese"
 msgstr "Assamesisk"
 
-#: common/models/lang.py:59
+#: common/models/lang.py:61
 msgid "Avaric"
 msgstr "Avarisk"
 
-#: common/models/lang.py:60
+#: common/models/lang.py:62
 msgid "Avestan"
 msgstr "Avestansk"
 
-#: common/models/lang.py:61
+#: common/models/lang.py:63
 msgid "Aymara"
 msgstr "Ayamarisk"
 
-#: common/models/lang.py:62
+#: common/models/lang.py:64
 msgid "Azerbaijani"
 msgstr "Aserbajdsjansk"
 
-#: common/models/lang.py:63
+#: common/models/lang.py:65
 msgid "Bashkir"
 msgstr "Basjkirsk"
 
-#: common/models/lang.py:64
+#: common/models/lang.py:66
 msgid "Bambara"
 msgstr "Bambara"
 
-#: common/models/lang.py:65
+#: common/models/lang.py:67
 msgid "Bislama"
 msgstr "Bislama"
 
-#: common/models/lang.py:66
+#: common/models/lang.py:68
 msgid "Tibetan"
 msgstr "Tibetansk"
 
-#: common/models/lang.py:67
+#: common/models/lang.py:69
 msgid "Breton"
 msgstr "Bretonsk"
 
-#: common/models/lang.py:68
+#: common/models/lang.py:70
 msgid "Catalan"
 msgstr "Catalansk"
 
-#: common/models/lang.py:69
+#: common/models/lang.py:71
 msgid "Czech"
 msgstr "Tjekkisk"
 
-#: common/models/lang.py:70
+#: common/models/lang.py:72
 msgid "Chechen"
 msgstr "Tjetjensk"
 
-#: common/models/lang.py:71
+#: common/models/lang.py:73
 msgid "Slavic"
 msgstr "Slavisk"
 
-#: common/models/lang.py:72
+#: common/models/lang.py:74
 msgid "Chuvash"
 msgstr "tjuvasisk"
 
-#: common/models/lang.py:73
+#: common/models/lang.py:75
 msgid "Cornish"
 msgstr "Cornisk"
 
-#: common/models/lang.py:74
+#: common/models/lang.py:76
 msgid "Corsican"
 msgstr "Korsikansk"
 
-#: common/models/lang.py:75
+#: common/models/lang.py:77
 msgid "Cree"
 msgstr "Cree"
 
-#: common/models/lang.py:76
+#: common/models/lang.py:78
 msgid "Welsh"
 msgstr "Walisisk"
 
-#: common/models/lang.py:79
+#: common/models/lang.py:81
 msgid "Divehi"
 msgstr "Divehi"
 
-#: common/models/lang.py:80
+#: common/models/lang.py:82
 msgid "Dzongkha"
 msgstr "Dzongkha"
 
-#: common/models/lang.py:81
+#: common/models/lang.py:83
 msgid "Esperanto"
 msgstr "Esperanto"
 
-#: common/models/lang.py:82
+#: common/models/lang.py:84
 msgid "Estonian"
 msgstr "Estisk"
 
-#: common/models/lang.py:83
+#: common/models/lang.py:85
 msgid "Basque"
 msgstr "Baskisk"
 
-#: common/models/lang.py:84
+#: common/models/lang.py:86
 msgid "Faroese"
 msgstr "Færørsk"
 
-#: common/models/lang.py:85
+#: common/models/lang.py:87
 msgid "Fijian"
 msgstr "Fijiansk"
 
-#: common/models/lang.py:86
+#: common/models/lang.py:88
 msgid "Finnish"
 msgstr "Finsk"
 
-#: common/models/lang.py:88
+#: common/models/lang.py:90
 msgid "Frisian"
 msgstr "Frisisk"
 
-#: common/models/lang.py:89
+#: common/models/lang.py:91
 msgid "Fulah"
 msgstr "Fulah"
 
-#: common/models/lang.py:90
+#: common/models/lang.py:92
 msgid "Gaelic"
 msgstr "Gælisk"
 
-#: common/models/lang.py:91
+#: common/models/lang.py:93
 msgid "Irish"
 msgstr "Irsk"
 
-#: common/models/lang.py:92
+#: common/models/lang.py:94
 msgid "Galician"
 msgstr "Galicisk"
 
-#: common/models/lang.py:93
+#: common/models/lang.py:95
 msgid "Manx"
 msgstr "Mansk"
 
-#: common/models/lang.py:94
+#: common/models/lang.py:96
 msgid "Guarani"
 msgstr "Guarani"
 
-#: common/models/lang.py:95
+#: common/models/lang.py:97
 msgid "Gujarati"
 msgstr "Gujarati"
 
-#: common/models/lang.py:96
+#: common/models/lang.py:98
 msgid "Haitian; Haitian Creole"
 msgstr "Haitiansk"
 
-#: common/models/lang.py:97
+#: common/models/lang.py:99
 msgid "Hausa"
 msgstr "Hausa"
 
-#: common/models/lang.py:98
+#: common/models/lang.py:100
 msgid "Serbo-Croatian"
 msgstr "Serbokroatisk"
 
-#: common/models/lang.py:99
+#: common/models/lang.py:101
 msgid "Herero"
 msgstr "Herero"
 
-#: common/models/lang.py:100
+#: common/models/lang.py:102
 msgid "Hiri Motu"
 msgstr "Hiri Motu"
 
-#: common/models/lang.py:101
+#: common/models/lang.py:103
 msgid "Croatian"
 msgstr "Kroatisk"
 
-#: common/models/lang.py:102
+#: common/models/lang.py:104
 msgid "Hungarian"
 msgstr "Ungarsk"
 
-#: common/models/lang.py:103
+#: common/models/lang.py:105
 msgid "Igbo"
 msgstr "Igbo"
 
-#: common/models/lang.py:104
+#: common/models/lang.py:106
 msgid "Ido"
 msgstr "Ido"
 
-#: common/models/lang.py:105
+#: common/models/lang.py:107
 msgid "Yi"
 msgstr "Yi"
 
-#: common/models/lang.py:106
+#: common/models/lang.py:108
 msgid "Inuktitut"
 msgstr "Inuktitut"
 
-#: common/models/lang.py:107
+#: common/models/lang.py:109
 msgid "Interlingue"
 msgstr "Interlingue"
 
-#: common/models/lang.py:108
+#: common/models/lang.py:110
 msgid "Interlingua"
 msgstr "Interlingua"
 
-#: common/models/lang.py:109
+#: common/models/lang.py:111
 msgid "Indonesian"
 msgstr "Indonesisk"
 
-#: common/models/lang.py:110
+#: common/models/lang.py:112
 msgid "Inupiaq"
 msgstr "Inupiaq"
 
-#: common/models/lang.py:111
+#: common/models/lang.py:113
 msgid "Icelandic"
 msgstr "Islandsk"
 
-#: common/models/lang.py:113
+#: common/models/lang.py:115
 msgid "Javanese"
 msgstr "Javanesisk"
 
-#: common/models/lang.py:114
+#: common/models/lang.py:116
 msgid "Japanese"
 msgstr "Japansk"
 
-#: common/models/lang.py:115
+#: common/models/lang.py:117
 msgid "Kalaallisut"
 msgstr "Grønlandsk"
 
-#: common/models/lang.py:116
+#: common/models/lang.py:118
 msgid "Kannada"
 msgstr "Kanaresisk"
 
-#: common/models/lang.py:117
+#: common/models/lang.py:119
 msgid "Kashmiri"
 msgstr "Kashmirisk"
 
-#: common/models/lang.py:118
+#: common/models/lang.py:120
 msgid "Kanuri"
 msgstr "Kanuri"
 
-#: common/models/lang.py:119
+#: common/models/lang.py:121
 msgid "Kazakh"
 msgstr "Kasakhisk"
 
-#: common/models/lang.py:120
+#: common/models/lang.py:122
 msgid "Khmer"
 msgstr "Khmer"
 
-#: common/models/lang.py:121
+#: common/models/lang.py:123
 msgid "Kikuyu"
 msgstr "Kikuyu"
 
-#: common/models/lang.py:122
+#: common/models/lang.py:124
 msgid "Kinyarwanda"
 msgstr "Kinyarwanda"
 
-#: common/models/lang.py:123
+#: common/models/lang.py:125
 msgid "Kirghiz"
 msgstr "Kirgisisk"
 
-#: common/models/lang.py:124
+#: common/models/lang.py:126
 msgid "Komi"
 msgstr "Komi"
 
-#: common/models/lang.py:125
+#: common/models/lang.py:127
 msgid "Kongo"
 msgstr "Congolesisk"
 
-#: common/models/lang.py:126
+#: common/models/lang.py:128
 msgid "Korean"
 msgstr "Koreansk"
 
-#: common/models/lang.py:127
+#: common/models/lang.py:129
 msgid "Kuanyama"
 msgstr "Kuanyama"
 
-#: common/models/lang.py:128
+#: common/models/lang.py:130
 msgid "Kurdish"
 msgstr "Kurdisk"
 
-#: common/models/lang.py:129
+#: common/models/lang.py:131
 msgid "Lao"
 msgstr "Laotisk"
 
-#: common/models/lang.py:130
+#: common/models/lang.py:132
 msgid "Latin"
 msgstr "Latinsk"
 
-#: common/models/lang.py:131
+#: common/models/lang.py:133
 msgid "Latvian"
 msgstr "Lettisk"
 
-#: common/models/lang.py:132
+#: common/models/lang.py:134
 msgid "Limburgish"
 msgstr "Limburgsk"
 
-#: common/models/lang.py:133
+#: common/models/lang.py:135
 msgid "Lingala"
 msgstr "Lingala"
 
-#: common/models/lang.py:134
+#: common/models/lang.py:136
 msgid "Lithuanian"
 msgstr "Litauisk"
 
-#: common/models/lang.py:135
+#: common/models/lang.py:137
 msgid "Letzeburgesch"
 msgstr "Letzeburgesch"
 
-#: common/models/lang.py:136
+#: common/models/lang.py:138
 msgid "Luba-Katanga"
 msgstr "Luba-Katanga"
 
-#: common/models/lang.py:137
+#: common/models/lang.py:139
 msgid "Ganda"
 msgstr "Ganda"
 
-#: common/models/lang.py:138
+#: common/models/lang.py:140
 msgid "Marshall"
 msgstr "Marshailandsk"
 
-#: common/models/lang.py:139
+#: common/models/lang.py:141
 msgid "Malayalam"
 msgstr "Malayalam"
 
-#: common/models/lang.py:140
+#: common/models/lang.py:142
 msgid "Marathi"
 msgstr "Marathisk"
 
-#: common/models/lang.py:141
+#: common/models/lang.py:143
 msgid "Malagasy"
 msgstr "Malagassisk"
 
-#: common/models/lang.py:142
+#: common/models/lang.py:144
 msgid "Maltese"
 msgstr "Maltesisk"
 
-#: common/models/lang.py:143
+#: common/models/lang.py:145
 msgid "Moldavian"
 msgstr "Moldovisk"
 
-#: common/models/lang.py:144
+#: common/models/lang.py:146
 msgid "Mongolian"
 msgstr "Mongolsk"
 
-#: common/models/lang.py:145
+#: common/models/lang.py:147
 msgid "Maori"
 msgstr "Maori"
 
-#: common/models/lang.py:146
+#: common/models/lang.py:148
 msgid "Malay"
 msgstr "Malaysisk"
 
-#: common/models/lang.py:147
+#: common/models/lang.py:149
 msgid "Burmese"
 msgstr "Burmesisk"
 
-#: common/models/lang.py:148
+#: common/models/lang.py:150
 msgid "Nauru"
 msgstr "Nauru"
 
-#: common/models/lang.py:149
+#: common/models/lang.py:151
 msgid "Navajo"
 msgstr "Navajo"
 
-#: common/models/lang.py:150 common/models/lang.py:151
+#: common/models/lang.py:152 common/models/lang.py:153
 msgid "Ndebele"
 msgstr "Ndebele"
 
-#: common/models/lang.py:152
+#: common/models/lang.py:154
 msgid "Ndonga"
 msgstr "Ndonga"
 
-#: common/models/lang.py:153
+#: common/models/lang.py:155
 msgid "Nepali"
 msgstr "Nepalesisk"
 
-#: common/models/lang.py:154
+#: common/models/lang.py:156
 msgid "Dutch"
 msgstr "Hollandsk"
 
-#: common/models/lang.py:155
+#: common/models/lang.py:157
 msgid "Norwegian Nynorsk"
 msgstr "Norsk nynorsk"
 
-#: common/models/lang.py:156
+#: common/models/lang.py:158
 msgid "Norwegian Bokmål"
 msgstr "Norsk bokmål"
 
-#: common/models/lang.py:157
+#: common/models/lang.py:159
 msgid "Norwegian"
 msgstr "Norsk"
 
-#: common/models/lang.py:158
+#: common/models/lang.py:160
 msgid "Chichewa; Nyanja"
 msgstr "Chichewa; Nyanja"
 
-#: common/models/lang.py:159
+#: common/models/lang.py:161
 msgid "Occitan"
 msgstr "Occitansk"
 
-#: common/models/lang.py:160
+#: common/models/lang.py:162
 msgid "Ojibwa"
 msgstr "Ojibwa"
 
-#: common/models/lang.py:161
+#: common/models/lang.py:163
 msgid "Oriya"
 msgstr "Oriya"
 
-#: common/models/lang.py:162
+#: common/models/lang.py:164
 msgid "Oromo"
 msgstr "Oromo"
 
-#: common/models/lang.py:163
+#: common/models/lang.py:165
 msgid "Ossetian; Ossetic"
 msgstr "Ossetisk"
 
-#: common/models/lang.py:164
+#: common/models/lang.py:166
 msgid "Pali"
 msgstr "Pali"
 
-#: common/models/lang.py:165
+#: common/models/lang.py:167
 msgid "Polish"
 msgstr "Polsk"
 
-#: common/models/lang.py:167
+#: common/models/lang.py:169
 msgid "Quechua"
 msgstr "Quechua"
 
-#: common/models/lang.py:168
+#: common/models/lang.py:170
 msgid "Raeto-Romance"
 msgstr "Rætoromansk"
 
-#: common/models/lang.py:169
+#: common/models/lang.py:171
 msgid "Romanian"
 msgstr "Rumænsk"
 
-#: common/models/lang.py:170
+#: common/models/lang.py:172
 msgid "Rundi"
 msgstr "Rundi"
 
-#: common/models/lang.py:171
+#: common/models/lang.py:173
 msgid "Russian"
 msgstr "Russisk"
 
-#: common/models/lang.py:172
+#: common/models/lang.py:174
 msgid "Sango"
 msgstr "Sango"
 
-#: common/models/lang.py:173
+#: common/models/lang.py:175
 msgid "Sanskrit"
 msgstr "Sanskrit"
 
-#: common/models/lang.py:174
+#: common/models/lang.py:176
 msgid "Sinhalese"
 msgstr "Singalesisk"
 
-#: common/models/lang.py:175
+#: common/models/lang.py:177
 msgid "Slovak"
 msgstr "Slovakisk"
 
-#: common/models/lang.py:176
+#: common/models/lang.py:178
 msgid "Slovenian"
 msgstr "Slovensk"
 
-#: common/models/lang.py:177
+#: common/models/lang.py:179
 msgid "Northern Sami"
 msgstr "Nordsamisk"
 
-#: common/models/lang.py:178
+#: common/models/lang.py:180
 msgid "Samoan"
 msgstr "Samoansk"
 
-#: common/models/lang.py:179
+#: common/models/lang.py:181
 msgid "Shona"
 msgstr "Shona"
 
-#: common/models/lang.py:180
+#: common/models/lang.py:182
 msgid "Sindhi"
 msgstr "Sindhi"
 
-#: common/models/lang.py:181
+#: common/models/lang.py:183
 msgid "Somali"
 msgstr "Somalisk"
 
-#: common/models/lang.py:182
+#: common/models/lang.py:184
 msgid "Sotho"
 msgstr "Sotho"
 
-#: common/models/lang.py:184
+#: common/models/lang.py:186
 msgid "Albanian"
 msgstr "Albansk"
 
-#: common/models/lang.py:185
+#: common/models/lang.py:187
 msgid "Sardinian"
 msgstr "Sardinsk"
 
-#: common/models/lang.py:186
+#: common/models/lang.py:188
 msgid "Serbian"
 msgstr "Serbisk"
 
-#: common/models/lang.py:187
+#: common/models/lang.py:189
 msgid "Swati"
 msgstr "Swati"
 
-#: common/models/lang.py:188
+#: common/models/lang.py:190
 msgid "Sundanese"
 msgstr "Sundanesisk"
 
-#: common/models/lang.py:189
+#: common/models/lang.py:191
 msgid "Swahili"
 msgstr "Swahili"
 
-#: common/models/lang.py:190
+#: common/models/lang.py:192
 msgid "Swedish"
 msgstr "Svensk"
 
-#: common/models/lang.py:191
+#: common/models/lang.py:193
 msgid "Tahitian"
 msgstr "Tahitiansk"
 
-#: common/models/lang.py:192
+#: common/models/lang.py:194
 msgid "Tamil"
 msgstr "Tamilsk"
 
-#: common/models/lang.py:193
+#: common/models/lang.py:195
 msgid "Tatar"
 msgstr "Tatarisk"
 
-#: common/models/lang.py:194
+#: common/models/lang.py:196
 msgid "Telugu"
 msgstr "Telugu"
 
-#: common/models/lang.py:195
+#: common/models/lang.py:197
 msgid "Tajik"
 msgstr "Tajikisk"
 
-#: common/models/lang.py:196
+#: common/models/lang.py:198
 msgid "Tagalog"
 msgstr "Tagalog"
 
-#: common/models/lang.py:197
+#: common/models/lang.py:199
 msgid "Thai"
 msgstr "Thai"
 
-#: common/models/lang.py:198
+#: common/models/lang.py:200
 msgid "Tigrinya"
 msgstr "Tigrinsk"
 
-#: common/models/lang.py:199
+#: common/models/lang.py:201
 msgid "Tonga"
 msgstr "Tonga"
 
-#: common/models/lang.py:200
+#: common/models/lang.py:202
 msgid "Tswana"
 msgstr "Tswana"
 
-#: common/models/lang.py:201
+#: common/models/lang.py:203
 msgid "Tsonga"
 msgstr "Tsonga"
 
-#: common/models/lang.py:202
+#: common/models/lang.py:204
 msgid "Turkmen"
 msgstr "Turkmensk"
 
-#: common/models/lang.py:203
+#: common/models/lang.py:205
 msgid "Turkish"
 msgstr "Tyrkisk"
 
-#: common/models/lang.py:204
+#: common/models/lang.py:206
 msgid "Twi"
 msgstr "Twi"
 
-#: common/models/lang.py:205
+#: common/models/lang.py:207
 msgid "Uighur"
 msgstr "Uigurisk"
 
-#: common/models/lang.py:206
+#: common/models/lang.py:208
 msgid "Ukrainian"
 msgstr "Ukrainsk"
 
-#: common/models/lang.py:207
+#: common/models/lang.py:209
 msgid "Urdu"
 msgstr "Urdu"
 
-#: common/models/lang.py:208
+#: common/models/lang.py:210
 msgid "Uzbek"
 msgstr "Usbekisk"
 
-#: common/models/lang.py:209
+#: common/models/lang.py:211
 msgid "Venda"
 msgstr "Venda"
 
-#: common/models/lang.py:210
+#: common/models/lang.py:212
 msgid "Vietnamese"
 msgstr "Vietnamesisk"
 
-#: common/models/lang.py:211
+#: common/models/lang.py:213
 msgid "Volapük"
 msgstr "Volapük"
 
-#: common/models/lang.py:212
+#: common/models/lang.py:214
 msgid "Walloon"
 msgstr "Vallonsk"
 
-#: common/models/lang.py:213
+#: common/models/lang.py:215
 msgid "Wolof"
 msgstr "Wolof"
 
-#: common/models/lang.py:214
+#: common/models/lang.py:216
 msgid "Xhosa"
 msgstr "Xhosa"
 
-#: common/models/lang.py:215
+#: common/models/lang.py:217
 msgid "Yiddish"
 msgstr "Jiddisch"
 
-#: common/models/lang.py:216
+#: common/models/lang.py:218
 msgid "Zhuang"
 msgstr "Zhuang"
 
-#: common/models/lang.py:217
+#: common/models/lang.py:219
 msgid "Zulu"
 msgstr "Zulu"
 
-#: common/models/lang.py:218
+#: common/models/lang.py:220
 msgid "Abkhazian"
 msgstr "Abkhasisk"
 
-#: common/models/lang.py:219
+#: common/models/lang.py:221
 msgid "Chinese"
 msgstr "Kinesisk"
 
-#: common/models/lang.py:220
+#: common/models/lang.py:222
 msgid "Pushto"
 msgstr "Pushto"
 
-#: common/models/lang.py:221
+#: common/models/lang.py:223
 msgid "Amharic"
 msgstr "Amharisk"
 
-#: common/models/lang.py:222
+#: common/models/lang.py:224
 msgid "Arabic"
 msgstr "Arabisk"
 
-#: common/models/lang.py:223
+#: common/models/lang.py:225
 msgid "Bulgarian"
 msgstr "Bulgarsk"
 
-#: common/models/lang.py:224
+#: common/models/lang.py:226
 msgid "Macedonian"
 msgstr "Makedonsk"
 
-#: common/models/lang.py:225
+#: common/models/lang.py:227
 msgid "Greek"
 msgstr "Græsk"
 
-#: common/models/lang.py:226
+#: common/models/lang.py:228
 msgid "Persian"
 msgstr "Persisk"
 
-#: common/models/lang.py:227
+#: common/models/lang.py:229
 msgid "Hebrew"
 msgstr "Hebræisk"
 
-#: common/models/lang.py:228
+#: common/models/lang.py:230
 msgid "Hindi"
 msgstr "Hindi"
 
-#: common/models/lang.py:229
+#: common/models/lang.py:231
 msgid "Armenian"
 msgstr "Armensk"
 
-#: common/models/lang.py:231
+#: common/models/lang.py:233
 msgid "Ewe"
 msgstr "Ewe"
 
-#: common/models/lang.py:232
+#: common/models/lang.py:234
 msgid "Georgian"
 msgstr "Georgisk"
 
-#: common/models/lang.py:233
+#: common/models/lang.py:235
 msgid "Punjabi"
 msgstr "Punjabi"
 
-#: common/models/lang.py:234
+#: common/models/lang.py:236
 msgid "Bengali"
 msgstr "Bengalsk"
 
-#: common/models/lang.py:235
+#: common/models/lang.py:237
 msgid "Bosnian"
 msgstr "Bosnisk"
 
-#: common/models/lang.py:236
+#: common/models/lang.py:238
 msgid "Chamorro"
 msgstr "Chamorro"
 
-#: common/models/lang.py:237
+#: common/models/lang.py:239
 msgid "Belarusian"
 msgstr "Hviderussisk"
 
-#: common/models/lang.py:238
+#: common/models/lang.py:240
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: common/models/lang.py:300
+#: common/models/lang.py:302
 msgid "Simplified Chinese (Mainland)"
 msgstr "Forenklet kinesisk (fastland)"
 
-#: common/models/lang.py:301
+#: common/models/lang.py:303
 msgid "Traditional Chinese (Taiwan)"
 msgstr "Traditionelt kinesisk (Taiwan)"
 
-#: common/models/lang.py:302
+#: common/models/lang.py:304
 msgid "Traditional Chinese (Hongkong)"
 msgstr "Traditionelt kinesisk (Hongkong)"
 
-#: common/models/lang.py:310
+#: common/models/lang.py:312
 #, fuzzy
 #| msgid "Portuguese"
 msgid "Portuguese (Brazil)"
 msgstr "Portugisisk"
 
-#: common/models/lang.py:313
+#: common/models/lang.py:315
 msgid "Simplified Chinese (Singapore)"
 msgstr "Forenklet kinesisk (Singapore)"
 
-#: common/models/lang.py:314
+#: common/models/lang.py:316
 msgid "Simplified Chinese (Malaysia)"
 msgstr "Forenklet kinesisk (Malaysia)"
 
-#: common/models/lang.py:315
+#: common/models/lang.py:317
 msgid "Traditional Chinese (Macau)"
 msgstr "Traditionel kinesisk (Macao)"
 
-#: common/models/lang.py:323
+#: common/models/lang.py:325
 msgid "Mandarin Chinese"
 msgstr "Mandarin kinesisk"
 
-#: common/models/lang.py:324
+#: common/models/lang.py:326
 msgid "Yue Chinese"
 msgstr "Yue kinesisk"
 
-#: common/models/lang.py:328
+#: common/models/lang.py:330
 msgid "Min Nan Chinese"
 msgstr "Min Nan kinesisk"
 
-#: common/models/lang.py:329
+#: common/models/lang.py:331
 msgid "Wu Chinese"
 msgstr "Wu kinesisk"
 
-#: common/models/lang.py:330
+#: common/models/lang.py:332
 msgid "Hakka Chinese"
 msgstr "Hakka kinesisk"
 
@@ -3998,61 +4036,37 @@ msgid "VCD"
 msgstr ""
 
 #: common/templates/400.html:23
-msgid ""
-"You may have submitted invalid data, or the content may have been deleted by "
-"the author."
-msgstr ""
-"Du kan have indsendt ugyldige data, eller indholdet kan være blevet slettet "
-"af forfatteren."
+msgid "You may have submitted invalid data, or the content may have been deleted by the author."
+msgstr "Du kan have indsendt ugyldige data, eller indholdet kan være blevet slettet af forfatteren."
 
 #: common/templates/400.html:25 common/templates/403.html:24
 #: common/templates/404.html:24
-msgid ""
-"If you believe this is our mistake, please contact us through the link at "
-"the bottom of the page."
-msgstr ""
-"Hvis du mener, at dette er vores fejl, bedes du kontakte os via linket "
-"nederst på siden."
+msgid "If you believe this is our mistake, please contact us through the link at the bottom of the page."
+msgstr "Hvis du mener, at dette er vores fejl, bedes du kontakte os via linket nederst på siden."
 
 #: common/templates/403.html:22
-msgid ""
-"Author may require you to log in before accessing this content, or you do "
-"not have permission to view it."
-msgstr ""
-"Forfatteren kan kræve, at du logger ind, før du får adgang til dette "
-"indhold, eller at du ikke har tilladelse til at se det."
+msgid "Author may require you to log in before accessing this content, or you do not have permission to view it."
+msgstr "Forfatteren kan kræve, at du logger ind, før du får adgang til dette indhold, eller at du ikke har tilladelse til at se det."
 
 #: common/templates/404.html:20
 msgid "Something is missing"
 msgstr "Der mangler noget"
 
 #: common/templates/404.html:22
-msgid ""
-"You may have visited an incorrect URL, or the content you are looking for "
-"has been deleted by the author."
-msgstr ""
-"Du har måske besøgt en forkert URL, eller det indhold, du leder efter, er "
-"blevet slettet af forfatteren."
+msgid "You may have visited an incorrect URL, or the content you are looking for has been deleted by the author."
+msgstr "Du har måske besøgt en forkert URL, eller det indhold, du leder efter, er blevet slettet af forfatteren."
 
 #: common/templates/404.html:26
 msgid "Go to Home"
 msgstr ""
 
 #: common/templates/500.html:22
-msgid ""
-"An internal error occurred. If this error occurs repeatedly, it will be "
-"recorded and handled by a human."
-msgstr ""
-"Der opstod en intern fejl. Hvis denne fejl opstår gentagne gange, vil den "
-"blive logget og håndteret af admininstrator."
+msgid "An internal error occurred. If this error occurs repeatedly, it will be recorded and handled by a human."
+msgstr "Der opstod en intern fejl. Hvis denne fejl opstår gentagne gange, vil den blive logget og håndteret af admininstrator."
 
 #: common/templates/500.html:24
-msgid ""
-"If you have an urgent situation or any questions, please contact us through "
-"the link at the bottom of the page."
-msgstr ""
-"Hvis du har en akut situation eller spørgsmål, bedes du kontakte os via "
-"linket nederst på siden."
+msgid "If you have an urgent situation or any questions, please contact us through the link at the bottom of the page."
+msgstr "Hvis du har en akut situation eller spørgsmål, bedes du kontakte os via linket nederst på siden."
 
 #: common/templates/_footer.html:6
 msgid "Rules"
@@ -4066,283 +4080,229 @@ msgstr "Vilkår"
 msgid "About"
 msgstr ""
 
-#: common/templates/_footer.html:12 users/templates/users/login.html:265
+#: common/templates/_footer.html:12 users/templates/users/login.html:259
 #, python-format
-msgid ""
-"You are visiting an alternative domain for %(site_name)s, please always use "
-"<a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if "
-"possible."
-msgstr ""
-"Du besøger et alternativt domæne for %(site_name)s, brug venligst altid <a "
-"href=\"%(site_url)s%(request.get_full_path)s\">original version</a> hvis det "
-"er muligt."
+msgid "You are visiting an alternative domain for %(site_name)s, please always use <a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if possible."
+msgstr "Du besøger et alternativt domæne for %(site_name)s, brug venligst altid <a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> hvis det er muligt."
 
-#: common/templates/_header.html:19 common/templates/_header.html:164
+#: common/templates/_header.html:19 common/templates/_header.html:177
 msgid "title, creator, ISBN, item url, @user, @user@instance"
 msgstr "titel, ophavsmand, ISBN, element url, @brugernavn, @brugernavn@instans"
 
-#: common/templates/_header.html:24
+#: common/templates/_header.html:34
 #, fuzzy
 #| msgid "Items"
 msgid "All Items"
 msgstr "Elementer"
 
-#: common/templates/_header.html:31
+#: common/templates/_header.html:41
 msgid "Movie & TV"
 msgstr "Film & TV"
 
-#: common/templates/_header.html:50
+#: common/templates/_header.html:60
 msgid "People & Organizations"
 msgstr ""
 
-#: common/templates/_header.html:52
+#: common/templates/_header.html:62
 msgid "Journal"
 msgstr ""
 
-#: common/templates/_header.html:54 journal/templates/user_post_list.html:10
+#: common/templates/_header.html:64 journal/templates/user_post_list.html:10
 #: journal/templates/user_post_list.html:23
 #, fuzzy
 #| msgid "New Post"
 msgid "Posts"
 msgstr "Nyt Indlæg"
 
-#: common/templates/_header.html:89
+#: common/templates/_header.html:102
 msgid "Explore"
 msgstr "Udforsk"
 
-#: common/templates/_header.html:93
+#: common/templates/_header.html:106 common/views_manage.py:36
 msgid "Feed"
 msgstr "Tidslinje"
 
-#: common/templates/_header.html:98 journal/templates/profile.html:13
+#: common/templates/_header.html:111 journal/templates/profile.html:13
 #: users/templates/users/preferences.html:46
 msgid "Home"
 msgstr "Hjem"
 
-#: common/templates/_header.html:114 common/templates/common/scan.html:9
+#: common/templates/_header.html:127 common/templates/common/scan.html:9
 #: common/templates/common/scan.html:42
 #, fuzzy
 #| msgid "barcode"
 msgid "Scan Barcode"
 msgstr "stregkode"
 
-#: common/templates/_header.html:118 social/templates/notification.html:12
+#: common/templates/_header.html:131 social/templates/notification.html:12
 #: social/templates/notification.html:53
 msgid "Notification"
 msgstr "Notifikation"
 
-#: common/templates/_header.html:122 users/models/task.py:21
+#: common/templates/_header.html:135 users/models/task.py:23
 #: users/templates/users/account.html:219
 #: users/templates/users/crossposts.html:9
 msgid "Pending"
 msgstr "Afventende"
 
-#: common/templates/_header.html:125
+#: common/templates/_header.html:138
 msgid "Data"
 msgstr "Data"
 
-#: common/templates/_header.html:128 common/templates/_header.html:146
+#: common/templates/_header.html:141 common/templates/_header.html:159
 #: users/templates/users/preferences.html:12
 #: users/templates/users/preferences.html:23
 #: users/templates/users/preferences_anonymous.html:13
 msgid "Preferences"
 msgstr "Brugerindstillinger"
 
-#: common/templates/_header.html:131
+#: common/templates/_header.html:144
 msgid "Account"
 msgstr "Konto"
 
-#: common/templates/_header.html:135
+#: common/templates/_header.html:148
 msgid "Manage"
 msgstr "Administrér"
 
-#: common/templates/_header.html:139
+#: common/templates/_header.html:152
 msgid "Logout"
 msgstr "Log ud"
 
-#: common/templates/_header.html:143
+#: common/templates/_header.html:156
 msgid "Sign up or Login"
 msgstr "Tilmeld dig eller log ind"
 
-#: common/templates/_header.html:160
-msgid ""
-"title or content  category:tv  status:complete  rating:8..10  "
-"date:2021-09-11..2022-02"
+#: common/templates/_header.html:173
+msgid "title or content  category:tv  status:complete  rating:8..10  date:2021-09-11..2022-02"
 msgstr ""
 
-#: common/templates/_header.html:162
+#: common/templates/_header.html:175
 msgid "name of a person or company"
 msgstr ""
 
-#: common/templates/_header.html:179
+#: common/templates/_header.html:192
 msgid "Open"
 msgstr "Åbn"
 
-#: common/templates/_sidebar.html:62
+#: common/templates/_sidebar.html:61
 #: users/templates/users/profile_actions.html:36
 msgid "approving followers manually"
 msgstr "godkender følgere manuelt"
 
-#: common/templates/_sidebar.html:81 common/templates/_sidebar.html:86
+#: common/templates/_sidebar.html:80 common/templates/_sidebar.html:85
 #, fuzzy
 #| msgid "followed"
 msgid "followers"
 msgstr "fulgt"
 
-#: common/templates/_sidebar.html:112
+#: common/templates/_sidebar.html:111
 msgid "Current Targets"
 msgstr "Aktuelle Mål"
 
-#: common/templates/_sidebar.html:125
+#: common/templates/_sidebar.html:124
 msgid "Set a collection as target, its progress will show up here."
 msgstr "Angiv en samling som et mål og fremskridt blive vist her."
 
-#: common/templates/_sidebar.html:138
+#: common/templates/_sidebar.html:137
 msgid "Recent podcast episodes"
 msgstr "Seneste podcast-afsnit"
 
-#: common/templates/_sidebar.html:173
+#: common/templates/_sidebar.html:172
 msgid "Currently reading"
 msgstr "Læser i øjeblikket"
 
-#: common/templates/_sidebar.html:215
+#: common/templates/_sidebar.html:214
 msgid "Currently watching"
 msgstr "Ser i øjeblikket"
 
-#: common/templates/_sidebar.html:238 journal/forms.py:217
+#: common/templates/_sidebar.html:237 journal/forms.py:217
 #: journal/templates/user_tag_list.html:13
 #: journal/templates/user_tagmember_list.html:4
 msgid "Tags"
 msgstr "Tags"
 
-#: common/templates/_sidebar.html:244 journal/templates/user_tag_list.html:28
+#: common/templates/_sidebar.html:243 journal/templates/user_tag_list.html:28
 #: journal/templates/user_tagmember_list.html:10
 msgid "featured tag"
 msgstr "fremhævet tag"
 
-#: common/templates/_sidebar.html:247 journal/templates/user_tag_list.html:31
+#: common/templates/_sidebar.html:246 journal/templates/user_tag_list.html:31
 #: journal/templates/user_tagmember_list.html:15
 msgid "personal tag"
 msgstr "personligt tag"
 
-#: common/templates/_sidebar.html:254 journal/templates/user_tag_list.html:39
+#: common/templates/_sidebar.html:253 journal/templates/user_tag_list.html:39
 msgid "no tags so far."
 msgstr "ingen tags indtil videre."
 
-#: common/templates/_sidebar.html:258 common/templates/_sidebar.html:271
+#: common/templates/_sidebar.html:257 common/templates/_sidebar.html:270
 msgid "show all"
 msgstr "vis alle"
 
-#: common/templates/_sidebar_anonymous.html:16
+#: common/templates/_sidebar_anonymous.html:15
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
 #| "        <h3>Welcome 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s "
-#| "is committed to creating a free, open, and interconnected space for "
-#| "collecting and reviewing books, movies, music, games, and podcasts. Here, "
-#| "you can document your collections and thoughts, discover new content, and "
-#| "connect with others.\n"
+#| "          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is committed to creating a free, open, and interconnected space for collecting and reviewing books, movies, music, games, and podcasts. Here, you can document your collections and thoughts, discover new content, and connect with others.\n"
 #| "        </p>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log "
-#| "in to %(site_name)s is through a Fediverse (a distributed social network, "
-#| "including Mastodon/Pleroma/etc) instance account. If you haven’t "
-#| "registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" "
-#| "target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
+#| "          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in to %(site_name)s is through a Fediverse (a distributed social network, including Mastodon/Pleroma/etc) instance account. If you haven’t registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
 #| "        </p>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not "
-#| "ready to join the Fediverse, that’s perfectly fine. You can create an "
-#| "account here using your email address, and link it to the Fediverse "
-#| "whenever you’re ready.\n"
+#| "          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready to join the Fediverse, that’s perfectly fine. You can create an account here using your email address, and link it to the Fediverse whenever you’re ready.\n"
 #| "        </p>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you "
-#| "have any questions or suggestions, feel free to contact us via <a "
-#| "href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a "
-#| "href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
+#| "          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have any questions or suggestions, feel free to contact us via <a href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 #| "        </p>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-#| "href=\"%(login_url)s\">Click here</a> to register or log in.\n"
+#| "          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Click here</a> to register or log in.\n"
 #| "        </p>\n"
 #| "        "
 msgid ""
 "\n"
 "        <h3>Welcome 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is "
-"committed to creating a free, open, and interconnected space for collecting "
-"and reviewing books, movies, music, games, and podcasts. Here, you can "
-"manage your collections, share your thoughts, discover new content, and "
-"connect with others.\n"
+"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is committed to creating a free, open, and interconnected space for collecting and reviewing books, movies, music, games, and podcasts. Here, you can manage your collections, share your thoughts, discover new content, and connect with others.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in "
-"to %(site_name)s is through a Fediverse (a distributed social network, "
-"including Mastodon/Pleroma/etc) instance account. If you haven’t registered "
-"yet, you can <a href=\"https://joinmastodon.org/en/servers\" "
-"target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
+"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in to %(site_name)s is through a Fediverse (a distributed social network, including Mastodon/Pleroma/etc) instance account. If you haven’t registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log "
-"in is through a Bluesky (another distributed social network, also called "
-"ATProto) account. If you haven’t registered yet, you may <a href=\"https://"
-"bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
+"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log in is through a Bluesky (another distributed social network, also called ATProto) account. If you haven’t registered yet, you may <a href=\"https://bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready "
-"to join either Fediverse or Bluesky, that’s perfectly fine. You can create "
-"an account here using your email address, and link it to the Fediverse and "
-"Bluesky in settings whenever you’re ready.\n"
+"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready to join either Fediverse or Bluesky, that’s perfectly fine. You can create an account here using your email address, and link it to the Fediverse and Bluesky in settings whenever you’re ready.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have "
-"any questions or suggestions, please feel free to contact us via <a "
-"href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://"
-"discord.gg/uprvcH8gqD\">Discord</a>.\n"
+"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have any questions or suggestions, please feel free to contact us via <a href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-"href=\"%(login_url)s\">Click here</a> to register or log in.\n"
+"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Click here</a> to register or log in.\n"
 "        </p>\n"
 "        "
 msgstr ""
 "\n"
 "        <h3>Velkommen 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s's "
-"mål er en gratis, åben, og sammenkoblet sted til samling og anmeldelse af "
-"bøger, film, musik, spil og podcasts. Her kan du dokumentere dine samlinger "
-"og tanker, opdage nyt indhold og skabe nye forbindelser til andre.\n"
+"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s's mål er en gratis, åben, og sammenkoblet sted til samling og anmeldelse af bøger, film, musik, spil og podcasts. Her kan du dokumentere dine samlinger og tanker, opdage nyt indhold og skabe nye forbindelser til andre.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-globe\"></i> &nbsp; Den bedste måde at "
-"logge ind på %(site_name)s er gennem en Fødivers (et distribueret socialt "
-"netværk, herunder Mastodon/Pleroma/etc) instanskonto. Hvis du endnu ikke har "
-"registreret dig, kan du <a href=\"https://joinmastodon.org/en/servers\" "
-"target=\"_blank\">vælge en Fødivers instans og tilmelde dig</a>.\n"
+"          <i class=\"fa-solid fa-globe\"></i> &nbsp; Den bedste måde at logge ind på %(site_name)s er gennem en Fødivers (et distribueret socialt netværk, herunder Mastodon/Pleroma/etc) instanskonto. Hvis du endnu ikke har registreret dig, kan du <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">vælge en Fødivers instans og tilmelde dig</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; Hvis du ikke er klar "
-"til at deltage i Fødiverset, er det også ok. Du kan oprette en konto her ved "
-"hjælp af din e-mail-adresse, og linke den til Fødiverset, når du er klar.\n"
+"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; Hvis du ikke er klar til at deltage i Fødiverset, er det også ok. Du kan oprette en konto her ved hjælp af din e-mail-adresse, og linke den til Fødiverset, når du er klar.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; Hvis du har "
-"spørgsmål eller forslag, er velkommen til at kontakte os via <a "
-"href=\"https://mastodon.social/@neodb\">Fødiverset</a> eller <a "
-"href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
+"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; Hvis du har spørgsmål eller forslag, er velkommen til at kontakte os via <a href=\"https://mastodon.social/@neodb\">Fødiverset</a> eller <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-"href=\"%(login_url)s\">Klik her</a> for at tilmelde dig eller logge ind.\n"
+"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Klik her</a> for at tilmelde dig eller logge ind.\n"
 "        </p>\n"
 "        "
 
-#: common/templates/_sidebar_anonymous.html:43
+#: common/templates/_sidebar_anonymous.html:42
 #: users/templates/users/announcements.html:12
 #: users/templates/users/announcements.html:39
 msgid "Announcements"
@@ -4370,7 +4330,7 @@ msgstr "Kildekode"
 msgid "Registration"
 msgstr "Registrering mislykkedes"
 
-#: common/templates/common/about.html:35 common/views_manage.py:493
+#: common/templates/common/about.html:35 common/views_manage.py:594
 #, fuzzy
 #| msgid "Mentioned Only"
 msgid "Invite Only"
@@ -4382,7 +4342,7 @@ msgstr "Kun Omtalte"
 msgid "Open Registration"
 msgstr "Registrering mislykkedes"
 
-#: common/templates/common/about.html:40 common/views_manage.py:556
+#: common/templates/common/about.html:40 common/views_manage.py:657
 #, fuzzy
 #| msgid "Preferences"
 msgid "Preferred Languages"
@@ -4437,9 +4397,7 @@ msgid "Error"
 msgstr "Fejl"
 
 #: common/templates/common/scan.html:45
-msgid ""
-"Point the camera at a book ISBN or product barcode (EAN / UPC). You will be "
-"redirected to the search once a code is detected."
+msgid "Point the camera at a book ISBN or product barcode (EAN / UPC). You will be redirected to the search once a code is detected."
 msgstr ""
 
 #: common/templates/common/scan.html:50
@@ -4450,7 +4408,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:628
+#: common/templates/common/scan.html:60 common/views_manage.py:738
 #, fuzzy
 #| msgid "Search results"
 msgid "Search"
@@ -4484,21 +4442,33 @@ msgstr ""
 msgid "Camera unavailable. Use manual entry below."
 msgstr ""
 
-#: common/templates/manage/settings.html:9
+#: common/templates/manage/base.html:9
 #, fuzzy
 #| msgid "Additional Settings"
 msgid "Site Settings"
 msgstr "Yderligere indstillinger"
 
-#: common/templates/manage/settings.html:109
+#: common/templates/manage/base.html:127
 msgid "Takahe Admin"
 msgstr ""
 
-#: common/templates/manage/settings.html:112
+#: common/templates/manage/base.html:130
 #, fuzzy
 #| msgid "Database"
 msgid "Database Admin"
 msgstr "Database"
+
+#: common/templates/manage/environment.html:6
+msgid "These settings come from environment variables and cannot be changed here. Edit .env and restart the server to change them. Passwords and keys are hidden."
+msgstr ""
+
+#: common/templates/manage/environment.html:23
+msgid "(empty)"
+msgstr ""
+
+#: common/templates/manage/environment.html:26
+msgid "default"
+msgstr ""
 
 #: common/templatetags/duration.py:59
 msgid "just now"
@@ -4516,7 +4486,7 @@ msgstr "fulgt"
 msgid "following you"
 msgstr "følger dig"
 
-#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:95
+#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:90
 msgid "you"
 msgstr ""
 
@@ -4524,874 +4494,887 @@ msgstr ""
 msgid "unavailable"
 msgstr ""
 
-#: common/utils.py:126 common/utils.py:167 users/views/actions.py:134
+#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr "Brugeren findes ikke længere"
 
-#: common/utils.py:133 common/utils.py:135 common/utils.py:138
-#: common/utils.py:174 common/utils.py:178 journal/views/profile.py:499
+#: common/utils.py:135 common/utils.py:137 common/utils.py:140
+#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
 msgid "Access denied"
 msgstr "Adgang nægtet"
 
-#: common/utils.py:141 common/utils.py:143 journal/views/article.py:204
+#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr "Login påkrævet"
 
-#: common/views_manage.py:144 common/views_manage.py:295
+#: common/views_manage.py:34 common/views_manage.py:373
 #, fuzzy
 #| msgid "reading"
 msgid "Branding"
 msgstr "læser"
 
-#: common/views_manage.py:146
+#: common/views_manage.py:37
 #, fuzzy
 #| msgid "comments"
 msgid "Recommendations"
 msgstr "kommentarer"
 
-#: common/views_manage.py:147
+#: common/views_manage.py:38
 #, fuzzy
 #| msgid "Access denied"
 msgid "Access"
 msgstr "Adgang nægtet"
 
-#: common/views_manage.py:148 common/views_manage.py:623
+#: common/views_manage.py:39 common/views_manage.py:733
 #, fuzzy
 #| msgid "duration"
 msgid "Federation"
 msgstr "varighed"
 
-#: common/views_manage.py:149
+#: common/views_manage.py:40
 #, fuzzy
 #| msgid "Catalan"
 msgid "Catalog"
 msgstr "Catalansk"
 
-#: common/views_manage.py:150
+#: common/views_manage.py:41
 msgid "API Keys"
 msgstr ""
 
-#: common/views_manage.py:151
+#: common/views_manage.py:42
 #, fuzzy
 #| msgid "Download"
 msgid "Downloader"
 msgstr "Download"
 
-#: common/views_manage.py:152 common/views_manage.py:303
+#: common/views_manage.py:43 common/views_manage.py:381
 #: users/templates/users/steam_import.html:113
 msgid "Advanced"
 msgstr ""
 
-#: common/views_manage.py:202
+#: common/views_manage.py:44
+msgid "Environment"
+msgstr ""
+
+#: common/views_manage.py:280
 #, fuzzy
 #| msgid "Invalid user."
 msgid "Invalid value."
 msgstr "Ugyldig bruger."
 
-#: common/views_manage.py:206
+#: common/views_manage.py:284
 msgid "Invalid configuration. Please check your input."
 msgstr ""
 
-#: common/views_manage.py:211
+#: common/views_manage.py:289
 #, fuzzy
 #| msgid "Settings saved."
 msgid "Settings have been saved."
 msgstr "Indstillinger gemt."
 
-#: common/views_manage.py:231
+#: common/views_manage.py:309
 msgid "Site Name"
 msgstr ""
 
-#: common/views_manage.py:234
+#: common/views_manage.py:312
 #, fuzzy
 #| msgid "Title and Description"
 msgid "Site Description"
 msgstr "Titel og beskrivelse"
 
-#: common/views_manage.py:235
+#: common/views_manage.py:313
 msgid "Short description shown in metadata and about page."
 msgstr ""
 
-#: common/views_manage.py:238
+#: common/views_manage.py:316
 msgid "Site Logo URL"
 msgstr ""
 
-#: common/views_manage.py:239
+#: common/views_manage.py:317
 msgid "URL path to the site logo image."
 msgstr ""
 
-#: common/views_manage.py:242
+#: common/views_manage.py:320
 msgid "Site Icon URL"
 msgstr ""
 
-#: common/views_manage.py:243
+#: common/views_manage.py:321
 msgid "URL path to the site icon/favicon."
 msgstr ""
 
-#: common/views_manage.py:246
+#: common/views_manage.py:324
 msgid "Default User Avatar URL"
 msgstr ""
 
-#: common/views_manage.py:247
+#: common/views_manage.py:325
 msgid "URL path to the default user avatar."
 msgstr ""
 
-#: common/views_manage.py:250
+#: common/views_manage.py:328
 msgid "Site Color Theme"
 msgstr ""
 
-#: common/views_manage.py:251
+#: common/views_manage.py:329
 msgid "PicoCSS color theme."
 msgstr ""
 
-#: common/views_manage.py:276
+#: common/views_manage.py:354
 #, fuzzy
 #| msgid "Production"
 msgid "Site Introduction"
 msgstr "Produktion"
 
-#: common/views_manage.py:277
+#: common/views_manage.py:355
 msgid "URL path for the intro/welcome sidebar page."
 msgstr ""
 
-#: common/views_manage.py:280
+#: common/views_manage.py:358
 msgid "Custom HTML Head"
 msgstr ""
 
-#: common/views_manage.py:281
+#: common/views_manage.py:359
 msgid "Extra HTML injected into the <head> of all pages."
 msgstr ""
 
-#: common/views_manage.py:285
+#: common/views_manage.py:363
 msgid "Footer Links"
 msgstr ""
 
-#: common/views_manage.py:286
+#: common/views_manage.py:364
 msgid "Link title mapped to URL."
 msgstr ""
 
-#: common/views_manage.py:315
+#: common/views_manage.py:393
 msgid "Minimum Marks for Discover"
 msgstr ""
 
-#: common/views_manage.py:317
+#: common/views_manage.py:395
 msgid "Number of marks required for an item to appear in discover."
 msgstr ""
 
-#: common/views_manage.py:322
+#: common/views_manage.py:400
 msgid "Update Interval (minutes)"
 msgstr ""
 
-#: common/views_manage.py:323
+#: common/views_manage.py:401
 msgid "How often to refresh the popular items list."
 msgstr ""
 
-#: common/views_manage.py:327
+#: common/views_manage.py:405
 msgid "Filter by Preferred Languages"
 msgstr ""
 
-#: common/views_manage.py:328
+#: common/views_manage.py:406
 msgid "Only show items with titles in the preferred languages."
 msgstr ""
 
-#: common/views_manage.py:331
+#: common/views_manage.py:409
 #, fuzzy
 #| msgid "show all"
 msgid "Show Local Only"
 msgstr "vis alle"
 
-#: common/views_manage.py:333
+#: common/views_manage.py:411
 msgid "Only show items marked by local users, not the entire network."
 msgstr ""
 
-#: common/views_manage.py:337
+#: common/views_manage.py:415
 #, fuzzy
 #| msgid "Popular Tags"
 msgid "Show Popular Posts"
 msgstr "Populære tags"
 
-#: common/views_manage.py:338
+#: common/views_manage.py:416
 msgid "Show popular public posts instead of recent ones."
 msgstr ""
 
-#: common/views_manage.py:341
+#: common/views_manage.py:419
 #, fuzzy
 #| msgid "Popular Tags"
 msgid "Show Popular Tags"
 msgstr "Populære tags"
 
-#: common/views_manage.py:342
+#: common/views_manage.py:420
 msgid "Show popular public tags on the discover page."
 msgstr ""
 
-#: common/views_manage.py:345
+#: common/views_manage.py:423
 #, fuzzy
 #| msgid "Spotify Podcast"
 msgid "Show Verified Podcasts"
 msgstr "Spotify podcast"
 
-#: common/views_manage.py:347
-msgid ""
-"Show a shelf of recent episodes from podcasts with a verified creator on the "
-"discover page."
+#: common/views_manage.py:425
+msgid "Show a shelf of recent episodes from podcasts with a verified creator on the discover page."
 msgstr ""
 
-#: common/views_manage.py:386
+#: common/views_manage.py:447
+#, fuzzy
+#| msgid "in public timeline"
+msgid "Show World Timeline"
+msgstr "på offentlig tidslinje"
+
+#: common/views_manage.py:449
+msgid "Offer a tab with public posts from this site and every server it federates with."
+msgstr ""
+
+#: common/views_manage.py:454
+#, fuzzy
+#| msgid "show all"
+msgid "Show Local Timeline"
+msgstr "vis alle"
+
+#: common/views_manage.py:455
+msgid "Offer a tab with public posts from this site only."
+msgstr ""
+
+#: common/views_manage.py:459
+#, fuzzy
+#| msgid "in public timeline"
+msgid "Timelines"
+msgstr "på offentlig tidslinje"
+
+#: common/views_manage.py:487
 msgid "Enable Recommendations"
 msgstr ""
 
-#: common/views_manage.py:388
-msgid ""
-"Master switch. When off, all recommendation surfaces are hidden and the cron "
-"jobs are not scheduled."
+#: common/views_manage.py:489
+msgid "Master switch. When off, all recommendation surfaces are hidden and the cron jobs are not scheduled."
 msgstr ""
 
-#: common/views_manage.py:393
+#: common/views_manage.py:494
 msgid "Source Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:395
-msgid ""
-"Minimum public marks an item needs before similarity rows are built for it."
+#: common/views_manage.py:496
+msgid "Minimum public marks an item needs before similarity rows are built for it."
 msgstr ""
 
-#: common/views_manage.py:401
+#: common/views_manage.py:502
 msgid "Target Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:403
-msgid ""
-"Minimum public marks an item needs to be eligible as a recommendation target."
+#: common/views_manage.py:504
+msgid "Minimum public marks an item needs to be eligible as a recommendation target."
 msgstr ""
 
-#: common/views_manage.py:409
+#: common/views_manage.py:510
 msgid "Top-K Similar Items per Source"
 msgstr ""
 
-#: common/views_manage.py:410
+#: common/views_manage.py:511
 msgid "Number of similar items stored per source item."
 msgstr ""
 
-#: common/views_manage.py:414
+#: common/views_manage.py:515
 msgid "Top-N Recommendations per User"
 msgstr ""
 
-#: common/views_manage.py:415
+#: common/views_manage.py:516
 msgid "Number of personalised rows stored per user."
 msgstr ""
 
-#: common/views_manage.py:419
+#: common/views_manage.py:520
 msgid "Dampen Heavy Shelvers"
 msgstr ""
 
-#: common/views_manage.py:421
-msgid ""
-"Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-"
-"shelvers in similarity scoring."
+#: common/views_manage.py:522
+msgid "Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-shelvers in similarity scoring."
 msgstr ""
 
-#: common/views_manage.py:426
+#: common/views_manage.py:527
 msgid "Per-User Mark Cap (training)"
 msgstr ""
 
-#: common/views_manage.py:428
-msgid ""
-"Truncate each user's contribution to their N most recent marks when building "
-"the similarity matrix."
+#: common/views_manage.py:529
+msgid "Truncate each user's contribution to their N most recent marks when building the similarity matrix."
 msgstr ""
 
-#: common/views_manage.py:434
+#: common/views_manage.py:535
 msgid "Active-User Window (days)"
 msgstr ""
 
-#: common/views_manage.py:436
-msgid ""
-"Refresh personalised recommendations for users with at least one public mark "
-"in the last N days."
+#: common/views_manage.py:537
+msgid "Refresh personalised recommendations for users with at least one public mark in the last N days."
 msgstr ""
 
-#: common/views_manage.py:442
+#: common/views_manage.py:543
 msgid "Per-User Seed Cap (serving)"
 msgstr ""
 
-#: common/views_manage.py:444
-msgid ""
-"Number of recent marks used as seeds when scoring personalised "
-"recommendations for one user."
+#: common/views_manage.py:545
+msgid "Number of recent marks used as seeds when scoring personalised recommendations for one user."
 msgstr ""
 
-#: common/views_manage.py:450
+#: common/views_manage.py:551
 msgid "Lazy Refresh TTL (days)"
 msgstr ""
 
-#: common/views_manage.py:452
-msgid ""
-"How long cached on-demand recommendations are valid before the next request "
-"triggers a refresh."
+#: common/views_manage.py:553
+msgid "How long cached on-demand recommendations are valid before the next request triggers a refresh."
 msgstr ""
 
-#: common/views_manage.py:458
+#: common/views_manage.py:559
 msgid "Circles Window (days)"
 msgstr ""
 
-#: common/views_manage.py:460
-msgid ""
-"Look back N days when finding items recently marked by people the viewer "
-"follows."
+#: common/views_manage.py:561
+msgid "Look back N days when finding items recently marked by people the viewer follows."
 msgstr ""
 
-#: common/views_manage.py:467
+#: common/views_manage.py:568
 msgid "Master Switch"
 msgstr ""
 
-#: common/views_manage.py:470
+#: common/views_manage.py:571
 msgid "Similarity Builder"
 msgstr ""
 
-#: common/views_manage.py:477
+#: common/views_manage.py:578
 #, fuzzy
 #| msgid "Personal"
 msgid "Personalisation"
 msgstr "Personlig"
 
-#: common/views_manage.py:495
-msgid ""
-"Require an invite token to register. Invite tokens can be generated with "
-"neodb-manage invite --create."
+#: common/views_manage.py:596
+msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
 msgstr ""
 
-#: common/views_manage.py:500
+#: common/views_manage.py:601
 msgid "Enable Local-Only Posting"
 msgstr ""
 
-#: common/views_manage.py:501
+#: common/views_manage.py:602
 msgid "Allow users to create posts visible only to local users."
 msgstr ""
 
-#: common/views_manage.py:504
+#: common/views_manage.py:605
 msgid "Mastodon Login Whitelist"
 msgstr ""
 
-#: common/views_manage.py:505
+#: common/views_manage.py:606
 msgid "One domain per line. Leave empty to allow any instance."
 msgstr ""
 
-#: common/views_manage.py:508
+#: common/views_manage.py:609
 #, fuzzy
 #| msgid "Registration failed"
 msgid "Registration Captcha Items"
 msgstr "Registrering mislykkedes"
 
-#: common/views_manage.py:512
-msgid ""
-"Number of item covers a new user must sort into two category rows before "
-"choosing a username. 0 disables the captcha; 5-6 is recommended. The covers "
-"carry no title text, so this cannot be solved with a screen reader: if you "
-"enable it, keep another way in, such as an invite link."
+#: common/views_manage.py:613
+msgid "Number of item covers a new user must sort into two category rows before choosing a username. 0 disables the captcha; 5-6 is recommended. The covers carry no title text, so this cannot be solved with a screen reader: if you enable it, keep another way in, such as an invite link."
 msgstr ""
 
-#: common/views_manage.py:520
+#: common/views_manage.py:621
 msgid "Registration Captcha Minimum Marks"
 msgstr ""
 
-#: common/views_manage.py:523
-msgid ""
-"Marks an item needs before the captcha treats it as well known enough to be "
-"recognizable. Categories with too few such items fall back to any item."
+#: common/views_manage.py:624
+msgid "Marks an item needs before the captcha treats it as well known enough to be recognizable. Categories with too few such items fall back to any item."
 msgstr ""
 
-#: common/views_manage.py:529
+#: common/views_manage.py:630
 msgid "Enable Mastodon Login"
 msgstr ""
 
-#: common/views_manage.py:532
+#: common/views_manage.py:633
 #, fuzzy
 #| msgid "Bluesky Login ID"
 msgid "Enable Bluesky Login"
 msgstr "Bluesky Login ID"
 
-#: common/views_manage.py:535
+#: common/views_manage.py:636
 msgid "Enable Threads Login"
 msgstr ""
 
-#: common/views_manage.py:538
+#: common/views_manage.py:639
 #, fuzzy
 #| msgid "Email"
 msgid "Email URL"
 msgstr "E-mail"
 
-#: common/views_manage.py:540
+#: common/views_manage.py:641
 msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
 msgstr ""
 
-#: common/views_manage.py:544
+#: common/views_manage.py:645
 #, fuzzy
 #| msgid "Email"
 msgid "Email From"
 msgstr "E-mail"
 
-#: common/views_manage.py:545
+#: common/views_manage.py:646
 msgid "Sender name and address for outgoing email."
 msgstr ""
 
-#: common/views_manage.py:548
+#: common/views_manage.py:649
 #, fuzzy
 #| msgid "Language"
 msgid "Default Language"
 msgstr "Sprog"
 
-#: common/views_manage.py:551
-msgid ""
-"Interface language for visitors and for users who have not chosen one "
-"themselves."
+#: common/views_manage.py:652
+msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:558
-msgid ""
-"Language codes, one per line (e.g. en, zh, ja). First language is the "
-"default."
+#: common/views_manage.py:659
+msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:564
+#: common/views_manage.py:665
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:571
+#: common/views_manage.py:672
 #, fuzzy
 #| msgid "Import Method"
 msgid "Login Methods"
 msgstr "Importeringsmetode"
 
-#: common/views_manage.py:576 mastodon/models/common.py:28
+#: common/views_manage.py:677 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr "E-mail"
 
-#: common/views_manage.py:580
+#: common/views_manage.py:681
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:591
+#: common/views_manage.py:692
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:593
-msgid ""
-"Disable relay.neodb.net federation for sharing public ratings across "
-"instances."
+#: common/views_manage.py:694
+msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:598
+#: common/views_manage.py:699
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:599
+#: common/views_manage.py:700
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:603
+#: common/views_manage.py:704
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:605
+#: common/views_manage.py:706
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:610
+#: common/views_manage.py:711
 #, fuzzy
 #| msgid "Search results"
 msgid "Search Sites"
 msgstr "Søgeresultater"
 
-#: common/views_manage.py:611
+#: common/views_manage.py:712
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:614
+#: common/views_manage.py:715
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:615
+#: common/views_manage.py:716
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:618
+#: common/views_manage.py:719
 #, fuzzy
 #| msgid "Add tv series"
 msgid "Hidden Categories"
 msgstr "Tilføj tv-serier"
 
-#: common/views_manage.py:619
+#: common/views_manage.py:720
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:640
+#: common/views_manage.py:723
+msgid "Guest Search Page Limit"
+msgstr ""
+
+#: common/views_manage.py:725
+msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
+msgstr ""
+
+#: common/views_manage.py:751
 #, fuzzy
 #| msgid "Spotify Album"
 msgid "Spotify API Key"
 msgstr "Spotify album"
 
-#: common/views_manage.py:641
+#: common/views_manage.py:752
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:644
+#: common/views_manage.py:755
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:645
+#: common/views_manage.py:756
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:648
+#: common/views_manage.py:759
 #, fuzzy
 #| msgid "Google Books"
 msgid "Google Books API Key"
 msgstr "Google Bøger"
 
-#: common/views_manage.py:649
+#: common/views_manage.py:760
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:652
+#: common/views_manage.py:763
 #, fuzzy
 #| msgid "Discogs"
 msgid "Discogs API Key"
 msgstr "Discogs"
 
-#: common/views_manage.py:654
+#: common/views_manage.py:765
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:658
+#: common/views_manage.py:769
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:770
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:662
+#: common/views_manage.py:773
 #, fuzzy
 #| msgid "client secret"
 msgid "IGDB Client Secret"
 msgstr "klienthemmelighed"
 
-#: common/views_manage.py:665
+#: common/views_manage.py:776
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:667
-msgid ""
-"Bearer token from https://boardgamegeek.com/applications (see https://"
-"boardgamegeek.com/using_the_xml_api#toc9)."
+#: common/views_manage.py:778
+msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:672 users/templates/users/steam_import.html:26
+#: common/views_manage.py:783
+msgid "MyAnimeList Client ID"
+msgstr ""
+
+#: common/views_manage.py:785
+msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
+msgstr ""
+
+#: common/views_manage.py:790 users/templates/users/steam_import.html:26
 #, fuzzy
 #| msgid "Steam Game"
 msgid "Steam API Key"
 msgstr "Steam spil"
 
-#: common/views_manage.py:674
-msgid ""
-"https://steamcommunity.com/dev - fallback key for Steam importer. Users can "
-"provide their own key when importing."
+#: common/views_manage.py:792
+msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:679
+#: common/views_manage.py:797
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:680
+#: common/views_manage.py:798
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:683
+#: common/views_manage.py:801
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:686
+#: common/views_manage.py:804
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:689
+#: common/views_manage.py:807
 #, fuzzy
 #| msgid "Threads"
 msgid "Threads App ID"
 msgstr "Threads"
 
-#: common/views_manage.py:690
+#: common/views_manage.py:808
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:693
+#: common/views_manage.py:811
 #, fuzzy
 #| msgid "Threads.net"
 msgid "Threads App Secret"
 msgstr "Threads.net"
 
-#: common/views_manage.py:696
+#: common/views_manage.py:814
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:698
-msgid ""
-"Webhook URLs keyed by channel (default, report, audit, suggest, system). All "
-"channels must be Discord forum or media channels (thread mode) because "
-"notifications are posted as threads."
+#: common/views_manage.py:816
+msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:715
+#: common/views_manage.py:833
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:844
 #, fuzzy
 #| msgid "translator"
 msgid "Translation"
 msgstr "oversætter"
 
-#: common/views_manage.py:730
+#: common/views_manage.py:849
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:734 social/templates/feed.html:27
+#: common/views_manage.py:853 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr "Notifikationer"
 
-#: common/views_manage.py:744
+#: common/views_manage.py:863
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:745
+#: common/views_manage.py:864
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:748
+#: common/views_manage.py:867
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:749
+#: common/views_manage.py:868
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:752
+#: common/views_manage.py:871
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:874
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:758
+#: common/views_manage.py:877
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:761
+#: common/views_manage.py:880
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:764
+#: common/views_manage.py:883
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:767
+#: common/views_manage.py:886
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:768
+#: common/views_manage.py:887
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:771
+#: common/views_manage.py:890
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:775
+#: common/views_manage.py:894
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:779
+#: common/views_manage.py:898
 #, fuzzy
 #| msgid "series"
 msgid "Retries"
 msgstr "serie"
 
-#: common/views_manage.py:784
+#: common/views_manage.py:903
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:789
+#: common/views_manage.py:908
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:796
+#: common/views_manage.py:915
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:808
+#: common/views_manage.py:927
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:809
+#: common/views_manage.py:928
 #, fuzzy
 #| msgid "site domain name"
 msgid "One domain per line."
 msgstr "websteds domænenavn"
 
-#: common/views_manage.py:812
+#: common/views_manage.py:931
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:813
+#: common/views_manage.py:932
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:935
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:818
-msgid ""
-"Timeout for requests to Mastodon instances and remote fediverse servers."
+#: common/views_manage.py:937
+msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:824
+#: common/views_manage.py:943
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:825
+#: common/views_manage.py:944
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:828
+#: common/views_manage.py:947
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:829
+#: common/views_manage.py:948
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:839
+#: common/views_manage.py:958
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:841
-msgid ""
-"Delete import/export tasks and their files after this many days. Set to 0 to "
-"disable cleanup."
+#: common/views_manage.py:960
+msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:847
+#: common/views_manage.py:966
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:849
-msgid ""
-"Post-migration job keys to skip, one per line (e.g. normalize_genre). "
-"Checked by the worker at dequeue time; skipped jobs log a warning and notify "
-"the Discord system channel."
+#: common/views_manage.py:968
+msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:855
+#: common/views_manage.py:974
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:857
-msgid ""
-"Private key (JWK) identifying this site to ATProto authorization servers. "
-"Auto-generated on first Bluesky login; clear to regenerate."
+#: common/views_manage.py:976
+msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:983
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:986
 #, fuzzy
 #| msgid "optional"
 msgid "Operational"
 msgstr "valgfrit"
 
-#: common/views_manage.py:883
+#: common/views_manage.py:1002
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:885
-msgid ""
-"Genre codes offered in the Movie edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1004
+msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:1009
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:892
-msgid ""
-"Genre codes offered in the TV edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1011
+msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:897
+#: common/views_manage.py:1016
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:899
-msgid ""
-"Genre codes offered in the Music edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1018
+msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:904
+#: common/views_manage.py:1023
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:906
-msgid ""
-"Genre codes offered in the Game edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1025
+msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:911
+#: common/views_manage.py:1030
 #, fuzzy
 #| msgid "Podcast"
 msgid "Podcast Genres"
 msgstr "Podcast"
 
-#: common/views_manage.py:913
-msgid ""
-"Genre codes offered in the Podcast edit dropdown, one per line. Leave empty "
-"to use the built-in default."
+#: common/views_manage.py:1032
+msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:918
+#: common/views_manage.py:1037
 #, fuzzy
 #| msgid "Performance"
 msgid "Performance Genres"
 msgstr "Forestilling"
 
-#: common/views_manage.py:920
-msgid ""
-"Genre codes offered in the Performance edit dropdown, one per line. Leave "
-"empty to use the built-in default."
+#: common/views_manage.py:1039
+msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:926
+#: common/views_manage.py:1045
 msgid "Genres by Category"
 msgstr ""
 
-#: journal/forms.py:12
-msgid ""
-"Tips: use >!text!< for spoilers; some instances may not be able to show "
-"posts longer than 360 charactors."
+#: common/views_manage.py:1069
+msgid "Site"
 msgstr ""
-"Tips: brug >!text!< for spoilers; nogle instanser kan ikke vise indlæg "
-"længere end 360 tegn."
+
+#: common/views_manage.py:1079
+#, fuzzy
+#| msgid "Database"
+msgid "Database and Services"
+msgstr "Database"
+
+#: common/views_manage.py:1089
+msgid "Media and Files"
+msgstr ""
+
+#: common/views_manage.py:1098
+msgid "Monitoring"
+msgstr ""
+
+#: common/views_manage.py:1102
+msgid "Security"
+msgstr ""
+
+#: common/views_manage.py:1111
+msgid "Other Environment Variables"
+msgstr ""
+
+#: common/views_manage.py:1113
+msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
+msgstr ""
+
+#: journal/forms.py:12
+msgid "Tips: use >!text!< for spoilers; some instances may not be able to show posts longer than 360 charactors."
+msgstr "Tips: brug >!text!< for spoilers; nogle instanser kan ikke vise indlæg længere end 360 tegn."
 
 #: journal/forms.py:29 journal/forms.py:31 journal/forms.py:80
 #: journal/forms.py:83 journal/forms.py:153
@@ -5405,14 +5388,14 @@ msgid "Content (Markdown)"
 msgstr "Indhold (Markdown)"
 
 #: journal/forms.py:46 journal/forms.py:124 journal/forms.py:226
-#: journal/forms.py:288 journal/views/note.py:38
+#: journal/forms.py:288 journal/views/note.py:37
 #, fuzzy
 #| msgid "Crosspost to timeline"
 msgid "Crosspost"
 msgstr "Krydspost til tidslinje"
 
 #: journal/forms.py:47 journal/forms.py:125 journal/forms.py:227
-#: journal/forms.py:289 journal/views/note.py:39
+#: journal/forms.py:289 journal/views/note.py:38
 #, fuzzy
 #| msgid "Turn on crosspost to other social networks by default"
 msgid "Crosspost to your connected social networks"
@@ -5429,10 +5412,10 @@ msgstr "Udskift indledende mellemrum med mellemrum med fuld bredde ved lagring"
 #: journal/forms.py:59 journal/forms.py:137 journal/forms.py:162
 #: journal/forms.py:219 journal/forms.py:281
 #: journal/templates/collection_share.html:24
-#: journal/templates/wrapped_share.html:36 journal/views/note.py:31
-#: users/templates/users/data.html:45 users/templates/users/data.html:98
-#: users/templates/users/data.html:155 users/templates/users/data.html:206
-#: users/templates/users/data.html:269 users/templates/users/data.html:328
+#: journal/templates/wrapped_share.html:36 journal/views/note.py:30
+#: users/templates/users/data.html:60 users/templates/users/data.html:113
+#: users/templates/users/data.html:170 users/templates/users/data.html:221
+#: users/templates/users/data.html:284 users/templates/users/data.html:346
 #: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
@@ -5479,7 +5462,6 @@ msgid "Collaborative editing"
 msgstr "Kollaborativ redigering"
 
 #: journal/forms.py:204 users/templates/users/crossposts.html:51
-#: users/templates/users/data.html:483
 msgid "Status"
 msgstr "Status"
 
@@ -5493,48 +5475,46 @@ msgstr "Kommentar"
 msgid "Rating"
 msgstr "bedømmelse"
 
-#: journal/importers/goodreads.py:196 journal/importers/letterboxd.py:144
-#: journal/importers/rym.py:442 journal/importers/storygraph.py:500
+#: journal/importers/goodreads.py:198 journal/importers/letterboxd.py:147
+#: journal/importers/rym.py:444 journal/importers/storygraph.py:504
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr "en anmeldelse af {item_title}"
 
-#: journal/importers/opml.py:45
+#: journal/importers/opml.py:49
 #, python-brace-format
 msgid "{username}'s podcast subscriptions"
 msgstr "{username}'s podcast-abonnementer"
 
-#: journal/importers/rym.py:168 journal/importers/storygraph.py:128
+#: journal/importers/rym.py:170 journal/importers/storygraph.py:132
 #, python-brace-format
-msgid ""
-"Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
+msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:178 journal/importers/storygraph.py:138
+#: journal/importers/rym.py:180 journal/importers/storygraph.py:142
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/importers/rym.py:233 journal/importers/storygraph.py:184
+#: journal/importers/rym.py:235 journal/importers/storygraph.py:188
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:348 journal/importers/storygraph.py:389
+#: journal/importers/rym.py:350 journal/importers/storygraph.py:393
 msgid "Matched file missing; cannot import."
 msgstr ""
 
-#: journal/importers/rym.py:376 journal/importers/storygraph.py:412
+#: journal/importers/rym.py:378 journal/importers/storygraph.py:416
 #, python-brace-format
-msgid ""
-"Import complete: {imported} imported, {skipped} skipped, {failed} failed"
+msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:212 journal/views/article.py:218
+#: journal/models/article.py:215 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
-#: journal/models/collection.py:44 journal/templates/add_to_collection.html:39
+#: journal/models/collection.py:48 journal/templates/add_to_collection.html:39
 #: journal/templates/collection_edit.html:64
 #: journal/templates/collection_share.html:63
 #: journal/templates/collection_update_item_note.html:3
@@ -5542,75 +5522,75 @@ msgstr ""
 msgid "note"
 msgstr "note"
 
-#: journal/models/collection.py:111
+#: journal/models/collection.py:115
 #, fuzzy
 #| msgid "shared {username}'s collection"
 msgid "search query for dynamic collection"
 msgstr "delte {username}'s samling"
 
-#: journal/models/collection.py:524 journal/templatetags/collection.py:35
+#: journal/models/collection.py:566 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] "%(count)d bog"
 msgstr[1] "%(count)d bøger"
 
-#: journal/models/collection.py:529 journal/templatetags/collection.py:43
+#: journal/models/collection.py:571 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] "%(count)d film"
 msgstr[1] "%(count)d film"
 
-#: journal/models/collection.py:534 journal/templatetags/collection.py:51
+#: journal/models/collection.py:576 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] "%(count)d tv-serie"
 msgstr[1] "%(count)d tv-serier"
 
-#: journal/models/collection.py:539 journal/templatetags/collection.py:59
+#: journal/models/collection.py:581 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] "%(count)d album"
 msgstr[1] "%(count)d albums"
 
-#: journal/models/collection.py:544 journal/templatetags/collection.py:67
+#: journal/models/collection.py:586 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] "%(count)d spil"
 msgstr[1] "%(count)d spil"
 
-#: journal/models/collection.py:549 journal/templatetags/collection.py:75
+#: journal/models/collection.py:591 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] "%(count)d podcast"
 msgstr[1] "%(count)d podcasts"
 
-#: journal/models/collection.py:555 journal/templatetags/collection.py:83
+#: journal/models/collection.py:597 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] "%(count)d forestilling"
 msgstr[1] "%(count)d forestillinger"
 
-#: journal/models/collection.py:563 journal/templatetags/collection.py:91
+#: journal/models/collection.py:605 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] "%(count)d element"
 msgstr[1] "%(count)d elementer"
 
-#: journal/models/common.py:50 journal/templates/action_open_post.html:15
-#: journal/templates/collection_share.html:35 journal/templates/mark.html:84
+#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
-#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:54
-#: users/templates/users/data.html:107 users/templates/users/data.html:164
-#: users/templates/users/data.html:215 users/templates/users/data.html:277
-#: users/templates/users/data.html:337 users/templates/users/data.html:534
+#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
+#: users/templates/users/data.html:122 users/templates/users/data.html:179
+#: users/templates/users/data.html:230 users/templates/users/data.html:292
+#: users/templates/users/data.html:355 users/templates/users/data.html:534
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5618,13 +5598,13 @@ msgstr[1] "%(count)d elementer"
 msgid "Public"
 msgstr "Offentlig"
 
-#: journal/models/common.py:51 journal/templates/action_open_post.html:9
-#: journal/templates/collection_share.html:46 journal/templates/mark.html:91
+#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
-#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
-#: users/templates/users/data.html:115 users/templates/users/data.html:172
-#: users/templates/users/data.html:223 users/templates/users/data.html:285
-#: users/templates/users/data.html:345 users/templates/users/data.html:542
+#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
+#: users/templates/users/data.html:130 users/templates/users/data.html:187
+#: users/templates/users/data.html:238 users/templates/users/data.html:300
+#: users/templates/users/data.html:363 users/templates/users/data.html:542
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5632,12 +5612,12 @@ msgstr "Offentlig"
 msgid "Followers Only"
 msgstr "Kun Følgere"
 
-#: journal/models/common.py:52 journal/templates/collection_share.html:57
-#: journal/templates/mark.html:98 journal/templates/post_compose.html:72
-#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
-#: users/templates/users/data.html:123 users/templates/users/data.html:180
-#: users/templates/users/data.html:231 users/templates/users/data.html:293
-#: users/templates/users/data.html:353 users/templates/users/data.html:550
+#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/templates/mark.html:102 journal/templates/post_compose.html:72
+#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
+#: users/templates/users/data.html:138 users/templates/users/data.html:195
+#: users/templates/users/data.html:246 users/templates/users/data.html:308
+#: users/templates/users/data.html:371 users/templates/users/data.html:550
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5645,39 +5625,33 @@ msgstr "Kun Følgere"
 msgid "Mentioned Only"
 msgstr "Kun Omtalte"
 
-#: journal/models/common.py:790
+#: journal/models/common.py:806
 #, fuzzy
 #| msgid "A recent post was not posted to Mastodon, please re-authorize."
-msgid ""
-"A recent post was not posted to Bluesky, please login NeoDB using ATProto "
-"again to re-authorize."
-msgstr ""
-"Et nyligt indlæg blev ikke sendt til Mastodon, prøv venligst at autorisere "
-"igen."
+msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
+msgstr "Et nyligt indlæg blev ikke sendt til Mastodon, prøv venligst at autorisere igen."
 
-#: journal/models/common.py:987
+#: journal/models/common.py:1003
 msgid "A recent post was not posted to Threads."
 msgstr "Et nyligt indlæg blev ikke sendt til Threads."
 
-#: journal/models/common.py:1020
+#: journal/models/common.py:1036
 #, fuzzy
 #| msgid "A recent post was not posted to Mastodon."
 msgid "A recent post was not boosted on Mastodon."
 msgstr "Et nyligt indlæg blev ikke sendt til Mastodon."
 
-#: journal/models/common.py:1030
+#: journal/models/common.py:1046
 #, fuzzy
 #| msgid "Item no longer exists"
 msgid "Original post no longer exists."
 msgstr "Elementet findes ikke længere"
 
-#: journal/models/common.py:1044
+#: journal/models/common.py:1060
 msgid "A recent post was not posted to Mastodon, please re-authorize."
-msgstr ""
-"Et nyligt indlæg blev ikke sendt til Mastodon, prøv venligst at autorisere "
-"igen."
+msgstr "Et nyligt indlæg blev ikke sendt til Mastodon, prøv venligst at autorisere igen."
 
-#: journal/models/common.py:1053
+#: journal/models/common.py:1069
 msgid "A recent post was not posted to Mastodon."
 msgstr "Et nyligt indlæg blev ikke sendt til Mastodon."
 
@@ -5687,7 +5661,7 @@ msgstr "Et nyligt indlæg blev ikke sendt til Mastodon."
 msgid "Authorization expired"
 msgstr "Godkendelse mislykkedes"
 
-#: journal/models/crosspost.py:17 users/models/task.py:24
+#: journal/models/crosspost.py:17 users/models/task.py:26
 msgid "Failed"
 msgstr "Mislykket"
 
@@ -5695,85 +5669,85 @@ msgstr "Mislykket"
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:469
+#: journal/models/mark.py:475
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:473
+#: journal/models/mark.py:479
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:480
+#: journal/models/mark.py:486
 #, fuzzy
 #| msgid "Invalid parameter"
 msgid "Invalid progress type."
 msgstr "Ugyldig parameter"
 
-#: journal/models/mark.py:482
+#: journal/models/mark.py:488
 #, fuzzy
 #| msgid "Invalid response from Fediverse instance."
 msgid "Invalid progress type for this item."
 msgstr "Ugyldigt svar fra Fødivers instans."
 
-#: journal/models/note.py:34 users/templates/users/rym_import.html:73
+#: journal/models/note.py:47 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr "Side"
 
-#: journal/models/note.py:35
+#: journal/models/note.py:48
 msgid "Chapter"
 msgstr "Kapitel"
 
-#: journal/models/note.py:38
+#: journal/models/note.py:51
 msgid "Part"
 msgstr "Del"
 
-#: journal/models/note.py:39
+#: journal/models/note.py:52
 msgid "Episode"
 msgstr "Afsnit"
 
-#: journal/models/note.py:40
+#: journal/models/note.py:53
 msgid "Track"
 msgstr "Nummer"
 
-#: journal/models/note.py:41
+#: journal/models/note.py:54
 msgid "Cycle"
 msgstr "Cyklus"
 
-#: journal/models/note.py:42
+#: journal/models/note.py:55
 msgid "Timestamp"
 msgstr "Tidsmærke"
 
-#: journal/models/note.py:43
+#: journal/models/note.py:56
 msgid "Percentage"
 msgstr "Procent"
 
-#: journal/models/note.py:60
+#: journal/models/note.py:77
 #, python-brace-format
 msgid "Page {value}"
 msgstr "Side {value}"
 
-#: journal/models/note.py:61
+#: journal/models/note.py:78
 #, python-brace-format
 msgid "Chapter {value}"
 msgstr "Kapitel {value}"
 
-#: journal/models/note.py:64
+#: journal/models/note.py:81
 #, python-brace-format
 msgid "Part {value}"
 msgstr "Del {value}"
 
-#: journal/models/note.py:65
+#: journal/models/note.py:82
 #, python-brace-format
 msgid "Episode {value}"
 msgstr "Afsnit {value}"
 
-#: journal/models/note.py:66
+#: journal/models/note.py:83
 #, python-brace-format
 msgid "Track {value}"
 msgstr "Nummer {value}"
 
-#: journal/models/note.py:67
+#: journal/models/note.py:84
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr "Cyklus {value}"
@@ -5781,449 +5755,447 @@ msgstr "Cyklus {value}"
 #: journal/models/renderers.py:208
 #, python-brace-format
 msgid "regarding {item_title}, may contain spoiler or triggering content"
-msgstr ""
-"vedrørende {item_title}, kan indeholde spoilers eller provokerende/"
-"triggerende indhold"
+msgstr "vedrørende {item_title}, kan indeholde spoilers eller provokerende/triggerende indhold"
 
-#: journal/models/review.py:78
+#: journal/models/review.py:79
 #, fuzzy, python-brace-format
 #| msgid "a review of {item_title}"
 msgid "a review of {title}"
 msgstr "en anmeldelse af {item_title}"
 
-#: journal/models/review.py:80
+#: journal/models/review.py:81
 #, fuzzy
 #| msgid "Item contains sub-items."
 msgid "(may contain spoilers)"
 msgstr "Elementet indeholder underelementer."
 
-#: journal/models/shelf.py:37
+#: journal/models/shelf.py:39
 msgid "WISHLIST"
 msgstr "ØNSKELISTE"
 
-#: journal/models/shelf.py:38
+#: journal/models/shelf.py:40
 msgid "PROGRESS"
 msgstr "I GANG"
 
-#: journal/models/shelf.py:39
+#: journal/models/shelf.py:41
 msgid "COMPLETE"
 msgstr "FÆRDIG"
 
-#: journal/models/shelf.py:40
+#: journal/models/shelf.py:42
 msgid "DROPPED"
 msgstr "DROPPET"
 
-#: journal/models/shelf.py:49
+#: journal/models/shelf.py:51
 msgid "books to read"
 msgstr "bøger der skal læses"
 
-#: journal/models/shelf.py:50
+#: journal/models/shelf.py:52
 msgid "want to read"
 msgstr "ønsker at læse"
 
-#: journal/models/shelf.py:51
+#: journal/models/shelf.py:53
 #, python-brace-format
 msgid "wants to read {item}"
 msgstr "ønsker at læse {item}"
 
-#: journal/models/shelf.py:52
+#: journal/models/shelf.py:54
 msgid "to read"
 msgstr "skal læses"
 
-#: journal/models/shelf.py:57
+#: journal/models/shelf.py:59
 msgid "books reading"
 msgstr "bøger der læses"
 
-#: journal/models/shelf.py:58
+#: journal/models/shelf.py:60
 msgid "start reading"
 msgstr "begynd at læse"
 
-#: journal/models/shelf.py:59
+#: journal/models/shelf.py:61
 #, python-brace-format
 msgid "started reading {item}"
 msgstr "begyndte at læse {item}"
 
-#: journal/models/shelf.py:60
+#: journal/models/shelf.py:62
 msgid "reading"
 msgstr "læser"
 
-#: journal/models/shelf.py:65
+#: journal/models/shelf.py:67
 msgid "books completed"
 msgstr "afsluttede bøger"
 
-#: journal/models/shelf.py:66
+#: journal/models/shelf.py:68
 msgid "finish reading"
 msgstr "færdig med at læse"
 
-#: journal/models/shelf.py:67
+#: journal/models/shelf.py:69
 #, python-brace-format
 msgid "finished reading {item}"
 msgstr "blev færdig med at læse {item}"
 
-#: journal/models/shelf.py:68
+#: journal/models/shelf.py:70
 msgid "read"
 msgstr "læst"
 
-#: journal/models/shelf.py:73
+#: journal/models/shelf.py:75
 msgid "books dropped"
 msgstr "droppede bøger"
 
-#: journal/models/shelf.py:74
+#: journal/models/shelf.py:76
 msgid "stop reading"
 msgstr "stop læsning"
 
-#: journal/models/shelf.py:75
+#: journal/models/shelf.py:77
 #, python-brace-format
 msgid "stopped reading {item}"
 msgstr "stoppede med at læse {item}"
 
-#: journal/models/shelf.py:76
+#: journal/models/shelf.py:78
 msgid "stopped reading"
 msgstr "stoppede læsning"
 
-#: journal/models/shelf.py:81
+#: journal/models/shelf.py:83
 msgid "books reviewed"
 msgstr "bøger anmeldt"
 
-#: journal/models/shelf.py:82 journal/models/shelf.py:122
-#: journal/models/shelf.py:162 journal/models/shelf.py:202
-#: journal/models/shelf.py:242 journal/models/shelf.py:282
-#: journal/models/shelf.py:316
+#: journal/models/shelf.py:84 journal/models/shelf.py:124
+#: journal/models/shelf.py:164 journal/models/shelf.py:204
+#: journal/models/shelf.py:244 journal/models/shelf.py:284
+#: journal/models/shelf.py:318
 msgid "review"
 msgstr "gennemgå"
 
-#: journal/models/shelf.py:83 journal/models/shelf.py:123
-#: journal/models/shelf.py:163 journal/models/shelf.py:203
-#: journal/models/shelf.py:243 journal/models/shelf.py:283
-#: journal/models/shelf.py:317
+#: journal/models/shelf.py:85 journal/models/shelf.py:125
+#: journal/models/shelf.py:165 journal/models/shelf.py:205
+#: journal/models/shelf.py:245 journal/models/shelf.py:285
+#: journal/models/shelf.py:319
 #, python-brace-format
 msgid "wrote a review of {item}"
 msgstr "skrev en anmeldelse af {item}"
 
-#: journal/models/shelf.py:89
+#: journal/models/shelf.py:91
 msgid "movies to watch"
 msgstr "film, der skal ses"
 
-#: journal/models/shelf.py:90 journal/models/shelf.py:130
+#: journal/models/shelf.py:92 journal/models/shelf.py:132
 msgid "want to watch"
 msgstr "ønsker at se"
 
-#: journal/models/shelf.py:91 journal/models/shelf.py:131
+#: journal/models/shelf.py:93 journal/models/shelf.py:133
 #, python-brace-format
 msgid "wants to watch {item}"
 msgstr "ønsker at se {item}"
 
-#: journal/models/shelf.py:92 journal/models/shelf.py:132
+#: journal/models/shelf.py:94 journal/models/shelf.py:134
 msgid "to watch"
 msgstr "skal ses"
 
-#: journal/models/shelf.py:97
+#: journal/models/shelf.py:99
 msgid "movies watching"
 msgstr "film der ses"
 
-#: journal/models/shelf.py:98 journal/models/shelf.py:138
+#: journal/models/shelf.py:100 journal/models/shelf.py:140
 msgid "start watching"
 msgstr "begynd at se"
 
-#: journal/models/shelf.py:99 journal/models/shelf.py:139
+#: journal/models/shelf.py:101 journal/models/shelf.py:141
 #, python-brace-format
 msgid "started watching {item}"
 msgstr "begyndte at se {item}"
 
-#: journal/models/shelf.py:100 journal/models/shelf.py:140
+#: journal/models/shelf.py:102 journal/models/shelf.py:142
 msgid "watching"
 msgstr "ser"
 
-#: journal/models/shelf.py:105
+#: journal/models/shelf.py:107
 msgid "movies watched"
 msgstr "film set"
 
-#: journal/models/shelf.py:106 journal/models/shelf.py:146
+#: journal/models/shelf.py:108 journal/models/shelf.py:148
 msgid "finish watching"
 msgstr "færdig med at se"
 
-#: journal/models/shelf.py:107 journal/models/shelf.py:147
+#: journal/models/shelf.py:109 journal/models/shelf.py:149
 #, python-brace-format
 msgid "finished watching {item}"
 msgstr "blev færdig med at se {item}"
 
-#: journal/models/shelf.py:108 journal/models/shelf.py:148
+#: journal/models/shelf.py:110 journal/models/shelf.py:150
 msgid "watched"
 msgstr "så"
 
-#: journal/models/shelf.py:113
+#: journal/models/shelf.py:115
 msgid "movies dropped"
 msgstr "droppede film"
 
-#: journal/models/shelf.py:114 journal/models/shelf.py:154
+#: journal/models/shelf.py:116 journal/models/shelf.py:156
 msgid "stop watching"
 msgstr "se ikke færdig"
 
-#: journal/models/shelf.py:115 journal/models/shelf.py:155
+#: journal/models/shelf.py:117 journal/models/shelf.py:157
 #, python-brace-format
 msgid "stopped watching {item}"
 msgstr "så ikke {item} færdig"
 
-#: journal/models/shelf.py:116 journal/models/shelf.py:156
+#: journal/models/shelf.py:118 journal/models/shelf.py:158
 msgid "stopped watching"
 msgstr "så ikke færdig"
 
-#: journal/models/shelf.py:121
+#: journal/models/shelf.py:123
 msgid "movies reviewed"
 msgstr "film anmeldt"
 
-#: journal/models/shelf.py:129
+#: journal/models/shelf.py:131
 msgid "TV shows to watch"
 msgstr "TV-serier, der skal ses"
 
-#: journal/models/shelf.py:137
+#: journal/models/shelf.py:139
 msgid "TV shows watching"
 msgstr "TV-serier, der ses"
 
-#: journal/models/shelf.py:145
+#: journal/models/shelf.py:147
 msgid "TV shows watched"
 msgstr "Tv-serier der er blevet set"
 
-#: journal/models/shelf.py:153
+#: journal/models/shelf.py:155
 msgid "TV shows dropped"
 msgstr "TV-serier droppet"
 
-#: journal/models/shelf.py:161
+#: journal/models/shelf.py:163
 msgid "TV shows reviewed"
 msgstr "TV-serier anmeldt"
 
-#: journal/models/shelf.py:169
+#: journal/models/shelf.py:171
 msgid "albums to listen"
 msgstr "albums der skal lyttes til"
 
-#: journal/models/shelf.py:170 journal/models/shelf.py:250
+#: journal/models/shelf.py:172 journal/models/shelf.py:252
 msgid "want to listen"
 msgstr "ønsker at lytte til"
 
-#: journal/models/shelf.py:171 journal/models/shelf.py:251
+#: journal/models/shelf.py:173 journal/models/shelf.py:253
 #, python-brace-format
 msgid "wants to listen {item}"
 msgstr "ønsker at lytte til {item}"
 
-#: journal/models/shelf.py:172 journal/models/shelf.py:252
+#: journal/models/shelf.py:174 journal/models/shelf.py:254
 msgid "to listen"
 msgstr "skal lyttes til"
 
-#: journal/models/shelf.py:177
+#: journal/models/shelf.py:179
 msgid "albums listening"
 msgstr "albums der lyttes til"
 
-#: journal/models/shelf.py:178 journal/models/shelf.py:258
+#: journal/models/shelf.py:180 journal/models/shelf.py:260
 msgid "start listening"
 msgstr "begynd at lytte"
 
-#: journal/models/shelf.py:179 journal/models/shelf.py:259
+#: journal/models/shelf.py:181 journal/models/shelf.py:261
 #, python-brace-format
 msgid "started listening {item}"
 msgstr "begyndte at lytte til {item}"
 
-#: journal/models/shelf.py:180 journal/models/shelf.py:260
+#: journal/models/shelf.py:182 journal/models/shelf.py:262
 msgid "listening"
 msgstr "lytter til"
 
-#: journal/models/shelf.py:185
+#: journal/models/shelf.py:187
 msgid "albums listened"
 msgstr "albums lyttet til"
 
-#: journal/models/shelf.py:186 journal/models/shelf.py:266
+#: journal/models/shelf.py:188 journal/models/shelf.py:268
 msgid "finish listening"
 msgstr "færdig med at lytte"
 
-#: journal/models/shelf.py:187 journal/models/shelf.py:267
+#: journal/models/shelf.py:189 journal/models/shelf.py:269
 #, python-brace-format
 msgid "finished listening {item}"
 msgstr "blev færdig med at lytte til {item}"
 
-#: journal/models/shelf.py:188 journal/models/shelf.py:268
+#: journal/models/shelf.py:190 journal/models/shelf.py:270
 msgid "listened"
 msgstr "lyttede"
 
-#: journal/models/shelf.py:193
+#: journal/models/shelf.py:195
 msgid "albums dropped"
 msgstr "albums droppet"
 
-#: journal/models/shelf.py:194 journal/models/shelf.py:274
+#: journal/models/shelf.py:196 journal/models/shelf.py:276
 msgid "stop listening"
 msgstr "stop lytning"
 
-#: journal/models/shelf.py:195 journal/models/shelf.py:275
+#: journal/models/shelf.py:197 journal/models/shelf.py:277
 #, python-brace-format
 msgid "stopped listening {item}"
 msgstr "afsluttede lytning af {item}"
 
-#: journal/models/shelf.py:196 journal/models/shelf.py:276
+#: journal/models/shelf.py:198 journal/models/shelf.py:278
 msgid "stopped listening"
 msgstr "stoppede lytning"
 
-#: journal/models/shelf.py:201
+#: journal/models/shelf.py:203
 msgid "albums reviewed"
 msgstr "albums anmeldt"
 
-#: journal/models/shelf.py:209
+#: journal/models/shelf.py:211
 msgid "games to play"
 msgstr "spil, der skal spilles"
 
-#: journal/models/shelf.py:210
+#: journal/models/shelf.py:212
 msgid "want to play"
 msgstr "ønsker at spille"
 
-#: journal/models/shelf.py:211
+#: journal/models/shelf.py:213
 #, python-brace-format
 msgid "wants to play {item}"
 msgstr "ønsker at spille {item}"
 
-#: journal/models/shelf.py:212
+#: journal/models/shelf.py:214
 msgid "to play"
 msgstr "skal spilles"
 
-#: journal/models/shelf.py:217
+#: journal/models/shelf.py:219
 msgid "games playing"
 msgstr "spil der spilles"
 
-#: journal/models/shelf.py:218
+#: journal/models/shelf.py:220
 msgid "start playing"
 msgstr "begynd med at spille"
 
-#: journal/models/shelf.py:219
+#: journal/models/shelf.py:221
 #, python-brace-format
 msgid "started playing {item}"
 msgstr "begyndte at spille {item}"
 
-#: journal/models/shelf.py:220
+#: journal/models/shelf.py:222
 msgid "playing"
 msgstr "spiller"
 
-#: journal/models/shelf.py:225
+#: journal/models/shelf.py:227
 msgid "games played"
 msgstr "spil spillet"
 
-#: journal/models/shelf.py:226
+#: journal/models/shelf.py:228
 msgid "finish playing"
 msgstr "færdig med at spille"
 
-#: journal/models/shelf.py:227
+#: journal/models/shelf.py:229
 #, python-brace-format
 msgid "finished playing {item}"
 msgstr "blev færdig med at spille {item}"
 
-#: journal/models/shelf.py:228
+#: journal/models/shelf.py:230
 msgid "played"
 msgstr "spillede"
 
-#: journal/models/shelf.py:233
+#: journal/models/shelf.py:235
 msgid "games dropped"
 msgstr "spil droppet"
 
-#: journal/models/shelf.py:234
+#: journal/models/shelf.py:236
 msgid "stop playing"
 msgstr "stop afspilning"
 
-#: journal/models/shelf.py:235
+#: journal/models/shelf.py:237
 #, python-brace-format
 msgid "stopped playing {item}"
 msgstr "stoppede afspilning af {item}"
 
-#: journal/models/shelf.py:236
+#: journal/models/shelf.py:238
 msgid "stopped playing"
 msgstr "stoppede afspilning"
 
-#: journal/models/shelf.py:241
+#: journal/models/shelf.py:243
 msgid "games reviewed"
 msgstr "spil anmeldt"
 
-#: journal/models/shelf.py:249
+#: journal/models/shelf.py:251
 msgid "podcasts to listen"
 msgstr "podcasts der skal lyttes til"
 
-#: journal/models/shelf.py:257
+#: journal/models/shelf.py:259
 msgid "podcasts listening"
 msgstr "podcasts der lyttes til"
 
-#: journal/models/shelf.py:265
+#: journal/models/shelf.py:267
 msgid "podcasts listened"
 msgstr "podcasts lyttet til"
 
-#: journal/models/shelf.py:273
+#: journal/models/shelf.py:275
 msgid "podcasts dropped"
 msgstr "podcasts droppet"
 
-#: journal/models/shelf.py:281
+#: journal/models/shelf.py:283
 msgid "podcasts reviewed"
 msgstr "podcasts anmeldt"
 
-#: journal/models/shelf.py:289
+#: journal/models/shelf.py:291
 msgid "performances to see"
 msgstr "forestillinger der skal ses"
 
-#: journal/models/shelf.py:290
+#: journal/models/shelf.py:292
 msgid "want to see"
 msgstr "ønsker at se"
 
-#: journal/models/shelf.py:291
+#: journal/models/shelf.py:293
 #, python-brace-format
 msgid "wants to see {item}"
 msgstr "ønsker at se {item}"
 
-#: journal/models/shelf.py:292
+#: journal/models/shelf.py:294
 msgid "to see"
 msgstr "skal ses"
 
-#: journal/models/shelf.py:299
+#: journal/models/shelf.py:301
 msgid "performances saw"
 msgstr "forestillinger set"
 
-#: journal/models/shelf.py:300
+#: journal/models/shelf.py:302
 msgid "finish seeing"
 msgstr "færdig med at se"
 
-#: journal/models/shelf.py:301
+#: journal/models/shelf.py:303
 #, python-brace-format
 msgid "finished seeing {item}"
 msgstr "blev færdig med at se {item}"
 
-#: journal/models/shelf.py:302
+#: journal/models/shelf.py:304
 msgid "seen"
 msgstr "set"
 
-#: journal/models/shelf.py:307
+#: journal/models/shelf.py:309
 msgid "performances dropped"
 msgstr "forestillinger droppet"
 
-#: journal/models/shelf.py:308
+#: journal/models/shelf.py:310
 msgid "stop seeing"
 msgstr "se ikke færdig"
 
-#: journal/models/shelf.py:309
+#: journal/models/shelf.py:311
 #, python-brace-format
 msgid "stopped seeing {item}"
 msgstr "så ikke {item} færdig"
 
-#: journal/models/shelf.py:310
+#: journal/models/shelf.py:312
 msgid "stopped seeing"
 msgstr "holdt op med at se"
 
-#: journal/models/shelf.py:315
+#: journal/models/shelf.py:317
 msgid "performances reviewed"
 msgstr "forestillinger anmeldt"
 
-#: journal/models/shelf.py:323
+#: journal/models/shelf.py:325
 #, fuzzy
 #| msgid "Users you are following"
 msgid "people following"
 msgstr "Brugere du følger"
 
-#: journal/models/shelf.py:325
+#: journal/models/shelf.py:327
 #, fuzzy, python-brace-format
 #| msgid "started playing {item}"
 msgid "started following {item}"
 msgstr "begyndte at spille {item}"
 
-#: journal/models/shelf.py:921
+#: journal/models/shelf.py:923
 msgid "removed mark"
 msgstr "fjernet markering"
 
@@ -6253,38 +6225,22 @@ msgstr ""
 msgid "Remove from collection"
 msgstr "Fjern fra samling"
 
-#: journal/templates/_list_item.html:34
-msgid "add mark"
-msgstr "tilføj markering"
-
-#: journal/templates/_list_item.html:42
-msgid "update mark"
-msgstr "opdater markering"
-
-#: journal/templates/_list_item.html:60
+#: journal/templates/_list_item.html:43
 #: journal/templates/collection_update_item_note_ok.html:3
 msgid "Update note"
 msgstr "Opdater note"
 
-#: journal/templates/_list_item.html:100 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:123
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
 msgstr "Anmeldelse"
 
-#: journal/templates/_list_item.html:133
+#: journal/templates/_list_item.html:91
 #, fuzzy, python-format
-#| msgid ""
-#| " %(dups)s items are from the same work or have the same identifier, they "
-#| "are hidden from the search results, <a _=\"on click toggle .unfold on "
-#| "#dup\">click here to show them.</a> "
-msgid ""
-"%(dups)s item(s) are from the same work or have the same identifier, click "
-"here to display:"
-msgstr ""
-" %(dups)s elementer er fra det samme værk eller har den samme identifikator, "
-"de er skjult fra søgeresultaterne, <a _=\"on click toggle .unfold on "
-"#dup\">klik her for at vise dem.</a> "
+#| msgid " %(dups)s items are from the same work or have the same identifier, they are hidden from the search results, <a _=\"on click toggle .unfold on #dup\">click here to show them.</a> "
+msgid "%(dups)s item(s) are from the same work or have the same identifier, click here to display:"
+msgstr " %(dups)s elementer er fra det samme værk eller har den samme identifikator, de er skjult fra søgeresultaterne, <a _=\"on click toggle .unfold on #dup\">klik her for at vise dem.</a> "
 
 #: journal/templates/_sidebar_collection_filter.html:32
 #, fuzzy
@@ -6374,9 +6330,7 @@ msgstr "Boost"
 
 #: journal/templates/action_delete_post.html:7
 msgid "Are you sure to delete this post and the mark or note related with it?"
-msgstr ""
-"Er du sikker på at du vil slette dette indlæg med tilhørende markering eller "
-"note?"
+msgstr "Er du sikker på at du vil slette dette indlæg med tilhørende markering eller note?"
 
 #: journal/templates/action_delete_post.html:7
 msgid "Are you sure to delete this reply?"
@@ -6404,6 +6358,14 @@ msgstr "syntes godt om"
 #: journal/templates/action_like_post.html:16
 msgid "Like"
 msgstr ""
+
+#: journal/templates/action_mark_item.html:10
+msgid "add mark"
+msgstr "tilføj markering"
+
+#: journal/templates/action_mark_item.html:18
+msgid "update mark"
+msgstr "opdater markering"
 
 #: journal/templates/action_open_post.html:7
 #, fuzzy
@@ -6465,13 +6427,13 @@ msgstr "Føj til samling"
 msgid "Create a new collection"
 msgstr "Opret ny samling"
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:81
+#: journal/templates/article.html:104 social/templates/_event_post.html:76
 #, fuzzy
 #| msgid "wrote a review of {item}"
 msgid "wrote a review"
 msgstr "skrev en anmeldelse af {item}"
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:83
+#: journal/templates/article.html:106 social/templates/_event_post.html:78
 #, fuzzy
 #| msgid "wrote a note"
 msgid "wrote an article"
@@ -6591,23 +6553,21 @@ msgstr "del med afspilningsposition"
 msgid "Mark"
 msgstr "Markering"
 
-#: journal/templates/mark.html:50
+#: journal/templates/mark.html:54
 msgid "not rated"
 msgstr "ikke bedømt"
 
-#: journal/templates/mark.html:70
+#: journal/templates/mark.html:74
 msgid "add a tag and press Enter"
 msgstr "tilføj et tag og tryk på enter"
 
-#: journal/templates/mark.html:122
+#: journal/templates/mark.html:126
 msgid "change mark date"
 msgstr "skift markeringsdato"
 
-#: journal/templates/mark.html:148
+#: journal/templates/mark.html:156
 msgid "Sure to delete mark, comment and tags for this item?"
-msgstr ""
-"Er du sikker på at du vil slette markeringer, kommentarer og tags for dette "
-"element?"
+msgstr "Er du sikker på at du vil slette markeringer, kommentarer og tags for dette element?"
 
 #: journal/templates/markdown_editor.html:9
 msgid "Markdown format references"
@@ -6625,15 +6585,13 @@ msgstr "Markdown format referencer"
 #| "\n"
 #| "  Paragraphs need to be separated by a blank line\n"
 #| "\n"
-#| "  Indentation at the beginning of the paragraph requires using a Unicode "
-#| "full-width space\n"
+#| "  Indentation at the beginning of the paragraph requires using a Unicode full-width space\n"
 #| "\n"
 #| "[Link](https://zh.wikipedia.org/wiki/Markdown)\n"
 #| "**Bold**  *Italic* ==Highlight== ~~Strikethrough~~\n"
 #| "^Super^script ~Sub~script [拼(pīn)音(yīn)]\n"
 #| "\n"
-#| "Drag and drop an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/"
-#| "Wikipedia-logo-v2.svg)\n"
+#| "Drag and drop an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 #| "\n"
 #| "> Quote\n"
 #| ">> Multi-level quote\n"
@@ -6693,8 +6651,7 @@ msgid ""
 "Content Cell  | Content Cell\n"
 "Content Cell  | Content Cell\n"
 "\n"
-"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/"
-"Wikipedia-logo-v2.svg)\n"
+"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 "\n"
 msgstr ""
 "\n"
@@ -6706,15 +6663,13 @@ msgstr ""
 "\n"
 "  Afsnit skal separeres med en blank linje\n"
 "\n"
-"  Indrykning i begyndelsen af ​​afsnittet kræver brug af et Unicode-mellemrum "
-"i fuld bredde\n"
+"  Indrykning i begyndelsen af ​​afsnittet kræver brug af et Unicode-mellemrum i fuld bredde\n"
 "\n"
 "[Link](https://zh.wikipedia.org/wiki/Markdown)\n"
 "**Fed**  *Kursiv* ==Fremhævet== ~~Gennemstregning~~\n"
 "^Hævet^skrift ~Sænket~skrift [拼(pīn)音(yīn)]\n"
 "\n"
-"Træk og slip et billede ![](https://upload.wikimedia.org/wikipedia/en/8/80/"
-"Wikipedia-logo-v2.svg)\n"
+"Træk og slip et billede ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 "\n"
 "> Citat\n"
 ">> Citat i flere niveauer\n"
@@ -6741,7 +6696,7 @@ msgstr ""
 "Indhold Celle  | Indhold Celle\n"
 "Indhold Celle  | Indhold Celle\n"
 
-#: journal/templates/note.html:19 journal/views/note.py:23
+#: journal/templates/note.html:19 journal/views/note.py:22
 msgid "Note"
 msgstr "Note"
 
@@ -6772,12 +6727,8 @@ msgid "Are you sure to delete this entire content?"
 msgstr "Er du sikker på at du vil slette hele dette indhold?"
 
 #: journal/templates/piece_delete.html:24
-msgid ""
-"By deleting it, you will also lose track of others' comments and feedbacks "
-"to your content."
-msgstr ""
-"Ved at slette det, vil du også miste andres kommentarer og feedbacks til dit "
-"indhold."
+msgid "By deleting it, you will also lose track of others' comments and feedbacks to your content."
+msgstr "Ved at slette det, vil du også miste andres kommentarer og feedbacks til dit indhold."
 
 #: journal/templates/piece_delete.html:25
 #: journal/templates/piece_delete.html:32
@@ -6870,7 +6821,7 @@ msgstr "årlig sammenfatning"
 msgid "Articles"
 msgstr ""
 
-#: journal/templates/profile.html:166 journal/views/collection.py:427
+#: journal/templates/profile.html:166 journal/views/collection.py:409
 #: journal/views/profile.py:401
 msgid "collection"
 msgstr "samling"
@@ -6906,13 +6857,8 @@ msgid "Personal"
 msgstr "Personlig"
 
 #: journal/templates/tag_edit.html:52
-msgid ""
-"Personal tags are not included in public index. However, if you use this tag "
-"when marking an item publicly, it might still be visible to others."
-msgstr ""
-"Personlige tags er ikke inkluderet i det offentlige indeks. Men hvis du "
-"bruger dette mærke ved markering af et element offentligt, kan det stadig "
-"være synligt for andre."
+msgid "Personal tags are not included in public index. However, if you use this tag when marking an item publicly, it might still be visible to others."
+msgstr "Personlige tags er ikke inkluderet i det offentlige indeks. Men hvis du bruger dette mærke ved markering af et element offentligt, kan det stadig være synligt for andre."
 
 #: journal/templates/tag_edit.html:55
 msgid "Delete this tag"
@@ -6993,127 +6939,128 @@ msgstr "Anmeldelser af {0}"
 msgid "Link invalid"
 msgstr "Link ugyldigt"
 
-#: journal/views/collection.py:58 journal/views/collection.py:96
+#: journal/views/collection.py:62 journal/views/collection.py:94
 #, python-brace-format
 msgid "Collection by {0}"
 msgstr "Samling af {0}"
 
-#: journal/views/collection.py:432
+#: journal/views/collection.py:414
 msgid "shared my collection"
 msgstr "delte min samling"
 
-#: journal/views/collection.py:435
+#: journal/views/collection.py:417
 #, python-brace-format
 msgid "shared {username}'s collection"
 msgstr "delte {username}'s samling"
 
-#: journal/views/collection.py:502 journal/views/collection.py:541
-#: journal/views/collection.py:553 journal/views/collection.py:579
+#: journal/views/collection.py:484 journal/views/collection.py:523
+#: journal/views/collection.py:535 journal/views/collection.py:561
 msgid "Dynamic collection is not editable"
 msgstr ""
 
-#: journal/views/collection.py:518
+#: journal/views/collection.py:500
 #, fuzzy
 #| msgid "This username is already in use."
 msgid "The item is already in the collection."
 msgstr "Dette brugernavn er allerede i brug."
 
-#: journal/views/collection.py:520
+#: journal/views/collection.py:502
 msgid "Unable to find the item, please use item url from this site."
 msgstr "Kan ikke finde elementet, brug venligst element url'en fra dette site."
 
-#: journal/views/collection.py:566
+#: journal/views/collection.py:548
 #, fuzzy
 #| msgid "Save"
 msgid "Saved."
 msgstr "Gem"
 
-#: journal/views/common.py:119 journal/views/mark.py:225
-#: journal/views/mark.py:279 journal/views/note.py:175
+#: journal/views/common.py:126 journal/views/mark.py:273
+#: journal/views/mark.py:315 journal/views/note.py:167
 #: journal/views/profile.py:42 journal/views/review.py:59
 #: journal/views/review.py:79
 msgid "Content not found"
 msgstr "Indhold ikke fundet"
 
-#: journal/views/common.py:174 journal/views/mark.py:159
+#: journal/views/common.py:184 journal/views/mark.py:210
 msgid "Data saved but unable to crosspost to Fediverse instance."
 msgstr "Data gemt, men kan ikke krydsposte til Fødivers instans."
 
-#: journal/views/common.py:176
+#: journal/views/common.py:186
 msgid "Redirecting to your Fediverse instance now to re-authenticate."
 msgstr "Omdirigerer til din Fødivers instans nu for godkendelse igen."
 
-#: journal/views/common.py:183
+#: journal/views/common.py:193
 msgid "List not found."
 msgstr "Listen kan ikke findes."
 
-#: journal/views/mark.py:150
+#: journal/views/mark.py:206
 msgid "Content too long for your Fediverse instance."
 msgstr "Indhold for langt for din Fødivers instans."
 
-#: journal/views/mark.py:178 journal/views/mark.py:238
+#: journal/views/mark.py:224 journal/views/mark.py:226
+#: journal/views/mark.py:280
 #, fuzzy
 #| msgid "Invalid tag"
 msgid "Invalid input"
 msgstr "Ugyldigt tag"
 
-#: journal/views/note.py:23
+#: journal/views/note.py:22
 msgid "Progress"
 msgstr ""
 
-#: journal/views/note.py:28
+#: journal/views/note.py:27
 #, fuzzy
 #| msgid "Update note"
 msgid "Update progress"
 msgstr "Opdater note"
 
-#: journal/views/note.py:59
+#: journal/views/note.py:58
 msgid "Progress (optional)"
 msgstr "Fremskridt (valgfri)"
 
-#: journal/views/note.py:61
+#: journal/views/note.py:60
 msgid "Note Content"
 msgstr "Indhold Af Note"
 
-#: journal/views/note.py:63
+#: journal/views/note.py:62
 msgid "Content Warning (optional)"
 msgstr "Advarsel Om Indhold (Valgfrit)"
 
-#: journal/views/note.py:85
+#: journal/views/note.py:84
 msgid "Progress Type (optional)"
 msgstr "Fremskridttype (valgfri)"
 
-#: journal/views/note.py:123 journal/views/note.py:183
+#: journal/views/note.py:115 journal/views/note.py:175
 msgid "Only in-progress items can have progress."
 msgstr ""
 
-#: journal/views/post.py:98 journal/views/post.py:392
+#: journal/views/post.py:100 journal/views/post.py:388
 msgid "Post not found"
 msgstr "Indlæg ikke fundet"
 
-#: journal/views/post.py:189
+#: journal/views/post.py:191
 msgid "Visibility too high for quoting this post"
 msgstr ""
 
-#: journal/views/post.py:337 journal/views/post.py:418
+#: journal/views/post.py:339 journal/views/post.py:414
 #, fuzzy
 #| msgid "Item cannot be deleted."
 msgid "Content cannot be empty."
 msgstr "Elementet kan ikke slettes."
 
-#: journal/views/post.py:396
+#: journal/views/post.py:392
 #, fuzzy
 #| msgid "This operation cannot be undone. Sure to merge?"
 msgid "This post cannot be edited here"
 msgstr "Denne handling kan ikke fortrydes. Vil du sammenlægge?"
 
-#: journal/views/post.py:541
+#: journal/views/post.py:531
 #, fuzzy
 #| msgid "Invalid file."
 msgid "Invalid choices"
 msgstr "Ugyldig fil."
 
-#: journal/views/post.py:544
+#: journal/views/post.py:534
 #, fuzzy
 #| msgid "Invalid tag"
 msgid "Invalid post"
@@ -7133,67 +7080,61 @@ msgstr "{review_title} - en anmeldelse af {item_title}"
 #, fuzzy
 #| msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgid "may contain spoiler or triggering content"
-msgstr ""
-"vedrørende {item_title}, kan indeholde spoilers eller provokerende/"
-"triggerende indhold"
+msgstr "vedrørende {item_title}, kan indeholde spoilers eller provokerende/triggerende indhold"
 
-#: journal/views/tag.py:47 journal/views/tag.py:61
+#: journal/views/tag.py:46 journal/views/tag.py:60
 msgid "Invalid tag"
 msgstr "Ugyldigt tag"
 
-#: journal/views/tag.py:50
+#: journal/views/tag.py:49
 msgid "Tag not found"
 msgstr "Tag ikke fundet"
 
-#: journal/views/tag.py:72
+#: journal/views/tag.py:65
 msgid "Tag deleted."
 msgstr "Tag slettet."
 
-#: journal/views/tag.py:82
+#: journal/views/tag.py:75
 msgid "Duplicated tag."
 msgstr "Duplikeret tag."
 
-#: journal/views/tag.py:96
+#: journal/views/tag.py:83
 msgid "Tag updated."
 msgstr "Tag opdateret."
 
-#: journal/views/wrapped.py:160
+#: journal/views/wrapped.py:161
 msgid "Summary posted to timeline."
 msgstr "Sammenfatning sendt til tidslinje."
 
-#: mastodon/models/common.py:29
+#: mastodon/models/common.py:31
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: mastodon/models/common.py:30 users/templates/users/login.html:120
+#: mastodon/models/common.py:32 users/templates/users/login.html:114
 msgid "Threads"
 msgstr "Threads"
 
-#: mastodon/models/common.py:31
+#: mastodon/models/common.py:33
 msgid "Bluesky"
 msgstr "Bluesky"
 
-#: mastodon/models/email.py:59
+#: mastodon/models/email.py:63
 msgid ""
 "\n"
 "\n"
-"If you did not mean to register or login, please ignore this email. If you "
-"are concerned with your account security, please change the email linked "
-"with your account, or contact us."
+"If you did not mean to register or login, please ignore this email. If you are concerned with your account security, please change the email linked with your account, or contact us."
 msgstr ""
 "\n"
 "\n"
-"Hvis du ikke ville registrere dig eller logge ind, bedes du venligst "
-"ignorere denne e-mail. Hvis du er bekymret om din kontosikkerhed, kan du "
-"skifte e-mailadressen tilnyttet din konto, eller kontakte os."
+"Hvis du ikke ville registrere dig eller logge ind, bedes du venligst ignorere denne e-mail. Hvis du er bekymret om din kontosikkerhed, kan du skifte e-mailadressen tilnyttet din konto, eller kontakte os."
 
-#: mastodon/models/email.py:64 mastodon/models/email.py:69
+#: mastodon/models/email.py:68 mastodon/models/email.py:73
 #, fuzzy
 #| msgid "Verification"
 msgid "Verification Code"
 msgstr "Bekræftelse"
 
-#: mastodon/models/email.py:66
+#: mastodon/models/email.py:70
 #, python-brace-format
 msgid ""
 "Use this code to verify your email address {email}\n"
@@ -7204,7 +7145,7 @@ msgstr ""
 "\n"
 "{code}"
 
-#: mastodon/models/email.py:70
+#: mastodon/models/email.py:74
 #, python-brace-format
 msgid ""
 "Use this code to login as {email}\n"
@@ -7215,31 +7156,27 @@ msgstr ""
 "\n"
 "{code}"
 
-#: mastodon/models/email.py:74 users/templates/users/captcha.html:13
+#: mastodon/models/email.py:78 users/templates/users/captcha.html:13
 #: users/templates/users/captcha_solved.html:9
 #: users/templates/users/login.html:20 users/templates/users/register.html:9
 #: users/templates/users/welcome.html:10
 msgid "Register"
 msgstr "Tilmeld"
 
-#: mastodon/models/email.py:76
+#: mastodon/models/email.py:80
 #, python-brace-format
 msgid ""
 "There is no account registered with this email address yet: {email}\n"
 "\n"
-"If you already have an account with us, just login and add this email to you "
-"account.\n"
+"If you already have an account with us, just login and add this email to you account.\n"
 "\n"
-"If you prefer to register a new account with this email, please use this "
-"verification code: {code}"
+"If you prefer to register a new account with this email, please use this verification code: {code}"
 msgstr ""
 "Der er ingen konto registreret med denne e-mailadresse endnu: {email}\n"
 "\n"
-"Hvis du allerede har en konto hos os, log ind og tilføj denne e-mail til din "
-"konto.\n"
+"Hvis du allerede har en konto hos os, log ind og tilføj denne e-mail til din konto.\n"
 "\n"
-"Hvis du foretrækker at registrere en ny konto med denne e-mail, skal du "
-"bruge denne bekræftelseskode: {code}"
+"Hvis du foretrækker at registrere en ny konto med denne e-mail, skal du bruge denne bekræftelseskode: {code}"
 
 #: mastodon/models/mastodon.py:570
 msgid "site domain name"
@@ -7281,56 +7218,61 @@ msgstr "maks. trutlængde"
 msgid "New Post"
 msgstr "Nyt Indlæg"
 
-#: mastodon/views/bluesky.py:26 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:32 mastodon/views/bluesky.py:93
 #, fuzzy
 #| msgid "Bluesky Login ID"
 msgid "Bluesky login is disabled."
 msgstr "Bluesky Login ID"
 
-#: mastodon/views/bluesky.py:28 mastodon/views/email.py:35
-#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:29
-#: users/templates/users/login.html:6 users/views/webauthn.py:133
+#: mastodon/views/bluesky.py:47 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:65 mastodon/views/bluesky.py:98
+#: mastodon/views/bluesky.py:106 mastodon/views/bluesky.py:112
+#: mastodon/views/common.py:36 mastodon/views/mastodon.py:62
+#: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
+#: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
+#: mastodon/views/threads.py:57 mastodon/views/threads.py:65
+#: mastodon/views/threads.py:71 users/views/account.py:256
+#: users/views/account.py:375
+msgid "Authentication failed"
+msgstr "Godkendelse mislykkedes"
+
+#: mastodon/views/bluesky.py:47 mastodon/views/common.py:103
+msgid "Identity not found."
+msgstr "Identitet er ikke fundet."
+
+#: mastodon/views/bluesky.py:53 mastodon/views/email.py:35
+#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:31
+#: users/templates/users/login.html:6 users/views/webauthn.py:136
 #, fuzzy
 #| msgid "Export file expired. Please export again."
 msgid "Security check failed. Please try again."
 msgstr "Eksport fil udløbet. Eksporter venligst igen."
 
-#: mastodon/views/bluesky.py:34 mastodon/views/bluesky.py:40
-#: mastodon/views/bluesky.py:64 mastodon/views/bluesky.py:72
-#: mastodon/views/bluesky.py:78 mastodon/views/common.py:36
-#: mastodon/views/mastodon.py:62 mastodon/views/mastodon.py:70
-#: mastodon/views/mastodon.py:77 mastodon/views/mastodon.py:87
-#: mastodon/views/mastodon.py:94 mastodon/views/threads.py:55
-#: mastodon/views/threads.py:63 mastodon/views/threads.py:69
-#: users/views/account.py:254 users/views/account.py:373
-msgid "Authentication failed"
-msgstr "Godkendelse mislykkedes"
-
-#: mastodon/views/bluesky.py:35 mastodon/views/email.py:66
+#: mastodon/views/bluesky.py:60 mastodon/views/email.py:66
 #, fuzzy
 #| msgid "System busy, please try again in a minute."
 msgid "Too many attempts, please try again later."
 msgstr "System er optaget, prøv venligst igen om et øjeblik."
 
-#: mastodon/views/bluesky.py:40
+#: mastodon/views/bluesky.py:65
 #, fuzzy
 #| msgid "ATProto handle"
 msgid "ATProto handle is required."
 msgstr "ATProto kontonavn"
 
-#: mastodon/views/bluesky.py:50
+#: mastodon/views/bluesky.py:84
 #, fuzzy
 #| msgid "Error connecting to instance"
 msgid "Error connecting to your ATProto server"
 msgstr "Fejl ved forbindelse til instans"
 
-#: mastodon/views/bluesky.py:73
+#: mastodon/views/bluesky.py:107
 #, fuzzy
 #| msgid "Invalid response from Fediverse instance."
 msgid "Invalid response from ATProto authorization server."
 msgstr "Ugyldigt svar fra Fødivers instans."
 
-#: mastodon/views/bluesky.py:78
+#: mastodon/views/bluesky.py:112
 msgid "Invalid account data from Bluesky."
 msgstr "Ugyldige kontodata fra Bluesky."
 
@@ -7338,7 +7280,7 @@ msgstr "Ugyldige kontodata fra Bluesky."
 msgid "Invalid user."
 msgstr "Ugyldig bruger."
 
-#: mastodon/views/common.py:52 users/views/account.py:414
+#: mastodon/views/common.py:52 users/views/account.py:416
 msgid "Registration failed"
 msgstr "Registrering mislykkedes"
 
@@ -7369,10 +7311,6 @@ msgstr "Login information opdateret som {handle}."
 #: mastodon/views/common.py:116
 msgid "Disconnect identity failed"
 msgstr "Afbrydelse af identitet mislykkedes"
-
-#: mastodon/views/common.py:103
-msgid "Identity not found."
-msgstr "Identitet er ikke fundet."
 
 #: mastodon/views/common.py:117
 msgid "You cannot disconnect last login identity."
@@ -7415,7 +7353,7 @@ msgstr "Fejl ved forbindelse til instans"
 msgid "Invalid response from Fediverse instance."
 msgstr "Ugyldigt svar fra Fødivers instans."
 
-#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:64
+#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:66
 msgid "Invalid OAuth state. Please try again."
 msgstr ""
 
@@ -7435,21 +7373,19 @@ msgstr "Ugyldigt token fra Fødivers instans."
 msgid "Invalid account data from Fediverse instance."
 msgstr "Ugyldig kontodata fra Fødivers instans."
 
-#: mastodon/views/threads.py:69
+#: mastodon/views/threads.py:71
 msgid "Invalid account data from Threads."
 msgstr "Ugyldige kontodata fra Threads."
 
-#: mastodon/views/threads.py:147
+#: mastodon/views/threads.py:149
 #, fuzzy
 #| msgid "Reset completed."
 msgid "Data deletion completed"
 msgstr "Nulstilling fuldført."
 
-#: mastodon/views/threads.py:149
+#: mastodon/views/threads.py:151
 #, python-brace-format
-msgid ""
-"Data linked to your Threads account has been deleted. Confirmation code: "
-"{code}"
+msgid "Data linked to your Threads account has been deleted. Confirmation code: {code}"
 msgstr ""
 
 #: social/templates/_article_teaser.html:10
@@ -7488,15 +7424,11 @@ msgstr "boostet"
 msgid "play"
 msgstr "afspil"
 
-#: social/templates/_event_post.html:50
-msgid "mark"
-msgstr "markering"
-
-#: social/templates/_event_post.html:79
+#: social/templates/_event_post.html:74
 msgid "wrote a note"
 msgstr "skrev en note"
 
-#: social/templates/_event_post.html:88
+#: social/templates/_event_post.html:83
 #, fuzzy
 #| msgid "playing"
 msgid "replying to"
@@ -7511,7 +7443,7 @@ msgstr ""
 msgid "Untitled article"
 msgstr ""
 
-#: social/templates/event/boosted.html:3
+#: social/templates/event/boosted.html:2
 msgid "boosted your post"
 msgstr "boostede dit indlæg"
 
@@ -7567,12 +7499,10 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"boostede din anmeldelse <a href=\"%(piece_url)s\">%(piece_title)s</a> på <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"boostede din anmeldelse <a href=\"%(piece_url)s\">%(piece_title)s</a> på <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/boosted_shelfmember.html:3
 #, python-format
@@ -7591,7 +7521,7 @@ msgstr "anmodede om at følge dig"
 msgid "followed you"
 msgstr "har fulgt dig"
 
-#: social/templates/event/liked.html:3
+#: social/templates/event/liked.html:2
 msgid "liked your post"
 msgstr "syntes om dit indlæg"
 
@@ -7647,12 +7577,10 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"syntes godt om din anmeldelse <a href=\"%(piece_url)s\">%(piece_title)s</a> "
-"på <a href=\"%(item_url)s\">%(item_title)s</a>\n"
+"syntes godt om din anmeldelse <a href=\"%(piece_url)s\">%(piece_title)s</a> på <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/liked_shelfmember.html:3
 #, python-format
@@ -7663,7 +7591,7 @@ msgstr ""
 "\n"
 "syntes om din markering på <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
-#: social/templates/event/mentioned.html:3
+#: social/templates/event/mentioned.html:2
 msgid "mentioned you"
 msgstr "har nævnt dig"
 
@@ -7719,12 +7647,10 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"svarede på din anmeldelse <a href=\"%(piece_url)s\">%(piece_title)s</a> på "
-"<a href=\"%(item_url)s\">%(item_title)s</a>\n"
+"svarede på din anmeldelse <a href=\"%(piece_url)s\">%(piece_title)s</a> på <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/mentioned_shelfmember.html:3
 #, python-format
@@ -7735,33 +7661,46 @@ msgstr ""
 "\n"
 "svarede på din markering på <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
-#: social/templates/feed.html:12 social/templates/feed.html:39
-#: social/templates/search_feed.html:12
-msgid "Activities from those you follow"
-msgstr "Aktiviteter fra dem, du følger"
+#: social/templates/feed.html:39 users/templates/users/preferences.html:40
+msgid "Activities"
+msgstr "Aktiviteter"
 
-#: social/templates/feed.html:42 social/templates/feed.html:44
+#: social/templates/feed.html:43 social/templates/feed.html:45
+msgid "world"
+msgstr ""
+
+#: social/templates/feed.html:51 social/templates/feed.html:53
+#, fuzzy
+#| msgid "locale"
+msgid "local"
+msgstr "sprogindstilling"
+
+#: social/templates/feed.html:58 social/templates/feed.html:60
+#, fuzzy
+#| msgid "sure to follow?"
+msgid "those you follow"
+msgstr "er du sikker på at du vil følge?"
+
+#: social/templates/feed.html:64 social/templates/feed.html:66
 #, fuzzy
 #| msgid "What they read/watch/..."
 msgid "what they read/watch/..."
 msgstr "Hvad de læser/ser..."
 
-#: social/templates/feed_events.html:30
+#: social/templates/feed_events.html:29
 msgid "no matching activities."
 msgstr ""
 
-#: social/templates/feed_events.html:33
+#: social/templates/feed_events.html:31
+#, fuzzy
+#| msgid "in public timeline"
+msgid "no public activities yet."
+msgstr "på offentlig tidslinje"
+
+#: social/templates/feed_events.html:34
 #, python-format
-msgid ""
-"Find and mark some books/movies/podcasts/games, <a "
-"href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/"
-"Douban, follow some fellow %(site_name)s users on the fediverse, so their "
-"recent activities and yours will show up here."
-msgstr ""
-"Find og marker nogle bøger/film/podcasts/spil, <a "
-"href=\"%(import_url)s\">importer dine data</a> fra Goodreads/Letterboxd/"
-"Douban, følg andre %(site_name)s brugere i fødiverset, så deres seneste "
-"aktiviteter vises her."
+msgid "Find and mark some books/movies/podcasts/games, <a href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/Douban, follow some fellow %(site_name)s users on the fediverse, so their recent activities and yours will show up here."
+msgstr "Find og marker nogle bøger/film/podcasts/spil, <a href=\"%(import_url)s\">importer dine data</a> fra Goodreads/Letterboxd/Douban, følg andre %(site_name)s brugere i fødiverset, så deres seneste aktiviteter vises her."
 
 #: social/templates/notification.html:58
 msgid "mention"
@@ -7797,6 +7736,10 @@ msgstr ""
 msgid "Poll ending at %(end_time)s"
 msgstr ""
 
+#: social/templates/search_feed.html:12 social/views.py:57 social/views.py:58
+msgid "Activities from those you follow"
+msgstr "Aktiviteter fra dem, du følger"
+
 #: social/templates/single_post.html:13 social/templates/single_post.html:32
 #, fuzzy
 #| msgid "New Post"
@@ -7811,61 +7754,69 @@ msgstr ""
 msgid "Poll"
 msgstr ""
 
-#: takahe/models.py:453
+#: social/views.py:59
+#, fuzzy
+#| msgid "Activities from those you follow"
+msgid "Activities on this site"
+msgstr "Aktiviteter fra dem, du følger"
+
+#: social/views.py:60
+#, fuzzy
+#| msgid "Activities from those you follow"
+msgid "Activities from the fediverse"
+msgstr "Aktiviteter fra dem, du følger"
+
+#: takahe/models.py:445
 msgid "Display Name"
 msgstr "Vist navn"
 
-#: takahe/models.py:455
+#: takahe/models.py:447
 msgid "Bio"
 msgstr "Biografi"
 
-#: takahe/models.py:457
+#: takahe/models.py:449
 msgid "Manually approve new followers"
 msgstr "Godkend nye følgere manuelt"
 
-#: takahe/models.py:461
+#: takahe/models.py:453
 #, fuzzy
 #| msgid "Include profile and posts in discovery"
 msgid "Include profile, marks and posts in discovery"
 msgstr "Inkluder profil og indlæg i \"discovery\""
 
-#: takahe/models.py:464
+#: takahe/models.py:456
 msgid "Include posts in search results"
 msgstr "Inkludér indlæg i søgeresultater"
 
-#: takahe/models.py:482
+#: takahe/models.py:474
 msgid "Profile picture"
 msgstr "Profilbillede"
 
-#: takahe/models.py:489
+#: takahe/models.py:481
 msgid "Header picture"
 msgstr "Sidehoved-billede"
 
-#: users/models/task.py:22
+#: users/models/task.py:24
 msgid "Started"
 msgstr "Påbegyndt"
 
-#: users/models/task.py:23
+#: users/models/task.py:25
 msgid "Complete"
 msgstr "Fuldført"
 
-#: users/models/user.py:69
-msgid ""
-"Enter a valid username. This value may contain only unaccented lowercase a-z "
-"and uppercase A-Z letters, numbers, and _ characters."
-msgstr ""
-"Indtast et gyldigt brugernavn. Denne værdi må kun indeholde små bogstaver a-"
-"z og store A-Z-bogstaver, tal og _ tegn."
+#: users/models/user.py:71
+msgid "Enter a valid username. This value may contain only unaccented lowercase a-z and uppercase A-Z letters, numbers, and _ characters."
+msgstr "Indtast et gyldigt brugernavn. Denne værdi må kun indeholde små bogstaver a-z og store A-Z-bogstaver, tal og _ tegn."
 
-#: users/models/user.py:130
+#: users/models/user.py:132
 msgid "username"
 msgstr "brugernavn"
 
-#: users/models/user.py:135
+#: users/models/user.py:137
 msgid "Required. 50 characters or fewer. Letters, digits and _ only."
 msgstr "Kræves. 50 tegn eller færre. Kun bogstaver, tal og _."
 
-#: users/models/user.py:138
+#: users/models/user.py:140
 msgid "A user with that username already exists."
 msgstr "Der findes allerede en bruger med dette brugernavn."
 
@@ -8022,9 +7973,7 @@ msgid "Cancel import"
 msgstr "Annuller"
 
 #: users/templates/users/_rym_section.html:29
-msgid ""
-"On RateYourMusic, go to your profile and use the <b>Export your music "
-"catalog</b> option to download your library as a CSV file."
+msgid "On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:31
@@ -8033,18 +7982,12 @@ msgid "Upload the downloaded CSV file below."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:33
-msgid ""
-"Albums are matched by title + artist (and year if present) — first against "
-"the local catalog, then MusicBrainz, then Spotify. After auto-matching, "
-"you'll preview the matches in a table, edit any link or shelf status, and "
-"confirm the import."
+msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:36
 #: users/templates/users/_storygraph_section.html:38
-msgid ""
-"You can also re-upload a previously-downloaded matched CSV — the existing "
-"<code>link</code> column will be honoured as the default match."
+msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:40
@@ -8075,18 +8018,11 @@ msgid "Cancel the StoryGraph import? Progress will be discarded."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:31
-msgid ""
-"On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to "
-"download your library as a CSV file."
+msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:35
-msgid ""
-"Books are matched by ISBN — first against the local catalog, then Google "
-"Books and OpenLibrary — with a title + author search as fallback. After auto-"
-"matching, you'll preview the matches in a table, edit any link or shelf "
-"status, and confirm the import."
+msgid "Books are matched by ISBN — first against the local catalog, then Google Books and OpenLibrary — with a title + author search as fallback. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/account.html:11
@@ -8098,13 +8034,8 @@ msgid "Display name, avatar and other information"
 msgstr "Vis navn, avatar og andre oplysninger"
 
 #: users/templates/users/account.html:23
-msgid ""
-"Updating profile information here will turn off automatic sync of display "
-"name, bio and avatar from your Mastodon instance. Sure to continue?"
-msgstr ""
-"Opdatering af profiloplysninger her vil deaktivere automatisk synkronisering "
-"af visningsnavn, bio og avatar fra din Mastodon-instans. Er du sikker på at "
-"du vil fortsætte?"
+msgid "Updating profile information here will turn off automatic sync of display name, bio and avatar from your Mastodon instance. Sure to continue?"
+msgstr "Opdatering af profiloplysninger her vil deaktivere automatisk synkronisering af visningsnavn, bio og avatar fra din Mastodon-instans. Er du sikker på at du vil fortsætte?"
 
 #: users/templates/users/account.html:26
 msgid "Username"
@@ -8116,22 +8047,12 @@ msgstr "E-mailadresse"
 
 #: users/templates/users/account.html:59 users/templates/users/register.html:47
 #, python-format
-msgid ""
-"Please click the confirmation link in the email sent to %(pending_email)s; "
-"if you haven't received it for more than a few minutes, please input and "
-"save again."
-msgstr ""
-"Klik venligst på bekræftelseslinket i den e-mail, der er sendt til "
-"%(pending_email)s. Hvis du ikke har modtaget det i løbet af et par minutter, "
-"skal du prøve igen."
+msgid "Please click the confirmation link in the email sent to %(pending_email)s; if you haven't received it for more than a few minutes, please input and save again."
+msgstr "Klik venligst på bekræftelseslinket i den e-mail, der er sendt til %(pending_email)s. Hvis du ikke har modtaget det i løbet af et par minutter, skal du prøve igen."
 
 #: users/templates/users/account.html:61 users/templates/users/register.html:50
-msgid ""
-"Email is recommended as a backup login method, if you log in via a Fediverse "
-"instance"
-msgstr ""
-"E-mail anbefales som en ekstra loginmetode, hvis du logger ind via en "
-"Fødivers instans"
+msgid "Email is recommended as a backup login method, if you log in via a Fediverse instance"
+msgstr "E-mail anbefales som en ekstra loginmetode, hvis du logger ind via en Fødivers instans"
 
 #: users/templates/users/account.html:73 users/templates/users/login.html:84
 msgid "Fediverse (Mastodon)"
@@ -8148,30 +8069,16 @@ msgid "Last updated"
 msgstr "Sidst opdateret"
 
 #: users/templates/users/account.html:92
-msgid ""
-"If you have not yet registered with any Federated instance, you may <a "
-"href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an "
-"instance</a> and register."
-msgstr ""
-"Hvis du endnu ikke har registreret dig hos en fødereret instans (Mastodon), "
-"kan du <a href=\"https://joinmastodon.org/zh/servers\" "
-"target=\"_blank\">vælge en instans</a> og registrere dig."
+msgid "If you have not yet registered with any Federated instance, you may <a href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an instance</a> and register."
+msgstr "Hvis du endnu ikke har registreret dig hos en fødereret instans (Mastodon), kan du <a href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">vælge en instans</a> og registrere dig."
 
 #: users/templates/users/account.html:97
-msgid ""
-"To associate with another federated identity, please enter the domain name "
-"of the instance where the new identity is located."
-msgstr ""
-"For at knytte til en anden fødereret identitet, angiv venligst domænenavnet "
-"for den instans, hvor den nye identitet er placeret."
+msgid "To associate with another federated identity, please enter the domain name of the instance where the new identity is located."
+msgstr "For at knytte til en anden fødereret identitet, angiv venligst domænenavnet for den instans, hvor den nye identitet er placeret."
 
 #: users/templates/users/account.html:99
-msgid ""
-"If you have registered with a Federated instance, please enter the instance "
-"domain name."
-msgstr ""
-"Hvis du har registreret dig i en Federated instans, så indtast venligst "
-"instansens domænenavn."
+msgid "If you have registered with a Federated instance, please enter the instance domain name."
+msgstr "Hvis du har registreret dig i en Federated instans, så indtast venligst instansens domænenavn."
 
 #: users/templates/users/account.html:104
 #, fuzzy
@@ -8184,32 +8091,18 @@ msgid "Go to target instance and authorize with the identity"
 msgstr "Gå til målinstans og autorisér med identiteten"
 
 #: users/templates/users/account.html:113
-msgid ""
-"After replacing the association, you may use the new Fediverse identity to "
-"log in and control data visibility. Existing data such as tags, comments, "
-"and collections will not be affected."
-msgstr ""
-"Efter udskiftning af associationen, kan du bruge den nye Fediverse identitet "
-"til at logge ind og kontrollere data synlighed. Eksisterende data såsom "
-"tags, kommentarer og samlinger vil ikke blive påvirket."
+msgid "After replacing the association, you may use the new Fediverse identity to log in and control data visibility. Existing data such as tags, comments, and collections will not be affected."
+msgstr "Efter udskiftning af associationen, kan du bruge den nye Fediverse identitet til at logge ind og kontrollere data synlighed. Eksisterende data såsom tags, kommentarer og samlinger vil ikke blive påvirket."
 
 #: users/templates/users/account.html:115
-msgid ""
-"Once associated with Fediverse identity, you can discover more users and use "
-"the full features of this site."
-msgstr ""
-"Når du har forbundet din Fødivers-identitet, kan du finde flere brugere og "
-"fuldt udnytte funktionerne på dette websted."
+msgid "Once associated with Fediverse identity, you can discover more users and use the full features of this site."
+msgstr "Når du har forbundet din Fødivers-identitet, kan du finde flere brugere og fuldt udnytte funktionerne på dette websted."
 
 #: users/templates/users/account.html:123
 #: users/templates/users/account.html:160
 #: users/templates/users/account.html:206
-msgid ""
-"Once disconnected, you will no longer be able login with this identity. Are "
-"you sure to continue?"
-msgstr ""
-"Når forbindelse afbrydes kan du ikke længere logge ind med denne identitet. "
-"Er du sikker på at du vil fortsætte?"
+msgid "Once disconnected, you will no longer be able login with this identity. Are you sure to continue?"
+msgstr "Når forbindelse afbrydes kan du ikke længere logge ind med denne identitet. Er du sikker på at du vil fortsætte?"
 
 #: users/templates/users/account.html:126
 msgid "Disconnect with this identity"
@@ -8235,7 +8128,7 @@ msgstr "Link med en threads.net konto"
 msgid "Disconnect with Threads"
 msgstr "Afbryd forbindelsen med Threads"
 
-#: users/templates/users/account.html:173 users/templates/users/login.html:112
+#: users/templates/users/account.html:173 users/templates/users/login.html:106
 msgid "Bluesky (ATProto)"
 msgstr "Bluesky (ATProto)"
 
@@ -8243,7 +8136,7 @@ msgstr "Bluesky (ATProto)"
 msgid "Verified ATProto identity"
 msgstr "Verificeret ATProto identitet"
 
-#: users/templates/users/account.html:194 users/templates/users/login.html:216
+#: users/templates/users/account.html:194 users/templates/users/login.html:210
 msgid "ATProto handle"
 msgstr "ATProto kontonavn"
 
@@ -8268,7 +8161,7 @@ msgid "Name this passkey:"
 msgstr ""
 
 #: users/templates/users/account.html:227 users/templates/users/login.html:69
-#: users/templates/users/welcome.html:33 users/views/webauthn.py:106
+#: users/templates/users/welcome.html:33 users/views/webauthn.py:109
 msgid "Passkey"
 msgstr ""
 
@@ -8317,12 +8210,8 @@ msgid "Save sync settings"
 msgstr "Gem indstillinger for synkronisering"
 
 #: users/templates/users/account.html:297
-msgid ""
-"New follow, mute and blocks in the associated identity may be automatically "
-"imported; removal has to be done manually."
-msgstr ""
-"Nye følgere, dæmpninger og blokeringer i den tilknyttede identitet kan "
-"automatisk importeres; fjernelse skal ske manuelt."
+msgid "New follow, mute and blocks in the associated identity may be automatically imported; removal has to be done manually."
+msgstr "Nye følgere, dæmpninger og blokeringer i den tilknyttede identitet kan automatisk importeres; fjernelse skal ske manuelt."
 
 #: users/templates/users/account.html:304
 msgid "Click button below to start sync now."
@@ -8358,15 +8247,11 @@ msgid "Log out everywhere"
 msgstr ""
 
 #: users/templates/users/account.html:365
-msgid ""
-"This will log you out of all browsers and devices (including the current "
-"one), and revoke all API tokens. Continue?"
+msgid "This will log you out of all browsers and devices (including the current one), and revoke all API tokens. Continue?"
 msgstr ""
 
 #: users/templates/users/account.html:368
-msgid ""
-"If you notice any suspicious activity or have logged in on a shared "
-"computer, you can log out of all sessions and revoke all API tokens."
+msgid "If you notice any suspicious activity or have logged in on a shared computer, you can log out of all sessions and revoke all API tokens."
 msgstr ""
 
 #: users/templates/users/account.html:378
@@ -8441,10 +8326,10 @@ msgstr "skal lyttes til"
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:74
-#: users/templates/users/data.html:126 users/templates/users/data.html:183
-#: users/templates/users/data.html:234 users/templates/users/data.html:298
-#: users/templates/users/data.html:358 users/templates/users/data.html:553
+#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/data.html:141 users/templates/users/data.html:198
+#: users/templates/users/data.html:249 users/templates/users/data.html:313
+#: users/templates/users/data.html:376 users/templates/users/data.html:553
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr "Import"
@@ -8476,14 +8361,9 @@ msgstr "Overflyt konto"
 
 #: users/templates/users/account.html:488
 #, fuzzy
-#| msgid ""
-#| "Link an email so that you can migrate followers from other Fediverse "
-#| "instances."
-msgid ""
-"Linking an email to your account is highly recommended before migrating from "
-"another Fediverse instance."
-msgstr ""
-"Link en e-mail, så du kan overflytte tilhængere fra andre Fødivers-instanser."
+#| msgid "Link an email so that you can migrate followers from other Fediverse instances."
+msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
+msgstr "Link en e-mail, så du kan overflytte tilhængere fra andre Fødivers-instanser."
 
 #: users/templates/users/account.html:491
 #, fuzzy
@@ -8503,17 +8383,11 @@ msgstr "Slet Konto"
 
 #: users/templates/users/account.html:504
 msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
-msgstr ""
-"Når kontodata er slettet, kan de ikke gendannes. Er du sikker på at du vil "
-"fortsætte?"
+msgstr "Når kontodata er slettet, kan de ikke gendannes. Er du sikker på at du vil fortsætte?"
 
 #: users/templates/users/account.html:507
-msgid ""
-"Enter full <code>username@instance.social</code> or <code>email@domain.com</"
-"code> to confirm deletion."
-msgstr ""
-"Indtast fuld <code>brugernavn@instance.social</code> eller "
-"<code>email@domain.com</code> for at bekræfte sletning."
+msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
+msgstr "Indtast fuld <code>brugernavn@instance.social</code> eller <code>email@domain.com</code> for at bekræfte sletning."
 
 #: users/templates/users/account.html:517
 msgid "Once deleted, account data cannot be recovered."
@@ -8574,9 +8448,7 @@ msgid "Token Created"
 msgstr "ikke bedømt"
 
 #: users/templates/users/authorized_app_created.html:22
-msgid ""
-"Your new personal access token has been created. Copy it now -- you will not "
-"be able to see it again."
+msgid "Your new personal access token has been created. Copy it now -- you will not be able to see it again."
 msgstr ""
 
 #: users/templates/users/authorized_app_created.html:25
@@ -8604,9 +8476,7 @@ msgid "One quick check"
 msgstr ""
 
 #: users/templates/users/captcha.html:28
-msgid ""
-"Put every cover into the row it belongs to. Drag it, or select a cover and "
-"then select a row."
+msgid "Put every cover into the row it belongs to. Drag it, or select a cover and then select a row."
 msgstr ""
 
 #: users/templates/users/captcha.html:41 users/templates/users/captcha.html:43
@@ -8641,7 +8511,7 @@ msgstr ""
 msgid "That is all we needed. Let's get you a username."
 msgstr ""
 
-#: users/templates/users/captcha_solved.html:34
+#: users/templates/users/captcha_solved.html:32
 #: users/templates/users/login.html:63
 #: users/templates/users/verify_email.html:25
 #: users/templates/users/welcome.html:51
@@ -8661,10 +8531,7 @@ msgid "Failed Crossposts"
 msgstr ""
 
 #: users/templates/users/crossposts.html:42
-msgid ""
-"These posts could not be crossposted to your linked social accounts. Re-"
-"authorize the account if needed, then retry. In rare cases retrying may "
-"create a duplicate post."
+msgid "These posts could not be crossposted to your linked social accounts. Re-authorize the account if needed, then retry. In rare cases retrying may create a duplicate post."
 msgstr ""
 
 #: users/templates/users/crossposts.html:48
@@ -8687,266 +8554,193 @@ msgstr ""
 msgid "Data Management"
 msgstr "Datastyring"
 
-#: users/templates/users/data.html:27
+#: users/templates/users/data.html:39
 msgid "Import Marks and Reviews from Douban"
 msgstr "Importér markeringer og anmeldelser fra Douban"
 
-#: users/templates/users/data.html:31
-msgid ""
-"Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
-"target=\"_blank\" rel=\"noopener\">Doufen</a>"
-msgstr ""
-"Vælg <code>.xlsx</code> eksporteret fra <a href=\"https://doufen.org\" "
-"target=\"_blank\" rel=\"noopener\">Doufen</a>"
+#: users/templates/users/data.html:43
+msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
+msgstr "Vælg <code>.xlsx</code> eksporteret fra <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 
 #: users/templates/users/data.html:45
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
-"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
-"NeoDB Archive</a> below."
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON format instead; upload it under <a href=\"#import-neodb-archive\">Import NeoDB Archive</a> below."
 msgstr ""
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:256
+#: users/templates/users/data.html:49 users/templates/users/data.html:271
 msgid "Import Method"
 msgstr "Importeringsmetode"
 
-#: users/templates/users/data.html:37
-msgid ""
-"Merge: only update when status changes from wishlist to in-progress, or from "
-"in-progress to complete."
-msgstr ""
-"Læg sammen: Opdater kun når status ændres fra ønskeliste til i-gang, eller "
-"fra i-gang til at færdig."
+#: users/templates/users/data.html:52
+msgid "Merge: only update when status changes from wishlist to in-progress, or from in-progress to complete."
+msgstr "Læg sammen: Opdater kun når status ændres fra ønskeliste til i-gang, eller fra i-gang til at færdig."
 
-#: users/templates/users/data.html:41
+#: users/templates/users/data.html:56
 msgid "Overwrite: update all imported status."
 msgstr "Overskriv: Opdater alle importerede statusser."
 
-#: users/templates/users/data.html:74
-msgid ""
-"Another import is in progress, starting a new import may cause issues, sure "
-"to import?"
-msgstr ""
-"En anden import er i gang. Det kan forårsage problemer at starte en ny "
-"import. Er du sikker på at du vil fortsætte?"
+#: users/templates/users/data.html:89
+msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
+msgstr "En anden import er i gang. Det kan forårsage problemer at starte en ny import. Er du sikker på at du vil fortsætte?"
 
-#: users/templates/users/data.html:74
+#: users/templates/users/data.html:89 users/views/data.py:1130
 msgid "Import in progress, please wait"
 msgstr "Import i gang, vent venligst"
 
-#: users/templates/users/data.html:81
+#: users/templates/users/data.html:96
 #, fuzzy
 #| msgid "Import Shelf or List from Goodreads"
 msgid "Import from Goodreads"
 msgstr "Importér hylde eller liste fra Goodreads"
 
-#: users/templates/users/data.html:87
-msgid ""
-"On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download "
-"your library as a CSV file."
+#: users/templates/users/data.html:102
+msgid "On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download your library as a CSV file."
 msgstr ""
 
-#: users/templates/users/data.html:90
-msgid ""
-"Upload the downloaded <code>goodreads_library_export.csv</code> file below."
+#: users/templates/users/data.html:105
+msgid "Upload the downloaded <code>goodreads_library_export.csv</code> file below."
 msgstr ""
 
-#: users/templates/users/data.html:93
+#: users/templates/users/data.html:108
 #, fuzzy
-#| msgid ""
-#| "want-to-read / currently-reading / read books and their reviews will be "
-#| "imported."
-msgid ""
-"want-to-read / currently-reading / read / did-not-finish books and their "
-"reviews will be imported."
-msgstr ""
-"ønsker at læse / læser i øjeblikket / læste bøger og deres anmeldelser vil "
-"blive importeret."
+#| msgid "want-to-read / currently-reading / read books and their reviews will be imported."
+msgid "want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported."
+msgstr "ønsker at læse / læser i øjeblikket / læste bøger og deres anmeldelser vil blive importeret."
 
-#: users/templates/users/data.html:134
+#: users/templates/users/data.html:149
 msgid "Import from Letterboxd"
 msgstr "Importeret fra Letterboxd"
 
-#: users/templates/users/data.html:140
-msgid ""
-"on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" "
-"target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap "
-"Advanced Settings in Settings, tap EXPORT YOUR DATA"
+#: users/templates/users/data.html:155
+msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
 msgstr ""
 
-#: users/templates/users/data.html:143
-msgid ""
-"download file with name like <code>letterboxd-username-2018-03-11-07-52-"
-"utc.zip</code>, do not unzip"
+#: users/templates/users/data.html:158
+msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
 msgstr ""
 
-#: users/templates/users/data.html:146
-msgid ""
-"the following files in the zip file will be processed: <code>reviews.csv</"
-"code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</"
-"code> <code>lists/*.csv</code>"
+#: users/templates/users/data.html:161
+msgid "the following files in the zip file will be processed: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
 msgstr ""
 
-#: users/templates/users/data.html:149
-msgid ""
-"exported file does not indicate whether a list is private, unlisted or "
-"public, so all imported marks, reviews and collections will be created with "
-"the visibility selected below"
+#: users/templates/users/data.html:164
+msgid "exported file does not indicate whether a list is private, unlisted or public, so all imported marks, reviews and collections will be created with the visibility selected below"
 msgstr ""
 
-#: users/templates/users/data.html:184 users/templates/users/data.html:235
+#: users/templates/users/data.html:199 users/templates/users/data.html:250
 msgid "Only forward changes(none->to-watch->watched) will be imported."
-msgstr ""
-"Kun fremadrettede ændringer(intet->skal ses->er set) vil blive importeret."
+msgstr "Kun fremadrettede ændringer(intet->skal ses->er set) vil blive importeret."
 
-#: users/templates/users/data.html:191
+#: users/templates/users/data.html:206
 #, fuzzy
 #| msgid "Import from Letterboxd"
 msgid "Import from Trakt"
 msgstr "Importeret fra Letterboxd"
 
-#: users/templates/users/data.html:197
-msgid ""
-"On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" "
-"rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait "
-"for the download link to appear."
+#: users/templates/users/data.html:212
+msgid "On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait for the download link to appear."
 msgstr ""
 
-#: users/templates/users/data.html:200
+#: users/templates/users/data.html:215
 msgid "Upload the downloaded <code>.zip</code> file below, do not unzip."
 msgstr ""
 
-#: users/templates/users/data.html:202
+#: users/templates/users/data.html:217
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:243
+#: users/templates/users/data.html:258
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr ""
 
-#: users/templates/users/data.html:246
+#: users/templates/users/data.html:261
 msgid "Login with Steam"
 msgstr ""
 
-#: users/templates/users/data.html:252
+#: users/templates/users/data.html:267
 msgid "Import Podcast Subscriptions"
 msgstr "Importer Podcast Abonnementer"
 
-#: users/templates/users/data.html:263
+#: users/templates/users/data.html:278
 msgid "Mark as listening"
 msgstr "Markér som lytter"
 
-#: users/templates/users/data.html:267
+#: users/templates/users/data.html:282
 msgid "Import as a new collection"
 msgstr "Importer som ny samling"
 
-#: users/templates/users/data.html:296
+#: users/templates/users/data.html:311
 msgid "Select OPML file"
 msgstr "Vælg OPML-fil"
 
-#: users/templates/users/data.html:306
+#: users/templates/users/data.html:321
 msgid "Import NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:312
-msgid ""
-"Upload a <code>.zip</code> file containing <code>.csv</code> or "
-"<code>.ndjson</code> files exported from NeoDB."
+#: users/templates/users/data.html:327
+msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr ""
 
 #: users/templates/users/data.html:330
 #, fuzzy
-#| msgid ""
-#| "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
-#| "target=\"_blank\" rel=\"noopener\">Doufen</a>"
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
-"imported here."
-msgstr ""
-"Vælg <code>.xlsx</code> eksporteret fra <a href=\"https://doufen.org\" "
-"target=\"_blank\" rel=\"noopener\">Doufen</a>"
+#| msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is imported here."
+msgstr "Vælg <code>.xlsx</code> eksporteret fra <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 
-#: users/templates/users/data.html:314
+#: users/templates/users/data.html:332
 #, fuzzy
 #| msgid "Existing metadata might get overwritten, sure to proceed?"
 msgid "Existing data may be overwritten."
 msgstr "Eksisterende metadata kan blive overskrevet, sikker på at fortsætte?"
 
-#: users/templates/users/data.html:324
+#: users/templates/users/data.html:342
 msgid "Detected format"
 msgstr ""
 
-#: users/templates/users/data.html:385
+#: users/templates/users/data.html:403
 msgid "Detecting format..."
 msgstr ""
 
-#: users/templates/users/data.html:411
+#: users/templates/users/data.html:429
 #, fuzzy
 #| msgid "Unknown or Other"
 msgid "Unknown format"
 msgstr "Ukendt eller andet"
 
-#: users/templates/users/data.html:436
+#: users/templates/users/data.html:454
 #, fuzzy
 #| msgid "Error connecting to instance"
 msgid "Error detecting format"
 msgstr "Fejl ved forbindelse til instans"
 
-#: users/templates/users/data.html:460
+#: users/templates/users/data.html:478
 msgid "Export NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:464
+#: users/templates/users/data.html:482
 #, fuzzy
 #| msgid "Export marks and reviews"
 msgid "Export marks, reviews and notes in CSV"
 msgstr "Eksporter markeringer og anmeldelser"
 
-#: users/templates/users/data.html:471
+#: users/templates/users/data.html:489
 msgid "Export everything in NDJSON"
 msgstr ""
-
-#: users/templates/users/data.html:479
-#, fuzzy
-#| msgid "Export marks and reviews"
-msgid "Export marks and reviews in XLSX (Doufen format)"
-msgstr "Eksporter markeringer og anmeldelser"
-
-#: users/templates/users/data.html:482
-#, fuzzy
-#| msgid "export"
-msgid "Last export"
-msgstr "eksport"
-
-#: users/templates/users/data.html:487
-msgid "Download"
-msgstr "Download"
 
 #: users/templates/users/data.html:496
 msgid "Import and Export Articles (WordPress)"
 msgstr ""
 
 #: users/templates/users/data.html:499
-msgid ""
-"Your articles are exchanged as WordPress posts in the WXR format, which "
-"WordPress and most blogging tools can read and write. Marks, reviews and "
-"notes are not included: use the NeoDB archive above for those."
+msgid "Your articles are exchanged as WordPress posts in the WXR format, which WordPress and most blogging tools can read and write. Marks, reviews and notes are not included: use the NeoDB archive above for those."
 msgstr ""
 
 #: users/templates/users/data.html:502
-msgid ""
-"Article title, body, excerpt, tags, dates and featured image are exchanged. "
-"Comments and custom fields are ignored."
+msgid "Article title, body, excerpt, tags, dates and featured image are exchanged. Comments and custom fields are ignored."
 msgstr ""
 
 #: users/templates/users/data.html:505
-msgid ""
-"The body is converted between Markdown and HTML, so formatting is kept but "
-"the text is not character-for-character identical."
+msgid "The body is converted between Markdown and HTML, so formatting is kept but the text is not character-for-character identical."
 msgstr ""
 
 #: users/templates/users/data.html:512
@@ -8956,16 +8750,11 @@ msgid "Export articles in WordPress format"
 msgstr "Eksporter markeringer og anmeldelser"
 
 #: users/templates/users/data.html:519
-msgid ""
-"In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download "
-"an <code>.xml</code> file, then upload it below."
+msgid "In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download an <code>.xml</code> file, then upload it below."
 msgstr ""
 
 #: users/templates/users/data.html:522
-msgid ""
-"Only published posts use the visibility below. Drafts, pending, private and "
-"password-protected posts are always imported as mentioned-only, so nothing "
-"unpublished becomes public."
+msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
 #: users/templates/users/data.html:560
@@ -8973,12 +8762,8 @@ msgid "View Annual Summary"
 msgstr "Vis Årlig Sammenfatning"
 
 #: users/templates/users/fetch_identity_failed.html:4
-msgid ""
-"Unable to find the user, please check your spelling; or the server may be "
-"busy, please try again later."
-msgstr ""
-"Kan ikke finde brugeren, tjek venligst din stavning; ellers kan serveren "
-"være optaget, prøv igen senere."
+msgid "Unable to find the user, please check your spelling; or the server may be busy, please try again later."
+msgstr "Kan ikke finde brugeren, tjek venligst din stavning; ellers kan serveren være optaget, prøv igen senere."
 
 #: users/templates/users/fetch_identity_pending.html:13
 #: users/templates/users/fetch_identity_pending.html:22
@@ -8997,114 +8782,78 @@ msgstr "Log ind"
 msgid "logo"
 msgstr ""
 
-#: users/templates/users/login.html:127
-msgid ""
-"Sign in with a passkey saved on this device or in your password manager."
+#: users/templates/users/login.html:121
+msgid "Sign in with a passkey saved on this device or in your password manager."
 msgstr ""
 
-#: users/templates/users/login.html:132
+#: users/templates/users/login.html:126
 msgid "Sign in with Passkey"
 msgstr ""
 
-#: users/templates/users/login.html:148
+#: users/templates/users/login.html:142
 msgid "Enter your email address"
 msgstr "Indtast din e-mailadresse"
 
-#: users/templates/users/login.html:152
+#: users/templates/users/login.html:146
 msgid "Send verification code"
 msgstr "Send bekræftelseskode"
 
-#: users/templates/users/login.html:171
+#: users/templates/users/login.html:165
 msgid "Domain of your instance, e.g. mastodon.social"
 msgstr "Domæne for din instans, fx mastodon.social"
 
-#: users/templates/users/login.html:177
-msgid ""
-"Please enter domain of your instance; e.g. if your id is "
-"<i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
-msgstr ""
-"Angiv venligst domæne for din instans; f.eks. hvis dit id er "
-"<i>@neodb@mastodon.social</i>, indtast kun <i>mastodon.social</i>."
+#: users/templates/users/login.html:171
+msgid "Please enter domain of your instance; e.g. if your id is <i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
+msgstr "Angiv venligst domæne for din instans; f.eks. hvis dit id er <i>@neodb@mastodon.social</i>, indtast kun <i>mastodon.social</i>."
 
-#: users/templates/users/login.html:182 users/templates/users/login.html:246
+#: users/templates/users/login.html:176 users/templates/users/login.html:240
 msgid "Authorize via Fediverse instance"
 msgstr "Godkend via Fødivers-instans"
 
-#: users/templates/users/login.html:187
-msgid ""
-"If you don't have a <a href=\"https://joinmastodon.org/servers\" "
-"target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or "
-"login with Email first, and link it with Fediverse (Mastodon) later in "
-"account settings."
-msgstr ""
-"Hvis du endnu ikke har en <a href=\"https://joinmastodon.org/servers\" "
-"target=\"_blank\">Fødivers (Mastodon) konto</a> kan du først registrere dig "
-"eller logge ind med email først og knytte kontoen til Fødiverset (Mastodon) "
-"senere i kontoindstillinger."
+#: users/templates/users/login.html:181
+msgid "If you don't have a <a href=\"https://joinmastodon.org/servers\" target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or login with Email first, and link it with Fediverse (Mastodon) later in account settings."
+msgstr "Hvis du endnu ikke har en <a href=\"https://joinmastodon.org/servers\" target=\"_blank\">Fødivers (Mastodon) konto</a> kan du først registrere dig eller logge ind med email først og knytte kontoen til Fødiverset (Mastodon) senere i kontoindstillinger."
 
-#: users/templates/users/login.html:200
+#: users/templates/users/login.html:194
 msgid "Authorize via Threads"
 msgstr "Godkend via Threads"
 
-#: users/templates/users/login.html:221
-msgid ""
-"Please input your ATProto handle (e.g. neodb.bsky.social, without the "
-"leading @), do not use email. If you changed handle recently, just use the "
-"latest one."
-msgstr ""
-"Indtast venligst dit ATProto kontonavn (f.eks. neodb.bsky.social, uden "
-"foranstillet @), brug ikke e-mail. Hvis du har ændret kontonavn for nylig, "
-"brug blot den seneste."
+#: users/templates/users/login.html:215
+msgid "Please input your ATProto handle (e.g. neodb.bsky.social, without the leading @), do not use email. If you changed handle recently, just use the latest one."
+msgstr "Indtast venligst dit ATProto kontonavn (f.eks. neodb.bsky.social, uden foranstillet @), brug ikke e-mail. Hvis du har ændret kontonavn for nylig, brug blot den seneste."
 
-#: users/templates/users/login.html:224
+#: users/templates/users/login.html:218
 #, fuzzy
 #| msgid "Authorize via Threads"
 msgid "Authorize via ATProto server"
 msgstr "Godkend via Threads"
 
-#: users/templates/users/login.html:231
+#: users/templates/users/login.html:225
 #, python-format
-msgid ""
-"Please choose one to register or login %(site_name)s. Have more than one of "
-"these identities? Don't worry, you may link them in account settings once "
-"logged in."
-msgstr ""
-"Vælg venligst en til at tilmelde dig eller logge ind på %(site_name)s. Har "
-"du flere end en af disse identiteter? Bare rolig, du kan linke dem i "
-"kontoindstillinger, når du er logget ind."
+msgid "Please choose one to register or login %(site_name)s. Have more than one of these identities? Don't worry, you may link them in account settings once logged in."
+msgstr "Vælg venligst en til at tilmelde dig eller logge ind på %(site_name)s. Har du flere end en af disse identiteter? Bare rolig, du kan linke dem i kontoindstillinger, når du er logget ind."
 
-#: users/templates/users/login.html:255
+#: users/templates/users/login.html:249
 msgid "Valid invitation code, please login or register."
 msgstr "Gyldig invitationskode, log venligst ind eller tilmeld dig."
 
-#: users/templates/users/login.html:257
-msgid ""
-"Please use invitation link to register a new account; existing user may "
-"login."
-msgstr ""
-"Brug invitationslinket til at registrere en ny konto; eksisterende brugere "
-"kan logge ind."
+#: users/templates/users/login.html:251
+msgid "Please use invitation link to register a new account; existing user may login."
+msgstr "Brug invitationslinket til at registrere en ny konto; eksisterende brugere kan logge ind."
 
-#: users/templates/users/login.html:259
+#: users/templates/users/login.html:253
 msgid "Invitation code invalid or expired."
 msgstr "Invitationskode ugyldig eller udløbet."
 
-#: users/templates/users/login.html:267
+#: users/templates/users/login.html:261
 msgid "Loading timed out, please check your network (VPN) settings."
 msgstr "Indlæsnings-timeout, tjek venligst dine netværk (VPN) indstillinger."
 
-#: users/templates/users/login.html:273
-msgid ""
-"Continue using this site implies consent to our <a href=\"/pages/rules/"
-"\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using "
-"cookies to provide necessary functionality."
-msgstr ""
-"Når du fortsætter med at bruge dette websted, indebærer det samtykke til "
-"vores <a href=\"/pages/rules/\">regler</a> og <a href=\"/pages/terms/"
-"\">vilkår</a>, herunder brug af cookies for at levere den nødvendige "
-"funktionalitet."
+#: users/templates/users/login.html:267
+msgid "Continue using this site implies consent to our <a href=\"/pages/rules/\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using cookies to provide necessary functionality."
+msgstr "Når du fortsætter med at bruge dette websted, indebærer det samtykke til vores <a href=\"/pages/rules/\">regler</a> og <a href=\"/pages/terms/\">vilkår</a>, herunder brug af cookies for at levere den nødvendige funktionalitet."
 
-#: users/templates/users/login.html:287
+#: users/templates/users/login.html:281
 msgid "Domain of your instance (excl. @)"
 msgstr "Domæne for din instans (uden @)"
 
@@ -9114,9 +8863,7 @@ msgid "Migrate Here"
 msgstr ""
 
 #: users/templates/users/migrate_in.html:22
-msgid ""
-"To move another account to this one, first add it as an alias here, and then "
-"go to the server where it is hosted and initiate the move."
+msgid "To move another account to this one, first add it as an alias here, and then go to the server where it is hosted and initiate the move."
 msgstr ""
 
 #: users/templates/users/migrate_in.html:27
@@ -9172,16 +8919,11 @@ msgstr ""
 
 #: users/templates/users/migrate_out.html:46
 #, python-format
-msgid ""
-"To migrate to another account, first add <code>@%(handle)s</code> as an "
-"alias on the target server, and then type the target account below to start "
-"the migration."
+msgid "To migrate to another account, first add <code>@%(handle)s</code> as an alias on the target server, and then type the target account below to start the migration."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:50
-msgid ""
-"Are you sure you want to migrate your account? Your followers will be moved "
-"to the target account."
+msgid "Are you sure you want to migrate your account? Your followers will be moved to the target account."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:53
@@ -9199,10 +8941,6 @@ msgstr "begynd at læse"
 #: users/templates/users/preferences.html:28
 msgid "Default view once logged in"
 msgstr "Standard visning, når du er logget ind"
-
-#: users/templates/users/preferences.html:40
-msgid "Activities"
-msgstr "Aktiviteter"
 
 #: users/templates/users/preferences.html:49
 msgid "Default visibility"
@@ -9231,9 +8969,7 @@ msgstr "Slå krydspostning til andre sociale netværk til som standard"
 
 #: users/templates/users/preferences.html:111
 #: users/templates/users/register.html:88
-msgid ""
-"If a Mastodon account is linked with this identity, boosting a post will "
-"also make the same post boosted with that Mastodon account."
+msgid "If a Mastodon account is linked with this identity, boosting a post will also make the same post boosted with that Mastodon account."
 msgstr ""
 
 #: users/templates/users/preferences.html:115
@@ -9249,18 +8985,12 @@ msgid "Create a new post"
 msgstr "Opret nyt indlæg"
 
 #: users/templates/users/preferences.html:130
-msgid ""
-"this method is less optimal, may generate duplicated posts and miss "
-"reactions."
-msgstr ""
-"denne metode er mindre optimal, kan forårsage dubletter og du kan gå glip af "
-"reaktioner."
+msgid "this method is less optimal, may generate duplicated posts and miss reactions."
+msgstr "denne metode er mindre optimal, kan forårsage dubletter og du kan gå glip af reaktioner."
 
 #: users/templates/users/preferences.html:140
 #: users/templates/users/register.html:97
-msgid ""
-"Always publish my public marks, reviews and articles as data records to my "
-"PDS."
+msgid "Always publish my public marks, reviews and articles as data records to my PDS."
 msgstr ""
 
 #: users/templates/users/preferences.html:145
@@ -9280,18 +9010,8 @@ msgid "Automatic bookmark for these categories"
 msgstr "Automatisk bogmærke for disse kategorier"
 
 #: users/templates/users/preferences.html:175
-msgid ""
-"When start to read/watch/play/... an item in these categories, a bookmark "
-"will be created automatically. Bookmarks can be viewed and managed in most "
-"<a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon "
-"compatible apps</a>; your replies to these posts will automatically become "
-"notes for the item."
-msgstr ""
-"Når du begynder at læse/se/spille/... et element i disse kategorier, "
-"oprettes et bogmærke automatisk. Bogmærker kan ses og administreres i de "
-"fleste <a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon-"
-"kompatible apps</a>; dine svar på disse indlæg vil automatisk blive noter "
-"til elementet."
+msgid "When start to read/watch/play/... an item in these categories, a bookmark will be created automatically. Bookmarks can be viewed and managed in most <a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon compatible apps</a>; your replies to these posts will automatically become notes for the item."
+msgstr "Når du begynder at læse/se/spille/... et element i disse kategorier, oprettes et bogmærke automatisk. Bogmærker kan ses og administreres i de fleste <a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon-kompatible apps</a>; dine svar på disse indlæg vil automatisk blive noter til elementet."
 
 #: users/templates/users/preferences.html:183
 msgid "Turn replies to my own catalog item posts into notes for the item"
@@ -9310,12 +9030,8 @@ msgid "Profile visible to anonymous web visitors and search engines"
 msgstr "Profil synlig for anonyme besøgende på nettet og søgemaskiner"
 
 #: users/templates/users/preferences.html:217
-msgid ""
-"this option limits web visits only; to limit fediverse visibility, choose "
-"followers only or mentioned only when posting"
-msgstr ""
-"denne indstilling begrænser kun webbesøg; for at begrænse synlighed på "
-"fødiverset, skal du kun vælge \"kun følgere\" eller \"kun nævnte brugere\""
+msgid "this option limits web visits only; to limit fediverse visibility, choose followers only or mentioned only when posting"
+msgstr "denne indstilling begrænser kun webbesøg; for at begrænse synlighed på fødiverset, skal du kun vælge \"kun følgere\" eller \"kun nævnte brugere\""
 
 #: users/templates/users/preferences.html:225
 msgid "Show your name on item page if you recently edited it"
@@ -9326,17 +9042,7 @@ msgid "Do not show me item recommendations"
 msgstr ""
 
 #: users/templates/users/preferences.html:237
-msgid ""
-"Recommendations are generated only from public marks, processed in batch on "
-"this server. Your private and follower-only marks are never used as a signal "
-"for anyone, and we never share your data with third parties for this "
-"feature. When you share marks publicly and keep your profile discoverable, "
-"your marks help others here and across the Fediverse find things they might "
-"enjoy -- that voluntary contribution is what makes the feature work for "
-"everyone. If you'd rather not contribute, uncheck \"Include profile, marks "
-"and posts in discovery\" on your account page; this setting is published "
-"over ActivityPub, so other servers will also stop including you in their "
-"discovery features."
+msgid "Recommendations are generated only from public marks, processed in batch on this server. Your private and follower-only marks are never used as a signal for anyone, and we never share your data with third parties for this feature. When you share marks publicly and keep your profile discoverable, your marks help others here and across the Fediverse find things they might enjoy -- that voluntary contribution is what makes the feature work for everyone. If you'd rather not contribute, uncheck \"Include profile, marks and posts in discovery\" on your account page; this setting is published over ActivityPub, so other servers will also stop including you in their discovery features."
 msgstr ""
 
 #: users/templates/users/profile_actions.html:12
@@ -9434,29 +9140,15 @@ msgstr "Dit brugernavn på %(site_name)s"
 
 #: users/templates/users/register.html:28
 msgid "2-30 alphabets, numbers or underscore, can't be changed once saved"
-msgstr ""
-"2-30 bogstaver, tal eller understregning, kan ikke ændres når først det er "
-"gemt"
+msgstr "2-30 bogstaver, tal eller understregning, kan ikke ændres når først det er gemt"
 
 #: users/templates/users/register.html:72
-msgid ""
-"Use display name, bio and avatar from the social network you authenticated "
-"with"
-msgstr ""
-"Brug visningsnavn, biografi og avatar fra det sociale netværk, du godkendte "
-"med"
+msgid "Use display name, bio and avatar from the social network you authenticated with"
+msgstr "Brug visningsnavn, biografi og avatar fra det sociale netværk, du godkendte med"
 
 #: users/templates/users/register.html:80
-msgid ""
-"Add follow, mute and block list from the social network you authenticated "
-"with"
-msgstr ""
-"Tilføj følgere, dæmpninger og blokeringer fra det sociale netværk, du "
-"godkendte med"
-
-#: users/templates/users/register.html:104
-msgid "Confirm and save"
-msgstr "Bekræft og gem"
+msgid "Add follow, mute and block list from the social network you authenticated with"
+msgstr "Tilføj følgere, dæmpninger og blokeringer fra det sociale netværk, du godkendte med"
 
 #: users/templates/users/register.html:106
 msgid "Close"
@@ -9484,8 +9176,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"              Matched %(local)s locally, %(external)s externally, "
-"%(unmatched)s unmatched out of %(total)s rows.\n"
+"              Matched %(local)s locally, %(external)s externally, %(unmatched)s unmatched out of %(total)s rows.\n"
 "            "
 msgstr ""
 
@@ -9620,9 +9311,7 @@ msgid "Played"
 msgstr "spillede"
 
 #: users/templates/users/steam_import.html:90
-msgid ""
-"Games in wishlist; or purchased in library but never played, mark date will "
-"be set as today"
+msgid "Games in wishlist; or purchased in library but never played, mark date will be set as today"
 msgstr ""
 
 #: users/templates/users/steam_import.html:91
@@ -9666,15 +9355,11 @@ msgid "Comma-separated Steam AppIDs"
 msgstr ""
 
 #: users/templates/users/steam_import.html:121
-msgid ""
-"Allow reverse override of status (e.g. playing -> want to, or played -> "
-"playing)"
+msgid "Allow reverse override of status (e.g. playing -> want to, or played -> playing)"
 msgstr ""
 
 #: users/templates/users/steam_import.html:139
-msgid ""
-"To import from Steam, your game details must be visible to public in Steam "
-"privacy settings."
+msgid "To import from Steam, your game details must be visible to public in Steam privacy settings."
 msgstr ""
 
 #: users/templates/users/storygraph_import.html:9
@@ -9694,13 +9379,9 @@ msgstr "Mislykket"
 
 #: users/templates/users/user_task_status.html:33
 #, fuzzy
-#| msgid ""
-#| "Failed links, likely due to Letterboxd error, you may have to mark them "
-#| "manually"
+#| msgid "Failed links, likely due to Letterboxd error, you may have to mark them manually"
 msgid "Failed links, you may have to mark them manually"
-msgstr ""
-"Mislykkede links, sandsynligvis på grund af Letterboxd fejl, skal du "
-"muligvis markere dem manuelt"
+msgstr "Mislykkede links, sandsynligvis på grund af Letterboxd fejl, skal du muligvis markere dem manuelt"
 
 #: users/templates/users/verify.html:22
 msgid "Please enter the verification code you received."
@@ -9731,37 +9412,23 @@ msgstr "Velkommen"
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
-#| "              %(site_name)s is flourishing because of collaborations and "
-#| "contributions from users like you. Please read our <a href=\"/pages/"
-#| "terms\">term of service</a>, and feel free to <a "
-#| "href=\"%(support_link)s\">contact us</a> if you have any question or "
-#| "feedback.\n"
+#| "              %(site_name)s is flourishing because of collaborations and contributions from users like you. Please read our <a href=\"/pages/terms\">term of service</a>, and feel free to <a href=\"%(support_link)s\">contact us</a> if you have any question or feedback.\n"
 #| "        "
 msgid ""
 "\n"
-"              %(site_name)s is flourishing because of collaborations and "
-"contributions from users like you. Please read our <a href=\"/pages/"
-"rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</"
-"a> if you have any question or feedback.\n"
+"              %(site_name)s is flourishing because of collaborations and contributions from users like you. Please read our <a href=\"/pages/rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</a> if you have any question or feedback.\n"
 "        "
 msgstr ""
 "\n"
-"              %(site_name)s blomstrer på grund af samarbejde og bidrag fra "
-"brugere som dig. Læs venligst vores <a href=\"/pages/terms\">servicevilkår</"
-"a>, og <a href=\"%(support_link)s\">kontakt os</a> endelig hvis du har "
-"spørgsmål eller feedback.\n"
+"              %(site_name)s blomstrer på grund af samarbejde og bidrag fra brugere som dig. Læs venligst vores <a href=\"/pages/terms\">servicevilkår</a>, og <a href=\"%(support_link)s\">kontakt os</a> endelig hvis du har spørgsmål eller feedback.\n"
 "        "
 
 #: users/templates/users/welcome.html:37
-msgid ""
-"Set up a passkey to sign in quickly next time using your fingerprint, face, "
-"or screen lock."
+msgid "Set up a passkey to sign in quickly next time using your fingerprint, face, or screen lock."
 msgstr ""
 
 #: users/templates/users/welcome.html:39
-msgid ""
-"Creating a passkey is highly recommended, as the website or email you use to "
-"create this account may not be always available."
+msgid "Creating a passkey is highly recommended, as the website or email you use to create this account may not be always available."
 msgstr ""
 
 #: users/templates/users/welcome.html:43
@@ -9778,340 +9445,244 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:124
+#: users/views/account.py:126
 msgid "This username is already in use."
 msgstr "Dette brugernavn er allerede i brug."
 
-#: users/views/account.py:135
+#: users/views/account.py:137
 msgid "This email address is already in use."
 msgstr "Denne e-mailadresse er allerede i brug."
 
-#: users/views/account.py:255 users/views/account.py:374
+#: users/views/account.py:257 users/views/account.py:376
 msgid "Registration is for invitation only"
 msgstr "Tilmelding er kun for inviterede"
 
-#: users/views/account.py:266 users/views/account.py:338
+#: users/views/account.py:268 users/views/account.py:340
 #, fuzzy
 #| msgid "Timestamp"
 msgid "Time is up"
 msgstr "Tidsmærke"
 
-#: users/views/account.py:267 users/views/account.py:310
-#: users/views/account.py:339
+#: users/views/account.py:269 users/views/account.py:312
+#: users/views/account.py:341
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:313
+#: users/views/account.py:315
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:325
+#: users/views/account.py:327
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:326
+#: users/views/account.py:328
 #, fuzzy
 #| msgid "System busy, please try again in a minute."
 msgid "Please try again later."
 msgstr "System er optaget, prøv venligst igen om et øjeblik."
 
-#: users/views/account.py:415
+#: users/views/account.py:417
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:445
+#: users/views/account.py:447
 msgid "Valid username required"
 msgstr "Gyldigt brugernavn kræves"
 
-#: users/views/account.py:526
+#: users/views/account.py:518
 msgid "Account is being deleted."
 msgstr "Kontoen bliver slettet."
 
-#: users/views/account.py:529
+#: users/views/account.py:521
 msgid "Account mismatch."
 msgstr "Konto matcher ikke."
 
-#: users/views/data.py:262 users/views/data.py:294
+#: users/views/data.py:264 users/views/data.py:296
 msgid "Export file not available."
 msgstr ""
 
-#: users/views/data.py:288
+#: users/views/data.py:290
 msgid "Generating exports."
 msgstr "Genererer eksport."
 
-#: users/views/data.py:306
+#: users/views/data.py:308
 msgid "Export file expired. Please export again."
 msgstr "Eksport fil udløbet. Eksporter venligst igen."
 
-#: users/views/data.py:321 users/views/data.py:342 users/views/data.py:363
+#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
 #, fuzzy
 #| msgid "Export in progress"
 msgid "Recent export still in progress."
 msgstr "Eksport er i gang"
 
-#: users/views/data.py:379 users/views/data.py:513 users/views/data.py:547
-#: users/views/data.py:772 users/views/data.py:989 users/views/data.py:1015
-#: users/views/data.py:1040 users/views/data.py:1065
+#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
+#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
+#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
 msgid "Invalid file."
 msgstr "Ugyldig fil."
 
-#: users/views/data.py:403
+#: users/views/data.py:405
 msgid "Sync in progress."
 msgstr "Synkronisering i gang."
 
-#: users/views/data.py:417
+#: users/views/data.py:419
 msgid "Settings saved."
 msgstr "Indstillinger gemt."
 
-#: users/views/data.py:472
+#: users/views/data.py:474
 #, fuzzy
 #| msgid "Account is being deleted."
 msgid "Account no longer linked."
 msgstr "Kontoen bliver slettet."
 
-#: users/views/data.py:475
+#: users/views/data.py:477
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:503
+#: users/views/data.py:505
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:583 users/views/data.py:808
+#: users/views/data.py:585 users/views/data.py:810
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:608 users/views/data.py:837
+#: users/views/data.py:610 users/views/data.py:839
 #, fuzzy
 #| msgid "Cancel"
 msgid "Cancelled."
 msgstr "Annuller"
 
-#: users/views/data.py:628
+#: users/views/data.py:630
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:636 users/views/data.py:746 users/views/data.py:867
-#: users/views/data.py:972
+#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
+#: users/views/data.py:974
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:732 users/views/data.py:958
+#: users/views/data.py:734 users/views/data.py:960
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:742 users/views/data.py:968
+#: users/views/data.py:744 users/views/data.py:970
 msgid "No matched file available."
 msgstr ""
 
-#: users/views/data.py:859
+#: users/views/data.py:861
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1188
+#: users/views/data.py:1226
 #, fuzzy
 #| msgid "Login required"
 msgid "Name is required."
 msgstr "Login påkrævet"
 
-#: users/views/data.py:1210
+#: users/views/data.py:1248
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1264
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1231
+#: users/views/data.py:1269
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1241 users/views/data.py:1292
+#: users/views/data.py:1279 users/views/data.py:1330
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:1248
+#: users/views/data.py:1286
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:1253
+#: users/views/data.py:1291
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:1279
+#: users/views/data.py:1317
 #, fuzzy
 #| msgid "Registration failed"
 msgid "Migration cancelled."
 msgstr "Registrering mislykkedes"
 
-#: users/views/data.py:1284
+#: users/views/data.py:1322
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:1297
+#: users/views/data.py:1335
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:1308
+#: users/views/data.py:1346
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:1314
+#: users/views/data.py:1352
 #, fuzzy, python-brace-format
 #| msgid "Continue login as {handle}."
 msgid "Start moving to {handle}."
 msgstr "Fortsæt login som {handle}."
 
-#: users/views/data.py:1372
+#: users/views/data.py:1410
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1388
+#: users/views/data.py:1426
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1392
+#: users/views/data.py:1430
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1402
+#: users/views/data.py:1440
 #, python-brace-format
-msgid ""
-"Import of {count} entries received. They will be processed in the background."
+msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""
 
-#: users/views/webauthn.py:103
+#: users/views/webauthn.py:106
 #, fuzzy
 #| msgid "Registration failed"
 msgid "Passkey registration failed"
 msgstr "Registrering mislykkedes"
 
-#: users/views/webauthn.py:123
+#: users/views/webauthn.py:126
 msgid "Credential already registered"
 msgstr ""
 
-#: users/views/webauthn.py:165 users/views/webauthn.py:172
-#: users/views/webauthn.py:181
+#: users/views/webauthn.py:168 users/views/webauthn.py:175
+#: users/views/webauthn.py:184
 msgid "Passkey not recognized"
 msgstr ""
 
-#: users/views/webauthn.py:186
+#: users/views/webauthn.py:189
 #, fuzzy
 #| msgid "Account is being deleted."
 msgid "Account is inactive"
 msgstr "Kontoen bliver slettet."
 
-#: users/views/webauthn.py:202
+#: users/views/webauthn.py:205
 #, fuzzy
 #| msgid "Send verification code"
 msgid "Passkey verification failed"
 msgstr "Send bekræftelseskode"
 
-#: users/views/webauthn.py:228 users/views/webauthn.py:250
+#: users/views/webauthn.py:231 users/views/webauthn.py:253
 #, fuzzy
 #| msgid "User not found"
 msgid "Passkey not found"
 msgstr "Bruger ikke fundet"
 
-#: users/views/webauthn.py:244
+#: users/views/webauthn.py:247
 #, fuzzy
 #| msgid "Login required"
 msgid "Name is required"
 msgstr "Login påkrævet"
-
-#~ msgid "Fanfic"
-#~ msgstr "Fanfic"
-
-#~ msgid "FanFic"
-#~ msgstr "FanFic"
-
-#~ msgid "year of publication"
-#~ msgstr "udgivelsesår"
-
-#~ msgid "YYYY-MM-DD"
-#~ msgstr "ÅÅÅÅ-MM-DD"
-
-#~ msgid "region or event"
-#~ msgstr "område eller begivenhed"
-
-#~ msgid "Germany or Toronto International Film Festival"
-#~ msgstr "Tyskland eller Toronto International Film Festival"
-
-#~ msgid "year"
-#~ msgstr "år"
-
-#~ msgctxt "music"
-#~ msgid "genre"
-#~ msgstr "genre"
-
-#~ msgid "my notes"
-#~ msgstr "mine noter"
-
-#~ msgid "release year"
-#~ msgstr "udgivelsesår"
-
-#~ msgid "episode Length"
-#~ msgstr "længde på afsnit"
-
-#~ msgid "show time"
-#~ msgstr "visningstidspunkt"
-
-#~ msgid "Region or Event"
-#~ msgstr "Område eller begivenhed"
-
-#~ msgid "Everything"
-#~ msgstr "Alt"
-
-#~ msgid "boost"
-#~ msgstr "boost"
-
-#~ msgid "Invalid form data"
-#~ msgstr "Ugyldige formulardata"
-
-#~ msgid "Username and app password is required."
-#~ msgstr "Brugernavn og app adgangskode er påkrævet."
-
-#~ msgid "All"
-#~ msgstr "Alle"
-
-#~ msgid "Bluesky app password"
-#~ msgstr "Bluesky app adgangskode"
-
-#~ msgid ""
-#~ "App password can be created on <a href=\"https://bsky.app/settings/app-"
-#~ "passwords\" target=\"_blank\">bsky.app</a>."
-#~ msgstr ""
-#~ "App-adgangskode kan oprettes på <a href=\"https://bsky.app/settings/app-"
-#~ "passwords\" target=\"_blank\">bsky.app</a>."
-
-#~ msgid "Link to Goodreads Profile / Shelf / List"
-#~ msgstr "Link til Goodreads Profil / Hylde / Liste"
-
-#~ msgid "Shelf will be imported as a new collection."
-#~ msgstr "Hylden vil blive importeret som en ny samling."
-
-#~ msgid "List will be imported as a new collection."
-#~ msgstr "Listen vil blive importeret som en ny samling."
-
-#~ msgid "Last import started"
-#~ msgstr "Seneste import startet"
-
-#~ msgid "Export Data"
-#~ msgstr "Eksporter data"
-
-#~ msgid "back to your home page."
-#~ msgstr "tilbage til din forside."
-
-#~ msgid "Turn on crosspost to timeline by default"
-#~ msgstr "Slå krydspost til tidslinje til som standard"
-
-#~ msgid "Username in use"
-#~ msgstr "Brugernavn i brug"
-
-#~ msgid "Invalid URL."
-#~ msgstr "Ugyldig URL."
-
-#~ msgid "File is uploaded and will be imported soon."
-#~ msgstr "Filen er uploadet og vil blive importeret snart."

--- a/neodb/locale/de/LC_MESSAGES/django.po
+++ b/neodb/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-23 15:40-0400\n"
+"POT-Creation-Date: 2026-09-06 20:04-0400\n"
 "PO-Revision-Date: 2026-08-09 06:31+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/neodb/neodb/de/>\n"
@@ -18,161 +18,161 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: boofilsic/settings.py:472 common/models/lang.py:230
+#: boofilsic/settings.py:501 common/models/lang.py:232
 msgid "English"
 msgstr "Englisch"
 
-#: boofilsic/settings.py:473 common/models/lang.py:77
+#: boofilsic/settings.py:502 common/models/lang.py:79
 msgid "Danish"
 msgstr "Dänisch"
 
-#: boofilsic/settings.py:474 common/models/lang.py:78
+#: boofilsic/settings.py:503 common/models/lang.py:80
 msgid "German"
 msgstr "Deutsch"
 
-#: boofilsic/settings.py:475 common/models/lang.py:183
+#: boofilsic/settings.py:504 common/models/lang.py:185
 msgid "Spanish"
 msgstr "Spanisch"
 
-#: boofilsic/settings.py:476 common/models/lang.py:87
+#: boofilsic/settings.py:505 common/models/lang.py:89
 msgid "French"
 msgstr "Französisch"
 
-#: boofilsic/settings.py:477 common/models/lang.py:112
+#: boofilsic/settings.py:506 common/models/lang.py:114
 msgid "Italian"
 msgstr "Italienisch"
 
-#: boofilsic/settings.py:478 common/models/lang.py:166
-#: common/models/lang.py:305
+#: boofilsic/settings.py:507 common/models/lang.py:168
+#: common/models/lang.py:307
 msgid "Portuguese"
 msgstr "Portugiesisch"
 
-#: boofilsic/settings.py:479
+#: boofilsic/settings.py:508
 #, fuzzy
 #| msgid "Portuguese"
 msgid "Brazilian Portuguese"
 msgstr "Portugiesisch"
 
-#: boofilsic/settings.py:480 common/models/lang.py:316
+#: boofilsic/settings.py:509 common/models/lang.py:318
 msgid "Simplified Chinese"
 msgstr "Chinesisch (vereinfacht)"
 
-#: boofilsic/settings.py:481 common/models/lang.py:317
+#: boofilsic/settings.py:510 common/models/lang.py:319
 msgid "Traditional Chinese"
 msgstr "Chinesisch (traditionell)"
 
-#: catalog/forms.py:35 catalog/models/item.py:291
+#: catalog/forms.py:35 catalog/models/item.py:307
 msgid "Primary ID Type"
 msgstr "primärer ID Typ"
 
-#: catalog/forms.py:40 catalog/models/item.py:294
+#: catalog/forms.py:40 catalog/models/item.py:310
 msgid "Primary ID Value"
 msgstr "primärer ID Wert"
 
-#: catalog/forms.py:181
+#: catalog/forms.py:176
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
-#: catalog/models/book.py:139 catalog/models/book.py:158
-#: catalog/models/common.py:280 catalog/models/common.py:298
+#: catalog/models/book.py:141 catalog/models/book.py:160
+#: catalog/models/common.py:279 catalog/models/common.py:297
 msgid "locale"
 msgstr "Gebietsschema"
 
-#: catalog/models/book.py:142 catalog/models/book.py:161
-#: catalog/models/common.py:283 catalog/models/common.py:303
+#: catalog/models/book.py:144 catalog/models/book.py:163
+#: catalog/models/common.py:282 catalog/models/common.py:302
 msgid "text content"
 msgstr "Textinhalt"
 
-#: catalog/models/book.py:177
+#: catalog/models/book.py:179
 msgid "Paperback"
 msgstr "Taschenbuch"
 
-#: catalog/models/book.py:178
+#: catalog/models/book.py:180
 msgid "Hardcover"
 msgstr "Hardcover"
 
-#: catalog/models/book.py:179
+#: catalog/models/book.py:181
 msgid "eBook"
 msgstr "eBook"
 
-#: catalog/models/book.py:180
+#: catalog/models/book.py:182
 msgid "Audiobook"
 msgstr "Hörbuch"
 
-#: catalog/models/book.py:182
+#: catalog/models/book.py:184
 msgid "Web Fiction"
 msgstr "Web Fiction"
 
-#: catalog/models/book.py:183 catalog/models/game.py:38
+#: catalog/models/book.py:185 catalog/models/game.py:38
 msgid "Other"
 msgstr "Sonstiges"
 
-#: catalog/models/book.py:260
+#: catalog/models/book.py:262
 msgid "subtitle"
 msgstr "Untertitel"
 
-#: catalog/models/book.py:270 catalog/models/movie.py:120
-#: catalog/models/performance.py:385 catalog/models/tv.py:211
-#: catalog/models/tv.py:437
+#: catalog/models/book.py:272 catalog/models/movie.py:120
+#: catalog/models/performance.py:385 catalog/models/tv.py:213
+#: catalog/models/tv.py:439
 msgid "original title"
 msgstr "Originaltitel"
 
-#: catalog/models/book.py:274
+#: catalog/models/book.py:276
 msgid "other title"
 msgstr "anderer Titel"
 
-#: catalog/models/book.py:280 catalog/models/book.py:564
-#: catalog/models/item.py:123
+#: catalog/models/book.py:282 catalog/models/book.py:566
+#: catalog/models/item.py:119
 msgid "author"
 msgstr "Autor/in"
 
-#: catalog/models/book.py:287 catalog/models/item.py:124
+#: catalog/models/book.py:289 catalog/models/item.py:120
 msgid "translator"
 msgstr "Übersetzer/in"
 
-#: catalog/models/book.py:294 catalog/templates/edition.html:26
+#: catalog/models/book.py:296 catalog/templates/edition.html:26
 msgid "book format"
 msgstr "Buchformat"
 
-#: catalog/models/book.py:301 catalog/models/game.py:135
-#: catalog/models/item.py:138 catalog/models/music.py:142
+#: catalog/models/book.py:303 catalog/models/game.py:135
+#: catalog/models/item.py:134 catalog/models/music.py:142
 msgid "publisher"
 msgstr "Publisher"
 
-#: catalog/models/book.py:308
+#: catalog/models/book.py:310
 msgid "publication year"
 msgstr "Veröffentlichungsjahr"
 
-#: catalog/models/book.py:314
+#: catalog/models/book.py:316
 msgid "publication month"
 msgstr "Veröffentlichungsmonat"
 
-#: catalog/models/book.py:319
+#: catalog/models/book.py:321
 msgid "binding"
 msgstr "Einband"
 
-#: catalog/models/book.py:320
+#: catalog/models/book.py:322
 msgid "pages"
 msgstr "Seiten"
 
-#: catalog/models/book.py:321 catalog/templates/edition.html:45
+#: catalog/models/book.py:323 catalog/templates/edition.html:45
 msgid "series"
 msgstr "Serie"
 
-#: catalog/models/book.py:322 catalog/templates/edition.html:65
+#: catalog/models/book.py:324 catalog/templates/edition.html:65
 msgid "contents"
 msgstr "Inhalt"
 
-#: catalog/models/book.py:323 catalog/templates/edition.html:51
+#: catalog/models/book.py:325 catalog/templates/edition.html:51
 msgid "price"
 msgstr "Preis"
 
-#: catalog/models/book.py:324 catalog/models/item.py:149
+#: catalog/models/book.py:326 catalog/models/item.py:145
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr "Impressum"
 
-#: catalog/models/common.py:26 common/models/lang.py:256
+#: catalog/models/common.py:26 common/models/lang.py:258
 msgid "Unknown"
 msgstr "Unbekannt"
 
@@ -180,11 +180,11 @@ msgstr "Unbekannt"
 msgid "Douban"
 msgstr "Douban"
 
-#: catalog/models/common.py:28 catalog/models/common.py:79
+#: catalog/models/common.py:28 catalog/models/common.py:81
 msgid "Goodreads"
 msgstr "Goodreads"
 
-#: catalog/models/common.py:29 catalog/models/common.py:81
+#: catalog/models/common.py:29 catalog/models/common.py:83
 msgid "Google Books"
 msgstr "Google Books"
 
@@ -192,16 +192,16 @@ msgstr "Google Books"
 msgid "BooksTW"
 msgstr "BooksTW"
 
-#: catalog/models/common.py:31 catalog/models/common.py:91
-#: catalog/models/common.py:93
+#: catalog/models/common.py:31 catalog/models/common.py:93
+#: catalog/models/common.py:95
 msgid "Bibliotek.dk"
 msgstr ""
 
-#: catalog/models/common.py:32 catalog/models/common.py:92
+#: catalog/models/common.py:32 catalog/models/common.py:94
 msgid "eReolen.dk"
 msgstr ""
 
-#: catalog/models/common.py:33 catalog/models/common.py:74
+#: catalog/models/common.py:33 catalog/models/common.py:76
 #: catalog/templates/movie.html:41 catalog/templates/people.html:37
 #: catalog/templates/tvseason.html:58 catalog/templates/tvshow.html:53
 msgid "IMDb"
@@ -211,7 +211,7 @@ msgstr "IMDb"
 msgid "TMDB"
 msgstr "TMDB"
 
-#: catalog/models/common.py:35 catalog/models/common.py:94
+#: catalog/models/common.py:35 catalog/models/common.py:96
 msgid "Bandcamp"
 msgstr "Bandcamp"
 
@@ -227,11 +227,11 @@ msgstr "IGDB"
 msgid "Steam"
 msgstr "Steam"
 
-#: catalog/models/common.py:39 catalog/models/common.py:114
+#: catalog/models/common.py:39 catalog/models/common.py:116
 msgid "itch.io"
 msgstr ""
 
-#: catalog/models/common.py:40 catalog/models/common.py:115
+#: catalog/models/common.py:40 catalog/models/common.py:117
 msgid "Bangumi"
 msgstr "Bangumi"
 
@@ -239,7 +239,7 @@ msgstr "Bangumi"
 msgid "BGG"
 msgstr "BGG"
 
-#: catalog/models/common.py:42 catalog/models/common.py:116
+#: catalog/models/common.py:42 catalog/models/common.py:118
 msgid "Apple Podcast"
 msgstr "Apple Podcast"
 
@@ -251,35 +251,35 @@ msgstr "RSS"
 msgid "Discogs"
 msgstr "Discogs"
 
-#: catalog/models/common.py:45 catalog/models/common.py:117
+#: catalog/models/common.py:45 catalog/models/common.py:119
 msgid "Apple Music"
 msgstr "Apple Music"
 
-#: catalog/models/common.py:46 catalog/models/common.py:119
+#: catalog/models/common.py:46 catalog/models/common.py:121
 msgid "Fediverse"
 msgstr "Fediverse"
 
-#: catalog/models/common.py:47 catalog/models/common.py:120
+#: catalog/models/common.py:47 catalog/models/common.py:122
 msgid "Qidian"
 msgstr "Qidian"
 
-#: catalog/models/common.py:48 catalog/models/common.py:121
+#: catalog/models/common.py:48 catalog/models/common.py:123
 msgid "Ypshuo"
 msgstr "Ypshuo"
 
-#: catalog/models/common.py:49 catalog/models/common.py:122
+#: catalog/models/common.py:49 catalog/models/common.py:124
 msgid "Archive of Our Own"
 msgstr "Archive of Our Own"
 
-#: catalog/models/common.py:50 catalog/models/common.py:123
+#: catalog/models/common.py:50 catalog/models/common.py:125
 msgid "JinJiang"
 msgstr "JinJiang"
 
-#: catalog/models/common.py:51 catalog/models/common.py:64
+#: catalog/models/common.py:51 catalog/models/common.py:66
 msgid "WikiData"
 msgstr "WikiData"
 
-#: catalog/models/common.py:52 catalog/models/common.py:124
+#: catalog/models/common.py:52 catalog/models/common.py:126
 msgid "Open Library"
 msgstr ""
 
@@ -293,17 +293,17 @@ msgstr "MusicBrainz ID"
 msgid "WorldCat"
 msgstr ""
 
-#: catalog/models/common.py:55 catalog/models/common.py:126
+#: catalog/models/common.py:55 catalog/models/common.py:128
 #, fuzzy
 #| msgid "Game"
 msgid "MobyGames"
 msgstr "Spiel"
 
-#: catalog/models/common.py:56 catalog/models/common.py:127
+#: catalog/models/common.py:56 catalog/models/common.py:129
 msgid "StoryGraph"
 msgstr ""
 
-#: catalog/models/common.py:57 catalog/models/common.py:118
+#: catalog/models/common.py:57 catalog/models/common.py:120
 #, fuzzy
 #| msgid "Douban Music"
 msgid "YouTube Music"
@@ -321,363 +321,374 @@ msgstr ""
 msgid "Readmoo"
 msgstr ""
 
-#: catalog/models/common.py:65
+#: catalog/models/common.py:61
+msgid "MyAnimeList"
+msgstr ""
+
+#: catalog/models/common.py:62 catalog/models/common.py:140
+#, fuzzy
+#| msgid "Update"
+msgid "MangaUpdates"
+msgstr "Aktuallisierung"
+
+#: catalog/models/common.py:67
 msgid "ISBN10"
 msgstr "ISBN10"
 
-#: catalog/models/common.py:66 catalog/templates/edition.html:19
+#: catalog/models/common.py:68 catalog/templates/edition.html:19
 msgid "ISBN"
 msgstr "ISBN"
 
-#: catalog/models/common.py:67
+#: catalog/models/common.py:69
 msgid "ASIN"
 msgstr "ASIN"
 
-#: catalog/models/common.py:68
+#: catalog/models/common.py:70
 msgid "ISSN"
 msgstr "ISSN"
 
-#: catalog/models/common.py:69
+#: catalog/models/common.py:71
 msgid "CUBN"
 msgstr "CUBN"
 
-#: catalog/models/common.py:70
+#: catalog/models/common.py:72
 msgid "ISRC"
 msgstr "ISRC"
 
-#: catalog/models/common.py:71
+#: catalog/models/common.py:73
 msgid "GTIN UPC EAN"
 msgstr "GTIN UPC EAN"
 
-#: catalog/models/common.py:72
+#: catalog/models/common.py:74
 msgid "OCLC Number"
 msgstr ""
 
-#: catalog/models/common.py:73
+#: catalog/models/common.py:75
 msgid "RSS Feed URL"
 msgstr "RSS Feed URL"
 
-#: catalog/models/common.py:75
+#: catalog/models/common.py:77
 #, fuzzy
 #| msgid "TMDB TV Serie"
 msgid "TMDB TV Series"
 msgstr "TMDB Serie"
 
-#: catalog/models/common.py:76
+#: catalog/models/common.py:78
 msgid "TMDB TV Season"
 msgstr "TMDB Staffel"
 
-#: catalog/models/common.py:77
+#: catalog/models/common.py:79
 msgid "TMDB TV Episode"
 msgstr "TMDB Folge"
 
-#: catalog/models/common.py:78
+#: catalog/models/common.py:80
 msgid "TMDB Movie"
 msgstr "TMDB Film"
 
-#: catalog/models/common.py:80
+#: catalog/models/common.py:82
 msgid "Goodreads Work"
 msgstr "Goodreads Werk"
 
-#: catalog/models/common.py:82
+#: catalog/models/common.py:84
 msgid "Douban Book"
 msgstr "Douban Buch"
 
-#: catalog/models/common.py:83
+#: catalog/models/common.py:85
 msgid "Douban Book Work"
 msgstr "Douban Buch Werk"
 
-#: catalog/models/common.py:84
+#: catalog/models/common.py:86
 msgid "Douban Movie"
 msgstr "Douban Film"
 
-#: catalog/models/common.py:85
+#: catalog/models/common.py:87
 msgid "Douban Music"
 msgstr "Douban Musik"
 
-#: catalog/models/common.py:86
+#: catalog/models/common.py:88
 msgid "Douban Game"
 msgstr "Douban Spiel"
 
-#: catalog/models/common.py:87
+#: catalog/models/common.py:89
 msgid "Douban Drama"
 msgstr "Douban Drama"
 
-#: catalog/models/common.py:88
+#: catalog/models/common.py:90
 msgid "Douban Drama Version"
 msgstr "Douban Drama Version"
 
-#: catalog/models/common.py:89
+#: catalog/models/common.py:91
 msgid "BooksTW Book"
 msgstr "BooksTW Buch"
 
-#: catalog/models/common.py:90
+#: catalog/models/common.py:92
 msgid "Readmoo Book"
 msgstr ""
 
-#: catalog/models/common.py:95
+#: catalog/models/common.py:97
 msgid "Spotify Album"
 msgstr "Spotify Album"
 
-#: catalog/models/common.py:96
+#: catalog/models/common.py:98
 msgid "Spotify Podcast"
 msgstr "Spotify Podcast"
 
-#: catalog/models/common.py:97
+#: catalog/models/common.py:99
 msgid "Discogs Release"
 msgstr "Discogs Veröffentlichung"
 
-#: catalog/models/common.py:98
+#: catalog/models/common.py:100
 msgid "Discogs Master"
 msgstr "Discogs Master"
 
-#: catalog/models/common.py:101
+#: catalog/models/common.py:103
 #, fuzzy
 #| msgid "MusicBrainz ID"
 msgid "MusicBrainz Release Group"
 msgstr "MusicBrainz ID"
 
-#: catalog/models/common.py:103
+#: catalog/models/common.py:105
 #, fuzzy
 #| msgid "MusicBrainz ID"
 msgid "MusicBrainz Release"
 msgstr "MusicBrainz ID"
 
-#: catalog/models/common.py:104
+#: catalog/models/common.py:106
 #, fuzzy
 #| msgid "MusicBrainz ID"
 msgid "MusicBrainz Artist"
 msgstr "MusicBrainz ID"
 
-#: catalog/models/common.py:105
+#: catalog/models/common.py:107
 #, fuzzy
 #| msgid "Douban Game"
 msgid "Douban Personage"
 msgstr "Douban Spiel"
 
-#: catalog/models/common.py:106
+#: catalog/models/common.py:108
 #, fuzzy
 #| msgid "Goodreads Work"
 msgid "Goodreads Author"
 msgstr "Goodreads Werk"
 
-#: catalog/models/common.py:107
+#: catalog/models/common.py:109
 #, fuzzy
 #| msgid "Spotify Podcast"
 msgid "Spotify Artist"
 msgstr "Spotify Podcast"
 
-#: catalog/models/common.py:108
+#: catalog/models/common.py:110
 #, fuzzy
 #| msgid "TMDB TV Season"
 msgid "TMDB Person"
 msgstr "TMDB Staffel"
 
-#: catalog/models/common.py:109
+#: catalog/models/common.py:111
 msgid "Open Library Author"
 msgstr ""
 
-#: catalog/models/common.py:110
+#: catalog/models/common.py:112
 msgid "IGDB Company"
 msgstr ""
 
-#: catalog/models/common.py:111
+#: catalog/models/common.py:113
 msgid "IGDB Game"
 msgstr "IGDB Spiel"
 
-#: catalog/models/common.py:112
+#: catalog/models/common.py:114
 msgid "BGG Boardgame"
 msgstr "BGG Brettspiel"
 
-#: catalog/models/common.py:113
+#: catalog/models/common.py:115
 msgid "Steam Game"
 msgstr "Steam Spiel"
 
-#: catalog/models/common.py:125
+#: catalog/models/common.py:127
 msgid "Open Library Work"
 msgstr ""
 
-#: catalog/models/common.py:128
+#: catalog/models/common.py:130
 msgid "RateYourMusic Release"
 msgstr ""
 
-#: catalog/models/common.py:132
+#: catalog/models/common.py:134
 msgid "AniList Anime"
 msgstr ""
 
-#: catalog/models/common.py:133
+#: catalog/models/common.py:135
 msgid "AniList Manga"
 msgstr ""
 
-#: catalog/models/common.py:134
+#: catalog/models/common.py:136
 msgid "MyAnimeList Anime"
 msgstr ""
 
-#: catalog/models/common.py:135
+#: catalog/models/common.py:137
 msgid "MyAnimeList Manga"
 msgstr ""
 
-#: catalog/models/common.py:156
+#: catalog/models/common.py:161
 #, fuzzy
 #| msgid "Editions"
 msgid "Edition"
 msgstr "Versionen"
 
-#: catalog/models/common.py:157 catalog/templates/_sidebar_edit.html:286
+#: catalog/models/common.py:162 catalog/templates/_sidebar_edit.html:289
 msgid "Work"
 msgstr "Werk"
 
-#: catalog/models/common.py:158
+#: catalog/models/common.py:163
 #, fuzzy
 #| msgid "TV Serie"
 msgid "TV Series"
 msgstr "Serie"
 
-#: catalog/models/common.py:159 catalog/templates/_sidebar_edit.html:207
+#: catalog/models/common.py:164 catalog/templates/_sidebar_edit.html:202
+#: catalog/views/edit.py:385
 msgid "TV Season"
 msgstr "Staffel"
 
-#: catalog/models/common.py:160
+#: catalog/models/common.py:165
 msgid "TV Episode"
 msgstr "Folge"
 
-#: catalog/models/common.py:161 catalog/models/common.py:177
-#: catalog/models/common.py:191 catalog/templates/_sidebar_edit.html:200
-#: journal/templates/_sidebar_user_mark_list.html:35
+#: catalog/models/common.py:166 catalog/models/common.py:182
+#: catalog/models/common.py:196 catalog/templates/_sidebar_edit.html:196
+#: catalog/views/edit.py:384 journal/templates/_sidebar_user_mark_list.html:35
 #: journal/templates/_sidebar_user_tag_filter.html:27
 msgid "Movie"
 msgstr "Filme"
 
-#: catalog/models/common.py:162
+#: catalog/models/common.py:167
 msgid "Album"
 msgstr "Album"
 
-#: catalog/models/common.py:163 catalog/models/common.py:180
-#: catalog/models/common.py:194 common/templates/_header.html:43
+#: catalog/models/common.py:168 catalog/models/common.py:185
+#: catalog/models/common.py:199 common/templates/_header.html:53
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
 msgstr "Spiel"
 
-#: catalog/models/common.py:164
+#: catalog/models/common.py:169
 msgid "Podcast Program"
 msgstr "Podcast Programm"
 
-#: catalog/models/common.py:165
+#: catalog/models/common.py:170
 msgid "Podcast Episode"
 msgstr "Podcast Folge"
 
-#: catalog/models/common.py:166 catalog/models/common.py:182
-#: catalog/models/common.py:196 common/templates/_header.html:47
+#: catalog/models/common.py:171 catalog/models/common.py:187
+#: catalog/models/common.py:201 common/templates/_header.html:57
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
 msgstr "Aufführung"
 
-#: catalog/models/common.py:167
+#: catalog/models/common.py:172
 msgid "Production"
 msgstr "Produktion"
 
-#: catalog/models/common.py:168
+#: catalog/models/common.py:173
 msgid "Exhibition"
 msgstr "Ausstellung"
 
-#: catalog/models/common.py:169 catalog/models/common.py:186
+#: catalog/models/common.py:174 catalog/models/common.py:191
 #: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr "Sammlung"
 
-#: catalog/models/common.py:172 catalog/models/common.py:185
+#: catalog/models/common.py:177 catalog/models/common.py:190
 msgid "Person / Organization"
 msgstr ""
 
-#: catalog/models/common.py:176 catalog/models/common.py:190
-#: common/templates/_header.html:27
+#: catalog/models/common.py:181 catalog/models/common.py:195
+#: common/templates/_header.html:37
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
 msgstr "Bücher"
 
-#: catalog/models/common.py:178 catalog/models/common.py:192
+#: catalog/models/common.py:183 catalog/models/common.py:197
 #: journal/templates/_sidebar_user_mark_list.html:38
 #: journal/templates/_sidebar_user_tag_filter.html:30
 msgid "TV"
 msgstr "Serien"
 
-#: catalog/models/common.py:179 catalog/models/common.py:193
-#: common/templates/_header.html:39
+#: catalog/models/common.py:184 catalog/models/common.py:198
+#: common/templates/_header.html:49
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr "Musik"
 
-#: catalog/models/common.py:181 catalog/models/common.py:195
-#: catalog/templates/_sidebar_edit.html:219 common/templates/_header.html:35
+#: catalog/models/common.py:186 catalog/models/common.py:200
+#: catalog/templates/_sidebar_edit.html:213 common/templates/_header.html:45
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
 msgstr "Podcasts"
 
-#: catalog/models/common.py:346 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:345 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr "Genre"
 
-#: catalog/models/common.py:384
+#: catalog/models/common.py:383
 #, fuzzy
 #| msgid "original creator"
 msgid "origin country"
 msgstr "originaler Ersteller"
 
-#: catalog/models/common.py:413 catalog/templates/album.html:33
+#: catalog/models/common.py:412 catalog/templates/album.html:33
 msgid "album type"
 msgstr "Album Typ"
 
-#: catalog/models/common.py:417 catalog/templates/_platform_list.html:5
+#: catalog/models/common.py:416 catalog/templates/_platform_list.html:5
 msgid "platform"
 msgstr "Plattform"
 
-#: catalog/models/common.py:421
+#: catalog/models/common.py:420
 #, fuzzy
 #| msgid "media type"
 msgid "media format"
 msgstr "Medientyp"
 
-#: catalog/models/common.py:426 catalog/templates/_language_list.html:5
-#: users/models/user.py:142
+#: catalog/models/common.py:425 catalog/templates/_language_list.html:5
+#: users/models/user.py:144
 msgid "language"
 msgstr "Sprache"
 
-#: catalog/models/creator.py:24
+#: catalog/models/creator.py:26
 #, fuzzy
 #| msgid "Pending"
 msgid "pending"
 msgstr "ausstehend"
 
-#: catalog/models/creator.py:25
+#: catalog/models/creator.py:27
 msgid "verified"
 msgstr ""
 
-#: catalog/models/creator.py:26
+#: catalog/models/creator.py:28
 #, fuzzy
 #| msgid "Failed"
 msgid "failed"
 msgstr "abgebrochen"
 
-#: catalog/models/creator.py:29
+#: catalog/models/creator.py:31
 msgid "no feed url available for this item"
 msgstr ""
 
-#: catalog/models/creator.py:30
+#: catalog/models/creator.py:32
 msgid "unable to fetch or parse the feed"
 msgstr ""
 
-#: catalog/models/creator.py:31
+#: catalog/models/creator.py:33
 msgid "no audio episode found in the feed"
 msgstr ""
 
-#: catalog/models/creator.py:34
+#: catalog/models/creator.py:36
 msgid "no matching identity found in the feed or its linked website"
 msgstr ""
 
@@ -713,16 +724,16 @@ msgstr "Remake"
 msgid "Special Edition"
 msgstr "Special Edition"
 
-#: catalog/models/game.py:111 catalog/models/item.py:130
+#: catalog/models/game.py:111 catalog/models/item.py:126
 msgid "designer"
 msgstr "Designer/in"
 
-#: catalog/models/game.py:119 catalog/models/item.py:129
+#: catalog/models/game.py:119 catalog/models/item.py:125
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr "Künstler/in"
 
-#: catalog/models/game.py:127 catalog/models/item.py:139
+#: catalog/models/game.py:127 catalog/models/item.py:135
 msgid "developer"
 msgstr "Entwickler/in"
 
@@ -731,8 +742,8 @@ msgid "date of publication"
 msgstr "Veröffentlichungsdatum"
 
 #: catalog/models/game.py:147 catalog/models/movie.py:156
-#: catalog/models/music.py:128 catalog/models/tv.py:247
-#: catalog/models/tv.py:473
+#: catalog/models/music.py:128 catalog/models/tv.py:249
+#: catalog/models/tv.py:475
 msgid "YYYY, YYYY-MM or YYYY-MM-DD"
 msgstr ""
 
@@ -743,7 +754,7 @@ msgstr "Veröffentlichungs-Typ"
 #: catalog/models/game.py:180 catalog/models/movie.py:158
 #: catalog/models/people.py:178 catalog/models/performance.py:258
 #: catalog/models/performance.py:465 catalog/models/podcast.py:89
-#: catalog/models/tv.py:249 catalog/models/tv.py:476
+#: catalog/models/tv.py:251 catalog/models/tv.py:478
 #: catalog/templates/game.html:33 catalog/templates/movie.html:48
 #: catalog/templates/people.html:44 catalog/templates/performance.html:35
 #: catalog/templates/performanceproduction.html:35
@@ -752,152 +763,152 @@ msgstr "Veröffentlichungs-Typ"
 msgid "website"
 msgstr "Webseite"
 
-#: catalog/models/item.py:125 catalog/models/movie.py:123
+#: catalog/models/item.py:121 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
-#: catalog/models/tv.py:214 catalog/models/tv.py:440
+#: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr "Regisseur/in"
 
-#: catalog/models/item.py:126 catalog/models/movie.py:130
+#: catalog/models/item.py:122 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
-#: catalog/models/tv.py:221 catalog/models/tv.py:447
+#: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr "Dramatiker"
 
-#: catalog/models/item.py:127 catalog/models/movie.py:137
+#: catalog/models/item.py:123 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
-#: catalog/models/tv.py:228 catalog/models/tv.py:454
+#: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr "Schauspieler/in"
 
-#: catalog/models/item.py:128 catalog/models/movie.py:144
-#: catalog/models/tv.py:235 catalog/models/tv.py:461
+#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/tv.py:237 catalog/models/tv.py:463
 #, fuzzy
 #| msgid "production"
 msgid "producer"
 msgstr "Produktion"
 
-#: catalog/models/item.py:131 catalog/models/performance.py:203
+#: catalog/models/item.py:127 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr "Komponist/in"
 
-#: catalog/models/item.py:132 catalog/models/performance.py:210
+#: catalog/models/item.py:128 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr "Choreograph/in"
 
-#: catalog/models/item.py:133 catalog/models/performance.py:224
+#: catalog/models/item.py:129 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr "Künstler/in"
 
-#: catalog/models/item.py:134 catalog/models/podcast.py:80
+#: catalog/models/item.py:130 catalog/models/podcast.py:80
 msgid "host"
 msgstr "Gastgeber"
 
-#: catalog/models/item.py:135 catalog/models/performance.py:196
+#: catalog/models/item.py:131 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr "originaler Ersteller"
 
-#: catalog/models/item.py:136 catalog/models/performance.py:238
+#: catalog/models/item.py:132 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr "Besatzung"
 
-#: catalog/models/item.py:140
+#: catalog/models/item.py:136
 #, fuzzy
 #| msgid "production"
 msgid "production company"
 msgstr "Produktion"
 
-#: catalog/models/item.py:141
+#: catalog/models/item.py:137
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:142
+#: catalog/models/item.py:138
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:139
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:144 catalog/models/performance.py:231
+#: catalog/models/item.py:140 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr "Gruppe"
 
-#: catalog/models/item.py:147
+#: catalog/models/item.py:143
 #, fuzzy
 #| msgid "director"
 msgid "voice actor"
 msgstr "Regisseur/in"
 
-#: catalog/models/item.py:148 catalog/templates/edition.html:30
+#: catalog/models/item.py:144 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr "Verlag"
 
-#: catalog/models/item.py:173 catalog/models/people.py:476
+#: catalog/models/item.py:169 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr "Rolle"
 
-#: catalog/models/item.py:174 catalog/models/people.py:155
+#: catalog/models/item.py:170 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr "Name"
 
-#: catalog/models/item.py:176 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:288 catalog/models/item.py:320
-#: journal/models/collection.py:96
+#: catalog/models/item.py:304 catalog/models/item.py:336
+#: journal/models/collection.py:100
 msgid "title"
 msgstr "Titel"
 
-#: catalog/models/item.py:289 catalog/models/item.py:328
-#: journal/models/collection.py:97
+#: catalog/models/item.py:305 catalog/models/item.py:344
+#: journal/models/collection.py:101
 msgid "description"
 msgstr "Beschreibung"
 
-#: catalog/models/item.py:300 catalog/models/people.py:484
+#: catalog/models/item.py:316 catalog/models/people.py:484
 msgid "metadata"
 msgstr "Metadaten"
 
-#: catalog/models/item.py:302 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
 msgid "cover"
 msgstr "Cover"
 
-#: catalog/models/item.py:1485
+#: catalog/models/item.py:1526
 msgid "source site"
 msgstr "Quellseite"
 
-#: catalog/models/item.py:1487
+#: catalog/models/item.py:1528
 msgid "ID on source site"
 msgstr "ID der Quellseite"
 
-#: catalog/models/item.py:1489
+#: catalog/models/item.py:1530
 msgid "source url"
 msgstr "Quell-URL"
 
-#: catalog/models/item.py:1505
+#: catalog/models/item.py:1546
 msgid "IdType of the source site"
 msgstr "ID-Typ der Quellseite"
 
-#: catalog/models/item.py:1511
+#: catalog/models/item.py:1552
 msgid "Primary Id on the source site"
 msgstr "primäre ID der Quellseite"
 
-#: catalog/models/item.py:1514
+#: catalog/models/item.py:1555
 msgid "url to the resource"
 msgstr "URL der Ressource"
 
 #: catalog/models/movie.py:152 catalog/models/music.py:124
-#: catalog/models/tv.py:243 catalog/models/tv.py:469
+#: catalog/models/tv.py:245 catalog/models/tv.py:471
 #: catalog/templates/_item_card_metadata_album.html:16
 #: catalog/templates/album.html:17 catalog/templates/game.html:22
 #: catalog/templates/movie.html:36 catalog/templates/tvseason.html:53
@@ -912,7 +923,7 @@ msgid "length"
 msgstr "Länge"
 
 #: catalog/models/movie.py:162 catalog/models/music.py:131
-#: catalog/models/tv.py:259 catalog/models/tv.py:486
+#: catalog/models/tv.py:261 catalog/models/tv.py:488
 #, fuzzy
 #| msgid "milliseconds"
 msgid "seconds"
@@ -1120,46 +1131,98 @@ msgstr "Eröffnungsdatum"
 msgid "closing date"
 msgstr "Schließungsdatum"
 
-#: catalog/models/tv.py:186 catalog/templates/tvseason.html:38
+#: catalog/models/tv.py:188 catalog/templates/tvseason.html:38
 #: catalog/templates/tvshow.html:33
 msgid "number of seasons"
 msgstr "Anzahl der Staffeln"
 
-#: catalog/models/tv.py:189 catalog/models/tv.py:415
+#: catalog/models/tv.py:191 catalog/models/tv.py:417
 #: catalog/templates/tvseason.html:43 catalog/templates/tvshow.html:38
 msgid "number of episodes"
 msgstr "Anzahl der Folgen"
 
-#: catalog/models/tv.py:256 catalog/models/tv.py:483
+#: catalog/models/tv.py:258 catalog/models/tv.py:485
 msgid "episode length"
 msgstr "Folgenlänge"
 
-#: catalog/models/tv.py:412 catalog/templates/tvseason.html:33
+#: catalog/models/tv.py:414 catalog/templates/tvseason.html:33
 msgid "season number"
 msgstr "Staffel Nummer"
 
-#: catalog/models/tv.py:530
+#: catalog/models/tv.py:532
 #, python-brace-format
 msgid "{show_title} Season {season_number}"
 msgstr "{show_title} Staffel {season_number}"
 
-#: catalog/models/tv.py:684
+#: catalog/models/tv.py:686
 #, python-brace-format
 msgid "{season_title} E{episode_number}"
 msgstr "{season_title} E{episode_number}"
+
+#: catalog/templates/_catalog_confirm_item.html:7
+#: catalog/templates/catalog_edit.html:62
+msgid "Item has been deleted."
+msgstr "Artikel wurde gelöscht."
+
+#: catalog/templates/_catalog_confirm_item.html:12
+#: catalog/templates/catalog_edit.html:65
+msgid "Item contains sub-items."
+msgstr "Artikel enthält Unterartikel."
+
+#: catalog/templates/_catalog_confirm_item.html:17
+msgid "Item has been merged to another item."
+msgstr "Artikel wurde mit einem anderen Artikel zusammengefügt."
+
+#: catalog/templates/_catalog_confirm_item.html:22
+msgid "Item has been marked by users."
+msgstr "Artikel wurde von Nutzern markiert."
+
+#: catalog/templates/_catalog_edit_preview.html:11
+#, fuzzy
+#| msgid "Confirm and save"
+msgid "Confirm changes"
+msgstr "Bestätigen und Speichern"
+
+#: catalog/templates/_catalog_edit_preview.html:16
+msgid "Please correct the errors below."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:24
+msgid "Field"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:25
+msgid "From"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:26
+msgid "To"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:45
+#, fuzzy
+#| msgid "Tag deleted."
+msgid "No changes detected."
+msgstr "Tag gelöscht."
+
+#: catalog/templates/_catalog_edit_preview.html:54
+#: users/templates/users/register.html:104
+msgid "Confirm and save"
+msgstr "Bestätigen und Speichern"
+
+#: catalog/templates/_catalog_edit_preview.html:57
+#, fuzzy
+#| msgid "back to item"
+msgid "Back to editing"
+msgstr "zurück zum Artikel"
 
 #: catalog/templates/_country_list.html:5
 msgid "region"
 msgstr "Region"
 
 #: catalog/templates/_fetch_failed.html:4
-msgid ""
-"Unable to fetch from the link, please check again. Some sites may require "
-"login for certain links, please manually create them here."
-msgstr ""
-"Der Abruf des Links ist fehlgeschlagen, bitte versuche es nochmal. Einige "
-"Seiten benötigen für bestimmte Links eine Anmeldung. Erstelle Diese manuell "
-"hier."
+msgid "Unable to fetch from the link, please check again. Some sites may require login for certain links, please manually create them here."
+msgstr "Der Abruf des Links ist fehlgeschlagen, bitte versuche es nochmal. Einige Seiten benötigen für bestimmte Links eine Anmeldung. Erstelle Diese manuell hier."
 
 #: catalog/templates/_item_card_metadata_album.html:7
 #: catalog/templates/_item_card_metadata_edition.html:7
@@ -1189,8 +1252,7 @@ msgstr "alle Staffeln"
 
 #: catalog/templates/_item_comments.html:25
 msgid "edit this item to fetch or add episode list here"
-msgstr ""
-"Bearbeite diesen Artikel, um die Episodenliste hinzuzufügen oder abzurufen"
+msgstr "Bearbeite diesen Artikel, um die Episodenliste hinzuzufügen oder abzurufen"
 
 #: catalog/templates/_item_comments.html:27
 msgid "hide this tooltip"
@@ -1219,7 +1281,7 @@ msgstr "mehr anzeigen"
 #: journal/templates/profile_posts.html:21
 #: journal/templates/user_follow_list_items.html:63
 #: journal/templates/user_post_list_items.html:24
-#: social/templates/events.html:43 social/templates/feed_events.html:28
+#: social/templates/events.html:43 social/templates/feed_events.html:27
 msgid "nothing more."
 msgstr "nichts weiter."
 
@@ -1318,7 +1380,7 @@ msgid "Add note"
 msgstr "Film hinzufügen"
 
 #: catalog/templates/_item_user_pieces.html:83
-#: common/templates/_sidebar.html:196 journal/templates/profile_items.html:46
+#: common/templates/_sidebar.html:195 journal/templates/profile_items.html:46
 #, fuzzy
 #| msgid "Sync in progress."
 msgid "Set progress"
@@ -1347,6 +1409,12 @@ msgstr "meine Sammlung"
 #: catalog/templates/_item_user_pieces.html:214
 msgid "mark history"
 msgstr "Markierungsverlauf"
+
+#: catalog/templates/_search_suggest.html:2
+#, fuzzy
+#| msgid "Suggest Edits"
+msgid "Suggestions"
+msgstr "Bearbeitung vorschlagen"
 
 #: catalog/templates/_sidebar_edit.html:8
 msgid "edit"
@@ -1377,15 +1445,15 @@ msgid "Edit Options"
 msgstr "bearbeite Optionen"
 
 #: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
-#: catalog/views/edit.py:82 catalog/views/edit.py:143 catalog/views/edit.py:197
-#: catalog/views/edit.py:218 catalog/views/edit.py:259
-#: catalog/views/edit.py:328 catalog/views/edit.py:332
-#: catalog/views/edit.py:351 catalog/views/edit.py:400
-#: catalog/views/edit.py:425 catalog/views/edit.py:440
-#: catalog/views/edit.py:480 catalog/views/edit.py:490
-#: catalog/views/edit.py:517 catalog/views/edit.py:582
-#: catalog/views/edit.py:637 catalog/views/edit.py:659
-#: catalog/views/search.py:367
+#: catalog/views/edit.py:160 catalog/views/edit.py:221
+#: catalog/views/edit.py:288 catalog/views/edit.py:309
+#: catalog/views/edit.py:364 catalog/views/edit.py:471
+#: catalog/views/edit.py:475 catalog/views/edit.py:509
+#: catalog/views/edit.py:576 catalog/views/edit.py:601
+#: catalog/views/edit.py:624 catalog/views/edit.py:664
+#: catalog/views/edit.py:674 catalog/views/edit.py:703
+#: catalog/views/edit.py:782 catalog/views/edit.py:837
+#: catalog/views/edit.py:859 catalog/views/search.py:418
 #, fuzzy
 #| msgid "Edit this item"
 msgid "Editing this item is restricted."
@@ -1423,7 +1491,7 @@ msgstr "Artikel wurde von Nutzern markiert."
 msgid "The following items are merged into this item"
 msgstr "Folgende Artikel wurden in diesen Artikel zusammengefügt"
 
-#: catalog/templates/_sidebar_edit.html:70
+#: catalog/templates/_sidebar_edit.html:70 catalog/views/edit.py:456
 msgid "External website"
 msgstr "Externe Website"
 
@@ -1437,49 +1505,41 @@ msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:88
 msgid "Existing metadata might get overwritten, sure to proceed?"
-msgstr ""
-"Vorhandene Metadaten werden möglicherweise überschrieben. Möchtest du "
-"fortfahren?"
+msgstr "Vorhandene Metadaten werden möglicherweise überschrieben. Möchtest du fortfahren?"
 
 #: catalog/templates/_sidebar_edit.html:92
 msgid "Fetch again"
 msgstr "Erneut abrufen"
 
-#: catalog/templates/_sidebar_edit.html:97
-msgid "You may not be able to undo this operation, sure to remove?"
-msgstr ""
-"Du kannst diesen Vorgang möglicherweise nicht rückgängig machen. Sicher, "
-"dass du es entfernen willst?"
-
-#: catalog/templates/_sidebar_edit.html:102
+#: catalog/templates/_sidebar_edit.html:100
 msgid "Remove link to site"
 msgstr "Verknüpfung zur Seite entfernen"
 
-#: catalog/templates/_sidebar_edit.html:110
+#: catalog/templates/_sidebar_edit.html:108
 #, fuzzy
 #| msgid "Discover"
 msgid "Choose cover"
 msgstr "Entdecken"
 
-#: catalog/templates/_sidebar_edit.html:119
+#: catalog/templates/_sidebar_edit.html:117
+#: catalog/templates/_sidebar_edit.html:118
 #: catalog/templates/_sidebar_edit.html:120
-#: catalog/templates/_sidebar_edit.html:122
 #, fuzzy
 #| msgid "Current Targets"
 msgid "Current cover"
 msgstr "Aktuelle Ziele"
 
-#: catalog/templates/_sidebar_edit.html:139
+#: catalog/templates/_sidebar_edit.html:137
 msgid "Select an image to use as the cover of this item."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:140
-#: catalog/templates/catalog_edit.html:65
-#: common/templates/manage/settings.html:136
+#: catalog/templates/_sidebar_edit.html:138
+#: catalog/templates/catalog_edit.html:78
+#: common/templates/manage/settings.html:19
 #: journal/templates/add_to_collection.html:43
 #: journal/templates/article_edit.html:60
 #: journal/templates/collection_edit.html:39 journal/templates/comment.html:41
-#: journal/templates/mark.html:134 journal/templates/note.html:65
+#: journal/templates/mark.html:138 journal/templates/note.html:65
 #: journal/templates/post_compose.html:103
 #: journal/templates/review_edit.html:46 journal/templates/tag_edit.html:51
 #: users/templates/users/_pref_device.html:37
@@ -1488,206 +1548,162 @@ msgstr ""
 msgid "Save"
 msgstr "Speichern"
 
-#: catalog/templates/_sidebar_edit.html:147
+#: catalog/templates/_sidebar_edit.html:145
 msgid "Edit sub-items"
 msgstr "bearbeite Unterartikel"
 
-#: catalog/templates/_sidebar_edit.html:160
+#: catalog/templates/_sidebar_edit.html:158
 msgid "create"
 msgstr "erstellen"
 
-#: catalog/templates/_sidebar_edit.html:166
+#: catalog/templates/_sidebar_edit.html:164
 msgid "Fetch all episodes"
 msgstr "Alle Folgen abrufen"
 
-#: catalog/templates/_sidebar_edit.html:171
+#: catalog/templates/_sidebar_edit.html:169
 msgid "Fetch all"
 msgstr "Alles abrufen"
 
-#: catalog/templates/_sidebar_edit.html:172
-msgid ""
-"Due to differences in how Douban, IMDB, and TMDB handle season data, a small "
-"number of TV shows and animations may not return correct results. Please "
-"manually verify and clean up after updating."
-msgstr ""
-"Aufgrund von Unterschieden, wie Douban, IMDB und TMDB Informationen über "
-"Staffeln handhaben, könnten einige Serien falsch angezeigt werden. Bitte "
-"überprüfe und korrigiere die Informationen nach der Aktuallisierung manuell."
+#: catalog/templates/_sidebar_edit.html:170
+msgid "Due to differences in how Douban, IMDB, and TMDB handle season data, a small number of TV shows and animations may not return correct results. Please manually verify and clean up after updating."
+msgstr "Aufgrund von Unterschieden, wie Douban, IMDB und TMDB Informationen über Staffeln handhaben, könnten einige Serien falsch angezeigt werden. Bitte überprüfe und korrigiere die Informationen nach der Aktuallisierung manuell."
 
-#: catalog/templates/_sidebar_edit.html:173
+#: catalog/templates/_sidebar_edit.html:171
 msgid "Up to 250 episodes will be fetched for a season."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:176
-msgid ""
-"To fetch all episodes, season numbers and IMDB information are required. If "
-"filling this out is inconvenient, you can also manually create sub-entries."
-msgstr ""
-"Um alle Episoden abzurufen, sind Staffelnummern und IMDB-Informationen "
-"erforderlich. Wenn das Ausfüllen dieser Angaben zu aufwendig ist, könntest "
-"du auch manuell Untereinträge erstellen."
+#: catalog/templates/_sidebar_edit.html:174
+msgid "To fetch all episodes, season numbers and IMDB information are required. If filling this out is inconvenient, you can also manually create sub-entries."
+msgstr "Um alle Episoden abzurufen, sind Staffelnummern und IMDB-Informationen erforderlich. Wenn das Ausfüllen dieser Angaben zu aufwendig ist, könntest du auch manuell Untereinträge erstellen."
 
-#: catalog/templates/_sidebar_edit.html:182
-#: catalog/templates/_sidebar_edit.html:194
-#: catalog/templates/_sidebar_edit.html:213
+#: catalog/templates/_sidebar_edit.html:180
+#: catalog/templates/_sidebar_edit.html:191
+#: catalog/templates/_sidebar_edit.html:208
 msgid "switch category"
 msgstr "Kategorie ändern"
 
-#: catalog/templates/_sidebar_edit.html:185
-msgid "Switching may remove some metadata. Sure to proceed?"
-msgstr ""
-"Das Ändern der Kategorie löscht möglicherweise Metadaten. Möchtest du "
-"fortfahren?"
-
-#: catalog/templates/_sidebar_edit.html:188
+#: catalog/templates/_sidebar_edit.html:185 catalog/views/edit.py:383
 msgid "TV Show"
 msgstr "Serie"
 
-#: catalog/templates/_sidebar_edit.html:227
+#: catalog/templates/_sidebar_edit.html:221
 msgid "Link to parent item"
 msgstr "Verknüpfung zum übergeordneten Artikel"
 
 #: catalog/templates/_sidebar_edit.html:230
-msgid "Sure to link?"
-msgstr "Sicher, dass du das verknüpfen möchtest?"
-
-#: catalog/templates/_sidebar_edit.html:237
 msgid "Update link"
 msgstr "Verknüpfung aktualisieren"
 
-#: catalog/templates/_sidebar_edit.html:243
+#: catalog/templates/_sidebar_edit.html:236
 msgid "Cleanup seasons"
 msgstr "Staffeln aufräumen"
 
-#: catalog/templates/_sidebar_edit.html:246
-#: catalog/templates/catalog_delete.html:45
-msgid "This operation cannot be undone. Sure to delete?"
-msgstr ""
-"Dieser Vorgang kann nicht rückgängig gemacht werden. Sicher, dass du das "
-"löschen möchtest?"
-
-#: catalog/templates/_sidebar_edit.html:250
+#: catalog/templates/_sidebar_edit.html:242
 msgid "remove seasons not marked"
 msgstr "nicht-markierte Staffeln entfernen"
 
-#: catalog/templates/_sidebar_edit.html:256
-#: catalog/templates/catalog_merge.html:12
+#: catalog/templates/_sidebar_edit.html:248
 msgid "Merge"
 msgstr "Zusammenfügen"
 
-#: catalog/templates/_sidebar_edit.html:262
+#: catalog/templates/_sidebar_edit.html:254
 msgid "URL of target item, or empty if undo merge"
-msgstr ""
-"URL des Ziel-Artikels, leerlassen wenn Zusammenfügung rückgängig gemacht "
-"werden soll"
+msgstr "URL des Ziel-Artikels, leerlassen wenn Zusammenfügung rückgängig gemacht werden soll"
 
-#: catalog/templates/_sidebar_edit.html:268
-#: catalog/templates/_sidebar_edit.html:348
+#: catalog/templates/_sidebar_edit.html:260
+#: catalog/templates/_sidebar_edit.html:350
 msgid "merge to another item"
 msgstr "mit anderem Artikel zusammenfügen"
 
-#: catalog/templates/_sidebar_edit.html:273
-#: catalog/templates/_sidebar_edit.html:277
-#: catalog/templates/catalog_delete.html:12
+#: catalog/templates/_sidebar_edit.html:265
+#: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
 #: journal/templates/article.html:199 journal/templates/collection.html:188
-#: journal/templates/mark.html:149 journal/templates/note.html:82
+#: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
 #: users/templates/users/account.html:254
 msgid "Delete"
 msgstr "löschen"
 
-#: catalog/templates/_sidebar_edit.html:287
+#: catalog/templates/_sidebar_edit.html:275
+#: catalog/templates/_sidebar_edit.html:279
+#, fuzzy
+#| msgid "Tag deleted."
+msgid "Undo delete"
+msgstr "Tag gelöscht."
+
+#: catalog/templates/_sidebar_edit.html:280
+msgid "Links to external sites and parent item were removed on delete and will not be restored."
+msgstr ""
+
+#: catalog/templates/_sidebar_edit.html:290
 msgid "This edition belongs to the following work"
 msgstr "Diese Version gehört zu folgendem Werk"
 
-#: catalog/templates/_sidebar_edit.html:292
-msgid "Sure to unlink?"
-msgstr "Verknüpfung aufheben?"
-
-#: catalog/templates/_sidebar_edit.html:298
+#: catalog/templates/_sidebar_edit.html:300
 msgid "Unlink from work"
 msgstr "Verknüpfung des Werks aufheben"
 
-#: catalog/templates/_sidebar_edit.html:304
+#: catalog/templates/_sidebar_edit.html:306
 msgid "Link"
 msgstr "Verknüpfung"
 
-#: catalog/templates/_sidebar_edit.html:315
+#: catalog/templates/_sidebar_edit.html:317
 msgid "Link to another edition from same work"
 msgstr "mit weiterer Version des selben Werks verknüpfen"
 
-#: catalog/templates/_sidebar_edit.html:324
+#: catalog/templates/_sidebar_edit.html:326
 #, fuzzy
 #| msgid "description"
 msgid "Restriction"
 msgstr "Beschreibung"
 
-#: catalog/templates/_sidebar_edit.html:337
+#: catalog/templates/_sidebar_edit.html:339
 #: journal/templates/collection_update_item_note.html:4
 msgid "Update"
 msgstr "Aktuallisierung"
 
-#: catalog/templates/_sidebar_edit.html:342
+#: catalog/templates/_sidebar_edit.html:344
 msgid "Suggest Edits"
 msgstr "Bearbeitung vorschlagen"
 
-#: catalog/templates/_sidebar_edit.html:347
+#: catalog/templates/_sidebar_edit.html:349
 msgid "proposed action"
 msgstr "vorgeschlagene Aktion"
 
-#: catalog/templates/_sidebar_edit.html:349
+#: catalog/templates/_sidebar_edit.html:351
 msgid "link to another item"
 msgstr "mit anderem Artikel verknüpfen"
 
-#: catalog/templates/_sidebar_edit.html:350
+#: catalog/templates/_sidebar_edit.html:352
 msgid "change item category"
 msgstr "Artikel Kategorie ändern"
 
-#: catalog/templates/_sidebar_edit.html:351
+#: catalog/templates/_sidebar_edit.html:353
 msgid "change item metadata"
 msgstr "Artikel Metadaten ändern"
 
-#: catalog/templates/_sidebar_edit.html:352
+#: catalog/templates/_sidebar_edit.html:354
 msgid "remove item"
 msgstr "Artikel löschen"
 
-#: catalog/templates/_sidebar_edit.html:353
+#: catalog/templates/_sidebar_edit.html:355
 msgid "other"
 msgstr "sonstiges"
 
-#: catalog/templates/_sidebar_edit.html:357
-msgid ""
-"To suggest merging or association, please include the URL of the target item"
-msgstr ""
-"Um eine Zusammenfügung vorzuschlagen, gib bitte die URL des Ziel-Artikels an"
+#: catalog/templates/_sidebar_edit.html:359
+msgid "To suggest merging or association, please include the URL of the target item"
+msgstr "Um eine Zusammenfügung vorzuschlagen, gib bitte die URL des Ziel-Artikels an"
 
-#: catalog/templates/_sidebar_edit.html:358
+#: catalog/templates/_sidebar_edit.html:360
 #: catalog/templates/catalog_verify.html:116
 msgid "submit"
 msgstr "einreichen"
 
-#: catalog/templates/_sidebar_edit.html:359
-msgid ""
-"As a user of this community, you may edit some metadata of items on this "
-"site. If you are unsure whether your edits are appropriate or are unable to "
-"make a certain change, you can make suggestions here. Moderators will "
-"consider each suggestion, although there is no guarantee that they will "
-"always be fully adopted; suggestions may also be viewed or discussed by "
-"other community users. If you have suggestions that are not related to a "
-"specific item, please contact us. Thank you for your support and "
-"contribution."
-msgstr ""
-"Als Teil dieser Community kannst du einige Metadaten von Artikeln auf dieser "
-"Seite bearbeiten. Wenn du dir nicht sicher bist, ob die Änderungen "
-"angemessen wäre oder du eine bestimmte Änderung nicht vornehmen kannst, "
-"kannst du einen Vorschlag machen. Moderatoren werden deinen Vorschlag "
-"prüfen, jedoch ohne Garantie dafür, dass dieser Vorschlag übernommen wird. "
-"Vorschläge können auch von anderen Community-Mitgliedern angezeigt und "
-"diskutiert werden. Wenn du Vorschläge hast, die sich nicht auf einen "
-"bestimmten Artikel beziehen, kontaktiere uns. Vielen Dank für deine "
-"Unterstützung und deinen Beitrag."
+#: catalog/templates/_sidebar_edit.html:361
+msgid "As a user of this community, you may edit some metadata of items on this site. If you are unsure whether your edits are appropriate or are unable to make a certain change, you can make suggestions here. Moderators will consider each suggestion, although there is no guarantee that they will always be fully adopted; suggestions may also be viewed or discussed by other community users. If you have suggestions that are not related to a specific item, please contact us. Thank you for your support and contribution."
+msgstr "Als Teil dieser Community kannst du einige Metadaten von Artikeln auf dieser Seite bearbeiten. Wenn du dir nicht sicher bist, ob die Änderungen angemessen wäre oder du eine bestimmte Änderung nicht vornehmen kannst, kannst du einen Vorschlag machen. Moderatoren werden deinen Vorschlag prüfen, jedoch ohne Garantie dafür, dass dieser Vorschlag übernommen wird. Vorschläge können auch von anderen Community-Mitgliedern angezeigt und diskutiert werden. Wenn du Vorschläge hast, die sich nicht auf einen bestimmten Artikel beziehen, kontaktiere uns. Vielen Dank für deine Unterstützung und deinen Beitrag."
 
 #: catalog/templates/_sidebar_search.html:5
 #: journal/templates/_sidebar_search_journal.html:4
@@ -1790,9 +1806,7 @@ msgid "matched"
 msgstr "angeschaut"
 
 #: catalog/templates/_verify_status.html:21
-msgid ""
-"Sure to remove your creator verification? Anyone will be able to edit this "
-"item again."
+msgid "Sure to remove your creator verification? Anyone will be able to edit this item again."
 msgstr ""
 
 #: catalog/templates/_verify_status.html:26
@@ -1801,7 +1815,7 @@ msgstr ""
 msgid "Remove my verification"
 msgstr "von Sammlung entfernen"
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:309
+#: catalog/templates/_verify_status.html:31 users/views/account.py:311
 #, fuzzy
 #| msgid "Verification Code"
 msgid "Verification failed"
@@ -1844,43 +1858,11 @@ msgstr "Strichcode"
 msgid "album media"
 msgstr "Albuminhalt"
 
-#: catalog/templates/catalog_delete.html:19
-msgid "Are you sure to delete?"
-msgstr "Sicher, dass du das löschen willst?"
-
-#: catalog/templates/catalog_delete.html:24
-#: catalog/templates/catalog_edit.html:52
-#: catalog/templates/catalog_merge.html:36
-#: catalog/templates/catalog_merge.html:64
-msgid "Item has been deleted."
-msgstr "Artikel wurde gelöscht."
-
-#: catalog/templates/catalog_delete.html:29
-#: catalog/templates/catalog_edit.html:55
-#: catalog/templates/catalog_merge.html:41
-#: catalog/templates/catalog_merge.html:69
-msgid "Item contains sub-items."
-msgstr "Artikel enthält Unterartikel."
-
-#: catalog/templates/catalog_delete.html:34
-#: catalog/templates/catalog_merge.html:46
-#: catalog/templates/catalog_merge.html:74
-msgid "Item has been merged to another item."
-msgstr "Artikel wurde mit einem anderen Artikel zusammengefügt."
-
-#: catalog/templates/catalog_delete.html:39
-#: catalog/templates/catalog_merge.html:51
-#: catalog/templates/catalog_merge.html:79
-msgid "Item has been marked by users."
-msgstr "Artikel wurde von Nutzern markiert."
-
-#: catalog/templates/catalog_delete.html:48
-#: catalog/templates/catalog_merge.html:92 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:55 common/views_manage.py:139
 msgid "Yes"
 msgstr "Ja"
 
-#: catalog/templates/catalog_delete.html:49
-#: catalog/templates/catalog_merge.html:93 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:56 common/views_manage.py:139
 msgid "No"
 msgstr "Nein"
 
@@ -1889,38 +1871,18 @@ msgstr "Nein"
 msgid "Create"
 msgstr "Erstellen"
 
-#: catalog/templates/catalog_edit.html:68
+#: catalog/templates/catalog_edit.html:81
 #: journal/templates/collection_update_item_note.html:8
 #: journal/templates/piece_delete.html:38
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: catalog/templates/catalog_edit.html:104
+#: catalog/templates/catalog_edit.html:118
 msgid "open linked people page"
 msgstr ""
 
-#: catalog/templates/catalog_merge.html:22
-msgid "Are you sure to merge?"
-msgstr "Sicher, dass du das zusammenfügen willst?"
-
-#: catalog/templates/catalog_merge.html:24
-msgid "Are you sure to cancel merge?"
-msgstr "Sicher, dass du die Zusammenfügung abbrechen willst?"
-
-#: catalog/templates/catalog_merge.html:27
-msgid "Are you sure to link?"
-msgstr "Sicher, dass du das verknüpfen willst?"
-
-#: catalog/templates/catalog_merge.html:86
-msgid "This operation cannot be undone. Sure to merge?"
-msgstr ""
-"Dieser Vorgang kann nicht rückgängig gemacht werden. Sicher, dass du das "
-"zusammenfügen willst?"
-
 #: catalog/templates/catalog_verify.html:21
-msgid ""
-"If you are a creator of this podcast, you may verify the ownership, so that "
-"only you (and other verified creators) can edit its metadata on this site."
+msgid "If you are a creator of this podcast, you may verify the ownership, so that only you (and other verified creators) can edit its metadata on this site."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:22
@@ -1928,9 +1890,7 @@ msgid "Your recent episodes may also occasionally be featured in discovery."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:24
-msgid ""
-"To verify, prove you control one of the following identifiers of your "
-"account (click to copy):"
+msgid "To verify, prove you control one of the following identifiers of your account (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:30
@@ -1941,18 +1901,11 @@ msgid "copied"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:35
-msgid ""
-"You can prove this in a few ways, then start verification: add one of the "
-"identifiers above to the podcast feed's description; add a <code>rel=\"me\"</"
-"code> link back to one of them on the web page your feed links to (the link "
-"verification Mastodon uses); or point your feed's website at your Bluesky "
-"handle's own domain."
+msgid "You can prove this in a few ways, then start verification: add one of the identifiers above to the podcast feed's description; add a <code>rel=\"me\"</code> link back to one of them on the web page your feed links to (the link verification Mastodon uses); or point your feed's website at your Bluesky handle's own domain."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:44
-msgid ""
-"For example, add this rel=me link to the web page your feed links to (click "
-"to copy):"
+msgid "For example, add this rel=me link to the web page your feed links to (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:50
@@ -1960,9 +1913,7 @@ msgid "or, in the page's head:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:57
-msgid ""
-"Can't edit the website? Just add a line like this to your feed's description "
-"instead (click to copy):"
+msgid "Can't edit the website? Just add a line like this to your feed's description instead (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:62
@@ -1970,10 +1921,7 @@ msgid "Welcome to follow me on the Fediverse:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:66
-msgid ""
-"NeoDB does not re-check this periodically at the moment, but we recommend "
-"you keep it so that your audience can discover and connect with you in "
-"distributed social media."
+msgid "NeoDB does not re-check this periodically at the moment, but we recommend you keep it so that your audience can discover and connect with you in distributed social media."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:72
@@ -2003,12 +1951,11 @@ msgid "Send feedback"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:115
-msgid ""
-"Questions or issues with creator verification? Let the site moderators know."
+msgid "Questions or issues with creator verification? Let the site moderators know."
 msgstr ""
 
-#: catalog/templates/discover.html:28 common/views_manage.py:145
-#: common/views_manage.py:353 users/templates/users/preferences.html:34
+#: catalog/templates/discover.html:28 common/views_manage.py:35
+#: common/views_manage.py:431 users/templates/users/preferences.html:34
 msgid "Discover"
 msgstr "Entdecken"
 
@@ -2046,17 +1993,17 @@ msgstr "anzeigen"
 msgid "hide"
 msgstr "verstecken"
 
-#: catalog/templates/discover.html:206 common/templates/_sidebar.html:14
+#: catalog/templates/discover.html:206 common/templates/_sidebar.html:13
 msgid "Unread Announcements"
 msgstr "ungelesene Ankündigungen"
 
-#: catalog/templates/discover.html:212 common/templates/_sidebar.html:20
+#: catalog/templates/discover.html:212 common/templates/_sidebar.html:19
 #: social/templates/notification.html:67
 msgid "mark all as read"
 msgstr "alles als gelesen markieren"
 
 #: catalog/templates/discover.html:222
-#: common/templates/_sidebar_anonymous.html:55
+#: common/templates/_sidebar_anonymous.html:54
 msgid "Popular Tags"
 msgstr "Beliebte Tags"
 
@@ -2067,9 +2014,9 @@ msgstr "Beliebte Tags"
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
 #: catalog/templates/user_verified_works.html:23
-#: common/templates/_sidebar.html:127
-#: common/templates/_sidebar_anonymous.html:46
-#: common/templates/_sidebar_anonymous.html:62 journal/templates/posts.html:8
+#: common/templates/_sidebar.html:126
+#: common/templates/_sidebar_anonymous.html:45
+#: common/templates/_sidebar_anonymous.html:61 journal/templates/posts.html:7
 #: journal/templates/profile_articles.html:24
 #: journal/templates/profile_articles.html:26
 #: journal/templates/profile_items.html:65
@@ -2085,7 +2032,7 @@ msgstr "Beliebte Tags"
 msgid "nothing so far."
 msgstr "bisher nichts."
 
-#: catalog/templates/discover.html:239 common/templates/_sidebar.html:269
+#: catalog/templates/discover.html:239 common/templates/_sidebar.html:268
 msgid "Recent Posts"
 msgstr "Kürzliche Beiträge"
 
@@ -2114,15 +2061,9 @@ msgstr "Leihen oder Kaufen"
 
 #: catalog/templates/external_search_results.html:10
 #, fuzzy
-#| msgid ""
-#| "System will search other websites and instances, click title of the item "
-#| "to save them locally. "
-msgid ""
-"Some items were found from other websites and instances, click their title "
-"to save them locally."
-msgstr ""
-"Es werden weitere Instanzen durchsucht. Klicke auf einen Artikel um ihn "
-"lokal zu speichern. "
+#| msgid "System will search other websites and instances, click title of the item to save them locally. "
+msgid "Some items were found from other websites and instances, click their title to save them locally."
+msgstr "Es werden weitere Instanzen durchsucht. Klicke auf einen Artikel um ihn lokal zu speichern. "
 
 #: catalog/templates/fetch_pending.html:13
 msgid "Search results"
@@ -2148,9 +2089,7 @@ msgstr "markieren, kommentieren und sammeln"
 
 #: catalog/templates/item_base.html:142
 msgid "Login or register to review or add this item to your collection."
-msgstr ""
-"Zum Bewerten, Kommentieren oder Hinzufügen des Artikels zu deiner Sammlung, "
-"musst du dich anmelden oder registrieren."
+msgstr "Zum Bewerten, Kommentieren oder Hinzufügen des Artikels zu deiner Sammlung, musst du dich anmelden oder registrieren."
 
 #: catalog/templates/item_base.html:151
 msgid "Related Collections"
@@ -2225,14 +2164,14 @@ msgstr "Anzahl der Staffeln"
 msgid "number of Episodes"
 msgstr "Anzahl der Folgen"
 
-#: catalog/templates/people.html:13 common/templates/_sidebar.html:77
-#: common/templates/_sidebar.html:84 journal/models/shelf.py:326
+#: catalog/templates/people.html:13 common/templates/_sidebar.html:76
+#: common/templates/_sidebar.html:83 journal/models/shelf.py:328
 #, fuzzy
 #| msgid "following you"
 msgid "following"
 msgstr "folgt dir"
 
-#: catalog/templates/people.html:15 journal/models/shelf.py:324
+#: catalog/templates/people.html:15 journal/models/shelf.py:326
 #: social/templates/notification.html:60
 msgid "follow"
 msgstr "folgen"
@@ -2251,7 +2190,6 @@ msgstr ""
 #: journal/templates/_sidebar_collection_filter.html:14
 #: journal/templates/_sidebar_collection_filter.html:28
 #: journal/templates/_sidebar_user_mark_list.html:56
-#: social/templates/feed.html:42 social/templates/feed.html:44
 #: social/templates/notification.html:56
 msgid "all"
 msgstr "alle"
@@ -2279,7 +2217,7 @@ msgstr "abgeschlossen"
 msgid "production"
 msgstr "Produktion"
 
-#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:54
+#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:53
 #, fuzzy
 #| msgid "original creator"
 msgid "verified creator"
@@ -2364,14 +2302,8 @@ msgid "No items matching your search query."
 msgstr "Keine Artikel die deiner Suchanfrage entsprechen."
 
 #: catalog/templates/search_results.html:34
-msgid ""
-"If you have URL from one of these sites, please put the full URL (e.g. "
-"<code>https://www.imdb.com/title/tt2513074/</code>) to the search box and "
-"press Enter."
-msgstr ""
-"Wenn du die URL von einer dieser Seiten hast, gib bitte die volle URL (e.g. "
-"<code>https://www.imdb.com/title/tt2513074/</code>) in das Suchfeld ein und "
-"drücke Enter."
+msgid "If you have URL from one of these sites, please put the full URL (e.g. <code>https://www.imdb.com/title/tt2513074/</code>) to the search box and press Enter."
+msgstr "Wenn du die URL von einer dieser Seiten hast, gib bitte die volle URL (e.g. <code>https://www.imdb.com/title/tt2513074/</code>) in das Suchfeld ein und drücke Enter."
 
 #: catalog/templates/search_results.html:48
 msgid "Searching from other sites"
@@ -2379,8 +2311,7 @@ msgstr "Andere Seiten werden durchsucht"
 
 #: catalog/templates/search_results.html:51
 msgid "Logged in user may see search results from other sites."
-msgstr ""
-"Angemeldete Nutzer sehen möglicherweise Suchergebnisse von anderen Seiten."
+msgstr "Angemeldete Nutzer sehen möglicherweise Suchergebnisse von anderen Seiten."
 
 #: catalog/templates/search_results_people.html:12
 #: journal/templates/profile.html:200 journal/views/profile.py:614
@@ -2410,103 +2341,192 @@ msgstr ""
 msgid "Editions"
 msgstr "Versionen"
 
-#: catalog/views/edit.py:202 catalog/views/edit.py:205
-#: catalog/views/edit.py:306 catalog/views/edit.py:309
-#: catalog/views/verify.py:197 journal/views/collection.py:77
-#: journal/views/collection.py:102 journal/views/collection.py:556
-#: journal/views/collection.py:651 journal/views/common.py:221
-#: journal/views/mark.py:196 journal/views/post.py:117
-#: journal/views/post.py:119 journal/views/post.py:166
-#: journal/views/post.py:185 journal/views/post.py:187
-#: journal/views/post.py:228 journal/views/post.py:241
+#: catalog/views/edit.py:293 catalog/views/edit.py:296
+#: catalog/views/edit.py:440 catalog/views/edit.py:443
+#: catalog/views/verify.py:197 journal/views/collection.py:75
+#: journal/views/collection.py:100 journal/views/collection.py:538
+#: journal/views/collection.py:634 journal/views/common.py:231
+#: journal/views/mark.py:244 journal/views/post.py:119
+#: journal/views/post.py:121 journal/views/post.py:168
+#: journal/views/post.py:187 journal/views/post.py:189
+#: journal/views/post.py:230 journal/views/post.py:243
 #: journal/views/review.py:154 journal/views/review.py:158
-#: users/views/actions.py:179
+#: users/views/actions.py:178
 msgid "Invalid parameter"
 msgstr "Ungültige Parameter"
 
-#: catalog/views/edit.py:220
+#: catalog/views/edit.py:313
 msgid "Item in use."
 msgstr "Artikel in Benutzung."
 
-#: catalog/views/edit.py:222
+#: catalog/views/edit.py:315
 msgid "Item cannot be deleted."
 msgstr "Artikel kann nicht gelöscht werden."
 
-#: catalog/views/edit.py:247 catalog/views/edit.py:303
-#: catalog/views/edit.py:427 catalog/views/edit.py:519
-#: catalog/views/edit.py:552 catalog/views/verify.py:158
+#: catalog/views/edit.py:319 catalog/views/edit.py:515
+msgid "Are you sure to delete?"
+msgstr "Sicher, dass du das löschen willst?"
+
+#: catalog/views/edit.py:323 catalog/views/edit.py:518
+#: catalog/views/edit.py:617
+#, fuzzy
+#| msgid "This operation cannot be undone. Sure to merge?"
+msgid "This operation cannot be undone."
+msgstr "Dieser Vorgang kann nicht rückgängig gemacht werden. Sicher, dass du das zusammenfügen willst?"
+
+#: catalog/views/edit.py:344 catalog/views/edit.py:437
+#: catalog/views/edit.py:603 catalog/views/edit.py:705
+#: catalog/views/edit.py:752 catalog/views/verify.py:158
 #: catalog/views/verify.py:206 journal/views/article.py:44
 #: journal/views/article.py:133 journal/views/article.py:153
 #: journal/views/collection.py:248 journal/views/collection.py:341
-#: journal/views/collection.py:360 journal/views/collection.py:384
-#: journal/views/collection.py:457 journal/views/collection.py:500
-#: journal/views/collection.py:539 journal/views/collection.py:551
-#: journal/views/collection.py:576 journal/views/collection.py:613
-#: journal/views/common.py:300 journal/views/mark.py:281
-#: journal/views/post.py:58 journal/views/post.py:78 journal/views/post.py:100
-#: journal/views/post.py:170 journal/views/post.py:199
-#: journal/views/post.py:272 journal/views/post.py:287
-#: journal/views/post.py:394 journal/views/post.py:549
+#: journal/views/collection.py:354 journal/views/collection.py:372
+#: journal/views/collection.py:439 journal/views/collection.py:482
+#: journal/views/collection.py:521 journal/views/collection.py:533
+#: journal/views/collection.py:558 journal/views/collection.py:595
+#: journal/views/common.py:304 journal/views/mark.py:317
+#: journal/views/post.py:60 journal/views/post.py:80 journal/views/post.py:102
+#: journal/views/post.py:172 journal/views/post.py:201
+#: journal/views/post.py:274 journal/views/post.py:289
+#: journal/views/post.py:390 journal/views/post.py:539
 #: journal/views/review.py:64 journal/views/review.py:81
 #: journal/views/review.py:106
 msgid "Insufficient permission"
 msgstr "Unzureichende Berechtigung"
 
-#: catalog/views/edit.py:374
+#: catalog/views/edit.py:346
+#, fuzzy
+#| msgid "Item has been deleted."
+msgid "Item is not deleted"
+msgstr "Artikel wurde gelöscht."
+
+#: catalog/views/edit.py:389
+#, fuzzy
+#| msgid "Switching may remove some metadata. Sure to proceed?"
+msgid "Switching may remove some metadata."
+msgstr "Das Ändern der Kategorie löscht möglicherweise Metadaten. Möchtest du fortfahren?"
+
+#: catalog/views/edit.py:395
+#, fuzzy
+#| msgid "The following items are merged into this item"
+msgid "The following seasons will be detached from this show"
+msgstr "Folgende Artikel wurden in diesen Artikel zusammengefügt"
+
+#: catalog/views/edit.py:400
+msgid "Links to IMDB and TMDB will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:403
+#, fuzzy
+#| msgid "Are you sure to merge?"
+msgid "Are you sure to switch category?"
+msgstr "Sicher, dass du das zusammenfügen willst?"
+
+#: catalog/views/edit.py:451
+#, fuzzy
+#| msgid "Are you sure to delete this post?"
+msgid "Are you sure to remove the link to this site?"
+msgstr "Möchtest du diesen Beitrag löschen?"
+
+#: catalog/views/edit.py:457
+#, fuzzy
+#| msgid "You may not be able to undo this operation, sure to remove?"
+msgid "You may not be able to undo this operation."
+msgstr "Du kannst diesen Vorgang möglicherweise nicht rückgängig machen. Sicher, dass du es entfernen willst?"
+
+#: catalog/views/edit.py:483
+#, fuzzy
+#| msgid "Link to parent item"
+msgid "Current parent item"
+msgstr "Verknüpfung zum übergeordneten Artikel"
+
+#: catalog/views/edit.py:487
+msgid "The link to the parent item will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:490 catalog/views/edit.py:680
+msgid "Are you sure to link?"
+msgstr "Sicher, dass du das verknüpfen willst?"
+
+#: catalog/views/edit.py:521
+msgid "The following seasons will be deleted"
+msgstr ""
+
+#: catalog/views/edit.py:525
+msgid "The following seasons will be kept"
+msgstr ""
+
+#: catalog/views/edit.py:550
 msgid "TV Season with IMDB id and season number required."
 msgstr "Staffel mit IMDB-ID und Staffelnummer benötigt."
 
-#: catalog/views/edit.py:380
+#: catalog/views/edit.py:556
 msgid "Updating episodes"
 msgstr "Aktualisiere Folgen"
 
-#: catalog/views/edit.py:405
+#: catalog/views/edit.py:581
 msgid "This person has no supported source to fetch works from."
 msgstr ""
 
-#: catalog/views/edit.py:412
+#: catalog/views/edit.py:588
 msgid "Already pulling works for this person, try again later."
 msgstr ""
 
-#: catalog/views/edit.py:416
+#: catalog/views/edit.py:592
 msgid "Pulling works in background."
 msgstr ""
 
-#: catalog/views/edit.py:438
-msgid "Cannot be merged to an item already deleted or merged"
-msgstr ""
-"Kann nicht mit einem bereits zusammengefügten oder gelöschten Artikel "
-"zusammengefügt werden"
+#: catalog/views/edit.py:609
+msgid "Are you sure to merge?"
+msgstr "Sicher, dass du das zusammenfügen willst?"
 
-#: catalog/views/edit.py:443
+#: catalog/views/edit.py:611
+msgid "Are you sure to cancel merge?"
+msgstr "Sicher, dass du die Zusammenfügung abbrechen willst?"
+
+#: catalog/views/edit.py:622
+msgid "Cannot be merged to an item already deleted or merged"
+msgstr "Kann nicht mit einem bereits zusammengefügten oder gelöschten Artikel zusammengefügt werden"
+
+#: catalog/views/edit.py:627
 msgid "Cannot merge items in different categories"
 msgstr "Zusammenfügen von Artikeln verschiedener Kategorien nicht möglich"
 
-#: catalog/views/edit.py:447
+#: catalog/views/edit.py:631
 #, fuzzy
 #| msgid "Cannot merge items in different categories"
 msgid "Cannot merge an item to itself"
 msgstr "Zusammenfügen von Artikeln verschiedener Kategorien nicht möglich"
 
-#: catalog/views/edit.py:488
+#: catalog/views/edit.py:672
 msgid "Cannot be linked to an item already deleted or merged"
-msgstr ""
-"Kann nicht mit einem bereits zusammengefügten oder gelöschten Artikel "
-"verknüpft werden"
+msgstr "Kann nicht mit einem bereits zusammengefügten oder gelöschten Artikel verknüpft werden"
 
-#: catalog/views/edit.py:492
+#: catalog/views/edit.py:676
 msgid "Cannot link items other than editions"
 msgstr "Andere Artikel als Versionen können nicht verknüpft werden"
 
-#: catalog/views/search.py:96
+#: catalog/views/edit.py:710
+#, fuzzy
+#| msgid "Are you sure to link?"
+msgid "Are you sure to unlink?"
+msgstr "Sicher, dass du das verknüpfen willst?"
+
+#: catalog/views/edit.py:715
+#, fuzzy
+#| msgid "This edition belongs to the following work"
+msgid "This edition will be unlinked from the following work"
+msgstr "Diese Version gehört zu folgendem Werk"
+
+#: catalog/views/search.py:113
 msgid "the internet"
 msgstr ""
 
-#: catalog/views/search.py:359
+#: catalog/views/search.py:410
 msgid "Invalid URL"
 msgstr "ungültige URL"
 
-#: catalog/views/search.py:362
+#: catalog/views/search.py:413
 #, fuzzy
 #| msgid "Unsupported item type."
 msgid "Unsupported URL"
@@ -2532,9 +2552,9 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:122 common/utils.py:163
+#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
 #: journal/views/article.py:186 journal/views/review.py:182
-#: users/views/actions.py:45 users/views/actions.py:131
+#: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
 msgstr "Benutzer nicht gefunden"
 
@@ -2548,15 +2568,15 @@ msgstr ""
 msgid "Creator verification removed."
 msgstr "sende Verifikations-Code"
 
-#: catalog/views/view.py:74 catalog/views/view.py:99
+#: catalog/views/view.py:77 catalog/views/view.py:102
 msgid "Item not found"
 msgstr "Artikel nicht gefunden"
 
-#: catalog/views/view.py:78 catalog/views/view.py:107 catalog/views/view.py:190
+#: catalog/views/view.py:81 catalog/views/view.py:110 catalog/views/view.py:193
 msgid "Item no longer exists"
 msgstr "Artikel existiert nicht mehr"
 
-#: catalog/views/view.py:187
+#: catalog/views/view.py:190
 #, fuzzy
 #| msgid "Invalid file."
 msgid "Invalid role"
@@ -3104,759 +3124,759 @@ msgctxt "genre"
 msgid "Health"
 msgstr ""
 
-#: common/models/lang.py:54
+#: common/models/lang.py:56
 msgid "Afar"
 msgstr "Afar"
 
-#: common/models/lang.py:55
+#: common/models/lang.py:57
 msgid "Afrikaans"
 msgstr "Afrikaans"
 
-#: common/models/lang.py:56
+#: common/models/lang.py:58
 msgid "Akan"
 msgstr "Akan"
 
-#: common/models/lang.py:57
+#: common/models/lang.py:59
 msgid "Aragonese"
 msgstr "Aragonesisch"
 
-#: common/models/lang.py:58
+#: common/models/lang.py:60
 msgid "Assamese"
 msgstr "Assamesisch"
 
-#: common/models/lang.py:59
+#: common/models/lang.py:61
 msgid "Avaric"
 msgstr "Avaric"
 
-#: common/models/lang.py:60
+#: common/models/lang.py:62
 msgid "Avestan"
 msgstr "Avestisch"
 
-#: common/models/lang.py:61
+#: common/models/lang.py:63
 msgid "Aymara"
 msgstr "Aymara"
 
-#: common/models/lang.py:62
+#: common/models/lang.py:64
 msgid "Azerbaijani"
 msgstr "Aserbaidschanisch"
 
-#: common/models/lang.py:63
+#: common/models/lang.py:65
 msgid "Bashkir"
 msgstr "Baschkirisch"
 
-#: common/models/lang.py:64
+#: common/models/lang.py:66
 msgid "Bambara"
 msgstr "Bambara"
 
-#: common/models/lang.py:65
+#: common/models/lang.py:67
 msgid "Bislama"
 msgstr "Bislama"
 
-#: common/models/lang.py:66
+#: common/models/lang.py:68
 msgid "Tibetan"
 msgstr "Tibetanisch"
 
-#: common/models/lang.py:67
+#: common/models/lang.py:69
 msgid "Breton"
 msgstr "Bretonisch"
 
-#: common/models/lang.py:68
+#: common/models/lang.py:70
 msgid "Catalan"
 msgstr "Katalanisch"
 
-#: common/models/lang.py:69
+#: common/models/lang.py:71
 msgid "Czech"
 msgstr "Tschechisch"
 
-#: common/models/lang.py:70
+#: common/models/lang.py:72
 msgid "Chechen"
 msgstr "Tschetschenisch"
 
-#: common/models/lang.py:71
+#: common/models/lang.py:73
 msgid "Slavic"
 msgstr "Slawisch"
 
-#: common/models/lang.py:72
+#: common/models/lang.py:74
 msgid "Chuvash"
 msgstr "Tschuwaschisch"
 
-#: common/models/lang.py:73
+#: common/models/lang.py:75
 msgid "Cornish"
 msgstr "Kornisch"
 
-#: common/models/lang.py:74
+#: common/models/lang.py:76
 msgid "Corsican"
 msgstr "Korsisch"
 
-#: common/models/lang.py:75
+#: common/models/lang.py:77
 msgid "Cree"
 msgstr "Cree"
 
-#: common/models/lang.py:76
+#: common/models/lang.py:78
 msgid "Welsh"
 msgstr "Walisisch"
 
-#: common/models/lang.py:79
+#: common/models/lang.py:81
 msgid "Divehi"
 msgstr "Dhivehi"
 
-#: common/models/lang.py:80
+#: common/models/lang.py:82
 msgid "Dzongkha"
 msgstr "Dzongkha"
 
-#: common/models/lang.py:81
+#: common/models/lang.py:83
 msgid "Esperanto"
 msgstr "Esperanto"
 
-#: common/models/lang.py:82
+#: common/models/lang.py:84
 msgid "Estonian"
 msgstr "Estnisch"
 
-#: common/models/lang.py:83
+#: common/models/lang.py:85
 msgid "Basque"
 msgstr "Baskisch"
 
-#: common/models/lang.py:84
+#: common/models/lang.py:86
 msgid "Faroese"
 msgstr "Färöisch"
 
-#: common/models/lang.py:85
+#: common/models/lang.py:87
 msgid "Fijian"
 msgstr "Fidschianisch"
 
-#: common/models/lang.py:86
+#: common/models/lang.py:88
 msgid "Finnish"
 msgstr "Finnisch"
 
-#: common/models/lang.py:88
+#: common/models/lang.py:90
 msgid "Frisian"
 msgstr "Friesisch"
 
-#: common/models/lang.py:89
+#: common/models/lang.py:91
 msgid "Fulah"
 msgstr "Fulah"
 
-#: common/models/lang.py:90
+#: common/models/lang.py:92
 msgid "Gaelic"
 msgstr "Gälisch"
 
-#: common/models/lang.py:91
+#: common/models/lang.py:93
 msgid "Irish"
 msgstr "Irisch"
 
-#: common/models/lang.py:92
+#: common/models/lang.py:94
 msgid "Galician"
 msgstr "Galicisch"
 
-#: common/models/lang.py:93
+#: common/models/lang.py:95
 msgid "Manx"
 msgstr "Manx"
 
-#: common/models/lang.py:94
+#: common/models/lang.py:96
 msgid "Guarani"
 msgstr "Guaraní"
 
-#: common/models/lang.py:95
+#: common/models/lang.py:97
 msgid "Gujarati"
 msgstr "Gujarati"
 
-#: common/models/lang.py:96
+#: common/models/lang.py:98
 msgid "Haitian; Haitian Creole"
 msgstr "Haitianisch; Haitianisch-Kreolisch"
 
-#: common/models/lang.py:97
+#: common/models/lang.py:99
 msgid "Hausa"
 msgstr "Hausa"
 
-#: common/models/lang.py:98
+#: common/models/lang.py:100
 msgid "Serbo-Croatian"
 msgstr "Serbokroatisch"
 
-#: common/models/lang.py:99
+#: common/models/lang.py:101
 msgid "Herero"
 msgstr "Herero"
 
-#: common/models/lang.py:100
+#: common/models/lang.py:102
 msgid "Hiri Motu"
 msgstr "Hiri Motu"
 
-#: common/models/lang.py:101
+#: common/models/lang.py:103
 msgid "Croatian"
 msgstr "Kroatisch"
 
-#: common/models/lang.py:102
+#: common/models/lang.py:104
 msgid "Hungarian"
 msgstr "Ungarisch"
 
-#: common/models/lang.py:103
+#: common/models/lang.py:105
 msgid "Igbo"
 msgstr "Igbo"
 
-#: common/models/lang.py:104
+#: common/models/lang.py:106
 msgid "Ido"
 msgstr "Ido"
 
-#: common/models/lang.py:105
+#: common/models/lang.py:107
 msgid "Yi"
 msgstr "Yi"
 
-#: common/models/lang.py:106
+#: common/models/lang.py:108
 msgid "Inuktitut"
 msgstr "Inuktitut"
 
-#: common/models/lang.py:107
+#: common/models/lang.py:109
 msgid "Interlingue"
 msgstr "Interlingue"
 
-#: common/models/lang.py:108
+#: common/models/lang.py:110
 msgid "Interlingua"
 msgstr "Interlingua"
 
-#: common/models/lang.py:109
+#: common/models/lang.py:111
 msgid "Indonesian"
 msgstr "Indonesisch"
 
-#: common/models/lang.py:110
+#: common/models/lang.py:112
 msgid "Inupiaq"
 msgstr "Inupiaq"
 
-#: common/models/lang.py:111
+#: common/models/lang.py:113
 msgid "Icelandic"
 msgstr "Isländisch"
 
-#: common/models/lang.py:113
+#: common/models/lang.py:115
 msgid "Javanese"
 msgstr "Javanisch"
 
-#: common/models/lang.py:114
+#: common/models/lang.py:116
 msgid "Japanese"
 msgstr "Japanisch"
 
-#: common/models/lang.py:115
+#: common/models/lang.py:117
 msgid "Kalaallisut"
 msgstr "Kalaallisut"
 
-#: common/models/lang.py:116
+#: common/models/lang.py:118
 msgid "Kannada"
 msgstr "Kanaresisch"
 
-#: common/models/lang.py:117
+#: common/models/lang.py:119
 msgid "Kashmiri"
 msgstr "Kaschmiri"
 
-#: common/models/lang.py:118
+#: common/models/lang.py:120
 msgid "Kanuri"
 msgstr "Kanuri"
 
-#: common/models/lang.py:119
+#: common/models/lang.py:121
 msgid "Kazakh"
 msgstr "Kasachisch"
 
-#: common/models/lang.py:120
+#: common/models/lang.py:122
 msgid "Khmer"
 msgstr "Khmer"
 
-#: common/models/lang.py:121
+#: common/models/lang.py:123
 msgid "Kikuyu"
 msgstr "Kikuyu"
 
-#: common/models/lang.py:122
+#: common/models/lang.py:124
 msgid "Kinyarwanda"
 msgstr "Kinyarwanda"
 
-#: common/models/lang.py:123
+#: common/models/lang.py:125
 msgid "Kirghiz"
 msgstr "Kirgisisch"
 
-#: common/models/lang.py:124
+#: common/models/lang.py:126
 msgid "Komi"
 msgstr "Komi"
 
-#: common/models/lang.py:125
+#: common/models/lang.py:127
 msgid "Kongo"
 msgstr "Kongo"
 
-#: common/models/lang.py:126
+#: common/models/lang.py:128
 msgid "Korean"
 msgstr "Koreanisch"
 
-#: common/models/lang.py:127
+#: common/models/lang.py:129
 msgid "Kuanyama"
 msgstr "Kuanyama"
 
-#: common/models/lang.py:128
+#: common/models/lang.py:130
 msgid "Kurdish"
 msgstr "Kurdisch"
 
-#: common/models/lang.py:129
+#: common/models/lang.py:131
 msgid "Lao"
 msgstr "Laotisch"
 
-#: common/models/lang.py:130
+#: common/models/lang.py:132
 msgid "Latin"
 msgstr "Latein"
 
-#: common/models/lang.py:131
+#: common/models/lang.py:133
 msgid "Latvian"
 msgstr "Lettisch"
 
-#: common/models/lang.py:132
+#: common/models/lang.py:134
 msgid "Limburgish"
 msgstr "Limburgisch"
 
-#: common/models/lang.py:133
+#: common/models/lang.py:135
 msgid "Lingala"
 msgstr "Lingala"
 
-#: common/models/lang.py:134
+#: common/models/lang.py:136
 msgid "Lithuanian"
 msgstr "Litauisch"
 
-#: common/models/lang.py:135
+#: common/models/lang.py:137
 msgid "Letzeburgesch"
 msgstr "Luxemburgisch"
 
-#: common/models/lang.py:136
+#: common/models/lang.py:138
 msgid "Luba-Katanga"
 msgstr "Luba-Katanga"
 
-#: common/models/lang.py:137
+#: common/models/lang.py:139
 msgid "Ganda"
 msgstr "Ganda"
 
-#: common/models/lang.py:138
+#: common/models/lang.py:140
 msgid "Marshall"
 msgstr "Marshallesisch"
 
-#: common/models/lang.py:139
+#: common/models/lang.py:141
 msgid "Malayalam"
 msgstr "Malayalam"
 
-#: common/models/lang.py:140
+#: common/models/lang.py:142
 msgid "Marathi"
 msgstr "Marathi"
 
-#: common/models/lang.py:141
+#: common/models/lang.py:143
 msgid "Malagasy"
 msgstr "Malagasy"
 
-#: common/models/lang.py:142
+#: common/models/lang.py:144
 msgid "Maltese"
 msgstr "Maltesisch"
 
-#: common/models/lang.py:143
+#: common/models/lang.py:145
 msgid "Moldavian"
 msgstr "Moldauisch"
 
-#: common/models/lang.py:144
+#: common/models/lang.py:146
 msgid "Mongolian"
 msgstr "Mongolisch"
 
-#: common/models/lang.py:145
+#: common/models/lang.py:147
 msgid "Maori"
 msgstr "Maorisch"
 
-#: common/models/lang.py:146
+#: common/models/lang.py:148
 msgid "Malay"
 msgstr "Malaiisch"
 
-#: common/models/lang.py:147
+#: common/models/lang.py:149
 msgid "Burmese"
 msgstr "Birmanisch"
 
-#: common/models/lang.py:148
+#: common/models/lang.py:150
 msgid "Nauru"
 msgstr "Nauruisch"
 
-#: common/models/lang.py:149
+#: common/models/lang.py:151
 msgid "Navajo"
 msgstr "Navajo"
 
-#: common/models/lang.py:150 common/models/lang.py:151
+#: common/models/lang.py:152 common/models/lang.py:153
 msgid "Ndebele"
 msgstr "Ndebele"
 
-#: common/models/lang.py:152
+#: common/models/lang.py:154
 msgid "Ndonga"
 msgstr "Ndonga"
 
-#: common/models/lang.py:153
+#: common/models/lang.py:155
 msgid "Nepali"
 msgstr "Nepali"
 
-#: common/models/lang.py:154
+#: common/models/lang.py:156
 msgid "Dutch"
 msgstr "Niederländisch"
 
-#: common/models/lang.py:155
+#: common/models/lang.py:157
 msgid "Norwegian Nynorsk"
 msgstr "Norwegisch Nynorsk"
 
-#: common/models/lang.py:156
+#: common/models/lang.py:158
 msgid "Norwegian Bokmål"
 msgstr "Norwegisch Bokmål"
 
-#: common/models/lang.py:157
+#: common/models/lang.py:159
 msgid "Norwegian"
 msgstr "Norwegisch"
 
-#: common/models/lang.py:158
+#: common/models/lang.py:160
 msgid "Chichewa; Nyanja"
 msgstr "Chichewa; Nyanja"
 
-#: common/models/lang.py:159
+#: common/models/lang.py:161
 msgid "Occitan"
 msgstr "Okzitanisch"
 
-#: common/models/lang.py:160
+#: common/models/lang.py:162
 msgid "Ojibwa"
 msgstr "Ojibwa"
 
-#: common/models/lang.py:161
+#: common/models/lang.py:163
 msgid "Oriya"
 msgstr "Oriya"
 
-#: common/models/lang.py:162
+#: common/models/lang.py:164
 msgid "Oromo"
 msgstr "Oromo"
 
-#: common/models/lang.py:163
+#: common/models/lang.py:165
 msgid "Ossetian; Ossetic"
 msgstr "Ossetisch"
 
-#: common/models/lang.py:164
+#: common/models/lang.py:166
 msgid "Pali"
 msgstr "Pali"
 
-#: common/models/lang.py:165
+#: common/models/lang.py:167
 msgid "Polish"
 msgstr "Polnisch"
 
-#: common/models/lang.py:167
+#: common/models/lang.py:169
 msgid "Quechua"
 msgstr "Quechua"
 
-#: common/models/lang.py:168
+#: common/models/lang.py:170
 msgid "Raeto-Romance"
 msgstr "Rätoromanisch"
 
-#: common/models/lang.py:169
+#: common/models/lang.py:171
 msgid "Romanian"
 msgstr "Rumänisch"
 
-#: common/models/lang.py:170
+#: common/models/lang.py:172
 msgid "Rundi"
 msgstr "Rundisch"
 
-#: common/models/lang.py:171
+#: common/models/lang.py:173
 msgid "Russian"
 msgstr "Russisch"
 
-#: common/models/lang.py:172
+#: common/models/lang.py:174
 msgid "Sango"
 msgstr "Sango"
 
-#: common/models/lang.py:173
+#: common/models/lang.py:175
 msgid "Sanskrit"
 msgstr "Sanskrit"
 
-#: common/models/lang.py:174
+#: common/models/lang.py:176
 msgid "Sinhalese"
 msgstr "Singhalesisch"
 
-#: common/models/lang.py:175
+#: common/models/lang.py:177
 msgid "Slovak"
 msgstr "Slowakisch"
 
-#: common/models/lang.py:176
+#: common/models/lang.py:178
 msgid "Slovenian"
 msgstr "Slowenisch"
 
-#: common/models/lang.py:177
+#: common/models/lang.py:179
 msgid "Northern Sami"
 msgstr "Nordsamisch"
 
-#: common/models/lang.py:178
+#: common/models/lang.py:180
 msgid "Samoan"
 msgstr "Samoanisch"
 
-#: common/models/lang.py:179
+#: common/models/lang.py:181
 msgid "Shona"
 msgstr "Shona"
 
-#: common/models/lang.py:180
+#: common/models/lang.py:182
 msgid "Sindhi"
 msgstr "Sindhi"
 
-#: common/models/lang.py:181
+#: common/models/lang.py:183
 msgid "Somali"
 msgstr "Somali"
 
-#: common/models/lang.py:182
+#: common/models/lang.py:184
 msgid "Sotho"
 msgstr "Sotho"
 
-#: common/models/lang.py:184
+#: common/models/lang.py:186
 msgid "Albanian"
 msgstr "Albanisch"
 
-#: common/models/lang.py:185
+#: common/models/lang.py:187
 msgid "Sardinian"
 msgstr "Sardisch"
 
-#: common/models/lang.py:186
+#: common/models/lang.py:188
 msgid "Serbian"
 msgstr "Serbisch"
 
-#: common/models/lang.py:187
+#: common/models/lang.py:189
 msgid "Swati"
 msgstr "Swati"
 
-#: common/models/lang.py:188
+#: common/models/lang.py:190
 msgid "Sundanese"
 msgstr "Sundanesisch"
 
-#: common/models/lang.py:189
+#: common/models/lang.py:191
 msgid "Swahili"
 msgstr "Swahili"
 
-#: common/models/lang.py:190
+#: common/models/lang.py:192
 msgid "Swedish"
 msgstr "Schwedisch"
 
-#: common/models/lang.py:191
+#: common/models/lang.py:193
 msgid "Tahitian"
 msgstr "Tahitianisch"
 
-#: common/models/lang.py:192
+#: common/models/lang.py:194
 msgid "Tamil"
 msgstr "Tamil"
 
-#: common/models/lang.py:193
+#: common/models/lang.py:195
 msgid "Tatar"
 msgstr "Tatarisch"
 
-#: common/models/lang.py:194
+#: common/models/lang.py:196
 msgid "Telugu"
 msgstr "Telugu"
 
-#: common/models/lang.py:195
+#: common/models/lang.py:197
 msgid "Tajik"
 msgstr "Tadschikisch"
 
-#: common/models/lang.py:196
+#: common/models/lang.py:198
 msgid "Tagalog"
 msgstr "Tagalog"
 
-#: common/models/lang.py:197
+#: common/models/lang.py:199
 msgid "Thai"
 msgstr "Thailändisch"
 
-#: common/models/lang.py:198
+#: common/models/lang.py:200
 msgid "Tigrinya"
 msgstr "Tigrinya"
 
-#: common/models/lang.py:199
+#: common/models/lang.py:201
 msgid "Tonga"
 msgstr "Tongaisch"
 
-#: common/models/lang.py:200
+#: common/models/lang.py:202
 msgid "Tswana"
 msgstr "Setswana"
 
-#: common/models/lang.py:201
+#: common/models/lang.py:203
 msgid "Tsonga"
 msgstr "Tsonga"
 
-#: common/models/lang.py:202
+#: common/models/lang.py:204
 msgid "Turkmen"
 msgstr "Turkmenisch"
 
-#: common/models/lang.py:203
+#: common/models/lang.py:205
 msgid "Turkish"
 msgstr "Türkisch"
 
-#: common/models/lang.py:204
+#: common/models/lang.py:206
 msgid "Twi"
 msgstr "Twi"
 
-#: common/models/lang.py:205
+#: common/models/lang.py:207
 msgid "Uighur"
 msgstr "Uigurisch"
 
-#: common/models/lang.py:206
+#: common/models/lang.py:208
 msgid "Ukrainian"
 msgstr "Ukrainisch"
 
-#: common/models/lang.py:207
+#: common/models/lang.py:209
 msgid "Urdu"
 msgstr "Urdu"
 
-#: common/models/lang.py:208
+#: common/models/lang.py:210
 msgid "Uzbek"
 msgstr "Usbekisch"
 
-#: common/models/lang.py:209
+#: common/models/lang.py:211
 msgid "Venda"
 msgstr "Venda"
 
-#: common/models/lang.py:210
+#: common/models/lang.py:212
 msgid "Vietnamese"
 msgstr "Vietnamesisch"
 
-#: common/models/lang.py:211
+#: common/models/lang.py:213
 msgid "Volapük"
 msgstr "Volapük"
 
-#: common/models/lang.py:212
+#: common/models/lang.py:214
 msgid "Walloon"
 msgstr "Wallonisch"
 
-#: common/models/lang.py:213
+#: common/models/lang.py:215
 msgid "Wolof"
 msgstr "Wolof"
 
-#: common/models/lang.py:214
+#: common/models/lang.py:216
 msgid "Xhosa"
 msgstr "Xhosa"
 
-#: common/models/lang.py:215
+#: common/models/lang.py:217
 msgid "Yiddish"
 msgstr "Jiddisch"
 
-#: common/models/lang.py:216
+#: common/models/lang.py:218
 msgid "Zhuang"
 msgstr "Zhuang"
 
-#: common/models/lang.py:217
+#: common/models/lang.py:219
 msgid "Zulu"
 msgstr "Zulu"
 
-#: common/models/lang.py:218
+#: common/models/lang.py:220
 msgid "Abkhazian"
 msgstr "Abchasisch"
 
-#: common/models/lang.py:219
+#: common/models/lang.py:221
 msgid "Chinese"
 msgstr "Chinesisch"
 
-#: common/models/lang.py:220
+#: common/models/lang.py:222
 msgid "Pushto"
 msgstr "Paschtunisch"
 
-#: common/models/lang.py:221
+#: common/models/lang.py:223
 msgid "Amharic"
 msgstr "Amharisch"
 
-#: common/models/lang.py:222
+#: common/models/lang.py:224
 msgid "Arabic"
 msgstr "Arabisch"
 
-#: common/models/lang.py:223
+#: common/models/lang.py:225
 msgid "Bulgarian"
 msgstr "Bulgarisch"
 
-#: common/models/lang.py:224
+#: common/models/lang.py:226
 msgid "Macedonian"
 msgstr "Mazedonisch"
 
-#: common/models/lang.py:225
+#: common/models/lang.py:227
 msgid "Greek"
 msgstr "Griechisch"
 
-#: common/models/lang.py:226
+#: common/models/lang.py:228
 msgid "Persian"
 msgstr "Persisch"
 
-#: common/models/lang.py:227
+#: common/models/lang.py:229
 msgid "Hebrew"
 msgstr "Hebräisch"
 
-#: common/models/lang.py:228
+#: common/models/lang.py:230
 msgid "Hindi"
 msgstr "Hindi"
 
-#: common/models/lang.py:229
+#: common/models/lang.py:231
 msgid "Armenian"
 msgstr "Armenisch"
 
-#: common/models/lang.py:231
+#: common/models/lang.py:233
 msgid "Ewe"
 msgstr "Ewe"
 
-#: common/models/lang.py:232
+#: common/models/lang.py:234
 msgid "Georgian"
 msgstr "Georgisch"
 
-#: common/models/lang.py:233
+#: common/models/lang.py:235
 msgid "Punjabi"
 msgstr "Punjabi"
 
-#: common/models/lang.py:234
+#: common/models/lang.py:236
 msgid "Bengali"
 msgstr "Bengalisch"
 
-#: common/models/lang.py:235
+#: common/models/lang.py:237
 msgid "Bosnian"
 msgstr "Bosnisch"
 
-#: common/models/lang.py:236
+#: common/models/lang.py:238
 msgid "Chamorro"
 msgstr "Chamorro"
 
-#: common/models/lang.py:237
+#: common/models/lang.py:239
 msgid "Belarusian"
 msgstr "Belarussisch"
 
-#: common/models/lang.py:238
+#: common/models/lang.py:240
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: common/models/lang.py:300
+#: common/models/lang.py:302
 msgid "Simplified Chinese (Mainland)"
 msgstr "vereinfachtes Chinesisch (Vereinigte Volksrepublik China)"
 
-#: common/models/lang.py:301
+#: common/models/lang.py:303
 msgid "Traditional Chinese (Taiwan)"
 msgstr "traditionelles Chinesisch (Taiwan)"
 
-#: common/models/lang.py:302
+#: common/models/lang.py:304
 msgid "Traditional Chinese (Hongkong)"
 msgstr "traditionelles Chinesisch (Hongkong)"
 
-#: common/models/lang.py:310
+#: common/models/lang.py:312
 msgid "Portuguese (Brazil)"
 msgstr "Portugiesisch (brasilianisch)"
 
-#: common/models/lang.py:313
+#: common/models/lang.py:315
 msgid "Simplified Chinese (Singapore)"
 msgstr "vereinfachtes Chinesisch (Singapur)"
 
-#: common/models/lang.py:314
+#: common/models/lang.py:316
 msgid "Simplified Chinese (Malaysia)"
 msgstr "vereinfachtes Chinesisch (Malaysia)"
 
-#: common/models/lang.py:315
+#: common/models/lang.py:317
 msgid "Traditional Chinese (Macau)"
 msgstr "traditionelles Chinesisch (Macau)"
 
-#: common/models/lang.py:323
+#: common/models/lang.py:325
 msgid "Mandarin Chinese"
 msgstr "Mandarin Chinesisch"
 
-#: common/models/lang.py:324
+#: common/models/lang.py:326
 msgid "Yue Chinese"
 msgstr "Yue Chinesisch"
 
-#: common/models/lang.py:328
+#: common/models/lang.py:330
 msgid "Min Nan Chinese"
 msgstr "Min Nan Chinesisch"
 
-#: common/models/lang.py:329
+#: common/models/lang.py:331
 msgid "Wu Chinese"
 msgstr "Wu Chinesisch"
 
-#: common/models/lang.py:330
+#: common/models/lang.py:332
 msgid "Hakka Chinese"
 msgstr "Hakka Chinesisch"
 
@@ -4002,62 +4022,37 @@ msgid "VCD"
 msgstr ""
 
 #: common/templates/400.html:23
-msgid ""
-"You may have submitted invalid data, or the content may have been deleted by "
-"the author."
-msgstr ""
-"Du hast möglicherweise ungültige Daten angegeben oder der Inhalt wurde vom "
-"Autor gelöscht."
+msgid "You may have submitted invalid data, or the content may have been deleted by the author."
+msgstr "Du hast möglicherweise ungültige Daten angegeben oder der Inhalt wurde vom Autor gelöscht."
 
 #: common/templates/400.html:25 common/templates/403.html:24
 #: common/templates/404.html:24
-msgid ""
-"If you believe this is our mistake, please contact us through the link at "
-"the bottom of the page."
-msgstr ""
-"Wenn du vermutest, dass das unser Fehler war, kontaktiere uns bitte über den "
-"Link unten auf der Seite."
+msgid "If you believe this is our mistake, please contact us through the link at the bottom of the page."
+msgstr "Wenn du vermutest, dass das unser Fehler war, kontaktiere uns bitte über den Link unten auf der Seite."
 
 #: common/templates/403.html:22
-msgid ""
-"Author may require you to log in before accessing this content, or you do "
-"not have permission to view it."
-msgstr ""
-"Der Autor verlangt möglicherweise, dass du dich einloggst bevor du auf den "
-"Inhalt zugreifen kannst, oder du bist nicht berechtigt, dir den Inhalt "
-"anzusehen."
+msgid "Author may require you to log in before accessing this content, or you do not have permission to view it."
+msgstr "Der Autor verlangt möglicherweise, dass du dich einloggst bevor du auf den Inhalt zugreifen kannst, oder du bist nicht berechtigt, dir den Inhalt anzusehen."
 
 #: common/templates/404.html:20
 msgid "Something is missing"
 msgstr "Irgendetwas fehlt"
 
 #: common/templates/404.html:22
-msgid ""
-"You may have visited an incorrect URL, or the content you are looking for "
-"has been deleted by the author."
-msgstr ""
-"Du hast eine ungültige URL aufgerufen oder der Inhalt, nachdem du suchst "
-"wurde vom Autor gelöscht."
+msgid "You may have visited an incorrect URL, or the content you are looking for has been deleted by the author."
+msgstr "Du hast eine ungültige URL aufgerufen oder der Inhalt, nachdem du suchst wurde vom Autor gelöscht."
 
 #: common/templates/404.html:26
 msgid "Go to Home"
 msgstr ""
 
 #: common/templates/500.html:22
-msgid ""
-"An internal error occurred. If this error occurs repeatedly, it will be "
-"recorded and handled by a human."
-msgstr ""
-"Ein interner Fehler ist aufgetreten. Wenn dieser Fehler mehrmals auftritt, "
-"wird Dieser aufgezeichnet und von einem Moderator bearbeitet."
+msgid "An internal error occurred. If this error occurs repeatedly, it will be recorded and handled by a human."
+msgstr "Ein interner Fehler ist aufgetreten. Wenn dieser Fehler mehrmals auftritt, wird Dieser aufgezeichnet und von einem Moderator bearbeitet."
 
 #: common/templates/500.html:24
-msgid ""
-"If you have an urgent situation or any questions, please contact us through "
-"the link at the bottom of the page."
-msgstr ""
-"Bei einem Notfall oder wenn du bei etwas Hilfe benötigst, kontaktiere uns "
-"über den Link, den du unten auf der Seite findest."
+msgid "If you have an urgent situation or any questions, please contact us through the link at the bottom of the page."
+msgstr "Bei einem Notfall oder wenn du bei etwas Hilfe benötigst, kontaktiere uns über den Link, den du unten auf der Seite findest."
 
 #: common/templates/_footer.html:6
 msgid "Rules"
@@ -4071,285 +4066,225 @@ msgstr "Bedingungen"
 msgid "About"
 msgstr ""
 
-#: common/templates/_footer.html:12 users/templates/users/login.html:265
+#: common/templates/_footer.html:12 users/templates/users/login.html:259
 #, python-format
-msgid ""
-"You are visiting an alternative domain for %(site_name)s, please always use "
-"<a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if "
-"possible."
-msgstr ""
-"Du besuchst eine alternative Domäne für %(site_name)s, bitte verwende immer "
-"<a href=\"%(site_url)s%(request.get_full_path)s\">die originale Seite</a> "
-"wenn möglich."
+msgid "You are visiting an alternative domain for %(site_name)s, please always use <a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if possible."
+msgstr "Du besuchst eine alternative Domäne für %(site_name)s, bitte verwende immer <a href=\"%(site_url)s%(request.get_full_path)s\">die originale Seite</a> wenn möglich."
 
-#: common/templates/_header.html:19 common/templates/_header.html:164
+#: common/templates/_header.html:19 common/templates/_header.html:177
 msgid "title, creator, ISBN, item url, @user, @user@instance"
 msgstr "Titel, Ersteller, ISBN, Artikel URL, @nutzer, @nutzer@instanz"
 
-#: common/templates/_header.html:24
+#: common/templates/_header.html:34
 msgid "All Items"
 msgstr "Alle Artikel"
 
-#: common/templates/_header.html:31
+#: common/templates/_header.html:41
 msgid "Movie & TV"
 msgstr "Filme & Serien"
 
-#: common/templates/_header.html:50
+#: common/templates/_header.html:60
 msgid "People & Organizations"
 msgstr ""
 
-#: common/templates/_header.html:52
+#: common/templates/_header.html:62
 msgid "Journal"
 msgstr "Tagebuch"
 
-#: common/templates/_header.html:54 journal/templates/user_post_list.html:10
+#: common/templates/_header.html:64 journal/templates/user_post_list.html:10
 #: journal/templates/user_post_list.html:23
 msgid "Posts"
 msgstr "Beiträge"
 
-#: common/templates/_header.html:89
+#: common/templates/_header.html:102
 msgid "Explore"
 msgstr "Erkunden"
 
-#: common/templates/_header.html:93
+#: common/templates/_header.html:106 common/views_manage.py:36
 msgid "Feed"
 msgstr "Feed"
 
-#: common/templates/_header.html:98 journal/templates/profile.html:13
+#: common/templates/_header.html:111 journal/templates/profile.html:13
 #: users/templates/users/preferences.html:46
 msgid "Home"
 msgstr "Startseite"
 
-#: common/templates/_header.html:114 common/templates/common/scan.html:9
+#: common/templates/_header.html:127 common/templates/common/scan.html:9
 #: common/templates/common/scan.html:42
 #, fuzzy
 #| msgid "barcode"
 msgid "Scan Barcode"
 msgstr "Strichcode"
 
-#: common/templates/_header.html:118 social/templates/notification.html:12
+#: common/templates/_header.html:131 social/templates/notification.html:12
 #: social/templates/notification.html:53
 msgid "Notification"
 msgstr "Mitteilungen"
 
-#: common/templates/_header.html:122 users/models/task.py:21
+#: common/templates/_header.html:135 users/models/task.py:23
 #: users/templates/users/account.html:219
 #: users/templates/users/crossposts.html:9
 msgid "Pending"
 msgstr "ausstehend"
 
-#: common/templates/_header.html:125
+#: common/templates/_header.html:138
 msgid "Data"
 msgstr "Daten"
 
-#: common/templates/_header.html:128 common/templates/_header.html:146
+#: common/templates/_header.html:141 common/templates/_header.html:159
 #: users/templates/users/preferences.html:12
 #: users/templates/users/preferences.html:23
 #: users/templates/users/preferences_anonymous.html:13
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#: common/templates/_header.html:131
+#: common/templates/_header.html:144
 msgid "Account"
 msgstr "Konto"
 
-#: common/templates/_header.html:135
+#: common/templates/_header.html:148
 msgid "Manage"
 msgstr "Verwalten"
 
-#: common/templates/_header.html:139
+#: common/templates/_header.html:152
 msgid "Logout"
 msgstr "Ausloggen"
 
-#: common/templates/_header.html:143
+#: common/templates/_header.html:156
 msgid "Sign up or Login"
 msgstr "Registrieren oder Anmelden"
 
-#: common/templates/_header.html:160
-msgid ""
-"title or content  category:tv  status:complete  rating:8..10  "
-"date:2021-09-11..2022-02"
-msgstr ""
-"Titel oder Inhalt  category:tv  status:complete  rating:8..10  "
-"date:2021-09-11..2022-02"
+#: common/templates/_header.html:173
+msgid "title or content  category:tv  status:complete  rating:8..10  date:2021-09-11..2022-02"
+msgstr "Titel oder Inhalt  category:tv  status:complete  rating:8..10  date:2021-09-11..2022-02"
 
-#: common/templates/_header.html:162
+#: common/templates/_header.html:175
 msgid "name of a person or company"
 msgstr ""
 
-#: common/templates/_header.html:179
+#: common/templates/_header.html:192
 msgid "Open"
 msgstr "Offen"
 
-#: common/templates/_sidebar.html:62
+#: common/templates/_sidebar.html:61
 #: users/templates/users/profile_actions.html:36
 msgid "approving followers manually"
 msgstr "Follower manuell genehmigen"
 
-#: common/templates/_sidebar.html:81 common/templates/_sidebar.html:86
+#: common/templates/_sidebar.html:80 common/templates/_sidebar.html:85
 #, fuzzy
 #| msgid "followed"
 msgid "followers"
 msgstr "gefolgt"
 
-#: common/templates/_sidebar.html:112
+#: common/templates/_sidebar.html:111
 msgid "Current Targets"
 msgstr "Aktuelle Ziele"
 
-#: common/templates/_sidebar.html:125
+#: common/templates/_sidebar.html:124
 msgid "Set a collection as target, its progress will show up here."
-msgstr ""
-"Lege eine Sammlung als Ziel fest, dein Fortschritt wird hier angezeigt."
+msgstr "Lege eine Sammlung als Ziel fest, dein Fortschritt wird hier angezeigt."
 
-#: common/templates/_sidebar.html:138
+#: common/templates/_sidebar.html:137
 msgid "Recent podcast episodes"
 msgstr "Kürzliche Podcast Folgen"
 
-#: common/templates/_sidebar.html:173
+#: common/templates/_sidebar.html:172
 msgid "Currently reading"
 msgstr "aktuell am Lesen"
 
-#: common/templates/_sidebar.html:215
+#: common/templates/_sidebar.html:214
 msgid "Currently watching"
 msgstr "aktuell am Schauen"
 
-#: common/templates/_sidebar.html:238 journal/forms.py:217
+#: common/templates/_sidebar.html:237 journal/forms.py:217
 #: journal/templates/user_tag_list.html:13
 #: journal/templates/user_tagmember_list.html:4
 msgid "Tags"
 msgstr "Tags"
 
-#: common/templates/_sidebar.html:244 journal/templates/user_tag_list.html:28
+#: common/templates/_sidebar.html:243 journal/templates/user_tag_list.html:28
 #: journal/templates/user_tagmember_list.html:10
 msgid "featured tag"
 msgstr "vorgestellter Tag"
 
-#: common/templates/_sidebar.html:247 journal/templates/user_tag_list.html:31
+#: common/templates/_sidebar.html:246 journal/templates/user_tag_list.html:31
 #: journal/templates/user_tagmember_list.html:15
 msgid "personal tag"
 msgstr "persönlicher Tag"
 
-#: common/templates/_sidebar.html:254 journal/templates/user_tag_list.html:39
+#: common/templates/_sidebar.html:253 journal/templates/user_tag_list.html:39
 msgid "no tags so far."
 msgstr "bisher keine Tags."
 
-#: common/templates/_sidebar.html:258 common/templates/_sidebar.html:271
+#: common/templates/_sidebar.html:257 common/templates/_sidebar.html:270
 msgid "show all"
 msgstr "alles anzeigen"
 
-#: common/templates/_sidebar_anonymous.html:16
+#: common/templates/_sidebar_anonymous.html:15
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
 #| "        <h3>Welcome 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s "
-#| "is committed to creating a free, open, and interconnected space for "
-#| "collecting and reviewing books, movies, music, games, and podcasts. Here, "
-#| "you can document your collections and thoughts, discover new content, and "
-#| "connect with others.\n"
+#| "          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is committed to creating a free, open, and interconnected space for collecting and reviewing books, movies, music, games, and podcasts. Here, you can document your collections and thoughts, discover new content, and connect with others.\n"
 #| "        </p>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log "
-#| "in to %(site_name)s is through a Fediverse (a distributed social network, "
-#| "including Mastodon/Pleroma/etc) instance account. If you haven’t "
-#| "registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" "
-#| "target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
+#| "          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in to %(site_name)s is through a Fediverse (a distributed social network, including Mastodon/Pleroma/etc) instance account. If you haven’t registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
 #| "        </p>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not "
-#| "ready to join the Fediverse, that’s perfectly fine. You can create an "
-#| "account here using your email address, and link it to the Fediverse "
-#| "whenever you’re ready.\n"
+#| "          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready to join the Fediverse, that’s perfectly fine. You can create an account here using your email address, and link it to the Fediverse whenever you’re ready.\n"
 #| "        </p>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you "
-#| "have any questions or suggestions, feel free to contact us via <a "
-#| "href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a "
-#| "href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
+#| "          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have any questions or suggestions, feel free to contact us via <a href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 #| "        </p>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-#| "href=\"%(login_url)s\">Click here</a> to register or log in.\n"
+#| "          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Click here</a> to register or log in.\n"
 #| "        </p>\n"
 #| "        "
 msgid ""
 "\n"
 "        <h3>Welcome 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is "
-"committed to creating a free, open, and interconnected space for collecting "
-"and reviewing books, movies, music, games, and podcasts. Here, you can "
-"manage your collections, share your thoughts, discover new content, and "
-"connect with others.\n"
+"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is committed to creating a free, open, and interconnected space for collecting and reviewing books, movies, music, games, and podcasts. Here, you can manage your collections, share your thoughts, discover new content, and connect with others.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in "
-"to %(site_name)s is through a Fediverse (a distributed social network, "
-"including Mastodon/Pleroma/etc) instance account. If you haven’t registered "
-"yet, you can <a href=\"https://joinmastodon.org/en/servers\" "
-"target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
+"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in to %(site_name)s is through a Fediverse (a distributed social network, including Mastodon/Pleroma/etc) instance account. If you haven’t registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log "
-"in is through a Bluesky (another distributed social network, also called "
-"ATProto) account. If you haven’t registered yet, you may <a href=\"https://"
-"bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
+"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log in is through a Bluesky (another distributed social network, also called ATProto) account. If you haven’t registered yet, you may <a href=\"https://bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready "
-"to join either Fediverse or Bluesky, that’s perfectly fine. You can create "
-"an account here using your email address, and link it to the Fediverse and "
-"Bluesky in settings whenever you’re ready.\n"
+"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready to join either Fediverse or Bluesky, that’s perfectly fine. You can create an account here using your email address, and link it to the Fediverse and Bluesky in settings whenever you’re ready.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have "
-"any questions or suggestions, please feel free to contact us via <a "
-"href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://"
-"discord.gg/uprvcH8gqD\">Discord</a>.\n"
+"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have any questions or suggestions, please feel free to contact us via <a href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-"href=\"%(login_url)s\">Click here</a> to register or log in.\n"
+"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Click here</a> to register or log in.\n"
 "        </p>\n"
 "        "
 msgstr ""
 "\n"
 "        <h3>Willkommen 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s "
-"hat sich zum Ziel gesetzt, Teil einer freien, offenen und föderierten "
-"Plattform zum Bewerten von Büchern, Filmen, Musik, Spielen und Podcasts zu "
-"werden. Hier kannst du deine Sammlungen und Gedanken festhalten, neue "
-"Inhalte entdecken und dich mit Anderen vernetzen.\n"
+"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s hat sich zum Ziel gesetzt, Teil einer freien, offenen und föderierten Plattform zum Bewerten von Büchern, Filmen, Musik, Spielen und Podcasts zu werden. Hier kannst du deine Sammlungen und Gedanken festhalten, neue Inhalte entdecken und dich mit Anderen vernetzen.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-globe\"></i> &nbsp; Der beste Weg dich in "
-"%(site_name)s einzuloggen, ist über ein Fediverse-Konto. Ein Konto aus einem "
-"föderiertem Netzwerk, wie Mastodon, Pleroma und vieles mehr! Wenn du noch "
-"kein Konto hast, <a href=\"https://joinmastodon.org/en/servers\" "
-"target=\"_blank\">suche dir eine Instanz aus und erstelle eins.</a>.\n"
+"          <i class=\"fa-solid fa-globe\"></i> &nbsp; Der beste Weg dich in %(site_name)s einzuloggen, ist über ein Fediverse-Konto. Ein Konto aus einem föderiertem Netzwerk, wie Mastodon, Pleroma und vieles mehr! Wenn du noch kein Konto hast, <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">suche dir eine Instanz aus und erstelle eins.</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; Wenn du noch nicht "
-"bereit bist dem Fediverse beizutreten, ist das absolut in Ordnung. Du kannst "
-"dir hier ein Konto mit deiner E-Mail Adresse erstellen und es später mit "
-"einem Fediverse-Konto verknüpfen, wenn du dich bereit dazu fühlst.\n"
+"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; Wenn du noch nicht bereit bist dem Fediverse beizutreten, ist das absolut in Ordnung. Du kannst dir hier ein Konto mit deiner E-Mail Adresse erstellen und es später mit einem Fediverse-Konto verknüpfen, wenn du dich bereit dazu fühlst.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; Bei weiteren "
-"Fragen oder Vorschlägen kannst du uns gerne über das <a href=\"https://"
-"mastodon.social/@neodb\">Fediverse</a> kontaktieren, oder trete unserem <a "
-"href=\"https://discord.gg/uprvcH8gqD\">Discord-Server</a> bei.\n"
+"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; Bei weiteren Fragen oder Vorschlägen kannst du uns gerne über das <a href=\"https://mastodon.social/@neodb\">Fediverse</a> kontaktieren, oder trete unserem <a href=\"https://discord.gg/uprvcH8gqD\">Discord-Server</a> bei.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-"href=\"%(login_url)s\">Klicke hier</a> um dich zu registrieren oder "
-"einzuloggen.\n"
+"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Klicke hier</a> um dich zu registrieren oder einzuloggen.\n"
 "        </p>\n"
 "        "
 
-#: common/templates/_sidebar_anonymous.html:43
+#: common/templates/_sidebar_anonymous.html:42
 #: users/templates/users/announcements.html:12
 #: users/templates/users/announcements.html:39
 msgid "Announcements"
@@ -4377,7 +4312,7 @@ msgstr "Quellcode"
 msgid "Registration"
 msgstr "Registrierung fehlgeschlagen"
 
-#: common/templates/common/about.html:35 common/views_manage.py:493
+#: common/templates/common/about.html:35 common/views_manage.py:594
 #, fuzzy
 #| msgid "Mentioned Only"
 msgid "Invite Only"
@@ -4389,7 +4324,7 @@ msgstr "nur Erwähnte"
 msgid "Open Registration"
 msgstr "Registrierung fehlgeschlagen"
 
-#: common/templates/common/about.html:40 common/views_manage.py:556
+#: common/templates/common/about.html:40 common/views_manage.py:657
 #, fuzzy
 #| msgid "Preferences"
 msgid "Preferred Languages"
@@ -4444,9 +4379,7 @@ msgid "Error"
 msgstr "Fehler"
 
 #: common/templates/common/scan.html:45
-msgid ""
-"Point the camera at a book ISBN or product barcode (EAN / UPC). You will be "
-"redirected to the search once a code is detected."
+msgid "Point the camera at a book ISBN or product barcode (EAN / UPC). You will be redirected to the search once a code is detected."
 msgstr ""
 
 #: common/templates/common/scan.html:50
@@ -4457,7 +4390,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:628
+#: common/templates/common/scan.html:60 common/views_manage.py:738
 #, fuzzy
 #| msgid "Search results"
 msgid "Search"
@@ -4491,21 +4424,33 @@ msgstr ""
 msgid "Camera unavailable. Use manual entry below."
 msgstr ""
 
-#: common/templates/manage/settings.html:9
+#: common/templates/manage/base.html:9
 #, fuzzy
 #| msgid "Additional Settings"
 msgid "Site Settings"
 msgstr "Zusätzliche Einstellungen"
 
-#: common/templates/manage/settings.html:109
+#: common/templates/manage/base.html:127
 msgid "Takahe Admin"
 msgstr ""
 
-#: common/templates/manage/settings.html:112
+#: common/templates/manage/base.html:130
 #, fuzzy
 #| msgid "Database"
 msgid "Database Admin"
 msgstr "Datenbank"
+
+#: common/templates/manage/environment.html:6
+msgid "These settings come from environment variables and cannot be changed here. Edit .env and restart the server to change them. Passwords and keys are hidden."
+msgstr ""
+
+#: common/templates/manage/environment.html:23
+msgid "(empty)"
+msgstr ""
+
+#: common/templates/manage/environment.html:26
+msgid "default"
+msgstr ""
 
 #: common/templatetags/duration.py:59
 msgid "just now"
@@ -4523,7 +4468,7 @@ msgstr "gefolgt"
 msgid "following you"
 msgstr "folgt dir"
 
-#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:95
+#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:90
 msgid "you"
 msgstr "Du"
 
@@ -4531,874 +4476,887 @@ msgstr "Du"
 msgid "unavailable"
 msgstr "nicht verfügbar"
 
-#: common/utils.py:126 common/utils.py:167 users/views/actions.py:134
+#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr "Benutzer existiert nicht mehr"
 
-#: common/utils.py:133 common/utils.py:135 common/utils.py:138
-#: common/utils.py:174 common/utils.py:178 journal/views/profile.py:499
+#: common/utils.py:135 common/utils.py:137 common/utils.py:140
+#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
 msgid "Access denied"
 msgstr "Zugriff verweigert"
 
-#: common/utils.py:141 common/utils.py:143 journal/views/article.py:204
+#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr "Anmeldung erforderlich"
 
-#: common/views_manage.py:144 common/views_manage.py:295
+#: common/views_manage.py:34 common/views_manage.py:373
 #, fuzzy
 #| msgid "reading"
 msgid "Branding"
 msgstr "am lesen"
 
-#: common/views_manage.py:146
+#: common/views_manage.py:37
 #, fuzzy
 #| msgid "comments"
 msgid "Recommendations"
 msgstr "Kommentare"
 
-#: common/views_manage.py:147
+#: common/views_manage.py:38
 #, fuzzy
 #| msgid "Access denied"
 msgid "Access"
 msgstr "Zugriff verweigert"
 
-#: common/views_manage.py:148 common/views_manage.py:623
+#: common/views_manage.py:39 common/views_manage.py:733
 #, fuzzy
 #| msgid "duration"
 msgid "Federation"
 msgstr "Dauer"
 
-#: common/views_manage.py:149
+#: common/views_manage.py:40
 #, fuzzy
 #| msgid "Catalan"
 msgid "Catalog"
 msgstr "Katalanisch"
 
-#: common/views_manage.py:150
+#: common/views_manage.py:41
 msgid "API Keys"
 msgstr ""
 
-#: common/views_manage.py:151
+#: common/views_manage.py:42
 #, fuzzy
 #| msgid "Download"
 msgid "Downloader"
 msgstr "Herunterladen"
 
-#: common/views_manage.py:152 common/views_manage.py:303
+#: common/views_manage.py:43 common/views_manage.py:381
 #: users/templates/users/steam_import.html:113
 msgid "Advanced"
 msgstr ""
 
-#: common/views_manage.py:202
+#: common/views_manage.py:44
+msgid "Environment"
+msgstr ""
+
+#: common/views_manage.py:280
 #, fuzzy
 #| msgid "Invalid user."
 msgid "Invalid value."
 msgstr "Ungültiger Benutzer."
 
-#: common/views_manage.py:206
+#: common/views_manage.py:284
 msgid "Invalid configuration. Please check your input."
 msgstr ""
 
-#: common/views_manage.py:211
+#: common/views_manage.py:289
 #, fuzzy
 #| msgid "Settings saved."
 msgid "Settings have been saved."
 msgstr "Einstellungen gespeichert."
 
-#: common/views_manage.py:231
+#: common/views_manage.py:309
 msgid "Site Name"
 msgstr ""
 
-#: common/views_manage.py:234
+#: common/views_manage.py:312
 #, fuzzy
 #| msgid "Title and Description"
 msgid "Site Description"
 msgstr "Titel und Beschreibung"
 
-#: common/views_manage.py:235
+#: common/views_manage.py:313
 msgid "Short description shown in metadata and about page."
 msgstr ""
 
-#: common/views_manage.py:238
+#: common/views_manage.py:316
 msgid "Site Logo URL"
 msgstr ""
 
-#: common/views_manage.py:239
+#: common/views_manage.py:317
 msgid "URL path to the site logo image."
 msgstr ""
 
-#: common/views_manage.py:242
+#: common/views_manage.py:320
 msgid "Site Icon URL"
 msgstr ""
 
-#: common/views_manage.py:243
+#: common/views_manage.py:321
 msgid "URL path to the site icon/favicon."
 msgstr ""
 
-#: common/views_manage.py:246
+#: common/views_manage.py:324
 msgid "Default User Avatar URL"
 msgstr ""
 
-#: common/views_manage.py:247
+#: common/views_manage.py:325
 msgid "URL path to the default user avatar."
 msgstr ""
 
-#: common/views_manage.py:250
+#: common/views_manage.py:328
 msgid "Site Color Theme"
 msgstr ""
 
-#: common/views_manage.py:251
+#: common/views_manage.py:329
 msgid "PicoCSS color theme."
 msgstr ""
 
-#: common/views_manage.py:276
+#: common/views_manage.py:354
 #, fuzzy
 #| msgid "Production"
 msgid "Site Introduction"
 msgstr "Produktion"
 
-#: common/views_manage.py:277
+#: common/views_manage.py:355
 msgid "URL path for the intro/welcome sidebar page."
 msgstr ""
 
-#: common/views_manage.py:280
+#: common/views_manage.py:358
 msgid "Custom HTML Head"
 msgstr ""
 
-#: common/views_manage.py:281
+#: common/views_manage.py:359
 msgid "Extra HTML injected into the <head> of all pages."
 msgstr ""
 
-#: common/views_manage.py:285
+#: common/views_manage.py:363
 msgid "Footer Links"
 msgstr ""
 
-#: common/views_manage.py:286
+#: common/views_manage.py:364
 msgid "Link title mapped to URL."
 msgstr ""
 
-#: common/views_manage.py:315
+#: common/views_manage.py:393
 msgid "Minimum Marks for Discover"
 msgstr ""
 
-#: common/views_manage.py:317
+#: common/views_manage.py:395
 msgid "Number of marks required for an item to appear in discover."
 msgstr ""
 
-#: common/views_manage.py:322
+#: common/views_manage.py:400
 msgid "Update Interval (minutes)"
 msgstr ""
 
-#: common/views_manage.py:323
+#: common/views_manage.py:401
 msgid "How often to refresh the popular items list."
 msgstr ""
 
-#: common/views_manage.py:327
+#: common/views_manage.py:405
 msgid "Filter by Preferred Languages"
 msgstr ""
 
-#: common/views_manage.py:328
+#: common/views_manage.py:406
 msgid "Only show items with titles in the preferred languages."
 msgstr ""
 
-#: common/views_manage.py:331
+#: common/views_manage.py:409
 #, fuzzy
 #| msgid "show all"
 msgid "Show Local Only"
 msgstr "alles anzeigen"
 
-#: common/views_manage.py:333
+#: common/views_manage.py:411
 msgid "Only show items marked by local users, not the entire network."
 msgstr ""
 
-#: common/views_manage.py:337
+#: common/views_manage.py:415
 #, fuzzy
 #| msgid "Popular Tags"
 msgid "Show Popular Posts"
 msgstr "Beliebte Tags"
 
-#: common/views_manage.py:338
+#: common/views_manage.py:416
 msgid "Show popular public posts instead of recent ones."
 msgstr ""
 
-#: common/views_manage.py:341
+#: common/views_manage.py:419
 #, fuzzy
 #| msgid "Popular Tags"
 msgid "Show Popular Tags"
 msgstr "Beliebte Tags"
 
-#: common/views_manage.py:342
+#: common/views_manage.py:420
 msgid "Show popular public tags on the discover page."
 msgstr ""
 
-#: common/views_manage.py:345
+#: common/views_manage.py:423
 #, fuzzy
 #| msgid "Spotify Podcast"
 msgid "Show Verified Podcasts"
 msgstr "Spotify Podcast"
 
-#: common/views_manage.py:347
-msgid ""
-"Show a shelf of recent episodes from podcasts with a verified creator on the "
-"discover page."
+#: common/views_manage.py:425
+msgid "Show a shelf of recent episodes from podcasts with a verified creator on the discover page."
 msgstr ""
 
-#: common/views_manage.py:386
+#: common/views_manage.py:447
+#, fuzzy
+#| msgid "your timeline"
+msgid "Show World Timeline"
+msgstr "deine Timeline"
+
+#: common/views_manage.py:449
+msgid "Offer a tab with public posts from this site and every server it federates with."
+msgstr ""
+
+#: common/views_manage.py:454
+#, fuzzy
+#| msgid "show all"
+msgid "Show Local Timeline"
+msgstr "alles anzeigen"
+
+#: common/views_manage.py:455
+msgid "Offer a tab with public posts from this site only."
+msgstr ""
+
+#: common/views_manage.py:459
+#, fuzzy
+#| msgid "your timeline"
+msgid "Timelines"
+msgstr "deine Timeline"
+
+#: common/views_manage.py:487
 msgid "Enable Recommendations"
 msgstr ""
 
-#: common/views_manage.py:388
-msgid ""
-"Master switch. When off, all recommendation surfaces are hidden and the cron "
-"jobs are not scheduled."
+#: common/views_manage.py:489
+msgid "Master switch. When off, all recommendation surfaces are hidden and the cron jobs are not scheduled."
 msgstr ""
 
-#: common/views_manage.py:393
+#: common/views_manage.py:494
 msgid "Source Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:395
-msgid ""
-"Minimum public marks an item needs before similarity rows are built for it."
+#: common/views_manage.py:496
+msgid "Minimum public marks an item needs before similarity rows are built for it."
 msgstr ""
 
-#: common/views_manage.py:401
+#: common/views_manage.py:502
 msgid "Target Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:403
-msgid ""
-"Minimum public marks an item needs to be eligible as a recommendation target."
+#: common/views_manage.py:504
+msgid "Minimum public marks an item needs to be eligible as a recommendation target."
 msgstr ""
 
-#: common/views_manage.py:409
+#: common/views_manage.py:510
 msgid "Top-K Similar Items per Source"
 msgstr ""
 
-#: common/views_manage.py:410
+#: common/views_manage.py:511
 msgid "Number of similar items stored per source item."
 msgstr ""
 
-#: common/views_manage.py:414
+#: common/views_manage.py:515
 msgid "Top-N Recommendations per User"
 msgstr ""
 
-#: common/views_manage.py:415
+#: common/views_manage.py:516
 msgid "Number of personalised rows stored per user."
 msgstr ""
 
-#: common/views_manage.py:419
+#: common/views_manage.py:520
 msgid "Dampen Heavy Shelvers"
 msgstr ""
 
-#: common/views_manage.py:421
-msgid ""
-"Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-"
-"shelvers in similarity scoring."
+#: common/views_manage.py:522
+msgid "Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-shelvers in similarity scoring."
 msgstr ""
 
-#: common/views_manage.py:426
+#: common/views_manage.py:527
 msgid "Per-User Mark Cap (training)"
 msgstr ""
 
-#: common/views_manage.py:428
-msgid ""
-"Truncate each user's contribution to their N most recent marks when building "
-"the similarity matrix."
+#: common/views_manage.py:529
+msgid "Truncate each user's contribution to their N most recent marks when building the similarity matrix."
 msgstr ""
 
-#: common/views_manage.py:434
+#: common/views_manage.py:535
 msgid "Active-User Window (days)"
 msgstr ""
 
-#: common/views_manage.py:436
-msgid ""
-"Refresh personalised recommendations for users with at least one public mark "
-"in the last N days."
+#: common/views_manage.py:537
+msgid "Refresh personalised recommendations for users with at least one public mark in the last N days."
 msgstr ""
 
-#: common/views_manage.py:442
+#: common/views_manage.py:543
 msgid "Per-User Seed Cap (serving)"
 msgstr ""
 
-#: common/views_manage.py:444
-msgid ""
-"Number of recent marks used as seeds when scoring personalised "
-"recommendations for one user."
+#: common/views_manage.py:545
+msgid "Number of recent marks used as seeds when scoring personalised recommendations for one user."
 msgstr ""
 
-#: common/views_manage.py:450
+#: common/views_manage.py:551
 msgid "Lazy Refresh TTL (days)"
 msgstr ""
 
-#: common/views_manage.py:452
-msgid ""
-"How long cached on-demand recommendations are valid before the next request "
-"triggers a refresh."
+#: common/views_manage.py:553
+msgid "How long cached on-demand recommendations are valid before the next request triggers a refresh."
 msgstr ""
 
-#: common/views_manage.py:458
+#: common/views_manage.py:559
 msgid "Circles Window (days)"
 msgstr ""
 
-#: common/views_manage.py:460
-msgid ""
-"Look back N days when finding items recently marked by people the viewer "
-"follows."
+#: common/views_manage.py:561
+msgid "Look back N days when finding items recently marked by people the viewer follows."
 msgstr ""
 
-#: common/views_manage.py:467
+#: common/views_manage.py:568
 msgid "Master Switch"
 msgstr ""
 
-#: common/views_manage.py:470
+#: common/views_manage.py:571
 msgid "Similarity Builder"
 msgstr ""
 
-#: common/views_manage.py:477
+#: common/views_manage.py:578
 #, fuzzy
 #| msgid "Personal"
 msgid "Personalisation"
 msgstr "Persönlich"
 
-#: common/views_manage.py:495
-msgid ""
-"Require an invite token to register. Invite tokens can be generated with "
-"neodb-manage invite --create."
+#: common/views_manage.py:596
+msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
 msgstr ""
 
-#: common/views_manage.py:500
+#: common/views_manage.py:601
 msgid "Enable Local-Only Posting"
 msgstr ""
 
-#: common/views_manage.py:501
+#: common/views_manage.py:602
 msgid "Allow users to create posts visible only to local users."
 msgstr ""
 
-#: common/views_manage.py:504
+#: common/views_manage.py:605
 msgid "Mastodon Login Whitelist"
 msgstr ""
 
-#: common/views_manage.py:505
+#: common/views_manage.py:606
 msgid "One domain per line. Leave empty to allow any instance."
 msgstr ""
 
-#: common/views_manage.py:508
+#: common/views_manage.py:609
 #, fuzzy
 #| msgid "Registration failed"
 msgid "Registration Captcha Items"
 msgstr "Registrierung fehlgeschlagen"
 
-#: common/views_manage.py:512
-msgid ""
-"Number of item covers a new user must sort into two category rows before "
-"choosing a username. 0 disables the captcha; 5-6 is recommended. The covers "
-"carry no title text, so this cannot be solved with a screen reader: if you "
-"enable it, keep another way in, such as an invite link."
+#: common/views_manage.py:613
+msgid "Number of item covers a new user must sort into two category rows before choosing a username. 0 disables the captcha; 5-6 is recommended. The covers carry no title text, so this cannot be solved with a screen reader: if you enable it, keep another way in, such as an invite link."
 msgstr ""
 
-#: common/views_manage.py:520
+#: common/views_manage.py:621
 msgid "Registration Captcha Minimum Marks"
 msgstr ""
 
-#: common/views_manage.py:523
-msgid ""
-"Marks an item needs before the captcha treats it as well known enough to be "
-"recognizable. Categories with too few such items fall back to any item."
+#: common/views_manage.py:624
+msgid "Marks an item needs before the captcha treats it as well known enough to be recognizable. Categories with too few such items fall back to any item."
 msgstr ""
 
-#: common/views_manage.py:529
+#: common/views_manage.py:630
 msgid "Enable Mastodon Login"
 msgstr ""
 
-#: common/views_manage.py:532
+#: common/views_manage.py:633
 #, fuzzy
 #| msgid "Bluesky Login ID"
 msgid "Enable Bluesky Login"
 msgstr "Bluesky Anmelde-ID"
 
-#: common/views_manage.py:535
+#: common/views_manage.py:636
 msgid "Enable Threads Login"
 msgstr ""
 
-#: common/views_manage.py:538
+#: common/views_manage.py:639
 #, fuzzy
 #| msgid "Email"
 msgid "Email URL"
 msgstr "E-Mail"
 
-#: common/views_manage.py:540
+#: common/views_manage.py:641
 msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
 msgstr ""
 
-#: common/views_manage.py:544
+#: common/views_manage.py:645
 #, fuzzy
 #| msgid "Email"
 msgid "Email From"
 msgstr "E-Mail"
 
-#: common/views_manage.py:545
+#: common/views_manage.py:646
 msgid "Sender name and address for outgoing email."
 msgstr ""
 
-#: common/views_manage.py:548
+#: common/views_manage.py:649
 #, fuzzy
 #| msgid "Language"
 msgid "Default Language"
 msgstr "Sprache"
 
-#: common/views_manage.py:551
-msgid ""
-"Interface language for visitors and for users who have not chosen one "
-"themselves."
+#: common/views_manage.py:652
+msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:558
-msgid ""
-"Language codes, one per line (e.g. en, zh, ja). First language is the "
-"default."
+#: common/views_manage.py:659
+msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:564
+#: common/views_manage.py:665
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:571
+#: common/views_manage.py:672
 #, fuzzy
 #| msgid "Import Method"
 msgid "Login Methods"
 msgstr "Importier-Methode"
 
-#: common/views_manage.py:576 mastodon/models/common.py:28
+#: common/views_manage.py:677 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr "E-Mail"
 
-#: common/views_manage.py:580
+#: common/views_manage.py:681
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:591
+#: common/views_manage.py:692
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:593
-msgid ""
-"Disable relay.neodb.net federation for sharing public ratings across "
-"instances."
+#: common/views_manage.py:694
+msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:598
+#: common/views_manage.py:699
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:599
+#: common/views_manage.py:700
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:603
+#: common/views_manage.py:704
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:605
+#: common/views_manage.py:706
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:610
+#: common/views_manage.py:711
 #, fuzzy
 #| msgid "Search results"
 msgid "Search Sites"
 msgstr "Suchergebnisse"
 
-#: common/views_manage.py:611
+#: common/views_manage.py:712
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:614
+#: common/views_manage.py:715
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:615
+#: common/views_manage.py:716
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:618
+#: common/views_manage.py:719
 #, fuzzy
 #| msgid "Add tv series"
 msgid "Hidden Categories"
 msgstr "Serie hinzufügen"
 
-#: common/views_manage.py:619
+#: common/views_manage.py:720
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:640
+#: common/views_manage.py:723
+msgid "Guest Search Page Limit"
+msgstr ""
+
+#: common/views_manage.py:725
+msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
+msgstr ""
+
+#: common/views_manage.py:751
 #, fuzzy
 #| msgid "Spotify Album"
 msgid "Spotify API Key"
 msgstr "Spotify Album"
 
-#: common/views_manage.py:641
+#: common/views_manage.py:752
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:644
+#: common/views_manage.py:755
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:645
+#: common/views_manage.py:756
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:648
+#: common/views_manage.py:759
 #, fuzzy
 #| msgid "Google Books"
 msgid "Google Books API Key"
 msgstr "Google Books"
 
-#: common/views_manage.py:649
+#: common/views_manage.py:760
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:652
+#: common/views_manage.py:763
 #, fuzzy
 #| msgid "Discogs"
 msgid "Discogs API Key"
 msgstr "Discogs"
 
-#: common/views_manage.py:654
+#: common/views_manage.py:765
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:658
+#: common/views_manage.py:769
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:770
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:662
+#: common/views_manage.py:773
 #, fuzzy
 #| msgid "client secret"
 msgid "IGDB Client Secret"
 msgstr "Client Geheimnis"
 
-#: common/views_manage.py:665
+#: common/views_manage.py:776
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:667
-msgid ""
-"Bearer token from https://boardgamegeek.com/applications (see https://"
-"boardgamegeek.com/using_the_xml_api#toc9)."
+#: common/views_manage.py:778
+msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:672 users/templates/users/steam_import.html:26
+#: common/views_manage.py:783
+msgid "MyAnimeList Client ID"
+msgstr ""
+
+#: common/views_manage.py:785
+msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
+msgstr ""
+
+#: common/views_manage.py:790 users/templates/users/steam_import.html:26
 #, fuzzy
 #| msgid "Steam Game"
 msgid "Steam API Key"
 msgstr "Steam Spiel"
 
-#: common/views_manage.py:674
-msgid ""
-"https://steamcommunity.com/dev - fallback key for Steam importer. Users can "
-"provide their own key when importing."
+#: common/views_manage.py:792
+msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:679
+#: common/views_manage.py:797
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:680
+#: common/views_manage.py:798
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:683
+#: common/views_manage.py:801
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:686
+#: common/views_manage.py:804
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:689
+#: common/views_manage.py:807
 #, fuzzy
 #| msgid "Threads"
 msgid "Threads App ID"
 msgstr "Threads"
 
-#: common/views_manage.py:690
+#: common/views_manage.py:808
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:693
+#: common/views_manage.py:811
 #, fuzzy
 #| msgid "Threads.net"
 msgid "Threads App Secret"
 msgstr "Threads.net"
 
-#: common/views_manage.py:696
+#: common/views_manage.py:814
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:698
-msgid ""
-"Webhook URLs keyed by channel (default, report, audit, suggest, system). All "
-"channels must be Discord forum or media channels (thread mode) because "
-"notifications are posted as threads."
+#: common/views_manage.py:816
+msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:715
+#: common/views_manage.py:833
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:844
 #, fuzzy
 #| msgid "translator"
 msgid "Translation"
 msgstr "Übersetzer/in"
 
-#: common/views_manage.py:730
+#: common/views_manage.py:849
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:734 social/templates/feed.html:27
+#: common/views_manage.py:853 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr "Benachrichtigungen"
 
-#: common/views_manage.py:744
+#: common/views_manage.py:863
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:745
+#: common/views_manage.py:864
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:748
+#: common/views_manage.py:867
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:749
+#: common/views_manage.py:868
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:752
+#: common/views_manage.py:871
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:874
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:758
+#: common/views_manage.py:877
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:761
+#: common/views_manage.py:880
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:764
+#: common/views_manage.py:883
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:767
+#: common/views_manage.py:886
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:768
+#: common/views_manage.py:887
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:771
+#: common/views_manage.py:890
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:775
+#: common/views_manage.py:894
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:779
+#: common/views_manage.py:898
 #, fuzzy
 #| msgid "series"
 msgid "Retries"
 msgstr "Serie"
 
-#: common/views_manage.py:784
+#: common/views_manage.py:903
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:789
+#: common/views_manage.py:908
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:796
+#: common/views_manage.py:915
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:808
+#: common/views_manage.py:927
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:809
+#: common/views_manage.py:928
 #, fuzzy
 #| msgid "site domain name"
 msgid "One domain per line."
 msgstr "Seiten Domäne Name"
 
-#: common/views_manage.py:812
+#: common/views_manage.py:931
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:813
+#: common/views_manage.py:932
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:935
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:818
-msgid ""
-"Timeout for requests to Mastodon instances and remote fediverse servers."
+#: common/views_manage.py:937
+msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:824
+#: common/views_manage.py:943
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:825
+#: common/views_manage.py:944
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:828
+#: common/views_manage.py:947
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:829
+#: common/views_manage.py:948
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:839
+#: common/views_manage.py:958
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:841
-msgid ""
-"Delete import/export tasks and their files after this many days. Set to 0 to "
-"disable cleanup."
+#: common/views_manage.py:960
+msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:847
+#: common/views_manage.py:966
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:849
-msgid ""
-"Post-migration job keys to skip, one per line (e.g. normalize_genre). "
-"Checked by the worker at dequeue time; skipped jobs log a warning and notify "
-"the Discord system channel."
+#: common/views_manage.py:968
+msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:855
+#: common/views_manage.py:974
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:857
-msgid ""
-"Private key (JWK) identifying this site to ATProto authorization servers. "
-"Auto-generated on first Bluesky login; clear to regenerate."
+#: common/views_manage.py:976
+msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:983
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:986
 #, fuzzy
 #| msgid "optional"
 msgid "Operational"
 msgstr "optional"
 
-#: common/views_manage.py:883
+#: common/views_manage.py:1002
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:885
-msgid ""
-"Genre codes offered in the Movie edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1004
+msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:1009
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:892
-msgid ""
-"Genre codes offered in the TV edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1011
+msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:897
+#: common/views_manage.py:1016
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:899
-msgid ""
-"Genre codes offered in the Music edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1018
+msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:904
+#: common/views_manage.py:1023
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:906
-msgid ""
-"Genre codes offered in the Game edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1025
+msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:911
+#: common/views_manage.py:1030
 #, fuzzy
 #| msgid "Podcast"
 msgid "Podcast Genres"
 msgstr "Podcasts"
 
-#: common/views_manage.py:913
-msgid ""
-"Genre codes offered in the Podcast edit dropdown, one per line. Leave empty "
-"to use the built-in default."
+#: common/views_manage.py:1032
+msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:918
+#: common/views_manage.py:1037
 #, fuzzy
 #| msgid "Performance"
 msgid "Performance Genres"
 msgstr "Aufführung"
 
-#: common/views_manage.py:920
-msgid ""
-"Genre codes offered in the Performance edit dropdown, one per line. Leave "
-"empty to use the built-in default."
+#: common/views_manage.py:1039
+msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:926
+#: common/views_manage.py:1045
 msgid "Genres by Category"
 msgstr ""
 
-#: journal/forms.py:12
-msgid ""
-"Tips: use >!text!< for spoilers; some instances may not be able to show "
-"posts longer than 360 charactors."
+#: common/views_manage.py:1069
+msgid "Site"
 msgstr ""
-"Tipp: Nutze &gt;!text!&lt; für Spoiler. Einige Instanzen können eventuell "
-"keine Beiträge länger als 360 Zeichen anzeigen."
+
+#: common/views_manage.py:1079
+#, fuzzy
+#| msgid "Database"
+msgid "Database and Services"
+msgstr "Datenbank"
+
+#: common/views_manage.py:1089
+msgid "Media and Files"
+msgstr ""
+
+#: common/views_manage.py:1098
+msgid "Monitoring"
+msgstr ""
+
+#: common/views_manage.py:1102
+msgid "Security"
+msgstr ""
+
+#: common/views_manage.py:1111
+msgid "Other Environment Variables"
+msgstr ""
+
+#: common/views_manage.py:1113
+msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
+msgstr ""
+
+#: journal/forms.py:12
+msgid "Tips: use >!text!< for spoilers; some instances may not be able to show posts longer than 360 charactors."
+msgstr "Tipp: Nutze &gt;!text!&lt; für Spoiler. Einige Instanzen können eventuell keine Beiträge länger als 360 Zeichen anzeigen."
 
 #: journal/forms.py:29 journal/forms.py:31 journal/forms.py:80
 #: journal/forms.py:83 journal/forms.py:153
@@ -5412,14 +5370,14 @@ msgid "Content (Markdown)"
 msgstr "Inhalt (Markdown)"
 
 #: journal/forms.py:46 journal/forms.py:124 journal/forms.py:226
-#: journal/forms.py:288 journal/views/note.py:38
+#: journal/forms.py:288 journal/views/note.py:37
 #, fuzzy
 #| msgid "Crosspost to timeline"
 msgid "Crosspost"
 msgstr "Crosspost zur Timeline"
 
 #: journal/forms.py:47 journal/forms.py:125 journal/forms.py:227
-#: journal/forms.py:289 journal/views/note.py:39
+#: journal/forms.py:289 journal/views/note.py:38
 #, fuzzy
 #| msgid "Turn on crosspost to other social networks by default"
 msgid "Crosspost to your connected social networks"
@@ -5431,17 +5389,15 @@ msgstr ""
 
 #: journal/forms.py:53 journal/forms.py:131
 msgid "When saving, replace leading spaces with full-width spaces"
-msgstr ""
-"Nach dem Speichern, führende Leerzeichen durch Leerzeichen voller Breite "
-"ersetzen"
+msgstr "Nach dem Speichern, führende Leerzeichen durch Leerzeichen voller Breite ersetzen"
 
 #: journal/forms.py:59 journal/forms.py:137 journal/forms.py:162
 #: journal/forms.py:219 journal/forms.py:281
 #: journal/templates/collection_share.html:24
-#: journal/templates/wrapped_share.html:36 journal/views/note.py:31
-#: users/templates/users/data.html:45 users/templates/users/data.html:98
-#: users/templates/users/data.html:155 users/templates/users/data.html:206
-#: users/templates/users/data.html:269 users/templates/users/data.html:328
+#: journal/templates/wrapped_share.html:36 journal/views/note.py:30
+#: users/templates/users/data.html:60 users/templates/users/data.html:113
+#: users/templates/users/data.html:170 users/templates/users/data.html:221
+#: users/templates/users/data.html:284 users/templates/users/data.html:346
 #: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
@@ -5488,7 +5444,6 @@ msgid "Collaborative editing"
 msgstr "gemeinsames Bearbeiten"
 
 #: journal/forms.py:204 users/templates/users/crossposts.html:51
-#: users/templates/users/data.html:483
 msgid "Status"
 msgstr "Status"
 
@@ -5502,48 +5457,46 @@ msgstr "Kommentar"
 msgid "Rating"
 msgstr "Bewertung"
 
-#: journal/importers/goodreads.py:196 journal/importers/letterboxd.py:144
-#: journal/importers/rym.py:442 journal/importers/storygraph.py:500
+#: journal/importers/goodreads.py:198 journal/importers/letterboxd.py:147
+#: journal/importers/rym.py:444 journal/importers/storygraph.py:504
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr "eine Rezension über {item_title}"
 
-#: journal/importers/opml.py:45
+#: journal/importers/opml.py:49
 #, python-brace-format
 msgid "{username}'s podcast subscriptions"
 msgstr "{username}'s Podcast Abonnements"
 
-#: journal/importers/rym.py:168 journal/importers/storygraph.py:128
+#: journal/importers/rym.py:170 journal/importers/storygraph.py:132
 #, python-brace-format
-msgid ""
-"Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
+msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:178 journal/importers/storygraph.py:138
+#: journal/importers/rym.py:180 journal/importers/storygraph.py:142
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/importers/rym.py:233 journal/importers/storygraph.py:184
+#: journal/importers/rym.py:235 journal/importers/storygraph.py:188
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:348 journal/importers/storygraph.py:389
+#: journal/importers/rym.py:350 journal/importers/storygraph.py:393
 msgid "Matched file missing; cannot import."
 msgstr ""
 
-#: journal/importers/rym.py:376 journal/importers/storygraph.py:412
+#: journal/importers/rym.py:378 journal/importers/storygraph.py:416
 #, python-brace-format
-msgid ""
-"Import complete: {imported} imported, {skipped} skipped, {failed} failed"
+msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:212 journal/views/article.py:218
+#: journal/models/article.py:215 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
-#: journal/models/collection.py:44 journal/templates/add_to_collection.html:39
+#: journal/models/collection.py:48 journal/templates/add_to_collection.html:39
 #: journal/templates/collection_edit.html:64
 #: journal/templates/collection_share.html:63
 #: journal/templates/collection_update_item_note.html:3
@@ -5551,75 +5504,75 @@ msgstr ""
 msgid "note"
 msgstr "Notiz"
 
-#: journal/models/collection.py:111
+#: journal/models/collection.py:115
 #, fuzzy
 #| msgid "shared {username}'s collection"
 msgid "search query for dynamic collection"
 msgstr "{username}'s geteilte Sammlung"
 
-#: journal/models/collection.py:524 journal/templatetags/collection.py:35
+#: journal/models/collection.py:566 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] "%(count)d Buch"
 msgstr[1] "%(count)d Bücher"
 
-#: journal/models/collection.py:529 journal/templatetags/collection.py:43
+#: journal/models/collection.py:571 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] "%(count)d Film"
 msgstr[1] "%(count)d Filme"
 
-#: journal/models/collection.py:534 journal/templatetags/collection.py:51
+#: journal/models/collection.py:576 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] "%(count)d Serie"
 msgstr[1] "%(count)d Serien"
 
-#: journal/models/collection.py:539 journal/templatetags/collection.py:59
+#: journal/models/collection.py:581 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] "%(count)d Album"
 msgstr[1] "%(count)d Alben"
 
-#: journal/models/collection.py:544 journal/templatetags/collection.py:67
+#: journal/models/collection.py:586 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] "%(count)d Spiel"
 msgstr[1] "%(count)d Spiele"
 
-#: journal/models/collection.py:549 journal/templatetags/collection.py:75
+#: journal/models/collection.py:591 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] "%(count)d Podcast"
 msgstr[1] "%(count)d Podcasts"
 
-#: journal/models/collection.py:555 journal/templatetags/collection.py:83
+#: journal/models/collection.py:597 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] "%(count)d Aufführung"
 msgstr[1] "%(count)d Aufführungen"
 
-#: journal/models/collection.py:563 journal/templatetags/collection.py:91
+#: journal/models/collection.py:605 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] "%(count)d Artikel"
 msgstr[1] "%(count)d Artikel"
 
-#: journal/models/common.py:50 journal/templates/action_open_post.html:15
-#: journal/templates/collection_share.html:35 journal/templates/mark.html:84
+#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
-#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:54
-#: users/templates/users/data.html:107 users/templates/users/data.html:164
-#: users/templates/users/data.html:215 users/templates/users/data.html:277
-#: users/templates/users/data.html:337 users/templates/users/data.html:534
+#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
+#: users/templates/users/data.html:122 users/templates/users/data.html:179
+#: users/templates/users/data.html:230 users/templates/users/data.html:292
+#: users/templates/users/data.html:355 users/templates/users/data.html:534
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5627,13 +5580,13 @@ msgstr[1] "%(count)d Artikel"
 msgid "Public"
 msgstr "Öffentlich"
 
-#: journal/models/common.py:51 journal/templates/action_open_post.html:9
-#: journal/templates/collection_share.html:46 journal/templates/mark.html:91
+#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
-#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
-#: users/templates/users/data.html:115 users/templates/users/data.html:172
-#: users/templates/users/data.html:223 users/templates/users/data.html:285
-#: users/templates/users/data.html:345 users/templates/users/data.html:542
+#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
+#: users/templates/users/data.html:130 users/templates/users/data.html:187
+#: users/templates/users/data.html:238 users/templates/users/data.html:300
+#: users/templates/users/data.html:363 users/templates/users/data.html:542
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5641,12 +5594,12 @@ msgstr "Öffentlich"
 msgid "Followers Only"
 msgstr "nur Follower"
 
-#: journal/models/common.py:52 journal/templates/collection_share.html:57
-#: journal/templates/mark.html:98 journal/templates/post_compose.html:72
-#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
-#: users/templates/users/data.html:123 users/templates/users/data.html:180
-#: users/templates/users/data.html:231 users/templates/users/data.html:293
-#: users/templates/users/data.html:353 users/templates/users/data.html:550
+#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/templates/mark.html:102 journal/templates/post_compose.html:72
+#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
+#: users/templates/users/data.html:138 users/templates/users/data.html:195
+#: users/templates/users/data.html:246 users/templates/users/data.html:308
+#: users/templates/users/data.html:371 users/templates/users/data.html:550
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5654,39 +5607,33 @@ msgstr "nur Follower"
 msgid "Mentioned Only"
 msgstr "nur Erwähnte"
 
-#: journal/models/common.py:790
+#: journal/models/common.py:806
 #, fuzzy
 #| msgid "A recent post was not posted to Mastodon, please re-authorize."
-msgid ""
-"A recent post was not posted to Bluesky, please login NeoDB using ATProto "
-"again to re-authorize."
-msgstr ""
-"Ein kürzlicher Beitrag wurde nicht auf Mastodon veröffentlicht, bitte "
-"autorisiere dein Konto erneut."
+msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
+msgstr "Ein kürzlicher Beitrag wurde nicht auf Mastodon veröffentlicht, bitte autorisiere dein Konto erneut."
 
-#: journal/models/common.py:987
+#: journal/models/common.py:1003
 msgid "A recent post was not posted to Threads."
 msgstr "Ein kürzlicher Beitrag wurde nicht auf Threads veröffentlicht."
 
-#: journal/models/common.py:1020
+#: journal/models/common.py:1036
 #, fuzzy
 #| msgid "A recent post was not posted to Mastodon."
 msgid "A recent post was not boosted on Mastodon."
 msgstr "Ein kürzlicher Beitrag wurde nicht auf Mastodon veröffentlicht."
 
-#: journal/models/common.py:1030
+#: journal/models/common.py:1046
 #, fuzzy
 #| msgid "Item no longer exists"
 msgid "Original post no longer exists."
 msgstr "Artikel existiert nicht mehr"
 
-#: journal/models/common.py:1044
+#: journal/models/common.py:1060
 msgid "A recent post was not posted to Mastodon, please re-authorize."
-msgstr ""
-"Ein kürzlicher Beitrag wurde nicht auf Mastodon veröffentlicht, bitte "
-"autorisiere dein Konto erneut."
+msgstr "Ein kürzlicher Beitrag wurde nicht auf Mastodon veröffentlicht, bitte autorisiere dein Konto erneut."
 
-#: journal/models/common.py:1053
+#: journal/models/common.py:1069
 msgid "A recent post was not posted to Mastodon."
 msgstr "Ein kürzlicher Beitrag wurde nicht auf Mastodon veröffentlicht."
 
@@ -5696,7 +5643,7 @@ msgstr "Ein kürzlicher Beitrag wurde nicht auf Mastodon veröffentlicht."
 msgid "Authorization expired"
 msgstr "Authentifikation fehlgeschlagen"
 
-#: journal/models/crosspost.py:17 users/models/task.py:24
+#: journal/models/crosspost.py:17 users/models/task.py:26
 msgid "Failed"
 msgstr "abgebrochen"
 
@@ -5704,85 +5651,85 @@ msgstr "abgebrochen"
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:469
+#: journal/models/mark.py:475
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:473
+#: journal/models/mark.py:479
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:480
+#: journal/models/mark.py:486
 #, fuzzy
 #| msgid "Invalid parameter"
 msgid "Invalid progress type."
 msgstr "Ungültige Parameter"
 
-#: journal/models/mark.py:482
+#: journal/models/mark.py:488
 #, fuzzy
 #| msgid "Invalid response from Fediverse instance."
 msgid "Invalid progress type for this item."
 msgstr "Ungültige Antwort der Fediverse Instanz."
 
-#: journal/models/note.py:34 users/templates/users/rym_import.html:73
+#: journal/models/note.py:47 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr "Seite"
 
-#: journal/models/note.py:35
+#: journal/models/note.py:48
 msgid "Chapter"
 msgstr "Kapitel"
 
-#: journal/models/note.py:38
+#: journal/models/note.py:51
 msgid "Part"
 msgstr "Teil"
 
-#: journal/models/note.py:39
+#: journal/models/note.py:52
 msgid "Episode"
 msgstr "Folge"
 
-#: journal/models/note.py:40
+#: journal/models/note.py:53
 msgid "Track"
 msgstr "Titel"
 
-#: journal/models/note.py:41
+#: journal/models/note.py:54
 msgid "Cycle"
 msgstr "Wiederholungen"
 
-#: journal/models/note.py:42
+#: journal/models/note.py:55
 msgid "Timestamp"
 msgstr "Zeitstempel"
 
-#: journal/models/note.py:43
+#: journal/models/note.py:56
 msgid "Percentage"
 msgstr "Prozent"
 
-#: journal/models/note.py:60
+#: journal/models/note.py:77
 #, python-brace-format
 msgid "Page {value}"
 msgstr "Seite {value}"
 
-#: journal/models/note.py:61
+#: journal/models/note.py:78
 #, python-brace-format
 msgid "Chapter {value}"
 msgstr "Kapitel {value}"
 
-#: journal/models/note.py:64
+#: journal/models/note.py:81
 #, python-brace-format
 msgid "Part {value}"
 msgstr "Teil {value}"
 
-#: journal/models/note.py:65
+#: journal/models/note.py:82
 #, python-brace-format
 msgid "Episode {value}"
 msgstr "Folge {value}"
 
-#: journal/models/note.py:66
+#: journal/models/note.py:83
 #, python-brace-format
 msgid "Track {value}"
 msgstr "Titel {value}"
 
-#: journal/models/note.py:67
+#: journal/models/note.py:84
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr "Wiederholungen {value}"
@@ -5792,445 +5739,445 @@ msgstr "Wiederholungen {value}"
 msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr "{item_title} enhält eventuell Spoiler oder triggernden Inhalt"
 
-#: journal/models/review.py:78
+#: journal/models/review.py:79
 #, fuzzy, python-brace-format
 #| msgid "a review of {item_title}"
 msgid "a review of {title}"
 msgstr "eine Rezension über {item_title}"
 
-#: journal/models/review.py:80
+#: journal/models/review.py:81
 #, fuzzy
 #| msgid "Item contains sub-items."
 msgid "(may contain spoilers)"
 msgstr "Artikel enthält Unterartikel."
 
-#: journal/models/shelf.py:37
+#: journal/models/shelf.py:39
 msgid "WISHLIST"
 msgstr "WUNSCHLISTE"
 
-#: journal/models/shelf.py:38
+#: journal/models/shelf.py:40
 msgid "PROGRESS"
 msgstr "FORTSCHRITT"
 
-#: journal/models/shelf.py:39
+#: journal/models/shelf.py:41
 msgid "COMPLETE"
 msgstr "VOLLSTÄNDIG"
 
-#: journal/models/shelf.py:40
+#: journal/models/shelf.py:42
 msgid "DROPPED"
 msgstr "ABGEBROCHEN"
 
-#: journal/models/shelf.py:49
+#: journal/models/shelf.py:51
 msgid "books to read"
 msgstr "Bücher, die ich lesen möchte:"
 
-#: journal/models/shelf.py:50
+#: journal/models/shelf.py:52
 msgid "want to read"
 msgstr "möchte lesen"
 
-#: journal/models/shelf.py:51
+#: journal/models/shelf.py:53
 #, python-brace-format
 msgid "wants to read {item}"
 msgstr "möchte demnächst {item} lesen"
 
-#: journal/models/shelf.py:52
+#: journal/models/shelf.py:54
 msgid "to read"
 msgstr "zu lesen"
 
-#: journal/models/shelf.py:57
+#: journal/models/shelf.py:59
 msgid "books reading"
 msgstr "Bücher, aktuell am Lesen:"
 
-#: journal/models/shelf.py:58
+#: journal/models/shelf.py:60
 msgid "start reading"
 msgstr "lesen anfangen"
 
-#: journal/models/shelf.py:59
+#: journal/models/shelf.py:61
 #, python-brace-format
 msgid "started reading {item}"
 msgstr "hat angefangen {item} zu lesen"
 
-#: journal/models/shelf.py:60
+#: journal/models/shelf.py:62
 msgid "reading"
 msgstr "am lesen"
 
-#: journal/models/shelf.py:65
+#: journal/models/shelf.py:67
 msgid "books completed"
 msgstr "Bücher gelesen:"
 
-#: journal/models/shelf.py:66
+#: journal/models/shelf.py:68
 msgid "finish reading"
 msgstr "lesen abschließen"
 
-#: journal/models/shelf.py:67
+#: journal/models/shelf.py:69
 #, python-brace-format
 msgid "finished reading {item}"
 msgstr "hat {item} fertig gelesen"
 
-#: journal/models/shelf.py:68
+#: journal/models/shelf.py:70
 msgid "read"
 msgstr "gelesen"
 
-#: journal/models/shelf.py:73
+#: journal/models/shelf.py:75
 msgid "books dropped"
 msgstr "Bücher abgebrochen"
 
-#: journal/models/shelf.py:74
+#: journal/models/shelf.py:76
 msgid "stop reading"
 msgstr "lesen aufhören"
 
-#: journal/models/shelf.py:75
+#: journal/models/shelf.py:77
 #, python-brace-format
 msgid "stopped reading {item}"
 msgstr "hat aufgehört {item} zu lesen"
 
-#: journal/models/shelf.py:76
+#: journal/models/shelf.py:78
 msgid "stopped reading"
 msgstr "lesen abbrechen"
 
-#: journal/models/shelf.py:81
+#: journal/models/shelf.py:83
 msgid "books reviewed"
 msgstr "Bücher rezensiert:"
 
-#: journal/models/shelf.py:82 journal/models/shelf.py:122
-#: journal/models/shelf.py:162 journal/models/shelf.py:202
-#: journal/models/shelf.py:242 journal/models/shelf.py:282
-#: journal/models/shelf.py:316
+#: journal/models/shelf.py:84 journal/models/shelf.py:124
+#: journal/models/shelf.py:164 journal/models/shelf.py:204
+#: journal/models/shelf.py:244 journal/models/shelf.py:284
+#: journal/models/shelf.py:318
 msgid "review"
 msgstr "Rezension"
 
-#: journal/models/shelf.py:83 journal/models/shelf.py:123
-#: journal/models/shelf.py:163 journal/models/shelf.py:203
-#: journal/models/shelf.py:243 journal/models/shelf.py:283
-#: journal/models/shelf.py:317
+#: journal/models/shelf.py:85 journal/models/shelf.py:125
+#: journal/models/shelf.py:165 journal/models/shelf.py:205
+#: journal/models/shelf.py:245 journal/models/shelf.py:285
+#: journal/models/shelf.py:319
 #, python-brace-format
 msgid "wrote a review of {item}"
 msgstr "hat eine Rezension über {item} verfasst"
 
-#: journal/models/shelf.py:89
+#: journal/models/shelf.py:91
 msgid "movies to watch"
 msgstr "Filme, die ich schauen möchte:"
 
-#: journal/models/shelf.py:90 journal/models/shelf.py:130
+#: journal/models/shelf.py:92 journal/models/shelf.py:132
 msgid "want to watch"
 msgstr "möchte anschauen"
 
-#: journal/models/shelf.py:91 journal/models/shelf.py:131
+#: journal/models/shelf.py:93 journal/models/shelf.py:133
 #, python-brace-format
 msgid "wants to watch {item}"
 msgstr "möchte sich demnächst {item} anschauen"
 
-#: journal/models/shelf.py:92 journal/models/shelf.py:132
+#: journal/models/shelf.py:94 journal/models/shelf.py:134
 msgid "to watch"
 msgstr "zu schauen"
 
-#: journal/models/shelf.py:97
+#: journal/models/shelf.py:99
 msgid "movies watching"
 msgstr "Filme, aktuell am Schauen:"
 
-#: journal/models/shelf.py:98 journal/models/shelf.py:138
+#: journal/models/shelf.py:100 journal/models/shelf.py:140
 msgid "start watching"
 msgstr "anschauen anfangen"
 
-#: journal/models/shelf.py:99 journal/models/shelf.py:139
+#: journal/models/shelf.py:101 journal/models/shelf.py:141
 #, python-brace-format
 msgid "started watching {item}"
 msgstr "hat angefangen sich {item} anzuschauen"
 
-#: journal/models/shelf.py:100 journal/models/shelf.py:140
+#: journal/models/shelf.py:102 journal/models/shelf.py:142
 msgid "watching"
 msgstr "am anschauen"
 
-#: journal/models/shelf.py:105
+#: journal/models/shelf.py:107
 msgid "movies watched"
 msgstr "Filme angeschaut:"
 
-#: journal/models/shelf.py:106 journal/models/shelf.py:146
+#: journal/models/shelf.py:108 journal/models/shelf.py:148
 msgid "finish watching"
 msgstr "anschauen abschließen"
 
-#: journal/models/shelf.py:107 journal/models/shelf.py:147
+#: journal/models/shelf.py:109 journal/models/shelf.py:149
 #, python-brace-format
 msgid "finished watching {item}"
 msgstr "hat sich {item} fertig angeschaut"
 
-#: journal/models/shelf.py:108 journal/models/shelf.py:148
+#: journal/models/shelf.py:110 journal/models/shelf.py:150
 msgid "watched"
 msgstr "angeschaut"
 
-#: journal/models/shelf.py:113
+#: journal/models/shelf.py:115
 msgid "movies dropped"
 msgstr "Filme abgebrochen"
 
-#: journal/models/shelf.py:114 journal/models/shelf.py:154
+#: journal/models/shelf.py:116 journal/models/shelf.py:156
 msgid "stop watching"
 msgstr "anschauen aufhören"
 
-#: journal/models/shelf.py:115 journal/models/shelf.py:155
+#: journal/models/shelf.py:117 journal/models/shelf.py:157
 #, python-brace-format
 msgid "stopped watching {item}"
 msgstr "hat aufgehört {item} zu schauen"
 
-#: journal/models/shelf.py:116 journal/models/shelf.py:156
+#: journal/models/shelf.py:118 journal/models/shelf.py:158
 msgid "stopped watching"
 msgstr "schauen abbrechen"
 
-#: journal/models/shelf.py:121
+#: journal/models/shelf.py:123
 msgid "movies reviewed"
 msgstr "Filme rezensiert:"
 
-#: journal/models/shelf.py:129
+#: journal/models/shelf.py:131
 msgid "TV shows to watch"
 msgstr "Serien, die ich schauen möchte:"
 
-#: journal/models/shelf.py:137
+#: journal/models/shelf.py:139
 msgid "TV shows watching"
 msgstr "Serien, aktuell am Schauen:"
 
-#: journal/models/shelf.py:145
+#: journal/models/shelf.py:147
 msgid "TV shows watched"
 msgstr "Serien abgeschlossen:"
 
-#: journal/models/shelf.py:153
+#: journal/models/shelf.py:155
 msgid "TV shows dropped"
 msgstr "Serien abgebrochen"
 
-#: journal/models/shelf.py:161
+#: journal/models/shelf.py:163
 msgid "TV shows reviewed"
 msgstr "Serien rezensiert:"
 
-#: journal/models/shelf.py:169
+#: journal/models/shelf.py:171
 msgid "albums to listen"
 msgstr "Alben, die ich anhören möchte:"
 
-#: journal/models/shelf.py:170 journal/models/shelf.py:250
+#: journal/models/shelf.py:172 journal/models/shelf.py:252
 msgid "want to listen"
 msgstr "möchte anhören"
 
-#: journal/models/shelf.py:171 journal/models/shelf.py:251
+#: journal/models/shelf.py:173 journal/models/shelf.py:253
 #, python-brace-format
 msgid "wants to listen {item}"
 msgstr "möchte sich demnächst {item} anhören"
 
-#: journal/models/shelf.py:172 journal/models/shelf.py:252
+#: journal/models/shelf.py:174 journal/models/shelf.py:254
 msgid "to listen"
 msgstr "zu hören"
 
-#: journal/models/shelf.py:177
+#: journal/models/shelf.py:179
 msgid "albums listening"
 msgstr "Alben, aktuell am Hören:"
 
-#: journal/models/shelf.py:178 journal/models/shelf.py:258
+#: journal/models/shelf.py:180 journal/models/shelf.py:260
 msgid "start listening"
 msgstr "hören anfangen"
 
-#: journal/models/shelf.py:179 journal/models/shelf.py:259
+#: journal/models/shelf.py:181 journal/models/shelf.py:261
 #, python-brace-format
 msgid "started listening {item}"
 msgstr "hat angefangen sich {item} anzuhören"
 
-#: journal/models/shelf.py:180 journal/models/shelf.py:260
+#: journal/models/shelf.py:182 journal/models/shelf.py:262
 msgid "listening"
 msgstr "am anhören"
 
-#: journal/models/shelf.py:185
+#: journal/models/shelf.py:187
 msgid "albums listened"
 msgstr "Alben angehört:"
 
-#: journal/models/shelf.py:186 journal/models/shelf.py:266
+#: journal/models/shelf.py:188 journal/models/shelf.py:268
 msgid "finish listening"
 msgstr "anhören abschließen"
 
-#: journal/models/shelf.py:187 journal/models/shelf.py:267
+#: journal/models/shelf.py:189 journal/models/shelf.py:269
 #, python-brace-format
 msgid "finished listening {item}"
 msgstr "hat sich {item} fertig angehört"
 
-#: journal/models/shelf.py:188 journal/models/shelf.py:268
+#: journal/models/shelf.py:190 journal/models/shelf.py:270
 msgid "listened"
 msgstr "gehört"
 
-#: journal/models/shelf.py:193
+#: journal/models/shelf.py:195
 msgid "albums dropped"
 msgstr "Alben abgebrochen"
 
-#: journal/models/shelf.py:194 journal/models/shelf.py:274
+#: journal/models/shelf.py:196 journal/models/shelf.py:276
 msgid "stop listening"
 msgstr "anhören aufhören"
 
-#: journal/models/shelf.py:195 journal/models/shelf.py:275
+#: journal/models/shelf.py:197 journal/models/shelf.py:277
 #, python-brace-format
 msgid "stopped listening {item}"
 msgstr "hat aufgehört {item} zu hören"
 
-#: journal/models/shelf.py:196 journal/models/shelf.py:276
+#: journal/models/shelf.py:198 journal/models/shelf.py:278
 msgid "stopped listening"
 msgstr "hören abbrechen"
 
-#: journal/models/shelf.py:201
+#: journal/models/shelf.py:203
 msgid "albums reviewed"
 msgstr "Alben rezensiert:"
 
-#: journal/models/shelf.py:209
+#: journal/models/shelf.py:211
 msgid "games to play"
 msgstr "Spiele, die ich spielen möchte:"
 
-#: journal/models/shelf.py:210
+#: journal/models/shelf.py:212
 msgid "want to play"
 msgstr "möchte spielen"
 
-#: journal/models/shelf.py:211
+#: journal/models/shelf.py:213
 #, python-brace-format
 msgid "wants to play {item}"
 msgstr "möchte demnächst {item} spielen"
 
-#: journal/models/shelf.py:212
+#: journal/models/shelf.py:214
 msgid "to play"
 msgstr "zu spielen"
 
-#: journal/models/shelf.py:217
+#: journal/models/shelf.py:219
 msgid "games playing"
 msgstr "Spiele, aktuell am Spielen:"
 
-#: journal/models/shelf.py:218
+#: journal/models/shelf.py:220
 msgid "start playing"
 msgstr "spielen anfangen"
 
-#: journal/models/shelf.py:219
+#: journal/models/shelf.py:221
 #, python-brace-format
 msgid "started playing {item}"
 msgstr "hat angefangen {item} zu spielen"
 
-#: journal/models/shelf.py:220
+#: journal/models/shelf.py:222
 msgid "playing"
 msgstr "am spielen"
 
-#: journal/models/shelf.py:225
+#: journal/models/shelf.py:227
 msgid "games played"
 msgstr "Spiele gespielt:"
 
-#: journal/models/shelf.py:226
+#: journal/models/shelf.py:228
 msgid "finish playing"
 msgstr "spielen abschließen"
 
-#: journal/models/shelf.py:227
+#: journal/models/shelf.py:229
 #, python-brace-format
 msgid "finished playing {item}"
 msgstr "hat {item} fertig gespielt"
 
-#: journal/models/shelf.py:228
+#: journal/models/shelf.py:230
 msgid "played"
 msgstr "gespielt"
 
-#: journal/models/shelf.py:233
+#: journal/models/shelf.py:235
 msgid "games dropped"
 msgstr "Spiele abgebrochen"
 
-#: journal/models/shelf.py:234
+#: journal/models/shelf.py:236
 msgid "stop playing"
 msgstr "spielen aufhören"
 
-#: journal/models/shelf.py:235
+#: journal/models/shelf.py:237
 #, python-brace-format
 msgid "stopped playing {item}"
 msgstr "hat aufgehört {item} zu spielen"
 
-#: journal/models/shelf.py:236
+#: journal/models/shelf.py:238
 msgid "stopped playing"
 msgstr "spielen abbrechen"
 
-#: journal/models/shelf.py:241
+#: journal/models/shelf.py:243
 msgid "games reviewed"
 msgstr "Spiele rezensiert:"
 
-#: journal/models/shelf.py:249
+#: journal/models/shelf.py:251
 msgid "podcasts to listen"
 msgstr "Podcasts, die ich anhören möchte:"
 
-#: journal/models/shelf.py:257
+#: journal/models/shelf.py:259
 msgid "podcasts listening"
 msgstr "Podcasts, aktuell am Hören:"
 
-#: journal/models/shelf.py:265
+#: journal/models/shelf.py:267
 msgid "podcasts listened"
 msgstr "Podcasts angehört:"
 
-#: journal/models/shelf.py:273
+#: journal/models/shelf.py:275
 msgid "podcasts dropped"
 msgstr "Podcasts abgebrochen"
 
-#: journal/models/shelf.py:281
+#: journal/models/shelf.py:283
 msgid "podcasts reviewed"
 msgstr "Podcasts rezensiert:"
 
-#: journal/models/shelf.py:289
+#: journal/models/shelf.py:291
 msgid "performances to see"
 msgstr "Aufführungen, die ich ansehen möchte:"
 
-#: journal/models/shelf.py:290
+#: journal/models/shelf.py:292
 msgid "want to see"
 msgstr "möchte ansehen"
 
-#: journal/models/shelf.py:291
+#: journal/models/shelf.py:293
 #, python-brace-format
 msgid "wants to see {item}"
 msgstr "möchte sich demnächst {item} ansehen"
 
-#: journal/models/shelf.py:292
+#: journal/models/shelf.py:294
 msgid "to see"
 msgstr "zu sehen"
 
-#: journal/models/shelf.py:299
+#: journal/models/shelf.py:301
 msgid "performances saw"
 msgstr "Aufführungen angesehen:"
 
-#: journal/models/shelf.py:300
+#: journal/models/shelf.py:302
 msgid "finish seeing"
 msgstr "ansehen abschließen"
 
-#: journal/models/shelf.py:301
+#: journal/models/shelf.py:303
 #, python-brace-format
 msgid "finished seeing {item}"
 msgstr "hat sich {item} fertig angesehen"
 
-#: journal/models/shelf.py:302
+#: journal/models/shelf.py:304
 msgid "seen"
 msgstr "gesehen"
 
-#: journal/models/shelf.py:307
+#: journal/models/shelf.py:309
 msgid "performances dropped"
 msgstr "Aufführungen abgebrochen"
 
-#: journal/models/shelf.py:308
+#: journal/models/shelf.py:310
 msgid "stop seeing"
 msgstr "ansehen aufhören"
 
-#: journal/models/shelf.py:309
+#: journal/models/shelf.py:311
 #, python-brace-format
 msgid "stopped seeing {item}"
 msgstr "hat aufgehört {item} zu sehen"
 
-#: journal/models/shelf.py:310
+#: journal/models/shelf.py:312
 msgid "stopped seeing"
 msgstr "ansehen abbrechen"
 
-#: journal/models/shelf.py:315
+#: journal/models/shelf.py:317
 msgid "performances reviewed"
 msgstr "Aufführungen rezensiert:"
 
-#: journal/models/shelf.py:323
+#: journal/models/shelf.py:325
 #, fuzzy
 #| msgid "Users you are following"
 msgid "people following"
 msgstr "Leuten denen du folgst"
 
-#: journal/models/shelf.py:325
+#: journal/models/shelf.py:327
 #, fuzzy, python-brace-format
 #| msgid "started playing {item}"
 msgid "started following {item}"
 msgstr "hat angefangen {item} zu spielen"
 
-#: journal/models/shelf.py:921
+#: journal/models/shelf.py:923
 msgid "removed mark"
 msgstr "gelöschte Markierungen"
 
@@ -6260,38 +6207,22 @@ msgstr ""
 msgid "Remove from collection"
 msgstr "von Sammlung entfernen"
 
-#: journal/templates/_list_item.html:34
-msgid "add mark"
-msgstr "Markierung hinzufügen"
-
-#: journal/templates/_list_item.html:42
-msgid "update mark"
-msgstr "Markierung aktuallisieren"
-
-#: journal/templates/_list_item.html:60
+#: journal/templates/_list_item.html:43
 #: journal/templates/collection_update_item_note_ok.html:3
 msgid "Update note"
 msgstr "Notiz aktuallisieren"
 
-#: journal/templates/_list_item.html:100 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:123
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
 msgstr "Rezension"
 
-#: journal/templates/_list_item.html:133
+#: journal/templates/_list_item.html:91
 #, fuzzy, python-format
-#| msgid ""
-#| " %(dups)s items are from the same work or have the same identifier, they "
-#| "are hidden from the search results, <a _=\"on click toggle .unfold on "
-#| "#dup\">click here to show them.</a> "
-msgid ""
-"%(dups)s item(s) are from the same work or have the same identifier, click "
-"here to display:"
-msgstr ""
-" %(dups)s Artikel entstammen dem selben Werk oder haben die selbe Kennung "
-"und werden deshalb nicht in den Suchergebnissen angezeigt, <a _=\"on click "
-"toggle .unfold on #dup\">drücke hier um sie anzuzeigen.</a> "
+#| msgid " %(dups)s items are from the same work or have the same identifier, they are hidden from the search results, <a _=\"on click toggle .unfold on #dup\">click here to show them.</a> "
+msgid "%(dups)s item(s) are from the same work or have the same identifier, click here to display:"
+msgstr " %(dups)s Artikel entstammen dem selben Werk oder haben die selbe Kennung und werden deshalb nicht in den Suchergebnissen angezeigt, <a _=\"on click toggle .unfold on #dup\">drücke hier um sie anzuzeigen.</a> "
 
 #: journal/templates/_sidebar_collection_filter.html:32
 #, fuzzy
@@ -6381,9 +6312,7 @@ msgstr "teilen"
 
 #: journal/templates/action_delete_post.html:7
 msgid "Are you sure to delete this post and the mark or note related with it?"
-msgstr ""
-"Möchtest du diesen Beitrag und alle zusammenhängende Markierungen und "
-"Notizen löschen?"
+msgstr "Möchtest du diesen Beitrag und alle zusammenhängende Markierungen und Notizen löschen?"
 
 #: journal/templates/action_delete_post.html:7
 msgid "Are you sure to delete this reply?"
@@ -6411,6 +6340,14 @@ msgstr "geliked"
 #: journal/templates/action_like_post.html:16
 msgid "Like"
 msgstr ""
+
+#: journal/templates/action_mark_item.html:10
+msgid "add mark"
+msgstr "Markierung hinzufügen"
+
+#: journal/templates/action_mark_item.html:18
+msgid "update mark"
+msgstr "Markierung aktuallisieren"
 
 #: journal/templates/action_open_post.html:7
 #, fuzzy
@@ -6472,13 +6409,13 @@ msgstr "zur Sammlung hinzufügen"
 msgid "Create a new collection"
 msgstr "neue Sammlung erstellen"
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:81
+#: journal/templates/article.html:104 social/templates/_event_post.html:76
 #, fuzzy
 #| msgid "wrote a review of {item}"
 msgid "wrote a review"
 msgstr "hat eine Rezension über {item} verfasst"
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:83
+#: journal/templates/article.html:106 social/templates/_event_post.html:78
 #, fuzzy
 #| msgid "wrote a note"
 msgid "wrote an article"
@@ -6490,8 +6427,7 @@ msgstr ""
 
 #: journal/templates/article.html:155
 msgid "The author has set it to be viewable only by logged-in users."
-msgstr ""
-"Der Autor hat diesen Inhalt nur für eingeloggte Nutzer sichtbar gemacht."
+msgstr "Der Autor hat diesen Inhalt nur für eingeloggte Nutzer sichtbar gemacht."
 
 #: journal/templates/article_edit.html:13
 #, fuzzy
@@ -6585,9 +6521,7 @@ msgstr "Artikel zu einer Sammlung hinzufügen"
 
 #: journal/templates/collection_edit.html:89
 msgid "Drag and drop to change the order order and click here to save"
-msgstr ""
-"Klicke und Ziehe ein Objekt um die Reihenfolge zu ändern und drücke hier um "
-"zu speichern"
+msgstr "Klicke und Ziehe ein Objekt um die Reihenfolge zu ändern und drücke hier um zu speichern"
 
 #: journal/templates/collection_share.html:24
 msgid "for the sharing post only, not visibility of the collection"
@@ -6601,23 +6535,21 @@ msgstr "Teile mit Wiedergabepunkt"
 msgid "Mark"
 msgstr "Markierung"
 
-#: journal/templates/mark.html:50
+#: journal/templates/mark.html:54
 msgid "not rated"
 msgstr "nicht bewertet"
 
-#: journal/templates/mark.html:70
+#: journal/templates/mark.html:74
 msgid "add a tag and press Enter"
 msgstr "Tag hinzufügen und drücke Enter"
 
-#: journal/templates/mark.html:122
+#: journal/templates/mark.html:126
 msgid "change mark date"
 msgstr "ändere Markierungs-Datum"
 
-#: journal/templates/mark.html:148
+#: journal/templates/mark.html:156
 msgid "Sure to delete mark, comment and tags for this item?"
-msgstr ""
-"Möchtest du diese Markierung und alle zusammenhängende Kommentare und Tags "
-"löschen?"
+msgstr "Möchtest du diese Markierung und alle zusammenhängende Kommentare und Tags löschen?"
 
 #: journal/templates/markdown_editor.html:9
 msgid "Markdown format references"
@@ -6635,15 +6567,13 @@ msgstr "Markdown Formatierungs Referenzen"
 #| "\n"
 #| "  Paragraphs need to be separated by a blank line\n"
 #| "\n"
-#| "  Indentation at the beginning of the paragraph requires using a Unicode "
-#| "full-width space\n"
+#| "  Indentation at the beginning of the paragraph requires using a Unicode full-width space\n"
 #| "\n"
 #| "[Link](https://zh.wikipedia.org/wiki/Markdown)\n"
 #| "**Bold**  *Italic* ==Highlight== ~~Strikethrough~~\n"
 #| "^Super^script ~Sub~script [拼(pīn)音(yīn)]\n"
 #| "\n"
-#| "Drag and drop an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/"
-#| "Wikipedia-logo-v2.svg)\n"
+#| "Drag and drop an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 #| "\n"
 #| "> Quote\n"
 #| ">> Multi-level quote\n"
@@ -6703,8 +6633,7 @@ msgid ""
 "Content Cell  | Content Cell\n"
 "Content Cell  | Content Cell\n"
 "\n"
-"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/"
-"Wikipedia-logo-v2.svg)\n"
+"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 "\n"
 msgstr ""
 "\n"
@@ -6716,15 +6645,13 @@ msgstr ""
 "\n"
 "  Absätze müssen durch eine leere Zeile getrennt werden\n"
 "\n"
-"  Einrückung am Anfang der Zeile benötigt ein Unicode Voll-Länge "
-"Leerzeichen\n"
+"  Einrückung am Anfang der Zeile benötigt ein Unicode Voll-Länge Leerzeichen\n"
 "\n"
 "[Link](https://www.markdownguide.org/basic-syntax/)\n"
 "**Fett**  *Kursiv* ==hervorheben== ~~durchstreichen~~\n"
 "^hoch^gestellt ~tief~gestellt [拼(pīn)音(yīn)]\n"
 "\n"
-"Klicke und Ziehe ein Bild hierhin ![](https://upload.wikimedia.org/wikipedia/"
-"en/8/80/Wikipedia-logo-v2.svg)\n"
+"Klicke und Ziehe ein Bild hierhin ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 "\n"
 "> Zitat\n"
 ">> ein eingerücktes Zitat\n"
@@ -6751,7 +6678,7 @@ msgstr ""
 "Zellen Inhalt Reihe 1  | Zellen Inhalt Reihe 1\n"
 "Zellen Inhalt Reihe 2  | Zellen Inhalt Reihe 2\n"
 
-#: journal/templates/note.html:19 journal/views/note.py:23
+#: journal/templates/note.html:19 journal/views/note.py:22
 msgid "Note"
 msgstr "Notiz"
 
@@ -6782,12 +6709,8 @@ msgid "Are you sure to delete this entire content?"
 msgstr "Möchtest du den gesamten Inhalt löschen?"
 
 #: journal/templates/piece_delete.html:24
-msgid ""
-"By deleting it, you will also lose track of others' comments and feedbacks "
-"to your content."
-msgstr ""
-"Durch die Löschung wirst du auch die Übersicht über die Kommentare und den "
-"Feedback anderer Nutzer zu deinem Inhalt verlieren."
+msgid "By deleting it, you will also lose track of others' comments and feedbacks to your content."
+msgstr "Durch die Löschung wirst du auch die Übersicht über die Kommentare und den Feedback anderer Nutzer zu deinem Inhalt verlieren."
 
 #: journal/templates/piece_delete.html:25
 #: journal/templates/piece_delete.html:32
@@ -6880,7 +6803,7 @@ msgstr "Jahresübersicht"
 msgid "Articles"
 msgstr ""
 
-#: journal/templates/profile.html:166 journal/views/collection.py:427
+#: journal/templates/profile.html:166 journal/views/collection.py:409
 #: journal/views/profile.py:401
 msgid "collection"
 msgstr "Sammlung"
@@ -6916,13 +6839,8 @@ msgid "Personal"
 msgstr "Persönlich"
 
 #: journal/templates/tag_edit.html:52
-msgid ""
-"Personal tags are not included in public index. However, if you use this tag "
-"when marking an item publicly, it might still be visible to others."
-msgstr ""
-"Persönliche Tags werden nicht im öffentlichen Index angezeigt. Wenn du "
-"jedoch diesen Tag in einer öffentlichen Markierung verwendest, könnte er "
-"auch für Andere sichtbar werden."
+msgid "Personal tags are not included in public index. However, if you use this tag when marking an item publicly, it might still be visible to others."
+msgstr "Persönliche Tags werden nicht im öffentlichen Index angezeigt. Wenn du jedoch diesen Tag in einer öffentlichen Markierung verwendest, könnte er auch für Andere sichtbar werden."
 
 #: journal/templates/tag_edit.html:55
 msgid "Delete this tag"
@@ -6997,133 +6915,128 @@ msgstr "Rezensionen von {0}"
 msgid "Link invalid"
 msgstr "Link ungültig"
 
-#: journal/views/collection.py:58 journal/views/collection.py:96
+#: journal/views/collection.py:62 journal/views/collection.py:94
 #, python-brace-format
 msgid "Collection by {0}"
 msgstr "Sammlung von {0}"
 
-#: journal/views/collection.py:432
+#: journal/views/collection.py:414
 msgid "shared my collection"
 msgstr "meine geteilte Sammlung"
 
-#: journal/views/collection.py:435
+#: journal/views/collection.py:417
 #, python-brace-format
 msgid "shared {username}'s collection"
 msgstr "{username}'s geteilte Sammlung"
 
-#: journal/views/collection.py:502 journal/views/collection.py:541
-#: journal/views/collection.py:553 journal/views/collection.py:579
+#: journal/views/collection.py:484 journal/views/collection.py:523
+#: journal/views/collection.py:535 journal/views/collection.py:561
 msgid "Dynamic collection is not editable"
 msgstr ""
 
-#: journal/views/collection.py:518
+#: journal/views/collection.py:500
 #, fuzzy
 #| msgid "This username is already in use."
 msgid "The item is already in the collection."
 msgstr "Dieser Benutzername wird bereits verwendet."
 
-#: journal/views/collection.py:520
+#: journal/views/collection.py:502
 msgid "Unable to find the item, please use item url from this site."
-msgstr ""
-"Der Artikel wurde nicht gefunden. Bitte benutze die URL des Artikels der "
-"jeweiligen Seite."
+msgstr "Der Artikel wurde nicht gefunden. Bitte benutze die URL des Artikels der jeweiligen Seite."
 
-#: journal/views/collection.py:566
+#: journal/views/collection.py:548
 #, fuzzy
 #| msgid "Save"
 msgid "Saved."
 msgstr "Speichern"
 
-#: journal/views/common.py:119 journal/views/mark.py:225
-#: journal/views/mark.py:279 journal/views/note.py:175
+#: journal/views/common.py:126 journal/views/mark.py:273
+#: journal/views/mark.py:315 journal/views/note.py:167
 #: journal/views/profile.py:42 journal/views/review.py:59
 #: journal/views/review.py:79
 msgid "Content not found"
 msgstr "Inhalt nicht gefunden"
 
-#: journal/views/common.py:174 journal/views/mark.py:159
+#: journal/views/common.py:184 journal/views/mark.py:210
 msgid "Data saved but unable to crosspost to Fediverse instance."
-msgstr ""
-"Daten gespeichert, Beiträge können jedoch nicht mit deiner Fediverse-Instanz "
-"geteilt werden."
+msgstr "Daten gespeichert, Beiträge können jedoch nicht mit deiner Fediverse-Instanz geteilt werden."
 
-#: journal/views/common.py:176
+#: journal/views/common.py:186
 msgid "Redirecting to your Fediverse instance now to re-authenticate."
 msgstr "Weiterleitung zu deiner Fediverse-Instanz zur Authentifikation."
 
-#: journal/views/common.py:183
+#: journal/views/common.py:193
 msgid "List not found."
 msgstr "Liste nicht gefunden."
 
-#: journal/views/mark.py:150
+#: journal/views/mark.py:206
 msgid "Content too long for your Fediverse instance."
 msgstr "Inhalt ist zu lang für deine Fediverse Instanz."
 
-#: journal/views/mark.py:178 journal/views/mark.py:238
+#: journal/views/mark.py:224 journal/views/mark.py:226
+#: journal/views/mark.py:280
 #, fuzzy
 #| msgid "Invalid tag"
 msgid "Invalid input"
 msgstr "ungültiger Tag"
 
-#: journal/views/note.py:23
+#: journal/views/note.py:22
 msgid "Progress"
 msgstr ""
 
-#: journal/views/note.py:28
+#: journal/views/note.py:27
 #, fuzzy
 #| msgid "Update note"
 msgid "Update progress"
 msgstr "Notiz aktuallisieren"
 
-#: journal/views/note.py:59
+#: journal/views/note.py:58
 msgid "Progress (optional)"
 msgstr "Fortschritt (optional)"
 
-#: journal/views/note.py:61
+#: journal/views/note.py:60
 msgid "Note Content"
 msgstr "Notiz Inhalt"
 
-#: journal/views/note.py:63
+#: journal/views/note.py:62
 msgid "Content Warning (optional)"
 msgstr "Inhalts-Warnung (optional)"
 
-#: journal/views/note.py:85
+#: journal/views/note.py:84
 msgid "Progress Type (optional)"
 msgstr "Fortschritts-Typ (optional)"
 
-#: journal/views/note.py:123 journal/views/note.py:183
+#: journal/views/note.py:115 journal/views/note.py:175
 msgid "Only in-progress items can have progress."
 msgstr ""
 
-#: journal/views/post.py:98 journal/views/post.py:392
+#: journal/views/post.py:100 journal/views/post.py:388
 msgid "Post not found"
 msgstr "Beitrag nicht gefunden"
 
-#: journal/views/post.py:189
+#: journal/views/post.py:191
 msgid "Visibility too high for quoting this post"
 msgstr ""
 
-#: journal/views/post.py:337 journal/views/post.py:418
+#: journal/views/post.py:339 journal/views/post.py:414
 #, fuzzy
 #| msgid "Item cannot be deleted."
 msgid "Content cannot be empty."
 msgstr "Artikel kann nicht gelöscht werden."
 
-#: journal/views/post.py:396
+#: journal/views/post.py:392
 #, fuzzy
 #| msgid "This operation cannot be undone. Sure to merge?"
 msgid "This post cannot be edited here"
-msgstr ""
-"Dieser Vorgang kann nicht rückgängig gemacht werden. Sicher, dass du das "
-"zusammenfügen willst?"
+msgstr "Dieser Vorgang kann nicht rückgängig gemacht werden. Sicher, dass du das zusammenfügen willst?"
 
-#: journal/views/post.py:541
+#: journal/views/post.py:531
 #, fuzzy
 #| msgid "Invalid file."
 msgid "Invalid choices"
 msgstr "Ungültige Datei."
 
-#: journal/views/post.py:544
+#: journal/views/post.py:534
 #, fuzzy
 #| msgid "Invalid tag"
 msgid "Invalid post"
@@ -7145,62 +7058,57 @@ msgstr "{review_title} - eine Rezension von {item_title}"
 msgid "may contain spoiler or triggering content"
 msgstr "{item_title} enhält eventuell Spoiler oder triggernden Inhalt"
 
-#: journal/views/tag.py:47 journal/views/tag.py:61
+#: journal/views/tag.py:46 journal/views/tag.py:60
 msgid "Invalid tag"
 msgstr "ungültiger Tag"
 
-#: journal/views/tag.py:50
+#: journal/views/tag.py:49
 msgid "Tag not found"
 msgstr "Tag nicht gefunden"
 
-#: journal/views/tag.py:72
+#: journal/views/tag.py:65
 msgid "Tag deleted."
 msgstr "Tag gelöscht."
 
-#: journal/views/tag.py:82
+#: journal/views/tag.py:75
 msgid "Duplicated tag."
 msgstr "Duplizierter Tag."
 
-#: journal/views/tag.py:96
+#: journal/views/tag.py:83
 msgid "Tag updated."
 msgstr "Tag aktuallisiert."
 
-#: journal/views/wrapped.py:160
+#: journal/views/wrapped.py:161
 msgid "Summary posted to timeline."
 msgstr "Zusammenfassung als Beitrag in der Timeline gesendet."
 
-#: mastodon/models/common.py:29
+#: mastodon/models/common.py:31
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: mastodon/models/common.py:30 users/templates/users/login.html:120
+#: mastodon/models/common.py:32 users/templates/users/login.html:114
 msgid "Threads"
 msgstr "Threads"
 
-#: mastodon/models/common.py:31
+#: mastodon/models/common.py:33
 msgid "Bluesky"
 msgstr "Bluesky"
 
-#: mastodon/models/email.py:59
+#: mastodon/models/email.py:63
 msgid ""
 "\n"
 "\n"
-"If you did not mean to register or login, please ignore this email. If you "
-"are concerned with your account security, please change the email linked "
-"with your account, or contact us."
+"If you did not mean to register or login, please ignore this email. If you are concerned with your account security, please change the email linked with your account, or contact us."
 msgstr ""
 "\n"
 "\n"
-"Wenn du dich nicht registrieren oder anmelden wolltest, ignoriere diese E-"
-"Mail einfach. Wenn du Bedenken über deine Konto-Sicherheit hast, ändere "
-"bitte die E-Mail Adresse welche mit deinem Konto verbunden ist oder "
-"kontaktiere uns."
+"Wenn du dich nicht registrieren oder anmelden wolltest, ignoriere diese E-Mail einfach. Wenn du Bedenken über deine Konto-Sicherheit hast, ändere bitte die E-Mail Adresse welche mit deinem Konto verbunden ist oder kontaktiere uns."
 
-#: mastodon/models/email.py:64 mastodon/models/email.py:69
+#: mastodon/models/email.py:68 mastodon/models/email.py:73
 msgid "Verification Code"
 msgstr "Verifikations-Code"
 
-#: mastodon/models/email.py:66
+#: mastodon/models/email.py:70
 #, python-brace-format
 msgid ""
 "Use this code to verify your email address {email}\n"
@@ -7211,7 +7119,7 @@ msgstr ""
 "\n"
 "{code}"
 
-#: mastodon/models/email.py:70
+#: mastodon/models/email.py:74
 #, python-brace-format
 msgid ""
 "Use this code to login as {email}\n"
@@ -7222,32 +7130,27 @@ msgstr ""
 "\n"
 "{code}"
 
-#: mastodon/models/email.py:74 users/templates/users/captcha.html:13
+#: mastodon/models/email.py:78 users/templates/users/captcha.html:13
 #: users/templates/users/captcha_solved.html:9
 #: users/templates/users/login.html:20 users/templates/users/register.html:9
 #: users/templates/users/welcome.html:10
 msgid "Register"
 msgstr "Registrieren"
 
-#: mastodon/models/email.py:76
+#: mastodon/models/email.py:80
 #, python-brace-format
 msgid ""
 "There is no account registered with this email address yet: {email}\n"
 "\n"
-"If you already have an account with us, just login and add this email to you "
-"account.\n"
+"If you already have an account with us, just login and add this email to you account.\n"
 "\n"
-"If you prefer to register a new account with this email, please use this "
-"verification code: {code}"
+"If you prefer to register a new account with this email, please use this verification code: {code}"
 msgstr ""
-"Bisher ist noch kein Konto mit folgender E-Mail Adresse registriert: "
-"{email}\n"
+"Bisher ist noch kein Konto mit folgender E-Mail Adresse registriert: {email}\n"
 "\n"
-"Wenn du bereits ein Konto bei uns hast, melde dich an und verbinde deine E-"
-"Mail Adresse mit deinem Konto.\n"
+"Wenn du bereits ein Konto bei uns hast, melde dich an und verbinde deine E-Mail Adresse mit deinem Konto.\n"
 "\n"
-"Wenn du ein neues Konto registrieren möchtest, verwende diesen Verifikations-"
-"Code: {code}"
+"Wenn du ein neues Konto registrieren möchtest, verwende diesen Verifikations-Code: {code}"
 
 #: mastodon/models/mastodon.py:570
 msgid "site domain name"
@@ -7289,56 +7192,61 @@ msgstr "maximale Beitrags-Länge"
 msgid "New Post"
 msgstr "Neuer Beitrag"
 
-#: mastodon/views/bluesky.py:26 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:32 mastodon/views/bluesky.py:93
 #, fuzzy
 #| msgid "Bluesky Login ID"
 msgid "Bluesky login is disabled."
 msgstr "Bluesky Anmelde-ID"
 
-#: mastodon/views/bluesky.py:28 mastodon/views/email.py:35
-#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:29
-#: users/templates/users/login.html:6 users/views/webauthn.py:133
+#: mastodon/views/bluesky.py:47 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:65 mastodon/views/bluesky.py:98
+#: mastodon/views/bluesky.py:106 mastodon/views/bluesky.py:112
+#: mastodon/views/common.py:36 mastodon/views/mastodon.py:62
+#: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
+#: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
+#: mastodon/views/threads.py:57 mastodon/views/threads.py:65
+#: mastodon/views/threads.py:71 users/views/account.py:256
+#: users/views/account.py:375
+msgid "Authentication failed"
+msgstr "Authentifikation fehlgeschlagen"
+
+#: mastodon/views/bluesky.py:47 mastodon/views/common.py:103
+msgid "Identity not found."
+msgstr "Identität nicht gefunden."
+
+#: mastodon/views/bluesky.py:53 mastodon/views/email.py:35
+#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:31
+#: users/templates/users/login.html:6 users/views/webauthn.py:136
 #, fuzzy
 #| msgid "Export file expired. Please export again."
 msgid "Security check failed. Please try again."
 msgstr "Export-Datei abgelaufen. Bitte erneut exportieren."
 
-#: mastodon/views/bluesky.py:34 mastodon/views/bluesky.py:40
-#: mastodon/views/bluesky.py:64 mastodon/views/bluesky.py:72
-#: mastodon/views/bluesky.py:78 mastodon/views/common.py:36
-#: mastodon/views/mastodon.py:62 mastodon/views/mastodon.py:70
-#: mastodon/views/mastodon.py:77 mastodon/views/mastodon.py:87
-#: mastodon/views/mastodon.py:94 mastodon/views/threads.py:55
-#: mastodon/views/threads.py:63 mastodon/views/threads.py:69
-#: users/views/account.py:254 users/views/account.py:373
-msgid "Authentication failed"
-msgstr "Authentifikation fehlgeschlagen"
-
-#: mastodon/views/bluesky.py:35 mastodon/views/email.py:66
+#: mastodon/views/bluesky.py:60 mastodon/views/email.py:66
 #, fuzzy
 #| msgid "System busy, please try again in a minute."
 msgid "Too many attempts, please try again later."
 msgstr "System ist beschäftigt, versuche es in einer Minute erneut."
 
-#: mastodon/views/bluesky.py:40
+#: mastodon/views/bluesky.py:65
 #, fuzzy
 #| msgid "ATProto handle"
 msgid "ATProto handle is required."
 msgstr "ATProto-Handle"
 
-#: mastodon/views/bluesky.py:50
+#: mastodon/views/bluesky.py:84
 #, fuzzy
 #| msgid "Error connecting to instance"
 msgid "Error connecting to your ATProto server"
 msgstr "Fehler beim Verbinden der Instanz aufgetreten"
 
-#: mastodon/views/bluesky.py:73
+#: mastodon/views/bluesky.py:107
 #, fuzzy
 #| msgid "Invalid response from Fediverse instance."
 msgid "Invalid response from ATProto authorization server."
 msgstr "Ungültige Antwort der Fediverse Instanz."
 
-#: mastodon/views/bluesky.py:78
+#: mastodon/views/bluesky.py:112
 msgid "Invalid account data from Bluesky."
 msgstr "Ungültige Konto-Daten von Bluesky."
 
@@ -7346,7 +7254,7 @@ msgstr "Ungültige Konto-Daten von Bluesky."
 msgid "Invalid user."
 msgstr "Ungültiger Benutzer."
 
-#: mastodon/views/common.py:52 users/views/account.py:414
+#: mastodon/views/common.py:52 users/views/account.py:416
 msgid "Registration failed"
 msgstr "Registrierung fehlgeschlagen"
 
@@ -7377,10 +7285,6 @@ msgstr "Anmelde-Informationen aktuallisiert als {handle}."
 #: mastodon/views/common.py:116
 msgid "Disconnect identity failed"
 msgstr "Identitäts-Verknüpfung aufheben fehlgeschlagen"
-
-#: mastodon/views/common.py:103
-msgid "Identity not found."
-msgstr "Identität nicht gefunden."
 
 #: mastodon/views/common.py:117
 msgid "You cannot disconnect last login identity."
@@ -7423,7 +7327,7 @@ msgstr "Fehler beim Verbinden der Instanz aufgetreten"
 msgid "Invalid response from Fediverse instance."
 msgstr "Ungültige Antwort der Fediverse Instanz."
 
-#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:64
+#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:66
 msgid "Invalid OAuth state. Please try again."
 msgstr ""
 
@@ -7443,21 +7347,19 @@ msgstr "Ungültiger Token der Fediverse Instanz."
 msgid "Invalid account data from Fediverse instance."
 msgstr "Ungültige Konto-Daten der Fediverse Instanz."
 
-#: mastodon/views/threads.py:69
+#: mastodon/views/threads.py:71
 msgid "Invalid account data from Threads."
 msgstr "Ungültige Konto-Daten von Threads."
 
-#: mastodon/views/threads.py:147
+#: mastodon/views/threads.py:149
 #, fuzzy
 #| msgid "Reset completed."
 msgid "Data deletion completed"
 msgstr "Zurücksetzen abgeschlossen."
 
-#: mastodon/views/threads.py:149
+#: mastodon/views/threads.py:151
 #, python-brace-format
-msgid ""
-"Data linked to your Threads account has been deleted. Confirmation code: "
-"{code}"
+msgid "Data linked to your Threads account has been deleted. Confirmation code: {code}"
 msgstr ""
 
 #: social/templates/_article_teaser.html:10
@@ -7496,15 +7398,11 @@ msgstr "geteilt"
 msgid "play"
 msgstr "spielen"
 
-#: social/templates/_event_post.html:50
-msgid "mark"
-msgstr "markieren"
-
-#: social/templates/_event_post.html:79
+#: social/templates/_event_post.html:74
 msgid "wrote a note"
 msgstr "schrieb eine Notiz"
 
-#: social/templates/_event_post.html:88
+#: social/templates/_event_post.html:83
 #, fuzzy
 #| msgid "playing"
 msgid "replying to"
@@ -7519,7 +7417,7 @@ msgstr ""
 msgid "Untitled article"
 msgstr ""
 
-#: social/templates/event/boosted.html:3
+#: social/templates/event/boosted.html:2
 msgid "boosted your post"
 msgstr "hat deinen Beitrag geteilt"
 
@@ -7551,8 +7449,7 @@ msgid ""
 "boosted your comment on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"hat deinen Kommentar auf <a href=\"%(item_url)s\">%(item_title)s</a> "
-"geteilt\n"
+"hat deinen Kommentar auf <a href=\"%(item_url)s\">%(item_title)s</a> geteilt\n"
 
 #: social/templates/event/boosted_note.html:3
 #, python-format
@@ -7570,19 +7467,16 @@ msgid ""
 "boosted your rating on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"hat deine Bewertung über <a href=\"%(item_url)s\">%(item_title)s</a> "
-"geteilt\n"
+"hat deine Bewertung über <a href=\"%(item_url)s\">%(item_title)s</a> geteilt\n"
 
 #: social/templates/event/boosted_review.html:2
 #, python-format
 msgid ""
 "\n"
-"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"hat deine Rezension <a href=\"%(piece_url)s\">%(piece_title)s</a> über <a "
-"href=\"%(item_url)s\">%(item_title)s</a> geteilt\n"
+"hat deine Rezension <a href=\"%(piece_url)s\">%(piece_title)s</a> über <a href=\"%(item_url)s\">%(item_title)s</a> geteilt\n"
 
 #: social/templates/event/boosted_shelfmember.html:3
 #, python-format
@@ -7601,7 +7495,7 @@ msgstr "hat angefragt, dir folgen zu dürfen"
 msgid "followed you"
 msgstr "folgt dir"
 
-#: social/templates/event/liked.html:3
+#: social/templates/event/liked.html:2
 msgid "liked your post"
 msgstr "hat deinen Beitrag favorisiert"
 
@@ -7633,8 +7527,7 @@ msgid ""
 "liked your comment on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"favorisierte deinen Kommentar auf <a href=\"%(item_url)s\">%(item_title)s</"
-"a>\n"
+"favorisierte deinen Kommentar auf <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/liked_note.html:3
 #, python-format
@@ -7643,8 +7536,7 @@ msgid ""
 "liked your note on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"hat deine Notiz über <a href=\"%(item_url)s\">%(item_title)s</a> "
-"favorisiert\n"
+"hat deine Notiz über <a href=\"%(item_url)s\">%(item_title)s</a> favorisiert\n"
 
 #: social/templates/event/liked_rating.html:3
 #, python-format
@@ -7653,19 +7545,16 @@ msgid ""
 "liked your rating on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"favorisierte deine Bewertung über <a href=\"%(item_url)s\">%(item_title)s</"
-"a>\n"
+"favorisierte deine Bewertung über <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/liked_review.html:2
 #, python-format
 msgid ""
 "\n"
-"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"favorisierte deine Rezension <a href=\"%(piece_url)s\">%(piece_title)s</a> "
-"über <a href=\"%(item_url)s\">%(item_title)s</a>\n"
+"favorisierte deine Rezension <a href=\"%(piece_url)s\">%(piece_title)s</a> über <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/liked_shelfmember.html:3
 #, python-format
@@ -7674,10 +7563,9 @@ msgid ""
 "liked your mark on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"favorisierte deine Markierung an <a href=\"%(item_url)s\">%(item_title)s</"
-"a>\n"
+"favorisierte deine Markierung an <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
-#: social/templates/event/mentioned.html:3
+#: social/templates/event/mentioned.html:2
 msgid "mentioned you"
 msgstr "hat dich erwähnt"
 
@@ -7691,8 +7579,7 @@ msgid ""
 "replied to your article <a href=\"%(piece_url)s\">%(piece_title)s</a>\n"
 msgstr ""
 "\n"
-"hat zu deiner Sammlung <a href=\"%(piece_url)s\">%(piece_title)s</a> "
-"geantwortet\n"
+"hat zu deiner Sammlung <a href=\"%(piece_url)s\">%(piece_title)s</a> geantwortet\n"
 
 #: social/templates/event/mentioned_collection.html:2
 #, python-format
@@ -7701,8 +7588,7 @@ msgid ""
 "replied to your collection <a href=\"%(piece_url)s\">%(piece_title)s</a>\n"
 msgstr ""
 "\n"
-"hat zu deiner Sammlung <a href=\"%(piece_url)s\">%(piece_title)s</a> "
-"geantwortet\n"
+"hat zu deiner Sammlung <a href=\"%(piece_url)s\">%(piece_title)s</a> geantwortet\n"
 
 #: social/templates/event/mentioned_comment.html:3
 #, python-format
@@ -7711,8 +7597,7 @@ msgid ""
 "replied to your comment on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"hat zu deinem Kommentar auf <a href=\"%(item_url)s\">%(item_title)s</a> "
-"geantwortet\n"
+"hat zu deinem Kommentar auf <a href=\"%(item_url)s\">%(item_title)s</a> geantwortet\n"
 
 #: social/templates/event/mentioned_note.html:3
 #, python-format
@@ -7730,19 +7615,16 @@ msgid ""
 "replied to your rating on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"hat zu deiner Bewertung über <a href=\"%(item_url)s\">%(item_title)s</a> "
-"geantwortet\n"
+"hat zu deiner Bewertung über <a href=\"%(item_url)s\">%(item_title)s</a> geantwortet\n"
 
 #: social/templates/event/mentioned_review.html:2
 #, python-format
 msgid ""
 "\n"
-"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"hat zu deiner Rezension <a href=\"%(piece_url)s\">%(piece_title)s</a> über "
-"<a href=\"%(item_url)s\">%(item_title)s</a> geantwortet\n"
+"hat zu deiner Rezension <a href=\"%(piece_url)s\">%(piece_title)s</a> über <a href=\"%(item_url)s\">%(item_title)s</a> geantwortet\n"
 
 #: social/templates/event/mentioned_shelfmember.html:3
 #, python-format
@@ -7751,36 +7633,48 @@ msgid ""
 "replied to your mark on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"hat zu deiner Markierung an <a href=\"%(item_url)s\">%(item_title)s</a> "
-"geantwortet\n"
+"hat zu deiner Markierung an <a href=\"%(item_url)s\">%(item_title)s</a> geantwortet\n"
 
-#: social/templates/feed.html:12 social/templates/feed.html:39
-#: social/templates/search_feed.html:12
-msgid "Activities from those you follow"
-msgstr "Aktivitäten der Personen, denen du folgst"
+#: social/templates/feed.html:39 users/templates/users/preferences.html:40
+msgid "Activities"
+msgstr "Aktivitäten"
 
-#: social/templates/feed.html:42 social/templates/feed.html:44
+#: social/templates/feed.html:43 social/templates/feed.html:45
+msgid "world"
+msgstr ""
+
+#: social/templates/feed.html:51 social/templates/feed.html:53
+#, fuzzy
+#| msgid "locale"
+msgid "local"
+msgstr "Gebietsschema"
+
+#: social/templates/feed.html:58 social/templates/feed.html:60
+#, fuzzy
+#| msgid "sure to follow?"
+msgid "those you follow"
+msgstr "Sicher, dass du folgen möchtest?"
+
+#: social/templates/feed.html:64 social/templates/feed.html:66
 #, fuzzy
 #| msgid "What they read/watch/..."
 msgid "what they read/watch/..."
 msgstr "Was sie lesen/anschauen/..."
 
-#: social/templates/feed_events.html:30
+#: social/templates/feed_events.html:29
 msgid "no matching activities."
 msgstr "Keine passenden Aktivitäten."
 
-#: social/templates/feed_events.html:33
+#: social/templates/feed_events.html:31
+#, fuzzy
+#| msgid "no matching activities."
+msgid "no public activities yet."
+msgstr "Keine passenden Aktivitäten."
+
+#: social/templates/feed_events.html:34
 #, python-format
-msgid ""
-"Find and mark some books/movies/podcasts/games, <a "
-"href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/"
-"Douban, follow some fellow %(site_name)s users on the fediverse, so their "
-"recent activities and yours will show up here."
-msgstr ""
-"Finde und markiere ein paar Bücher/Filme/Podcasts/Spiele, <a "
-"href=\"%(import_url)s\">importiere deine Daten</a> von Goodreads/Letterboxd/"
-"Douban und folge ein paar %(site_name)s Nutzer im Fediverse, damit ihre und "
-"deine kürzlichen Aktivitäten hier angezeigt werden."
+msgid "Find and mark some books/movies/podcasts/games, <a href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/Douban, follow some fellow %(site_name)s users on the fediverse, so their recent activities and yours will show up here."
+msgstr "Finde und markiere ein paar Bücher/Filme/Podcasts/Spiele, <a href=\"%(import_url)s\">importiere deine Daten</a> von Goodreads/Letterboxd/Douban und folge ein paar %(site_name)s Nutzer im Fediverse, damit ihre und deine kürzlichen Aktivitäten hier angezeigt werden."
 
 #: social/templates/notification.html:58
 msgid "mention"
@@ -7816,6 +7710,10 @@ msgstr ""
 msgid "Poll ending at %(end_time)s"
 msgstr ""
 
+#: social/templates/search_feed.html:12 social/views.py:57 social/views.py:58
+msgid "Activities from those you follow"
+msgstr "Aktivitäten der Personen, denen du folgst"
+
 #: social/templates/single_post.html:13 social/templates/single_post.html:32
 #, fuzzy
 #| msgid "Posts"
@@ -7830,61 +7728,69 @@ msgstr ""
 msgid "Poll"
 msgstr ""
 
-#: takahe/models.py:453
+#: social/views.py:59
+#, fuzzy
+#| msgid "Activities from those you follow"
+msgid "Activities on this site"
+msgstr "Aktivitäten der Personen, denen du folgst"
+
+#: social/views.py:60
+#, fuzzy
+#| msgid "Activities from those you follow"
+msgid "Activities from the fediverse"
+msgstr "Aktivitäten der Personen, denen du folgst"
+
+#: takahe/models.py:445
 msgid "Display Name"
 msgstr "Anzeige Name"
 
-#: takahe/models.py:455
+#: takahe/models.py:447
 msgid "Bio"
 msgstr "Über mich"
 
-#: takahe/models.py:457
+#: takahe/models.py:449
 msgid "Manually approve new followers"
 msgstr "manuell neue Follower annehmen/ablehnen"
 
-#: takahe/models.py:461
+#: takahe/models.py:453
 #, fuzzy
 #| msgid "Include profile and posts in discovery"
 msgid "Include profile, marks and posts in discovery"
 msgstr "Profile und Beiträge auf der \"Entdecken\"-Seite anzeigen"
 
-#: takahe/models.py:464
+#: takahe/models.py:456
 msgid "Include posts in search results"
 msgstr "Beiträge in den Suchergebnissen anzeigen"
 
-#: takahe/models.py:482
+#: takahe/models.py:474
 msgid "Profile picture"
 msgstr "Profil Bild"
 
-#: takahe/models.py:489
+#: takahe/models.py:481
 msgid "Header picture"
 msgstr "Hintergrund Bild"
 
-#: users/models/task.py:22
+#: users/models/task.py:24
 msgid "Started"
 msgstr "angefangen"
 
-#: users/models/task.py:23
+#: users/models/task.py:25
 msgid "Complete"
 msgstr "abgeschlossen"
 
-#: users/models/user.py:69
-msgid ""
-"Enter a valid username. This value may contain only unaccented lowercase a-z "
-"and uppercase A-Z letters, numbers, and _ characters."
-msgstr ""
-"Gib einen gültigen Benutzernamen ein. Diese Angabe darf nur Kleinbuchstaben "
-"(a–z), Großbuchstaben (A–Z) ohne Akzent, Zahlen und _-Zeichen enthalten."
+#: users/models/user.py:71
+msgid "Enter a valid username. This value may contain only unaccented lowercase a-z and uppercase A-Z letters, numbers, and _ characters."
+msgstr "Gib einen gültigen Benutzernamen ein. Diese Angabe darf nur Kleinbuchstaben (a–z), Großbuchstaben (A–Z) ohne Akzent, Zahlen und _-Zeichen enthalten."
 
-#: users/models/user.py:130
+#: users/models/user.py:132
 msgid "username"
 msgstr "Benutzername"
 
-#: users/models/user.py:135
+#: users/models/user.py:137
 msgid "Required. 50 characters or fewer. Letters, digits and _ only."
 msgstr "Erforderlich. 50 Ziffern oder weniger. Nur Buchstaben, Zahlen und _."
 
-#: users/models/user.py:138
+#: users/models/user.py:140
 msgid "A user with that username already exists."
 msgstr "Ein Nutzer mit diesem Namen existiert bereits."
 
@@ -8039,9 +7945,7 @@ msgid "Cancel import"
 msgstr "Abbrechen"
 
 #: users/templates/users/_rym_section.html:29
-msgid ""
-"On RateYourMusic, go to your profile and use the <b>Export your music "
-"catalog</b> option to download your library as a CSV file."
+msgid "On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:31
@@ -8050,18 +7954,12 @@ msgid "Upload the downloaded CSV file below."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:33
-msgid ""
-"Albums are matched by title + artist (and year if present) — first against "
-"the local catalog, then MusicBrainz, then Spotify. After auto-matching, "
-"you'll preview the matches in a table, edit any link or shelf status, and "
-"confirm the import."
+msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:36
 #: users/templates/users/_storygraph_section.html:38
-msgid ""
-"You can also re-upload a previously-downloaded matched CSV — the existing "
-"<code>link</code> column will be honoured as the default match."
+msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:40
@@ -8092,18 +7990,11 @@ msgid "Cancel the StoryGraph import? Progress will be discarded."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:31
-msgid ""
-"On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to "
-"download your library as a CSV file."
+msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:35
-msgid ""
-"Books are matched by ISBN — first against the local catalog, then Google "
-"Books and OpenLibrary — with a title + author search as fallback. After auto-"
-"matching, you'll preview the matches in a table, edit any link or shelf "
-"status, and confirm the import."
+msgid "Books are matched by ISBN — first against the local catalog, then Google Books and OpenLibrary — with a title + author search as fallback. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/account.html:11
@@ -8115,15 +8006,8 @@ msgid "Display name, avatar and other information"
 msgstr "Anzeige-Name, Profilbild und weitere Informationen"
 
 #: users/templates/users/account.html:23
-msgid ""
-"Updating profile information here will turn off automatic sync of display "
-"name, bio and avatar from your Mastodon instance. Sure to continue?"
-msgstr ""
-"Das Aktuallisieren deiner Konto-Informationen wird die automatische "
-"Synchronisation mit deinem Mastodon Konto ausschalten. Du kannst diese "
-"Informationen auch auf deinem Mastodon Konto abändern und diese "
-"Informationen somit auf NeoDB synchronisiseren. Möchtest du dennoch "
-"fortfahren?"
+msgid "Updating profile information here will turn off automatic sync of display name, bio and avatar from your Mastodon instance. Sure to continue?"
+msgstr "Das Aktuallisieren deiner Konto-Informationen wird die automatische Synchronisation mit deinem Mastodon Konto ausschalten. Du kannst diese Informationen auch auf deinem Mastodon Konto abändern und diese Informationen somit auf NeoDB synchronisiseren. Möchtest du dennoch fortfahren?"
 
 #: users/templates/users/account.html:26
 msgid "Username"
@@ -8135,22 +8019,12 @@ msgstr "E-Mail Adresse"
 
 #: users/templates/users/account.html:59 users/templates/users/register.html:47
 #, python-format
-msgid ""
-"Please click the confirmation link in the email sent to %(pending_email)s; "
-"if you haven't received it for more than a few minutes, please input and "
-"save again."
-msgstr ""
-"Klicke auf den Bestätigungslink in der E-Mail, welche an %(pending_email)s "
-"gesendet wurde. Wenn du innerhalb der nächsten paar Minuten keine E-Mail "
-"erhälst, versuche es noch einmal oder überprüfe den Spam Ordner."
+msgid "Please click the confirmation link in the email sent to %(pending_email)s; if you haven't received it for more than a few minutes, please input and save again."
+msgstr "Klicke auf den Bestätigungslink in der E-Mail, welche an %(pending_email)s gesendet wurde. Wenn du innerhalb der nächsten paar Minuten keine E-Mail erhälst, versuche es noch einmal oder überprüfe den Spam Ordner."
 
 #: users/templates/users/account.html:61 users/templates/users/register.html:50
-msgid ""
-"Email is recommended as a backup login method, if you log in via a Fediverse "
-"instance"
-msgstr ""
-"Eine E-Mail Adresse wird als Backup-Anmelde-Methode empfohlen, wenn du dich "
-"sonst über ein Fediverse-Konto anmeldest"
+msgid "Email is recommended as a backup login method, if you log in via a Fediverse instance"
+msgstr "Eine E-Mail Adresse wird als Backup-Anmelde-Methode empfohlen, wenn du dich sonst über ein Fediverse-Konto anmeldest"
 
 #: users/templates/users/account.html:73 users/templates/users/login.html:84
 msgid "Fediverse (Mastodon)"
@@ -8167,30 +8041,16 @@ msgid "Last updated"
 msgstr "zuletzt aktualisiert"
 
 #: users/templates/users/account.html:92
-msgid ""
-"If you have not yet registered with any Federated instance, you may <a "
-"href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an "
-"instance</a> and register."
-msgstr ""
-"Wenn du dich noch bei keiner Fediverse-Instanz registriert hast, suche dir "
-"<a href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">eine "
-"Instanz aus</a> und registriere dich."
+msgid "If you have not yet registered with any Federated instance, you may <a href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an instance</a> and register."
+msgstr "Wenn du dich noch bei keiner Fediverse-Instanz registriert hast, suche dir <a href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">eine Instanz aus</a> und registriere dich."
 
 #: users/templates/users/account.html:97
-msgid ""
-"To associate with another federated identity, please enter the domain name "
-"of the instance where the new identity is located."
-msgstr ""
-"Um dich mit einer weiteren föderierten Identität zu verbinden, gib bitte die "
-"Domäne der Instanz an, auf der sich diese Identität befindet."
+msgid "To associate with another federated identity, please enter the domain name of the instance where the new identity is located."
+msgstr "Um dich mit einer weiteren föderierten Identität zu verbinden, gib bitte die Domäne der Instanz an, auf der sich diese Identität befindet."
 
 #: users/templates/users/account.html:99
-msgid ""
-"If you have registered with a Federated instance, please enter the instance "
-"domain name."
-msgstr ""
-"Wenn du bereits ein Fediverse-Konto besitzt, gib bitte die Domäne der "
-"Instanz an."
+msgid "If you have registered with a Federated instance, please enter the instance domain name."
+msgstr "Wenn du bereits ein Fediverse-Konto besitzt, gib bitte die Domäne der Instanz an."
 
 #: users/templates/users/account.html:104
 #, fuzzy
@@ -8203,32 +8063,18 @@ msgid "Go to target instance and authorize with the identity"
 msgstr "Gehe zur Ziel-Instanz und authorisiere deine Identität"
 
 #: users/templates/users/account.html:113
-msgid ""
-"After replacing the association, you may use the new Fediverse identity to "
-"log in and control data visibility. Existing data such as tags, comments, "
-"and collections will not be affected."
-msgstr ""
-"Nach der Abänderung der Verknüpfung zu einem Fediverse-Konto, kannst du dich "
-"mit den neuen Daten anmelden und deinen Datenschutz anpassen. Existierende "
-"Daten wie Tags, Kommentare und Sammlungen sind davon nicht betroffen."
+msgid "After replacing the association, you may use the new Fediverse identity to log in and control data visibility. Existing data such as tags, comments, and collections will not be affected."
+msgstr "Nach der Abänderung der Verknüpfung zu einem Fediverse-Konto, kannst du dich mit den neuen Daten anmelden und deinen Datenschutz anpassen. Existierende Daten wie Tags, Kommentare und Sammlungen sind davon nicht betroffen."
 
 #: users/templates/users/account.html:115
-msgid ""
-"Once associated with Fediverse identity, you can discover more users and use "
-"the full features of this site."
-msgstr ""
-"Einmal mit einem Fediverse-Konto verbunden, wirst du auf der \"Entdecken\"-"
-"Seite viele neue Nutzer finden und den vollen Funktionsumfang nutzen können."
+msgid "Once associated with Fediverse identity, you can discover more users and use the full features of this site."
+msgstr "Einmal mit einem Fediverse-Konto verbunden, wirst du auf der \"Entdecken\"-Seite viele neue Nutzer finden und den vollen Funktionsumfang nutzen können."
 
 #: users/templates/users/account.html:123
 #: users/templates/users/account.html:160
 #: users/templates/users/account.html:206
-msgid ""
-"Once disconnected, you will no longer be able login with this identity. Are "
-"you sure to continue?"
-msgstr ""
-"Sobald die Verbindung getrennt wurde, wirst du dich nicht länger mit dieser "
-"Identität anmelden können. Möchtest du fortfahren?"
+msgid "Once disconnected, you will no longer be able login with this identity. Are you sure to continue?"
+msgstr "Sobald die Verbindung getrennt wurde, wirst du dich nicht länger mit dieser Identität anmelden können. Möchtest du fortfahren?"
 
 #: users/templates/users/account.html:126
 msgid "Disconnect with this identity"
@@ -8254,7 +8100,7 @@ msgstr "mit einem threads.net Konto verbinden"
 msgid "Disconnect with Threads"
 msgstr "Verbindung zu Threads trennen"
 
-#: users/templates/users/account.html:173 users/templates/users/login.html:112
+#: users/templates/users/account.html:173 users/templates/users/login.html:106
 msgid "Bluesky (ATProto)"
 msgstr "Bluesky (ATProto)"
 
@@ -8262,7 +8108,7 @@ msgstr "Bluesky (ATProto)"
 msgid "Verified ATProto identity"
 msgstr "ATProto Identität verifiziert"
 
-#: users/templates/users/account.html:194 users/templates/users/login.html:216
+#: users/templates/users/account.html:194 users/templates/users/login.html:210
 msgid "ATProto handle"
 msgstr "ATProto-Handle"
 
@@ -8287,7 +8133,7 @@ msgid "Name this passkey:"
 msgstr ""
 
 #: users/templates/users/account.html:227 users/templates/users/login.html:69
-#: users/templates/users/welcome.html:33 users/views/webauthn.py:106
+#: users/templates/users/welcome.html:33 users/views/webauthn.py:109
 msgid "Passkey"
 msgstr ""
 
@@ -8329,21 +8175,15 @@ msgstr "Synchronisiere Anzeige-Name, \"Über mich\" und Profilbild"
 
 #: users/templates/users/account.html:292
 msgid "Sync follow, mute and block"
-msgstr ""
-"Synchronisiere 'Leute denen du folgst, stummgestellt oder blockiert hast'"
+msgstr "Synchronisiere 'Leute denen du folgst, stummgestellt oder blockiert hast'"
 
 #: users/templates/users/account.html:295
 msgid "Save sync settings"
 msgstr "Synchronisations Einstellungen speichern"
 
 #: users/templates/users/account.html:297
-msgid ""
-"New follow, mute and blocks in the associated identity may be automatically "
-"imported; removal has to be done manually."
-msgstr ""
-"Leuten, denen du folgst, die du stummgeschalten oder blockiert hast, werden "
-"vielleicht von der neuen Identität automatisch importiert. Das Löschen/"
-"Zurücksetzen dieser Einstellungen muss jedoch manuell erfolgen."
+msgid "New follow, mute and blocks in the associated identity may be automatically imported; removal has to be done manually."
+msgstr "Leuten, denen du folgst, die du stummgeschalten oder blockiert hast, werden vielleicht von der neuen Identität automatisch importiert. Das Löschen/Zurücksetzen dieser Einstellungen muss jedoch manuell erfolgen."
 
 #: users/templates/users/account.html:304
 msgid "Click button below to start sync now."
@@ -8379,15 +8219,11 @@ msgid "Log out everywhere"
 msgstr ""
 
 #: users/templates/users/account.html:365
-msgid ""
-"This will log you out of all browsers and devices (including the current "
-"one), and revoke all API tokens. Continue?"
+msgid "This will log you out of all browsers and devices (including the current one), and revoke all API tokens. Continue?"
 msgstr ""
 
 #: users/templates/users/account.html:368
-msgid ""
-"If you notice any suspicious activity or have logged in on a shared "
-"computer, you can log out of all sessions and revoke all API tokens."
+msgid "If you notice any suspicious activity or have logged in on a shared computer, you can log out of all sessions and revoke all API tokens."
 msgstr ""
 
 #: users/templates/users/account.html:378
@@ -8462,10 +8298,10 @@ msgstr "zu hören"
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:74
-#: users/templates/users/data.html:126 users/templates/users/data.html:183
-#: users/templates/users/data.html:234 users/templates/users/data.html:298
-#: users/templates/users/data.html:358 users/templates/users/data.html:553
+#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/data.html:141 users/templates/users/data.html:198
+#: users/templates/users/data.html:249 users/templates/users/data.html:313
+#: users/templates/users/data.html:376 users/templates/users/data.html:553
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr "importieren"
@@ -8497,15 +8333,9 @@ msgstr "Konto migrieren"
 
 #: users/templates/users/account.html:488
 #, fuzzy
-#| msgid ""
-#| "Link an email so that you can migrate followers from other Fediverse "
-#| "instances."
-msgid ""
-"Linking an email to your account is highly recommended before migrating from "
-"another Fediverse instance."
-msgstr ""
-"Verbinde eine E-Mail, damit du deine Follower von anderen Fediverse "
-"Instanzen migrieren kannst."
+#| msgid "Link an email so that you can migrate followers from other Fediverse instances."
+msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
+msgstr "Verbinde eine E-Mail, damit du deine Follower von anderen Fediverse Instanzen migrieren kannst."
 
 #: users/templates/users/account.html:491
 #, fuzzy
@@ -8525,22 +8355,15 @@ msgstr "Konto löschen"
 
 #: users/templates/users/account.html:504
 msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
-msgstr ""
-"Einmal gelöscht, kann dein Konto nicht wieder hergestellt werden. Möchtest "
-"du fortfahren?"
+msgstr "Einmal gelöscht, kann dein Konto nicht wieder hergestellt werden. Möchtest du fortfahren?"
 
 #: users/templates/users/account.html:507
-msgid ""
-"Enter full <code>username@instance.social</code> or <code>email@domain.com</"
-"code> to confirm deletion."
-msgstr ""
-"Gib deinen vollen <code>benutzername@fediverse.instanz</code> oder "
-"<code>benutzername@e-mail.konto</code> an, um die Löschung durchzuführen."
+msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
+msgstr "Gib deinen vollen <code>benutzername@fediverse.instanz</code> oder <code>benutzername@e-mail.konto</code> an, um die Löschung durchzuführen."
 
 #: users/templates/users/account.html:517
 msgid "Once deleted, account data cannot be recovered."
-msgstr ""
-"Einmal gelöscht, können deine Kontodaten nicht wieder hergestellt werden."
+msgstr "Einmal gelöscht, können deine Kontodaten nicht wieder hergestellt werden."
 
 #: users/templates/users/account.html:520
 #, fuzzy
@@ -8597,9 +8420,7 @@ msgid "Token Created"
 msgstr "nicht bewertet"
 
 #: users/templates/users/authorized_app_created.html:22
-msgid ""
-"Your new personal access token has been created. Copy it now -- you will not "
-"be able to see it again."
+msgid "Your new personal access token has been created. Copy it now -- you will not be able to see it again."
 msgstr ""
 
 #: users/templates/users/authorized_app_created.html:25
@@ -8627,9 +8448,7 @@ msgid "One quick check"
 msgstr ""
 
 #: users/templates/users/captcha.html:28
-msgid ""
-"Put every cover into the row it belongs to. Drag it, or select a cover and "
-"then select a row."
+msgid "Put every cover into the row it belongs to. Drag it, or select a cover and then select a row."
 msgstr ""
 
 #: users/templates/users/captcha.html:41 users/templates/users/captcha.html:43
@@ -8664,7 +8483,7 @@ msgstr ""
 msgid "That is all we needed. Let's get you a username."
 msgstr ""
 
-#: users/templates/users/captcha_solved.html:34
+#: users/templates/users/captcha_solved.html:32
 #: users/templates/users/login.html:63
 #: users/templates/users/verify_email.html:25
 #: users/templates/users/welcome.html:51
@@ -8684,10 +8503,7 @@ msgid "Failed Crossposts"
 msgstr ""
 
 #: users/templates/users/crossposts.html:42
-msgid ""
-"These posts could not be crossposted to your linked social accounts. Re-"
-"authorize the account if needed, then retry. In rare cases retrying may "
-"create a duplicate post."
+msgid "These posts could not be crossposted to your linked social accounts. Re-authorize the account if needed, then retry. In rare cases retrying may create a duplicate post."
 msgstr ""
 
 #: users/templates/users/crossposts.html:48
@@ -8710,268 +8526,193 @@ msgstr ""
 msgid "Data Management"
 msgstr "Daten Verwaltung"
 
-#: users/templates/users/data.html:27
+#: users/templates/users/data.html:39
 msgid "Import Marks and Reviews from Douban"
 msgstr "Importiere Markierungen und Rezensionen von Douban"
 
-#: users/templates/users/data.html:31
-msgid ""
-"Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
-"target=\"_blank\" rel=\"noopener\">Doufen</a>"
-msgstr ""
-"Wähle die <code>.xlsx</code> Datei aus, welche von <a href=\"https://"
-"doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a> exportiert wurde"
+#: users/templates/users/data.html:43
+msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
+msgstr "Wähle die <code>.xlsx</code> Datei aus, welche von <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a> exportiert wurde"
 
 #: users/templates/users/data.html:45
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
-"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
-"NeoDB Archive</a> below."
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON format instead; upload it under <a href=\"#import-neodb-archive\">Import NeoDB Archive</a> below."
 msgstr ""
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:256
+#: users/templates/users/data.html:49 users/templates/users/data.html:271
 msgid "Import Method"
 msgstr "Importier-Methode"
 
-#: users/templates/users/data.html:37
-msgid ""
-"Merge: only update when status changes from wishlist to in-progress, or from "
-"in-progress to complete."
-msgstr ""
-"Zusammenfügen: Nur aktuallisieren, wenn Status-Änderungen von der "
-"\"Wunschliste\" zu \"im Gange\", oder von \"im Gange\" zu \"abgeschlossen\" "
-"stattfinden."
+#: users/templates/users/data.html:52
+msgid "Merge: only update when status changes from wishlist to in-progress, or from in-progress to complete."
+msgstr "Zusammenfügen: Nur aktuallisieren, wenn Status-Änderungen von der \"Wunschliste\" zu \"im Gange\", oder von \"im Gange\" zu \"abgeschlossen\" stattfinden."
 
-#: users/templates/users/data.html:41
+#: users/templates/users/data.html:56
 msgid "Overwrite: update all imported status."
 msgstr "Überschreiben: Aktuallisiere jeden importierten Status."
 
-#: users/templates/users/data.html:74
-msgid ""
-"Another import is in progress, starting a new import may cause issues, sure "
-"to import?"
-msgstr ""
-"Eine andere Importierung ist im Gange. Einen neuen Import zu starten könnte "
-"Probleme verursachen. Möchtest du fortfahren?"
+#: users/templates/users/data.html:89
+msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
+msgstr "Eine andere Importierung ist im Gange. Einen neuen Import zu starten könnte Probleme verursachen. Möchtest du fortfahren?"
 
-#: users/templates/users/data.html:74
+#: users/templates/users/data.html:89 users/views/data.py:1130
 msgid "Import in progress, please wait"
 msgstr "Importierung läuft, bitte warten"
 
-#: users/templates/users/data.html:81
+#: users/templates/users/data.html:96
 #, fuzzy
 #| msgid "Import Shelf or List from Goodreads"
 msgid "Import from Goodreads"
 msgstr "Importiere Regal oder Liste von Goodreads"
 
-#: users/templates/users/data.html:87
-msgid ""
-"On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download "
-"your library as a CSV file."
+#: users/templates/users/data.html:102
+msgid "On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download your library as a CSV file."
 msgstr ""
 
-#: users/templates/users/data.html:90
-msgid ""
-"Upload the downloaded <code>goodreads_library_export.csv</code> file below."
+#: users/templates/users/data.html:105
+msgid "Upload the downloaded <code>goodreads_library_export.csv</code> file below."
 msgstr ""
 
-#: users/templates/users/data.html:93
+#: users/templates/users/data.html:108
 #, fuzzy
-#| msgid ""
-#| "want-to-read / currently-reading / read books and their reviews will be "
-#| "imported."
-msgid ""
-"want-to-read / currently-reading / read / did-not-finish books and their "
-"reviews will be imported."
-msgstr ""
-"möchte-ich-lesen / derzeitig-am-lesen / gelesene-Bücher und deren "
-"Rezensionen werden importiert."
+#| msgid "want-to-read / currently-reading / read books and their reviews will be imported."
+msgid "want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported."
+msgstr "möchte-ich-lesen / derzeitig-am-lesen / gelesene-Bücher und deren Rezensionen werden importiert."
 
-#: users/templates/users/data.html:134
+#: users/templates/users/data.html:149
 msgid "Import from Letterboxd"
 msgstr "von Letterboxd imporieren"
 
-#: users/templates/users/data.html:140
-msgid ""
-"on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" "
-"target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap "
-"Advanced Settings in Settings, tap EXPORT YOUR DATA"
+#: users/templates/users/data.html:155
+msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
 msgstr ""
 
-#: users/templates/users/data.html:143
-msgid ""
-"download file with name like <code>letterboxd-username-2018-03-11-07-52-"
-"utc.zip</code>, do not unzip"
+#: users/templates/users/data.html:158
+msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
 msgstr ""
 
-#: users/templates/users/data.html:146
-msgid ""
-"the following files in the zip file will be processed: <code>reviews.csv</"
-"code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</"
-"code> <code>lists/*.csv</code>"
+#: users/templates/users/data.html:161
+msgid "the following files in the zip file will be processed: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
 msgstr ""
 
-#: users/templates/users/data.html:149
-msgid ""
-"exported file does not indicate whether a list is private, unlisted or "
-"public, so all imported marks, reviews and collections will be created with "
-"the visibility selected below"
+#: users/templates/users/data.html:164
+msgid "exported file does not indicate whether a list is private, unlisted or public, so all imported marks, reviews and collections will be created with the visibility selected below"
 msgstr ""
 
-#: users/templates/users/data.html:184 users/templates/users/data.html:235
+#: users/templates/users/data.html:199 users/templates/users/data.html:250
 msgid "Only forward changes(none->to-watch->watched) will be imported."
-msgstr ""
-"Nur Veränderungen wie möchte-ich-schauen / derzeitig-am-schauen / geschaute-"
-"Filme werden importiert."
+msgstr "Nur Veränderungen wie möchte-ich-schauen / derzeitig-am-schauen / geschaute-Filme werden importiert."
 
-#: users/templates/users/data.html:191
+#: users/templates/users/data.html:206
 #, fuzzy
 #| msgid "Import from Letterboxd"
 msgid "Import from Trakt"
 msgstr "von Letterboxd imporieren"
 
-#: users/templates/users/data.html:197
-msgid ""
-"On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" "
-"rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait "
-"for the download link to appear."
+#: users/templates/users/data.html:212
+msgid "On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait for the download link to appear."
 msgstr ""
 
-#: users/templates/users/data.html:200
+#: users/templates/users/data.html:215
 msgid "Upload the downloaded <code>.zip</code> file below, do not unzip."
 msgstr ""
 
-#: users/templates/users/data.html:202
+#: users/templates/users/data.html:217
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:243
+#: users/templates/users/data.html:258
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr ""
 
-#: users/templates/users/data.html:246
+#: users/templates/users/data.html:261
 msgid "Login with Steam"
 msgstr ""
 
-#: users/templates/users/data.html:252
+#: users/templates/users/data.html:267
 msgid "Import Podcast Subscriptions"
 msgstr "Podcast Abonnements imporieren"
 
-#: users/templates/users/data.html:263
+#: users/templates/users/data.html:278
 msgid "Mark as listening"
 msgstr "als \"am anhören\" markieren"
 
-#: users/templates/users/data.html:267
+#: users/templates/users/data.html:282
 msgid "Import as a new collection"
 msgstr "als neue Sammlung importieren"
 
-#: users/templates/users/data.html:296
+#: users/templates/users/data.html:311
 msgid "Select OPML file"
 msgstr "wähle OPML Datei aus"
 
-#: users/templates/users/data.html:306
+#: users/templates/users/data.html:321
 msgid "Import NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:312
-msgid ""
-"Upload a <code>.zip</code> file containing <code>.csv</code> or "
-"<code>.ndjson</code> files exported from NeoDB."
+#: users/templates/users/data.html:327
+msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr ""
 
 #: users/templates/users/data.html:330
 #, fuzzy
-#| msgid ""
-#| "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
-#| "target=\"_blank\" rel=\"noopener\">Doufen</a>"
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
-"imported here."
-msgstr ""
-"Wähle die <code>.xlsx</code> Datei aus, welche von <a href=\"https://"
-"doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a> exportiert wurde"
+#| msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is imported here."
+msgstr "Wähle die <code>.xlsx</code> Datei aus, welche von <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a> exportiert wurde"
 
-#: users/templates/users/data.html:314
+#: users/templates/users/data.html:332
 #, fuzzy
 #| msgid "Existing metadata might get overwritten, sure to proceed?"
 msgid "Existing data may be overwritten."
-msgstr ""
-"Vorhandene Metadaten werden möglicherweise überschrieben. Möchtest du "
-"fortfahren?"
+msgstr "Vorhandene Metadaten werden möglicherweise überschrieben. Möchtest du fortfahren?"
 
-#: users/templates/users/data.html:324
+#: users/templates/users/data.html:342
 msgid "Detected format"
 msgstr ""
 
-#: users/templates/users/data.html:385
+#: users/templates/users/data.html:403
 msgid "Detecting format..."
 msgstr ""
 
-#: users/templates/users/data.html:411
+#: users/templates/users/data.html:429
 #, fuzzy
 #| msgid "Unknown or Other"
 msgid "Unknown format"
 msgstr "Sonstiges oder Unbekannt"
 
-#: users/templates/users/data.html:436
+#: users/templates/users/data.html:454
 #, fuzzy
 #| msgid "Error connecting to instance"
 msgid "Error detecting format"
 msgstr "Fehler beim Verbinden der Instanz aufgetreten"
 
-#: users/templates/users/data.html:460
+#: users/templates/users/data.html:478
 msgid "Export NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:464
+#: users/templates/users/data.html:482
 #, fuzzy
 #| msgid "Export marks and reviews"
 msgid "Export marks, reviews and notes in CSV"
 msgstr "exportiere Markierungen und Rezensionen"
 
-#: users/templates/users/data.html:471
+#: users/templates/users/data.html:489
 msgid "Export everything in NDJSON"
 msgstr ""
-
-#: users/templates/users/data.html:479
-#, fuzzy
-#| msgid "Export marks and reviews"
-msgid "Export marks and reviews in XLSX (Doufen format)"
-msgstr "exportiere Markierungen und Rezensionen"
-
-#: users/templates/users/data.html:482
-msgid "Last export"
-msgstr "letzter Export"
-
-#: users/templates/users/data.html:487
-msgid "Download"
-msgstr "Herunterladen"
 
 #: users/templates/users/data.html:496
 msgid "Import and Export Articles (WordPress)"
 msgstr ""
 
 #: users/templates/users/data.html:499
-msgid ""
-"Your articles are exchanged as WordPress posts in the WXR format, which "
-"WordPress and most blogging tools can read and write. Marks, reviews and "
-"notes are not included: use the NeoDB archive above for those."
+msgid "Your articles are exchanged as WordPress posts in the WXR format, which WordPress and most blogging tools can read and write. Marks, reviews and notes are not included: use the NeoDB archive above for those."
 msgstr ""
 
 #: users/templates/users/data.html:502
-msgid ""
-"Article title, body, excerpt, tags, dates and featured image are exchanged. "
-"Comments and custom fields are ignored."
+msgid "Article title, body, excerpt, tags, dates and featured image are exchanged. Comments and custom fields are ignored."
 msgstr ""
 
 #: users/templates/users/data.html:505
-msgid ""
-"The body is converted between Markdown and HTML, so formatting is kept but "
-"the text is not character-for-character identical."
+msgid "The body is converted between Markdown and HTML, so formatting is kept but the text is not character-for-character identical."
 msgstr ""
 
 #: users/templates/users/data.html:512
@@ -8981,16 +8722,11 @@ msgid "Export articles in WordPress format"
 msgstr "exportiere Markierungen und Rezensionen"
 
 #: users/templates/users/data.html:519
-msgid ""
-"In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download "
-"an <code>.xml</code> file, then upload it below."
+msgid "In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download an <code>.xml</code> file, then upload it below."
 msgstr ""
 
 #: users/templates/users/data.html:522
-msgid ""
-"Only published posts use the visibility below. Drafts, pending, private and "
-"password-protected posts are always imported as mentioned-only, so nothing "
-"unpublished becomes public."
+msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
 #: users/templates/users/data.html:560
@@ -8998,13 +8734,8 @@ msgid "View Annual Summary"
 msgstr "Jahresübersicht ansehen"
 
 #: users/templates/users/fetch_identity_failed.html:4
-msgid ""
-"Unable to find the user, please check your spelling; or the server may be "
-"busy, please try again later."
-msgstr ""
-"Benutzer konnte nicht gefunden werden. Überprüfe, ob du den korrekten "
-"Benutzernamen angegeben hast. Eventuell ist auch der Server momentan zu sehr "
-"beschäftigt, dann versuche es später noch einmal."
+msgid "Unable to find the user, please check your spelling; or the server may be busy, please try again later."
+msgstr "Benutzer konnte nicht gefunden werden. Überprüfe, ob du den korrekten Benutzernamen angegeben hast. Eventuell ist auch der Server momentan zu sehr beschäftigt, dann versuche es später noch einmal."
 
 #: users/templates/users/fetch_identity_pending.html:13
 #: users/templates/users/fetch_identity_pending.html:22
@@ -9023,118 +8754,78 @@ msgstr "Anmelden"
 msgid "logo"
 msgstr ""
 
-#: users/templates/users/login.html:127
-msgid ""
-"Sign in with a passkey saved on this device or in your password manager."
+#: users/templates/users/login.html:121
+msgid "Sign in with a passkey saved on this device or in your password manager."
 msgstr ""
 
-#: users/templates/users/login.html:132
+#: users/templates/users/login.html:126
 msgid "Sign in with Passkey"
 msgstr ""
 
-#: users/templates/users/login.html:148
+#: users/templates/users/login.html:142
 msgid "Enter your email address"
 msgstr "Gib deine E-Mail Adresse an"
 
-#: users/templates/users/login.html:152
+#: users/templates/users/login.html:146
 msgid "Send verification code"
 msgstr "sende Verifikations-Code"
 
-#: users/templates/users/login.html:171
+#: users/templates/users/login.html:165
 msgid "Domain of your instance, e.g. mastodon.social"
 msgstr "Domäne deiner Instanz, wie mastodon.social"
 
-#: users/templates/users/login.html:177
-msgid ""
-"Please enter domain of your instance; e.g. if your id is "
-"<i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
-msgstr ""
-"Gib die Domäne deiner Instanz an. Wenn deine ID <i>@neodb@mastodon.social</"
-"i> ist, gib nur <i>mastodon.social</i> an."
+#: users/templates/users/login.html:171
+msgid "Please enter domain of your instance; e.g. if your id is <i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
+msgstr "Gib die Domäne deiner Instanz an. Wenn deine ID <i>@neodb@mastodon.social</i> ist, gib nur <i>mastodon.social</i> an."
 
-#: users/templates/users/login.html:182 users/templates/users/login.html:246
+#: users/templates/users/login.html:176 users/templates/users/login.html:240
 msgid "Authorize via Fediverse instance"
 msgstr "Authorisiere über die Fediverse-Instanz"
 
-#: users/templates/users/login.html:187
-msgid ""
-"If you don't have a <a href=\"https://joinmastodon.org/servers\" "
-"target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or "
-"login with Email first, and link it with Fediverse (Mastodon) later in "
-"account settings."
-msgstr ""
-"Wenn du kein <a href=\"https://joinmastodon.org/servers\" "
-"target=\"_blank\">Fediverse (Mastodon) Konto</a> hast, könntest du dir ein "
-"Konto erstellen, oder du registrierst dich mit deiner E-Mail Adresse und "
-"verbindest dein Konto später mit deinem Fediverse Konto."
+#: users/templates/users/login.html:181
+msgid "If you don't have a <a href=\"https://joinmastodon.org/servers\" target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or login with Email first, and link it with Fediverse (Mastodon) later in account settings."
+msgstr "Wenn du kein <a href=\"https://joinmastodon.org/servers\" target=\"_blank\">Fediverse (Mastodon) Konto</a> hast, könntest du dir ein Konto erstellen, oder du registrierst dich mit deiner E-Mail Adresse und verbindest dein Konto später mit deinem Fediverse Konto."
 
-#: users/templates/users/login.html:200
+#: users/templates/users/login.html:194
 msgid "Authorize via Threads"
 msgstr "Authorisierung über Threads"
 
-#: users/templates/users/login.html:221
-msgid ""
-"Please input your ATProto handle (e.g. neodb.bsky.social, without the "
-"leading @), do not use email. If you changed handle recently, just use the "
-"latest one."
-msgstr ""
-"Bitte gib deinen ATProto-Handle ein (wie neodb.bsky.social, ohne dem "
-"leitenden @), benutze nicht deine E-Mail. Wenn du einen Handle neulich "
-"geändert hast, versuche deinen alten Handle."
+#: users/templates/users/login.html:215
+msgid "Please input your ATProto handle (e.g. neodb.bsky.social, without the leading @), do not use email. If you changed handle recently, just use the latest one."
+msgstr "Bitte gib deinen ATProto-Handle ein (wie neodb.bsky.social, ohne dem leitenden @), benutze nicht deine E-Mail. Wenn du einen Handle neulich geändert hast, versuche deinen alten Handle."
 
-#: users/templates/users/login.html:224
+#: users/templates/users/login.html:218
 #, fuzzy
 #| msgid "Authorize via Threads"
 msgid "Authorize via ATProto server"
 msgstr "Authorisierung über Threads"
 
-#: users/templates/users/login.html:231
+#: users/templates/users/login.html:225
 #, python-format
-msgid ""
-"Please choose one to register or login %(site_name)s. Have more than one of "
-"these identities? Don't worry, you may link them in account settings once "
-"logged in."
-msgstr ""
-"Wähle eine Methode aus, wie du dich bei %(site_name)s registrieren oder "
-"anmelden möchtest. Wenn du einen oder mehrere Identitäten hast, mache dir "
-"keine Sorgen. Du kannst sie später mit deinem Konto verbinden, sobald du "
-"angemeldet bist."
+msgid "Please choose one to register or login %(site_name)s. Have more than one of these identities? Don't worry, you may link them in account settings once logged in."
+msgstr "Wähle eine Methode aus, wie du dich bei %(site_name)s registrieren oder anmelden möchtest. Wenn du einen oder mehrere Identitäten hast, mache dir keine Sorgen. Du kannst sie später mit deinem Konto verbinden, sobald du angemeldet bist."
 
-#: users/templates/users/login.html:255
+#: users/templates/users/login.html:249
 msgid "Valid invitation code, please login or register."
-msgstr ""
-"Gültiger Einladungs Code akzeptiert. Jetzt bitte anmelden oder registrieren."
+msgstr "Gültiger Einladungs Code akzeptiert. Jetzt bitte anmelden oder registrieren."
 
-#: users/templates/users/login.html:257
-msgid ""
-"Please use invitation link to register a new account; existing user may "
-"login."
-msgstr ""
-"Bitte nutze einen Einladungs-Code um ein neues Konto zu registrieren. Wenn "
-"du bereits registriert bist, kannst du dich einfach anmelden."
+#: users/templates/users/login.html:251
+msgid "Please use invitation link to register a new account; existing user may login."
+msgstr "Bitte nutze einen Einladungs-Code um ein neues Konto zu registrieren. Wenn du bereits registriert bist, kannst du dich einfach anmelden."
 
-#: users/templates/users/login.html:259
+#: users/templates/users/login.html:253
 msgid "Invitation code invalid or expired."
 msgstr "Einladungs-Code ist ungültig oder abgelaufen."
 
-#: users/templates/users/login.html:267
+#: users/templates/users/login.html:261
 msgid "Loading timed out, please check your network (VPN) settings."
-msgstr ""
-"Zeitüberschreitung beim Laden aufgetreten. Prüfe deine Netzwerkverbindung "
-"oder deine VPN-Einstellungen."
+msgstr "Zeitüberschreitung beim Laden aufgetreten. Prüfe deine Netzwerkverbindung oder deine VPN-Einstellungen."
 
-#: users/templates/users/login.html:273
-msgid ""
-"Continue using this site implies consent to our <a href=\"/pages/rules/"
-"\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using "
-"cookies to provide necessary functionality."
-msgstr ""
-"Wenn du nun fortfährst und diese Seite verwendest, stimmst du unseren <a "
-"href=\"/pages/rules/\">Regeln</a> und <a href=\"/pages/terms/\">Bedingungen</"
-"a> zu, unter anderem der Benutzung/Speicherung von essenziellen Cookies für "
-"grundlegende Funkionen."
+#: users/templates/users/login.html:267
+msgid "Continue using this site implies consent to our <a href=\"/pages/rules/\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using cookies to provide necessary functionality."
+msgstr "Wenn du nun fortfährst und diese Seite verwendest, stimmst du unseren <a href=\"/pages/rules/\">Regeln</a> und <a href=\"/pages/terms/\">Bedingungen</a> zu, unter anderem der Benutzung/Speicherung von essenziellen Cookies für grundlegende Funkionen."
 
-#: users/templates/users/login.html:287
+#: users/templates/users/login.html:281
 msgid "Domain of your instance (excl. @)"
 msgstr "Domäne deiner Instanz (ohne dem @)"
 
@@ -9144,9 +8835,7 @@ msgid "Migrate Here"
 msgstr ""
 
 #: users/templates/users/migrate_in.html:22
-msgid ""
-"To move another account to this one, first add it as an alias here, and then "
-"go to the server where it is hosted and initiate the move."
+msgid "To move another account to this one, first add it as an alias here, and then go to the server where it is hosted and initiate the move."
 msgstr ""
 
 #: users/templates/users/migrate_in.html:27
@@ -9202,16 +8891,11 @@ msgstr ""
 
 #: users/templates/users/migrate_out.html:46
 #, python-format
-msgid ""
-"To migrate to another account, first add <code>@%(handle)s</code> as an "
-"alias on the target server, and then type the target account below to start "
-"the migration."
+msgid "To migrate to another account, first add <code>@%(handle)s</code> as an alias on the target server, and then type the target account below to start the migration."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:50
-msgid ""
-"Are you sure you want to migrate your account? Your followers will be moved "
-"to the target account."
+msgid "Are you sure you want to migrate your account? Your followers will be moved to the target account."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:53
@@ -9229,10 +8913,6 @@ msgstr "lesen anfangen"
 #: users/templates/users/preferences.html:28
 msgid "Default view once logged in"
 msgstr "Standart-Seite nach der Anmeldung"
-
-#: users/templates/users/preferences.html:40
-msgid "Activities"
-msgstr "Aktivitäten"
 
 #: users/templates/users/preferences.html:49
 msgid "Default visibility"
@@ -9261,9 +8941,7 @@ msgstr "standartgemäß Crossposts zu anderen Social Media Netzwerken aktivieren
 
 #: users/templates/users/preferences.html:111
 #: users/templates/users/register.html:88
-msgid ""
-"If a Mastodon account is linked with this identity, boosting a post will "
-"also make the same post boosted with that Mastodon account."
+msgid "If a Mastodon account is linked with this identity, boosting a post will also make the same post boosted with that Mastodon account."
 msgstr ""
 
 #: users/templates/users/preferences.html:115
@@ -9279,18 +8957,12 @@ msgid "Create a new post"
 msgstr "erstelle neuen Beitrag"
 
 #: users/templates/users/preferences.html:130
-msgid ""
-"this method is less optimal, may generate duplicated posts and miss "
-"reactions."
-msgstr ""
-"Diese Methode ist weniger optimal und könnte mehrere Beiträge erstellen "
-"sowie Reaktionen verwerfen."
+msgid "this method is less optimal, may generate duplicated posts and miss reactions."
+msgstr "Diese Methode ist weniger optimal und könnte mehrere Beiträge erstellen sowie Reaktionen verwerfen."
 
 #: users/templates/users/preferences.html:140
 #: users/templates/users/register.html:97
-msgid ""
-"Always publish my public marks, reviews and articles as data records to my "
-"PDS."
+msgid "Always publish my public marks, reviews and articles as data records to my PDS."
 msgstr ""
 
 #: users/templates/users/preferences.html:145
@@ -9310,19 +8982,8 @@ msgid "Automatic bookmark for these categories"
 msgstr "automatisches Lesezeichen für diese Kategorien"
 
 #: users/templates/users/preferences.html:175
-msgid ""
-"When start to read/watch/play/... an item in these categories, a bookmark "
-"will be created automatically. Bookmarks can be viewed and managed in most "
-"<a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon "
-"compatible apps</a>; your replies to these posts will automatically become "
-"notes for the item."
-msgstr ""
-"Wenn du anfängst einen Artikel in dieser Kategorie zu lesen/schauen/"
-"spielen/, wird automatisch ein Lesezeichen erstellt. Lesezeichen können in "
-"den meisten <a href=\"https://joinmastodon.org/apps\" "
-"target=\"_blank\">Mastodon kompatiblen Plattformen</a> verwaltet werden. "
-"Deine Antworten auf diese Posts, werden automatisch zu Notizen für diesen "
-"Artikel."
+msgid "When start to read/watch/play/... an item in these categories, a bookmark will be created automatically. Bookmarks can be viewed and managed in most <a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon compatible apps</a>; your replies to these posts will automatically become notes for the item."
+msgstr "Wenn du anfängst einen Artikel in dieser Kategorie zu lesen/schauen/spielen/, wird automatisch ein Lesezeichen erstellt. Lesezeichen können in den meisten <a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon kompatiblen Plattformen</a> verwaltet werden. Deine Antworten auf diese Posts, werden automatisch zu Notizen für diesen Artikel."
 
 #: users/templates/users/preferences.html:183
 msgid "Turn replies to my own catalog item posts into notes for the item"
@@ -9341,36 +9002,19 @@ msgid "Profile visible to anonymous web visitors and search engines"
 msgstr "Profil sichtbar für anonyme Besucher und Suchmaschinen"
 
 #: users/templates/users/preferences.html:217
-msgid ""
-"this option limits web visits only; to limit fediverse visibility, choose "
-"followers only or mentioned only when posting"
-msgstr ""
-"diese Option beschränkt die Sichtbarkeit auf Web-Besucher, um jedoch die "
-"Sichtbarkeit innerhalb des Fediverse einzuschränken, wähle \"nur Follower\" "
-"oder \"nur Erwähnte\" wenn du einen Beitrag verfasst"
+msgid "this option limits web visits only; to limit fediverse visibility, choose followers only or mentioned only when posting"
+msgstr "diese Option beschränkt die Sichtbarkeit auf Web-Besucher, um jedoch die Sichtbarkeit innerhalb des Fediverse einzuschränken, wähle \"nur Follower\" oder \"nur Erwähnte\" wenn du einen Beitrag verfasst"
 
 #: users/templates/users/preferences.html:225
 msgid "Show your name on item page if you recently edited it"
-msgstr ""
-"zeige deinen Namen auf der Artikel-Seite an, wenn du Diesen neulich editiert "
-"hast"
+msgstr "zeige deinen Namen auf der Artikel-Seite an, wenn du Diesen neulich editiert hast"
 
 #: users/templates/users/preferences.html:234
 msgid "Do not show me item recommendations"
 msgstr ""
 
 #: users/templates/users/preferences.html:237
-msgid ""
-"Recommendations are generated only from public marks, processed in batch on "
-"this server. Your private and follower-only marks are never used as a signal "
-"for anyone, and we never share your data with third parties for this "
-"feature. When you share marks publicly and keep your profile discoverable, "
-"your marks help others here and across the Fediverse find things they might "
-"enjoy -- that voluntary contribution is what makes the feature work for "
-"everyone. If you'd rather not contribute, uncheck \"Include profile, marks "
-"and posts in discovery\" on your account page; this setting is published "
-"over ActivityPub, so other servers will also stop including you in their "
-"discovery features."
+msgid "Recommendations are generated only from public marks, processed in batch on this server. Your private and follower-only marks are never used as a signal for anyone, and we never share your data with third parties for this feature. When you share marks publicly and keep your profile discoverable, your marks help others here and across the Fediverse find things they might enjoy -- that voluntary contribution is what makes the feature work for everyone. If you'd rather not contribute, uncheck \"Include profile, marks and posts in discovery\" on your account page; this setting is published over ActivityPub, so other servers will also stop including you in their discovery features."
 msgstr ""
 
 #: users/templates/users/profile_actions.html:12
@@ -9468,29 +9112,15 @@ msgstr "Dein Benutzername auf %(site_name)s"
 
 #: users/templates/users/register.html:28
 msgid "2-30 alphabets, numbers or underscore, can't be changed once saved"
-msgstr ""
-"2-30 Buchstaben, Nummern oder Unterstriche, kann nach dem Speichern nicht "
-"mehr verändert werden"
+msgstr "2-30 Buchstaben, Nummern oder Unterstriche, kann nach dem Speichern nicht mehr verändert werden"
 
 #: users/templates/users/register.html:72
-msgid ""
-"Use display name, bio and avatar from the social network you authenticated "
-"with"
-msgstr ""
-"Nutze Anzeigename, \"Über mich\" und Profilbild des Social Media Netzwerks "
-"mit dem du dich authentifiziert hast"
+msgid "Use display name, bio and avatar from the social network you authenticated with"
+msgstr "Nutze Anzeigename, \"Über mich\" und Profilbild des Social Media Netzwerks mit dem du dich authentifiziert hast"
 
 #: users/templates/users/register.html:80
-msgid ""
-"Add follow, mute and block list from the social network you authenticated "
-"with"
-msgstr ""
-"Füge \"folgen, stummschalten und blockieren\"-Liste des Social Media "
-"Netzwerks hinzu, mit dem du dich authentifiziert hast"
-
-#: users/templates/users/register.html:104
-msgid "Confirm and save"
-msgstr "Bestätigen und Speichern"
+msgid "Add follow, mute and block list from the social network you authenticated with"
+msgstr "Füge \"folgen, stummschalten und blockieren\"-Liste des Social Media Netzwerks hinzu, mit dem du dich authentifiziert hast"
 
 #: users/templates/users/register.html:106
 msgid "Close"
@@ -9518,8 +9148,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"              Matched %(local)s locally, %(external)s externally, "
-"%(unmatched)s unmatched out of %(total)s rows.\n"
+"              Matched %(local)s locally, %(external)s externally, %(unmatched)s unmatched out of %(total)s rows.\n"
 "            "
 msgstr ""
 
@@ -9654,9 +9283,7 @@ msgid "Played"
 msgstr "gespielt"
 
 #: users/templates/users/steam_import.html:90
-msgid ""
-"Games in wishlist; or purchased in library but never played, mark date will "
-"be set as today"
+msgid "Games in wishlist; or purchased in library but never played, mark date will be set as today"
 msgstr ""
 
 #: users/templates/users/steam_import.html:91
@@ -9700,15 +9327,11 @@ msgid "Comma-separated Steam AppIDs"
 msgstr ""
 
 #: users/templates/users/steam_import.html:121
-msgid ""
-"Allow reverse override of status (e.g. playing -> want to, or played -> "
-"playing)"
+msgid "Allow reverse override of status (e.g. playing -> want to, or played -> playing)"
 msgstr ""
 
 #: users/templates/users/steam_import.html:139
-msgid ""
-"To import from Steam, your game details must be visible to public in Steam "
-"privacy settings."
+msgid "To import from Steam, your game details must be visible to public in Steam privacy settings."
 msgstr ""
 
 #: users/templates/users/storygraph_import.html:9
@@ -9728,8 +9351,7 @@ msgstr "abgebrochen"
 
 #: users/templates/users/user_task_status.html:33
 msgid "Failed links, you may have to mark them manually"
-msgstr ""
-"Verbindung fehlgeschlagen, du musst die Artikel eventuell manuell markieren"
+msgstr "Verbindung fehlgeschlagen, du musst die Artikel eventuell manuell markieren"
 
 #: users/templates/users/verify.html:22
 msgid "Please enter the verification code you received."
@@ -9760,38 +9382,23 @@ msgstr "Willkommen"
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
-#| "              %(site_name)s is flourishing because of collaborations and "
-#| "contributions from users like you. Please read our <a href=\"/pages/"
-#| "terms\">term of service</a>, and feel free to <a "
-#| "href=\"%(support_link)s\">contact us</a> if you have any question or "
-#| "feedback.\n"
+#| "              %(site_name)s is flourishing because of collaborations and contributions from users like you. Please read our <a href=\"/pages/terms\">term of service</a>, and feel free to <a href=\"%(support_link)s\">contact us</a> if you have any question or feedback.\n"
 #| "        "
 msgid ""
 "\n"
-"              %(site_name)s is flourishing because of collaborations and "
-"contributions from users like you. Please read our <a href=\"/pages/"
-"rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</"
-"a> if you have any question or feedback.\n"
+"              %(site_name)s is flourishing because of collaborations and contributions from users like you. Please read our <a href=\"/pages/rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</a> if you have any question or feedback.\n"
 "        "
 msgstr ""
 "\n"
-"              %(site_name)s existiert nur wegen so tollen Nutzern wie dir "
-"und allen, die etwas zur Platform beitragen. Lies doch bitte unsere <a "
-"href=\"/pages/terms\">Servicebedingungen</a>, und <a "
-"href=\"%(support_link)s\">kontaktiere uns</a> wenn du irgendwelche Fragen "
-"hast oder uns Feedback geben möchtest.\n"
+"              %(site_name)s existiert nur wegen so tollen Nutzern wie dir und allen, die etwas zur Platform beitragen. Lies doch bitte unsere <a href=\"/pages/terms\">Servicebedingungen</a>, und <a href=\"%(support_link)s\">kontaktiere uns</a> wenn du irgendwelche Fragen hast oder uns Feedback geben möchtest.\n"
 "        "
 
 #: users/templates/users/welcome.html:37
-msgid ""
-"Set up a passkey to sign in quickly next time using your fingerprint, face, "
-"or screen lock."
+msgid "Set up a passkey to sign in quickly next time using your fingerprint, face, or screen lock."
 msgstr ""
 
 #: users/templates/users/welcome.html:39
-msgid ""
-"Creating a passkey is highly recommended, as the website or email you use to "
-"create this account may not be always available."
+msgid "Creating a passkey is highly recommended, as the website or email you use to create this account may not be always available."
 msgstr ""
 
 #: users/templates/users/welcome.html:43
@@ -9808,346 +9415,246 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:124
+#: users/views/account.py:126
 msgid "This username is already in use."
 msgstr "Dieser Benutzername wird bereits verwendet."
 
-#: users/views/account.py:135
+#: users/views/account.py:137
 msgid "This email address is already in use."
 msgstr "Diese E-Mail Adresse wird bereits verwendet."
 
-#: users/views/account.py:255 users/views/account.py:374
+#: users/views/account.py:257 users/views/account.py:376
 msgid "Registration is for invitation only"
 msgstr "Registrierungen sind nur mit einem Einladungslink möglich"
 
-#: users/views/account.py:266 users/views/account.py:338
+#: users/views/account.py:268 users/views/account.py:340
 #, fuzzy
 #| msgid "Timestamp"
 msgid "Time is up"
 msgstr "Zeitstempel"
 
-#: users/views/account.py:267 users/views/account.py:310
-#: users/views/account.py:339
+#: users/views/account.py:269 users/views/account.py:312
+#: users/views/account.py:341
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:313
+#: users/views/account.py:315
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:325
+#: users/views/account.py:327
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:326
+#: users/views/account.py:328
 #, fuzzy
 #| msgid "System busy, please try again in a minute."
 msgid "Please try again later."
 msgstr "System ist beschäftigt, versuche es in einer Minute erneut."
 
-#: users/views/account.py:415
+#: users/views/account.py:417
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:445
+#: users/views/account.py:447
 msgid "Valid username required"
 msgstr "gültiger Benutzername erforderlich"
 
-#: users/views/account.py:526
+#: users/views/account.py:518
 msgid "Account is being deleted."
 msgstr "Konto wurde gelöscht."
 
-#: users/views/account.py:529
+#: users/views/account.py:521
 msgid "Account mismatch."
 msgstr "Konten stimmen nicht überein."
 
-#: users/views/data.py:262 users/views/data.py:294
+#: users/views/data.py:264 users/views/data.py:296
 msgid "Export file not available."
 msgstr "Export-Datei nicht verfügbar."
 
-#: users/views/data.py:288
+#: users/views/data.py:290
 msgid "Generating exports."
 msgstr "Exporte werden generiert."
 
-#: users/views/data.py:306
+#: users/views/data.py:308
 msgid "Export file expired. Please export again."
 msgstr "Export-Datei abgelaufen. Bitte erneut exportieren."
 
-#: users/views/data.py:321 users/views/data.py:342 users/views/data.py:363
+#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
 #, fuzzy
 #| msgid "Import in progress."
 msgid "Recent export still in progress."
 msgstr "Import läuft."
 
-#: users/views/data.py:379 users/views/data.py:513 users/views/data.py:547
-#: users/views/data.py:772 users/views/data.py:989 users/views/data.py:1015
-#: users/views/data.py:1040 users/views/data.py:1065
+#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
+#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
+#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
 msgid "Invalid file."
 msgstr "Ungültige Datei."
 
-#: users/views/data.py:403
+#: users/views/data.py:405
 msgid "Sync in progress."
 msgstr "Synchronisation läuft."
 
-#: users/views/data.py:417
+#: users/views/data.py:419
 msgid "Settings saved."
 msgstr "Einstellungen gespeichert."
 
-#: users/views/data.py:472
+#: users/views/data.py:474
 #, fuzzy
 #| msgid "Account is being deleted."
 msgid "Account no longer linked."
 msgstr "Konto wurde gelöscht."
 
-#: users/views/data.py:475
+#: users/views/data.py:477
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:503
+#: users/views/data.py:505
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:583 users/views/data.py:808
+#: users/views/data.py:585 users/views/data.py:810
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:608 users/views/data.py:837
+#: users/views/data.py:610 users/views/data.py:839
 #, fuzzy
 #| msgid "Cancel"
 msgid "Cancelled."
 msgstr "Abbrechen"
 
-#: users/views/data.py:628
+#: users/views/data.py:630
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:636 users/views/data.py:746 users/views/data.py:867
-#: users/views/data.py:972
+#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
+#: users/views/data.py:974
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:732 users/views/data.py:958
+#: users/views/data.py:734 users/views/data.py:960
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:742 users/views/data.py:968
+#: users/views/data.py:744 users/views/data.py:970
 #, fuzzy
 #| msgid "Export file not available."
 msgid "No matched file available."
 msgstr "Export-Datei nicht verfügbar."
 
-#: users/views/data.py:859
+#: users/views/data.py:861
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1188
+#: users/views/data.py:1226
 #, fuzzy
 #| msgid "Login required"
 msgid "Name is required."
 msgstr "Anmeldung erforderlich"
 
-#: users/views/data.py:1210
+#: users/views/data.py:1248
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1264
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1231
+#: users/views/data.py:1269
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1241 users/views/data.py:1292
+#: users/views/data.py:1279 users/views/data.py:1330
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:1248
+#: users/views/data.py:1286
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:1253
+#: users/views/data.py:1291
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:1279
+#: users/views/data.py:1317
 #, fuzzy
 #| msgid "Registration failed"
 msgid "Migration cancelled."
 msgstr "Registrierung fehlgeschlagen"
 
-#: users/views/data.py:1284
+#: users/views/data.py:1322
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:1297
+#: users/views/data.py:1335
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:1308
+#: users/views/data.py:1346
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:1314
+#: users/views/data.py:1352
 #, fuzzy, python-brace-format
 #| msgid "Continue login as {handle}."
 msgid "Start moving to {handle}."
 msgstr "Anmeldung als {handle} fortfahren."
 
-#: users/views/data.py:1372
+#: users/views/data.py:1410
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1388
+#: users/views/data.py:1426
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1392
+#: users/views/data.py:1430
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1402
+#: users/views/data.py:1440
 #, python-brace-format
-msgid ""
-"Import of {count} entries received. They will be processed in the background."
+msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""
 
-#: users/views/webauthn.py:103
+#: users/views/webauthn.py:106
 #, fuzzy
 #| msgid "Registration failed"
 msgid "Passkey registration failed"
 msgstr "Registrierung fehlgeschlagen"
 
-#: users/views/webauthn.py:123
+#: users/views/webauthn.py:126
 msgid "Credential already registered"
 msgstr ""
 
-#: users/views/webauthn.py:165 users/views/webauthn.py:172
-#: users/views/webauthn.py:181
+#: users/views/webauthn.py:168 users/views/webauthn.py:175
+#: users/views/webauthn.py:184
 msgid "Passkey not recognized"
 msgstr ""
 
-#: users/views/webauthn.py:186
+#: users/views/webauthn.py:189
 #, fuzzy
 #| msgid "Account is being deleted."
 msgid "Account is inactive"
 msgstr "Konto wurde gelöscht."
 
-#: users/views/webauthn.py:202
+#: users/views/webauthn.py:205
 #, fuzzy
 #| msgid "Send verification code"
 msgid "Passkey verification failed"
 msgstr "sende Verifikations-Code"
 
-#: users/views/webauthn.py:228 users/views/webauthn.py:250
+#: users/views/webauthn.py:231 users/views/webauthn.py:253
 #, fuzzy
 #| msgid "User not found"
 msgid "Passkey not found"
 msgstr "Benutzer nicht gefunden"
 
-#: users/views/webauthn.py:244
+#: users/views/webauthn.py:247
 #, fuzzy
 #| msgid "Login required"
 msgid "Name is required"
 msgstr "Anmeldung erforderlich"
-
-#~ msgid "Fanfic"
-#~ msgstr "Fanfiction"
-
-#~ msgid "FanFic"
-#~ msgstr "Fanficiton"
-
-#~ msgid "year of publication"
-#~ msgstr "Veröffentlichungsjahr"
-
-#~ msgid "YYYY-MM-DD"
-#~ msgstr "JJJJ-MM-TT"
-
-#~ msgid "region or event"
-#~ msgstr "Region oder Veranstaltung"
-
-#~ msgid "Germany or Toronto International Film Festival"
-#~ msgstr "Deutschland oder Toronto International Film Festival"
-
-#~ msgid "year"
-#~ msgstr "Jahr"
-
-#~ msgctxt "music"
-#~ msgid "genre"
-#~ msgstr "Genre"
-
-#~ msgid "my notes"
-#~ msgstr "meine Notizen"
-
-#~ msgid "release year"
-#~ msgstr "Veröffentlichungsjahr"
-
-#~ msgid "episode Length"
-#~ msgstr "Folgen-Länge"
-
-#~ msgid "show time"
-#~ msgstr "Erstausstrahlung"
-
-#~ msgid "Region or Event"
-#~ msgstr "Region oder Veranstaltung"
-
-#~ msgid "boost"
-#~ msgstr "teilen"
-
-#~ msgid "Invalid form data"
-#~ msgstr "ungültige Daten-Form"
-
-#~ msgid "Username and app password is required."
-#~ msgstr "Benutzer und App-Passwort benötigt."
-
-#~ msgid "All"
-#~ msgstr "Alle"
-
-#~ msgid "Bluesky app password"
-#~ msgstr "Bluesky App Passwort"
-
-#~ msgid ""
-#~ "App password can be created on <a href=\"https://bsky.app/settings/app-"
-#~ "passwords\" target=\"_blank\">bsky.app</a>."
-#~ msgstr ""
-#~ "Ein App Passwort kann hier erstellt werden <a href=\"https://bsky.app/"
-#~ "settings/app-passwords\" target=\"_blank\">bsky.app</a>."
-
-#~ msgid "Link to Goodreads Profile / Shelf / List"
-#~ msgstr "Link zum Goodreads Profil / Regal / Liste"
-
-#~ msgid "Last import started"
-#~ msgstr "Letzte Importierung wurde gestartet"
-
-#~ msgid "Shelf will be imported as a new collection."
-#~ msgstr "Regal wird als neue Sammlung importiert."
-
-#~ msgid "List will be imported as a new collection."
-#~ msgstr "Liste wird als neue Sammlung imporiert."
-
-#~ msgid ""
-#~ "Failed links, likely due to Letterboxd error, you may have to mark them "
-#~ "manually"
-#~ msgstr ""
-#~ "Verbindungen fehlgeschlagen, höchstwahrscheinlich aufgrund eines Errors "
-#~ "von Letterboxd. Du musst die Artikel eventuell manuell markieren"
-
-#~ msgid "Export Data"
-#~ msgstr "exportiere Daten"
-
-#~ msgid "back to your home page."
-#~ msgstr "Zurück zur Startseite."
-
-#~ msgid "Turn on crosspost to timeline by default"
-#~ msgstr "Crosspost zur Timeline standartgemäß einschalten"
-
-#~ msgid "Username in use"
-#~ msgstr "Benutzername wird bereits verwendet"
-
-#~ msgid "Invalid URL."
-#~ msgstr "Ungültige URL."
-
-#~ msgid "File is uploaded and will be imported soon."
-#~ msgstr "Datei wird hochgeladen und bald importiert."

--- a/neodb/locale/es/LC_MESSAGES/django.po
+++ b/neodb/locale/es/LC_MESSAGES/django.po
@@ -7,11 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-23 15:40-0400\n"
+"POT-Creation-Date: 2026-09-06 20:04-0400\n"
 "PO-Revision-Date: 2026-08-09 06:31+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Spanish <https://hosted.weblate.org/projects/neodb/neodb/es/"
-">\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/neodb/neodb/es/>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,161 +18,161 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: boofilsic/settings.py:472 common/models/lang.py:230
+#: boofilsic/settings.py:501 common/models/lang.py:232
 msgid "English"
 msgstr "Inglés"
 
-#: boofilsic/settings.py:473 common/models/lang.py:77
+#: boofilsic/settings.py:502 common/models/lang.py:79
 msgid "Danish"
 msgstr "Danés"
 
-#: boofilsic/settings.py:474 common/models/lang.py:78
+#: boofilsic/settings.py:503 common/models/lang.py:80
 msgid "German"
 msgstr "Alemán"
 
-#: boofilsic/settings.py:475 common/models/lang.py:183
+#: boofilsic/settings.py:504 common/models/lang.py:185
 msgid "Spanish"
 msgstr "Español"
 
-#: boofilsic/settings.py:476 common/models/lang.py:87
+#: boofilsic/settings.py:505 common/models/lang.py:89
 msgid "French"
 msgstr "Francés"
 
-#: boofilsic/settings.py:477 common/models/lang.py:112
+#: boofilsic/settings.py:506 common/models/lang.py:114
 msgid "Italian"
 msgstr "Italiano"
 
-#: boofilsic/settings.py:478 common/models/lang.py:166
-#: common/models/lang.py:305
+#: boofilsic/settings.py:507 common/models/lang.py:168
+#: common/models/lang.py:307
 msgid "Portuguese"
 msgstr "Portugués"
 
-#: boofilsic/settings.py:479
+#: boofilsic/settings.py:508
 #, fuzzy
 #| msgid "Portuguese"
 msgid "Brazilian Portuguese"
 msgstr "Portugués"
 
-#: boofilsic/settings.py:480 common/models/lang.py:316
+#: boofilsic/settings.py:509 common/models/lang.py:318
 msgid "Simplified Chinese"
 msgstr "Chino simplificado"
 
-#: boofilsic/settings.py:481 common/models/lang.py:317
+#: boofilsic/settings.py:510 common/models/lang.py:319
 msgid "Traditional Chinese"
 msgstr "Chino tradicional"
 
-#: catalog/forms.py:35 catalog/models/item.py:291
+#: catalog/forms.py:35 catalog/models/item.py:307
 msgid "Primary ID Type"
 msgstr "Tipo de identificador principal"
 
-#: catalog/forms.py:40 catalog/models/item.py:294
+#: catalog/forms.py:40 catalog/models/item.py:310
 msgid "Primary ID Value"
 msgstr "Valor de identificador principal"
 
-#: catalog/forms.py:181
+#: catalog/forms.py:176
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
-#: catalog/models/book.py:139 catalog/models/book.py:158
-#: catalog/models/common.py:280 catalog/models/common.py:298
+#: catalog/models/book.py:141 catalog/models/book.py:160
+#: catalog/models/common.py:279 catalog/models/common.py:297
 msgid "locale"
 msgstr "Localización"
 
-#: catalog/models/book.py:142 catalog/models/book.py:161
-#: catalog/models/common.py:283 catalog/models/common.py:303
+#: catalog/models/book.py:144 catalog/models/book.py:163
+#: catalog/models/common.py:282 catalog/models/common.py:302
 msgid "text content"
 msgstr "texto"
 
-#: catalog/models/book.py:177
+#: catalog/models/book.py:179
 msgid "Paperback"
 msgstr "Tapa blanda"
 
-#: catalog/models/book.py:178
+#: catalog/models/book.py:180
 msgid "Hardcover"
 msgstr "Tapa dura"
 
-#: catalog/models/book.py:179
+#: catalog/models/book.py:181
 msgid "eBook"
 msgstr "eBook"
 
-#: catalog/models/book.py:180
+#: catalog/models/book.py:182
 msgid "Audiobook"
 msgstr "Audiolibro"
 
-#: catalog/models/book.py:182
+#: catalog/models/book.py:184
 msgid "Web Fiction"
 msgstr "Ficción Web"
 
-#: catalog/models/book.py:183 catalog/models/game.py:38
+#: catalog/models/book.py:185 catalog/models/game.py:38
 msgid "Other"
 msgstr "Otro"
 
-#: catalog/models/book.py:260
+#: catalog/models/book.py:262
 msgid "subtitle"
 msgstr "subtítulo"
 
-#: catalog/models/book.py:270 catalog/models/movie.py:120
-#: catalog/models/performance.py:385 catalog/models/tv.py:211
-#: catalog/models/tv.py:437
+#: catalog/models/book.py:272 catalog/models/movie.py:120
+#: catalog/models/performance.py:385 catalog/models/tv.py:213
+#: catalog/models/tv.py:439
 msgid "original title"
 msgstr "título original"
 
-#: catalog/models/book.py:274
+#: catalog/models/book.py:276
 msgid "other title"
 msgstr "otro título"
 
-#: catalog/models/book.py:280 catalog/models/book.py:564
-#: catalog/models/item.py:123
+#: catalog/models/book.py:282 catalog/models/book.py:566
+#: catalog/models/item.py:119
 msgid "author"
 msgstr "autor"
 
-#: catalog/models/book.py:287 catalog/models/item.py:124
+#: catalog/models/book.py:289 catalog/models/item.py:120
 msgid "translator"
 msgstr "traductor"
 
-#: catalog/models/book.py:294 catalog/templates/edition.html:26
+#: catalog/models/book.py:296 catalog/templates/edition.html:26
 msgid "book format"
 msgstr "formato del libro"
 
-#: catalog/models/book.py:301 catalog/models/game.py:135
-#: catalog/models/item.py:138 catalog/models/music.py:142
+#: catalog/models/book.py:303 catalog/models/game.py:135
+#: catalog/models/item.py:134 catalog/models/music.py:142
 msgid "publisher"
 msgstr "editor"
 
-#: catalog/models/book.py:308
+#: catalog/models/book.py:310
 msgid "publication year"
 msgstr "año de publicación"
 
-#: catalog/models/book.py:314
+#: catalog/models/book.py:316
 msgid "publication month"
 msgstr "mes de publicación"
 
-#: catalog/models/book.py:319
+#: catalog/models/book.py:321
 msgid "binding"
 msgstr "encuadernación"
 
-#: catalog/models/book.py:320
+#: catalog/models/book.py:322
 msgid "pages"
 msgstr "páginas"
 
-#: catalog/models/book.py:321 catalog/templates/edition.html:45
+#: catalog/models/book.py:323 catalog/templates/edition.html:45
 msgid "series"
 msgstr "serie"
 
-#: catalog/models/book.py:322 catalog/templates/edition.html:65
+#: catalog/models/book.py:324 catalog/templates/edition.html:65
 msgid "contents"
 msgstr "contenidos"
 
-#: catalog/models/book.py:323 catalog/templates/edition.html:51
+#: catalog/models/book.py:325 catalog/templates/edition.html:51
 msgid "price"
 msgstr "precio"
 
-#: catalog/models/book.py:324 catalog/models/item.py:149
+#: catalog/models/book.py:326 catalog/models/item.py:145
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr "impresión"
 
-#: catalog/models/common.py:26 common/models/lang.py:256
+#: catalog/models/common.py:26 common/models/lang.py:258
 msgid "Unknown"
 msgstr "Desconocido"
 
@@ -181,11 +180,11 @@ msgstr "Desconocido"
 msgid "Douban"
 msgstr "Douban"
 
-#: catalog/models/common.py:28 catalog/models/common.py:79
+#: catalog/models/common.py:28 catalog/models/common.py:81
 msgid "Goodreads"
 msgstr "Goodreads"
 
-#: catalog/models/common.py:29 catalog/models/common.py:81
+#: catalog/models/common.py:29 catalog/models/common.py:83
 msgid "Google Books"
 msgstr "Google Books"
 
@@ -193,16 +192,16 @@ msgstr "Google Books"
 msgid "BooksTW"
 msgstr "BooksTW"
 
-#: catalog/models/common.py:31 catalog/models/common.py:91
-#: catalog/models/common.py:93
+#: catalog/models/common.py:31 catalog/models/common.py:93
+#: catalog/models/common.py:95
 msgid "Bibliotek.dk"
 msgstr ""
 
-#: catalog/models/common.py:32 catalog/models/common.py:92
+#: catalog/models/common.py:32 catalog/models/common.py:94
 msgid "eReolen.dk"
 msgstr ""
 
-#: catalog/models/common.py:33 catalog/models/common.py:74
+#: catalog/models/common.py:33 catalog/models/common.py:76
 #: catalog/templates/movie.html:41 catalog/templates/people.html:37
 #: catalog/templates/tvseason.html:58 catalog/templates/tvshow.html:53
 msgid "IMDb"
@@ -212,7 +211,7 @@ msgstr "IMDb"
 msgid "TMDB"
 msgstr "TMDB"
 
-#: catalog/models/common.py:35 catalog/models/common.py:94
+#: catalog/models/common.py:35 catalog/models/common.py:96
 msgid "Bandcamp"
 msgstr "Bandcamp"
 
@@ -228,11 +227,11 @@ msgstr "IGDB"
 msgid "Steam"
 msgstr "Steam"
 
-#: catalog/models/common.py:39 catalog/models/common.py:114
+#: catalog/models/common.py:39 catalog/models/common.py:116
 msgid "itch.io"
 msgstr ""
 
-#: catalog/models/common.py:40 catalog/models/common.py:115
+#: catalog/models/common.py:40 catalog/models/common.py:117
 msgid "Bangumi"
 msgstr "Bangumi"
 
@@ -240,7 +239,7 @@ msgstr "Bangumi"
 msgid "BGG"
 msgstr "BGG"
 
-#: catalog/models/common.py:42 catalog/models/common.py:116
+#: catalog/models/common.py:42 catalog/models/common.py:118
 msgid "Apple Podcast"
 msgstr "Apple Podcast"
 
@@ -252,35 +251,35 @@ msgstr "RSS"
 msgid "Discogs"
 msgstr "Discogs"
 
-#: catalog/models/common.py:45 catalog/models/common.py:117
+#: catalog/models/common.py:45 catalog/models/common.py:119
 msgid "Apple Music"
 msgstr "Apple Music"
 
-#: catalog/models/common.py:46 catalog/models/common.py:119
+#: catalog/models/common.py:46 catalog/models/common.py:121
 msgid "Fediverse"
 msgstr "Fediverso"
 
-#: catalog/models/common.py:47 catalog/models/common.py:120
+#: catalog/models/common.py:47 catalog/models/common.py:122
 msgid "Qidian"
 msgstr "Qidian"
 
-#: catalog/models/common.py:48 catalog/models/common.py:121
+#: catalog/models/common.py:48 catalog/models/common.py:123
 msgid "Ypshuo"
 msgstr "Ypshuo"
 
-#: catalog/models/common.py:49 catalog/models/common.py:122
+#: catalog/models/common.py:49 catalog/models/common.py:124
 msgid "Archive of Our Own"
 msgstr "Archivo propio"
 
-#: catalog/models/common.py:50 catalog/models/common.py:123
+#: catalog/models/common.py:50 catalog/models/common.py:125
 msgid "JinJiang"
 msgstr "JinJiang"
 
-#: catalog/models/common.py:51 catalog/models/common.py:64
+#: catalog/models/common.py:51 catalog/models/common.py:66
 msgid "WikiData"
 msgstr "WikiData"
 
-#: catalog/models/common.py:52 catalog/models/common.py:124
+#: catalog/models/common.py:52 catalog/models/common.py:126
 msgid "Open Library"
 msgstr ""
 
@@ -294,17 +293,17 @@ msgstr "ID de MusicBrainz"
 msgid "WorldCat"
 msgstr ""
 
-#: catalog/models/common.py:55 catalog/models/common.py:126
+#: catalog/models/common.py:55 catalog/models/common.py:128
 #, fuzzy
 #| msgid "Game"
 msgid "MobyGames"
 msgstr "Juego"
 
-#: catalog/models/common.py:56 catalog/models/common.py:127
+#: catalog/models/common.py:56 catalog/models/common.py:129
 msgid "StoryGraph"
 msgstr ""
 
-#: catalog/models/common.py:57 catalog/models/common.py:118
+#: catalog/models/common.py:57 catalog/models/common.py:120
 #, fuzzy
 #| msgid "Douban Music"
 msgid "YouTube Music"
@@ -322,359 +321,368 @@ msgstr ""
 msgid "Readmoo"
 msgstr ""
 
-#: catalog/models/common.py:65
+#: catalog/models/common.py:61
+msgid "MyAnimeList"
+msgstr ""
+
+#: catalog/models/common.py:62 catalog/models/common.py:140
+msgid "MangaUpdates"
+msgstr ""
+
+#: catalog/models/common.py:67
 msgid "ISBN10"
 msgstr "ISBN10"
 
-#: catalog/models/common.py:66 catalog/templates/edition.html:19
+#: catalog/models/common.py:68 catalog/templates/edition.html:19
 msgid "ISBN"
 msgstr "ISBN"
 
-#: catalog/models/common.py:67
+#: catalog/models/common.py:69
 msgid "ASIN"
 msgstr "ASIN"
 
-#: catalog/models/common.py:68
+#: catalog/models/common.py:70
 msgid "ISSN"
 msgstr "ISSN"
 
-#: catalog/models/common.py:69
+#: catalog/models/common.py:71
 msgid "CUBN"
 msgstr "CUBN"
 
-#: catalog/models/common.py:70
+#: catalog/models/common.py:72
 msgid "ISRC"
 msgstr "ISRC"
 
-#: catalog/models/common.py:71
+#: catalog/models/common.py:73
 msgid "GTIN UPC EAN"
 msgstr "GTIN UPC EAN"
 
-#: catalog/models/common.py:72
+#: catalog/models/common.py:74
 msgid "OCLC Number"
 msgstr ""
 
-#: catalog/models/common.py:73
+#: catalog/models/common.py:75
 msgid "RSS Feed URL"
 msgstr "URL del feed RSS"
 
-#: catalog/models/common.py:75
+#: catalog/models/common.py:77
 #, fuzzy
 #| msgid "TMDB TV Serie"
 msgid "TMDB TV Series"
 msgstr "Serie de TMDB"
 
-#: catalog/models/common.py:76
+#: catalog/models/common.py:78
 msgid "TMDB TV Season"
 msgstr "Temporada de TMDB"
 
-#: catalog/models/common.py:77
+#: catalog/models/common.py:79
 msgid "TMDB TV Episode"
 msgstr "Episodio de TMDB"
 
-#: catalog/models/common.py:78
+#: catalog/models/common.py:80
 msgid "TMDB Movie"
 msgstr "Película de TMDB"
 
-#: catalog/models/common.py:80
+#: catalog/models/common.py:82
 msgid "Goodreads Work"
 msgstr "Trabajo de Goodreads"
 
-#: catalog/models/common.py:82
+#: catalog/models/common.py:84
 msgid "Douban Book"
 msgstr "Libro de Douban"
 
-#: catalog/models/common.py:83
+#: catalog/models/common.py:85
 msgid "Douban Book Work"
 msgstr "Trabajo de libro de Douban"
 
-#: catalog/models/common.py:84
+#: catalog/models/common.py:86
 msgid "Douban Movie"
 msgstr "Película de Douban"
 
-#: catalog/models/common.py:85
+#: catalog/models/common.py:87
 msgid "Douban Music"
 msgstr "Música de Douban"
 
-#: catalog/models/common.py:86
+#: catalog/models/common.py:88
 msgid "Douban Game"
 msgstr "Juego de Douban"
 
-#: catalog/models/common.py:87
+#: catalog/models/common.py:89
 msgid "Douban Drama"
 msgstr "Drama de Douban"
 
-#: catalog/models/common.py:88
+#: catalog/models/common.py:90
 msgid "Douban Drama Version"
 msgstr "Versión de drama de Douban"
 
-#: catalog/models/common.py:89
+#: catalog/models/common.py:91
 msgid "BooksTW Book"
 msgstr "Libro de BooksTW"
 
-#: catalog/models/common.py:90
+#: catalog/models/common.py:92
 msgid "Readmoo Book"
 msgstr ""
 
-#: catalog/models/common.py:95
+#: catalog/models/common.py:97
 msgid "Spotify Album"
 msgstr "Álbum de Spotify"
 
-#: catalog/models/common.py:96
+#: catalog/models/common.py:98
 msgid "Spotify Podcast"
 msgstr "Podcast de Spotify"
 
-#: catalog/models/common.py:97
+#: catalog/models/common.py:99
 msgid "Discogs Release"
 msgstr "Lanzamiento de Discogs"
 
-#: catalog/models/common.py:98
+#: catalog/models/common.py:100
 msgid "Discogs Master"
 msgstr "Máster de Discogs"
 
-#: catalog/models/common.py:101
+#: catalog/models/common.py:103
 #, fuzzy
 #| msgid "MusicBrainz ID"
 msgid "MusicBrainz Release Group"
 msgstr "ID de MusicBrainz"
 
-#: catalog/models/common.py:103
+#: catalog/models/common.py:105
 #, fuzzy
 #| msgid "MusicBrainz ID"
 msgid "MusicBrainz Release"
 msgstr "ID de MusicBrainz"
 
-#: catalog/models/common.py:104
+#: catalog/models/common.py:106
 #, fuzzy
 #| msgid "MusicBrainz ID"
 msgid "MusicBrainz Artist"
 msgstr "ID de MusicBrainz"
 
-#: catalog/models/common.py:105
+#: catalog/models/common.py:107
 #, fuzzy
 #| msgid "Douban Game"
 msgid "Douban Personage"
 msgstr "Juego de Douban"
 
-#: catalog/models/common.py:106
+#: catalog/models/common.py:108
 #, fuzzy
 #| msgid "Goodreads Work"
 msgid "Goodreads Author"
 msgstr "Trabajo de Goodreads"
 
-#: catalog/models/common.py:107
+#: catalog/models/common.py:109
 #, fuzzy
 #| msgid "Spotify Podcast"
 msgid "Spotify Artist"
 msgstr "Podcast de Spotify"
 
-#: catalog/models/common.py:108
+#: catalog/models/common.py:110
 #, fuzzy
 #| msgid "TMDB TV Season"
 msgid "TMDB Person"
 msgstr "Temporada de TMDB"
 
-#: catalog/models/common.py:109
+#: catalog/models/common.py:111
 msgid "Open Library Author"
 msgstr ""
 
-#: catalog/models/common.py:110
+#: catalog/models/common.py:112
 msgid "IGDB Company"
 msgstr ""
 
-#: catalog/models/common.py:111
+#: catalog/models/common.py:113
 msgid "IGDB Game"
 msgstr "Juego de IGDB"
 
-#: catalog/models/common.py:112
+#: catalog/models/common.py:114
 msgid "BGG Boardgame"
 msgstr "Juego de mesa de la BGG"
 
-#: catalog/models/common.py:113
+#: catalog/models/common.py:115
 msgid "Steam Game"
 msgstr "Juego de Steam"
 
-#: catalog/models/common.py:125
+#: catalog/models/common.py:127
 msgid "Open Library Work"
 msgstr ""
 
-#: catalog/models/common.py:128
+#: catalog/models/common.py:130
 msgid "RateYourMusic Release"
 msgstr ""
 
-#: catalog/models/common.py:132
+#: catalog/models/common.py:134
 msgid "AniList Anime"
 msgstr ""
 
-#: catalog/models/common.py:133
+#: catalog/models/common.py:135
 msgid "AniList Manga"
 msgstr ""
 
-#: catalog/models/common.py:134
+#: catalog/models/common.py:136
 msgid "MyAnimeList Anime"
 msgstr ""
 
-#: catalog/models/common.py:135
+#: catalog/models/common.py:137
 msgid "MyAnimeList Manga"
 msgstr ""
 
-#: catalog/models/common.py:156
+#: catalog/models/common.py:161
 msgid "Edition"
 msgstr "Edición"
 
-#: catalog/models/common.py:157 catalog/templates/_sidebar_edit.html:286
+#: catalog/models/common.py:162 catalog/templates/_sidebar_edit.html:289
 msgid "Work"
 msgstr "Obra"
 
-#: catalog/models/common.py:158
+#: catalog/models/common.py:163
 #, fuzzy
 #| msgid "TV Serie"
 msgid "TV Series"
 msgstr "Serie de TV"
 
-#: catalog/models/common.py:159 catalog/templates/_sidebar_edit.html:207
+#: catalog/models/common.py:164 catalog/templates/_sidebar_edit.html:202
+#: catalog/views/edit.py:385
 msgid "TV Season"
 msgstr "Temporada"
 
-#: catalog/models/common.py:160
+#: catalog/models/common.py:165
 msgid "TV Episode"
 msgstr "Episodio de TV"
 
-#: catalog/models/common.py:161 catalog/models/common.py:177
-#: catalog/models/common.py:191 catalog/templates/_sidebar_edit.html:200
-#: journal/templates/_sidebar_user_mark_list.html:35
+#: catalog/models/common.py:166 catalog/models/common.py:182
+#: catalog/models/common.py:196 catalog/templates/_sidebar_edit.html:196
+#: catalog/views/edit.py:384 journal/templates/_sidebar_user_mark_list.html:35
 #: journal/templates/_sidebar_user_tag_filter.html:27
 msgid "Movie"
 msgstr "Película"
 
-#: catalog/models/common.py:162
+#: catalog/models/common.py:167
 msgid "Album"
 msgstr "Álbum"
 
-#: catalog/models/common.py:163 catalog/models/common.py:180
-#: catalog/models/common.py:194 common/templates/_header.html:43
+#: catalog/models/common.py:168 catalog/models/common.py:185
+#: catalog/models/common.py:199 common/templates/_header.html:53
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
 msgstr "Juego"
 
-#: catalog/models/common.py:164
+#: catalog/models/common.py:169
 msgid "Podcast Program"
 msgstr "Podcast"
 
-#: catalog/models/common.py:165
+#: catalog/models/common.py:170
 msgid "Podcast Episode"
 msgstr "Episodio de podcast"
 
-#: catalog/models/common.py:166 catalog/models/common.py:182
-#: catalog/models/common.py:196 common/templates/_header.html:47
+#: catalog/models/common.py:171 catalog/models/common.py:187
+#: catalog/models/common.py:201 common/templates/_header.html:57
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
 msgstr "Espectáculo"
 
-#: catalog/models/common.py:167
+#: catalog/models/common.py:172
 msgid "Production"
 msgstr "Producción"
 
-#: catalog/models/common.py:168
+#: catalog/models/common.py:173
 msgid "Exhibition"
 msgstr "Exhibición"
 
-#: catalog/models/common.py:169 catalog/models/common.py:186
+#: catalog/models/common.py:174 catalog/models/common.py:191
 #: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr "Colección"
 
-#: catalog/models/common.py:172 catalog/models/common.py:185
+#: catalog/models/common.py:177 catalog/models/common.py:190
 msgid "Person / Organization"
 msgstr ""
 
-#: catalog/models/common.py:176 catalog/models/common.py:190
-#: common/templates/_header.html:27
+#: catalog/models/common.py:181 catalog/models/common.py:195
+#: common/templates/_header.html:37
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
 msgstr "Libro"
 
-#: catalog/models/common.py:178 catalog/models/common.py:192
+#: catalog/models/common.py:183 catalog/models/common.py:197
 #: journal/templates/_sidebar_user_mark_list.html:38
 #: journal/templates/_sidebar_user_tag_filter.html:30
 msgid "TV"
 msgstr "TV"
 
-#: catalog/models/common.py:179 catalog/models/common.py:193
-#: common/templates/_header.html:39
+#: catalog/models/common.py:184 catalog/models/common.py:198
+#: common/templates/_header.html:49
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr "Música"
 
-#: catalog/models/common.py:181 catalog/models/common.py:195
-#: catalog/templates/_sidebar_edit.html:219 common/templates/_header.html:35
+#: catalog/models/common.py:186 catalog/models/common.py:200
+#: catalog/templates/_sidebar_edit.html:213 common/templates/_header.html:45
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
 msgstr "Podcast"
 
-#: catalog/models/common.py:346 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:345 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr "género"
 
-#: catalog/models/common.py:384
+#: catalog/models/common.py:383
 #, fuzzy
 #| msgid "original creator"
 msgid "origin country"
 msgstr "creador original"
 
-#: catalog/models/common.py:413 catalog/templates/album.html:33
+#: catalog/models/common.py:412 catalog/templates/album.html:33
 msgid "album type"
 msgstr "tipo de álbum"
 
-#: catalog/models/common.py:417 catalog/templates/_platform_list.html:5
+#: catalog/models/common.py:416 catalog/templates/_platform_list.html:5
 msgid "platform"
 msgstr "plataforma"
 
-#: catalog/models/common.py:421
+#: catalog/models/common.py:420
 #, fuzzy
 #| msgid "media type"
 msgid "media format"
 msgstr "tipo de medio"
 
-#: catalog/models/common.py:426 catalog/templates/_language_list.html:5
-#: users/models/user.py:142
+#: catalog/models/common.py:425 catalog/templates/_language_list.html:5
+#: users/models/user.py:144
 msgid "language"
 msgstr "idioma"
 
-#: catalog/models/creator.py:24
+#: catalog/models/creator.py:26
 #, fuzzy
 #| msgid "binding"
 msgid "pending"
 msgstr "encuadernación"
 
-#: catalog/models/creator.py:25
+#: catalog/models/creator.py:27
 msgid "verified"
 msgstr ""
 
-#: catalog/models/creator.py:26
+#: catalog/models/creator.py:28
 msgid "failed"
 msgstr ""
 
-#: catalog/models/creator.py:29
+#: catalog/models/creator.py:31
 msgid "no feed url available for this item"
 msgstr ""
 
-#: catalog/models/creator.py:30
+#: catalog/models/creator.py:32
 msgid "unable to fetch or parse the feed"
 msgstr ""
 
-#: catalog/models/creator.py:31
+#: catalog/models/creator.py:33
 msgid "no audio episode found in the feed"
 msgstr ""
 
-#: catalog/models/creator.py:34
+#: catalog/models/creator.py:36
 msgid "no matching identity found in the feed or its linked website"
 msgstr ""
 
@@ -710,16 +718,16 @@ msgstr "Remake"
 msgid "Special Edition"
 msgstr "Edición Especial"
 
-#: catalog/models/game.py:111 catalog/models/item.py:130
+#: catalog/models/game.py:111 catalog/models/item.py:126
 msgid "designer"
 msgstr "diseñador"
 
-#: catalog/models/game.py:119 catalog/models/item.py:129
+#: catalog/models/game.py:119 catalog/models/item.py:125
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr "artista"
 
-#: catalog/models/game.py:127 catalog/models/item.py:139
+#: catalog/models/game.py:127 catalog/models/item.py:135
 msgid "developer"
 msgstr "desarrollador"
 
@@ -728,8 +736,8 @@ msgid "date of publication"
 msgstr "fecha de publicación"
 
 #: catalog/models/game.py:147 catalog/models/movie.py:156
-#: catalog/models/music.py:128 catalog/models/tv.py:247
-#: catalog/models/tv.py:473
+#: catalog/models/music.py:128 catalog/models/tv.py:249
+#: catalog/models/tv.py:475
 msgid "YYYY, YYYY-MM or YYYY-MM-DD"
 msgstr ""
 
@@ -740,7 +748,7 @@ msgstr "tipo de lanzamiento"
 #: catalog/models/game.py:180 catalog/models/movie.py:158
 #: catalog/models/people.py:178 catalog/models/performance.py:258
 #: catalog/models/performance.py:465 catalog/models/podcast.py:89
-#: catalog/models/tv.py:249 catalog/models/tv.py:476
+#: catalog/models/tv.py:251 catalog/models/tv.py:478
 #: catalog/templates/game.html:33 catalog/templates/movie.html:48
 #: catalog/templates/people.html:44 catalog/templates/performance.html:35
 #: catalog/templates/performanceproduction.html:35
@@ -749,152 +757,152 @@ msgstr "tipo de lanzamiento"
 msgid "website"
 msgstr "sitio web"
 
-#: catalog/models/item.py:125 catalog/models/movie.py:123
+#: catalog/models/item.py:121 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
-#: catalog/models/tv.py:214 catalog/models/tv.py:440
+#: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr "director"
 
-#: catalog/models/item.py:126 catalog/models/movie.py:130
+#: catalog/models/item.py:122 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
-#: catalog/models/tv.py:221 catalog/models/tv.py:447
+#: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr "guión"
 
-#: catalog/models/item.py:127 catalog/models/movie.py:137
+#: catalog/models/item.py:123 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
-#: catalog/models/tv.py:228 catalog/models/tv.py:454
+#: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr "actor"
 
-#: catalog/models/item.py:128 catalog/models/movie.py:144
-#: catalog/models/tv.py:235 catalog/models/tv.py:461
+#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/tv.py:237 catalog/models/tv.py:463
 #, fuzzy
 #| msgid "production"
 msgid "producer"
 msgstr "producción"
 
-#: catalog/models/item.py:131 catalog/models/performance.py:203
+#: catalog/models/item.py:127 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr "compositor"
 
-#: catalog/models/item.py:132 catalog/models/performance.py:210
+#: catalog/models/item.py:128 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr "coreógrafo"
 
-#: catalog/models/item.py:133 catalog/models/performance.py:224
+#: catalog/models/item.py:129 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr "intérprete"
 
-#: catalog/models/item.py:134 catalog/models/podcast.py:80
+#: catalog/models/item.py:130 catalog/models/podcast.py:80
 msgid "host"
 msgstr "anfitrión"
 
-#: catalog/models/item.py:135 catalog/models/performance.py:196
+#: catalog/models/item.py:131 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr "creador original"
 
-#: catalog/models/item.py:136 catalog/models/performance.py:238
+#: catalog/models/item.py:132 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr "personal"
 
-#: catalog/models/item.py:140
+#: catalog/models/item.py:136
 #, fuzzy
 #| msgid "production"
 msgid "production company"
 msgstr "producción"
 
-#: catalog/models/item.py:141
+#: catalog/models/item.py:137
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:142
+#: catalog/models/item.py:138
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:139
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:144 catalog/models/performance.py:231
+#: catalog/models/item.py:140 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr "elenco"
 
-#: catalog/models/item.py:147
+#: catalog/models/item.py:143
 #, fuzzy
 #| msgid "director"
 msgid "voice actor"
 msgstr "director"
 
-#: catalog/models/item.py:148 catalog/templates/edition.html:30
+#: catalog/models/item.py:144 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr "editorial"
 
-#: catalog/models/item.py:173 catalog/models/people.py:476
+#: catalog/models/item.py:169 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr "rol"
 
-#: catalog/models/item.py:174 catalog/models/people.py:155
+#: catalog/models/item.py:170 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr "nombre"
 
-#: catalog/models/item.py:176 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:288 catalog/models/item.py:320
-#: journal/models/collection.py:96
+#: catalog/models/item.py:304 catalog/models/item.py:336
+#: journal/models/collection.py:100
 msgid "title"
 msgstr "título"
 
-#: catalog/models/item.py:289 catalog/models/item.py:328
-#: journal/models/collection.py:97
+#: catalog/models/item.py:305 catalog/models/item.py:344
+#: journal/models/collection.py:101
 msgid "description"
 msgstr "descripción"
 
-#: catalog/models/item.py:300 catalog/models/people.py:484
+#: catalog/models/item.py:316 catalog/models/people.py:484
 msgid "metadata"
 msgstr "metadatos"
 
-#: catalog/models/item.py:302 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
 msgid "cover"
 msgstr "cubierta"
 
-#: catalog/models/item.py:1485
+#: catalog/models/item.py:1526
 msgid "source site"
 msgstr "fuente"
 
-#: catalog/models/item.py:1487
+#: catalog/models/item.py:1528
 msgid "ID on source site"
 msgstr "ID de la fuente"
 
-#: catalog/models/item.py:1489
+#: catalog/models/item.py:1530
 msgid "source url"
 msgstr "URL de la fuente"
 
-#: catalog/models/item.py:1505
+#: catalog/models/item.py:1546
 msgid "IdType of the source site"
 msgstr "IdType de la fuente"
 
-#: catalog/models/item.py:1511
+#: catalog/models/item.py:1552
 msgid "Primary Id on the source site"
 msgstr "Identificador principal de la fuente"
 
-#: catalog/models/item.py:1514
+#: catalog/models/item.py:1555
 msgid "url to the resource"
 msgstr "URL del recurso"
 
 #: catalog/models/movie.py:152 catalog/models/music.py:124
-#: catalog/models/tv.py:243 catalog/models/tv.py:469
+#: catalog/models/tv.py:245 catalog/models/tv.py:471
 #: catalog/templates/_item_card_metadata_album.html:16
 #: catalog/templates/album.html:17 catalog/templates/game.html:22
 #: catalog/templates/movie.html:36 catalog/templates/tvseason.html:53
@@ -909,7 +917,7 @@ msgid "length"
 msgstr "duración"
 
 #: catalog/models/movie.py:162 catalog/models/music.py:131
-#: catalog/models/tv.py:259 catalog/models/tv.py:486
+#: catalog/models/tv.py:261 catalog/models/tv.py:488
 #, fuzzy
 #| msgid "milliseconds"
 msgid "seconds"
@@ -1115,46 +1123,96 @@ msgstr "fecha de apertura"
 msgid "closing date"
 msgstr "fecha de cierre"
 
-#: catalog/models/tv.py:186 catalog/templates/tvseason.html:38
+#: catalog/models/tv.py:188 catalog/templates/tvseason.html:38
 #: catalog/templates/tvshow.html:33
 msgid "number of seasons"
 msgstr "cantidad de temporadas"
 
-#: catalog/models/tv.py:189 catalog/models/tv.py:415
+#: catalog/models/tv.py:191 catalog/models/tv.py:417
 #: catalog/templates/tvseason.html:43 catalog/templates/tvshow.html:38
 msgid "number of episodes"
 msgstr "cantidad de episodios"
 
-#: catalog/models/tv.py:256 catalog/models/tv.py:483
+#: catalog/models/tv.py:258 catalog/models/tv.py:485
 msgid "episode length"
 msgstr "duración del episodio"
 
-#: catalog/models/tv.py:412 catalog/templates/tvseason.html:33
+#: catalog/models/tv.py:414 catalog/templates/tvseason.html:33
 msgid "season number"
 msgstr "número de temporada"
 
-#: catalog/models/tv.py:530
+#: catalog/models/tv.py:532
 #, python-brace-format
 msgid "{show_title} Season {season_number}"
 msgstr "{show_title} Temporada {season_number}"
 
-#: catalog/models/tv.py:684
+#: catalog/models/tv.py:686
 #, python-brace-format
 msgid "{season_title} E{episode_number}"
 msgstr "{season_title} Episodio {episode_number}"
+
+#: catalog/templates/_catalog_confirm_item.html:7
+#: catalog/templates/catalog_edit.html:62
+msgid "Item has been deleted."
+msgstr "El elemento ha sido eliminado."
+
+#: catalog/templates/_catalog_confirm_item.html:12
+#: catalog/templates/catalog_edit.html:65
+msgid "Item contains sub-items."
+msgstr "El elemento contiene sub-elementos."
+
+#: catalog/templates/_catalog_confirm_item.html:17
+msgid "Item has been merged to another item."
+msgstr "El elemento ha sido fusionado con otro."
+
+#: catalog/templates/_catalog_confirm_item.html:22
+msgid "Item has been marked by users."
+msgstr "El elemento ha sido marcado por los usuarios."
+
+#: catalog/templates/_catalog_edit_preview.html:11
+msgid "Confirm changes"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:16
+msgid "Please correct the errors below."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:24
+msgid "Field"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:25
+msgid "From"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:26
+msgid "To"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:45
+#, fuzzy
+#| msgid "Item cannot be deleted."
+msgid "No changes detected."
+msgstr "El elemento no se puede eliminar."
+
+#: catalog/templates/_catalog_edit_preview.html:54
+#: users/templates/users/register.html:104
+msgid "Confirm and save"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:57
+#, fuzzy
+#| msgid "back to item"
+msgid "Back to editing"
+msgstr "volver al elemento"
 
 #: catalog/templates/_country_list.html:5
 msgid "region"
 msgstr "región"
 
 #: catalog/templates/_fetch_failed.html:4
-msgid ""
-"Unable to fetch from the link, please check again. Some sites may require "
-"login for certain links, please manually create them here."
-msgstr ""
-"No se ha podido obtener la información del enlace, por favor inténtalo de "
-"nuevo. Algunas webs requieren autenticación para ciertos enlaces, por favor "
-"añáde la información manualmente si es neceario."
+msgid "Unable to fetch from the link, please check again. Some sites may require login for certain links, please manually create them here."
+msgstr "No se ha podido obtener la información del enlace, por favor inténtalo de nuevo. Algunas webs requieren autenticación para ciertos enlaces, por favor añáde la información manualmente si es neceario."
 
 #: catalog/templates/_item_card_metadata_album.html:7
 #: catalog/templates/_item_card_metadata_edition.html:7
@@ -1211,7 +1269,7 @@ msgstr "ver más"
 #: journal/templates/profile_posts.html:21
 #: journal/templates/user_follow_list_items.html:63
 #: journal/templates/user_post_list_items.html:24
-#: social/templates/events.html:43 social/templates/feed_events.html:28
+#: social/templates/events.html:43 social/templates/feed_events.html:27
 msgid "nothing more."
 msgstr "nada más."
 
@@ -1310,7 +1368,7 @@ msgid "Add note"
 msgstr "Añadir películas"
 
 #: catalog/templates/_item_user_pieces.html:83
-#: common/templates/_sidebar.html:196 journal/templates/profile_items.html:46
+#: common/templates/_sidebar.html:195 journal/templates/profile_items.html:46
 msgid "Set progress"
 msgstr ""
 
@@ -1337,6 +1395,12 @@ msgstr "mi colección"
 #: catalog/templates/_item_user_pieces.html:214
 msgid "mark history"
 msgstr "historial de marcadores"
+
+#: catalog/templates/_search_suggest.html:2
+#, fuzzy
+#| msgid "Suggest Edits"
+msgid "Suggestions"
+msgstr "Sugerir edición"
 
 #: catalog/templates/_sidebar_edit.html:8
 msgid "edit"
@@ -1367,15 +1431,15 @@ msgid "Edit Options"
 msgstr "Editar Opciones"
 
 #: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
-#: catalog/views/edit.py:82 catalog/views/edit.py:143 catalog/views/edit.py:197
-#: catalog/views/edit.py:218 catalog/views/edit.py:259
-#: catalog/views/edit.py:328 catalog/views/edit.py:332
-#: catalog/views/edit.py:351 catalog/views/edit.py:400
-#: catalog/views/edit.py:425 catalog/views/edit.py:440
-#: catalog/views/edit.py:480 catalog/views/edit.py:490
-#: catalog/views/edit.py:517 catalog/views/edit.py:582
-#: catalog/views/edit.py:637 catalog/views/edit.py:659
-#: catalog/views/search.py:367
+#: catalog/views/edit.py:160 catalog/views/edit.py:221
+#: catalog/views/edit.py:288 catalog/views/edit.py:309
+#: catalog/views/edit.py:364 catalog/views/edit.py:471
+#: catalog/views/edit.py:475 catalog/views/edit.py:509
+#: catalog/views/edit.py:576 catalog/views/edit.py:601
+#: catalog/views/edit.py:624 catalog/views/edit.py:664
+#: catalog/views/edit.py:674 catalog/views/edit.py:703
+#: catalog/views/edit.py:782 catalog/views/edit.py:837
+#: catalog/views/edit.py:859 catalog/views/search.py:418
 #, fuzzy
 #| msgid "Edit this item"
 msgid "Editing this item is restricted."
@@ -1413,7 +1477,7 @@ msgstr "El elemento ha sido marcado por los usuarios."
 msgid "The following items are merged into this item"
 msgstr "Los siguientes elementos han sido fusionados con este elemento"
 
-#: catalog/templates/_sidebar_edit.html:70
+#: catalog/templates/_sidebar_edit.html:70 catalog/views/edit.py:456
 msgid "External website"
 msgstr "Sitio web externo"
 
@@ -1427,47 +1491,41 @@ msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:88
 msgid "Existing metadata might get overwritten, sure to proceed?"
-msgstr ""
-"Los metadatos existentes podrían ser sobreescritos, ¿estás seguro de "
-"continuar?"
+msgstr "Los metadatos existentes podrían ser sobreescritos, ¿estás seguro de continuar?"
 
 #: catalog/templates/_sidebar_edit.html:92
 msgid "Fetch again"
 msgstr "Obtener nuevamente"
 
-#: catalog/templates/_sidebar_edit.html:97
-msgid "You may not be able to undo this operation, sure to remove?"
-msgstr "Esta operación no podrá ser anulada, ¿desea eliminarlo?"
-
-#: catalog/templates/_sidebar_edit.html:102
+#: catalog/templates/_sidebar_edit.html:100
 msgid "Remove link to site"
 msgstr "Eliminar enlace al sitio web"
 
-#: catalog/templates/_sidebar_edit.html:110
+#: catalog/templates/_sidebar_edit.html:108
 #, fuzzy
 #| msgid "Discover"
 msgid "Choose cover"
 msgstr "Descubrir"
 
-#: catalog/templates/_sidebar_edit.html:119
+#: catalog/templates/_sidebar_edit.html:117
+#: catalog/templates/_sidebar_edit.html:118
 #: catalog/templates/_sidebar_edit.html:120
-#: catalog/templates/_sidebar_edit.html:122
 #, fuzzy
 #| msgid "Current Targets"
 msgid "Current cover"
 msgstr "Metas actuales"
 
-#: catalog/templates/_sidebar_edit.html:139
+#: catalog/templates/_sidebar_edit.html:137
 msgid "Select an image to use as the cover of this item."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:140
-#: catalog/templates/catalog_edit.html:65
-#: common/templates/manage/settings.html:136
+#: catalog/templates/_sidebar_edit.html:138
+#: catalog/templates/catalog_edit.html:78
+#: common/templates/manage/settings.html:19
 #: journal/templates/add_to_collection.html:43
 #: journal/templates/article_edit.html:60
 #: journal/templates/collection_edit.html:39 journal/templates/comment.html:41
-#: journal/templates/mark.html:134 journal/templates/note.html:65
+#: journal/templates/mark.html:138 journal/templates/note.html:65
 #: journal/templates/post_compose.html:103
 #: journal/templates/review_edit.html:46 journal/templates/tag_edit.html:51
 #: users/templates/users/_pref_device.html:37
@@ -1476,202 +1534,160 @@ msgstr ""
 msgid "Save"
 msgstr "Guardar"
 
-#: catalog/templates/_sidebar_edit.html:147
+#: catalog/templates/_sidebar_edit.html:145
 msgid "Edit sub-items"
 msgstr "Editar sub-elementos"
 
-#: catalog/templates/_sidebar_edit.html:160
+#: catalog/templates/_sidebar_edit.html:158
 msgid "create"
 msgstr "crear"
 
-#: catalog/templates/_sidebar_edit.html:166
+#: catalog/templates/_sidebar_edit.html:164
 msgid "Fetch all episodes"
 msgstr "Obtener todos los episodios"
 
-#: catalog/templates/_sidebar_edit.html:171
+#: catalog/templates/_sidebar_edit.html:169
 msgid "Fetch all"
 msgstr "Obtener todo"
 
-#: catalog/templates/_sidebar_edit.html:172
-msgid ""
-"Due to differences in how Douban, IMDB, and TMDB handle season data, a small "
-"number of TV shows and animations may not return correct results. Please "
-"manually verify and clean up after updating."
-msgstr ""
-"Debido a las diferencias en cómo Douban, IMDB y TMDB manejan la información "
-"de las temporadas, un pequeño número de series de TV y animaciones podrían "
-"no devolver un resultado correcto. Por favor, verifícalo manualmente y "
-"realiza una limpieza después de actualizarlo."
+#: catalog/templates/_sidebar_edit.html:170
+msgid "Due to differences in how Douban, IMDB, and TMDB handle season data, a small number of TV shows and animations may not return correct results. Please manually verify and clean up after updating."
+msgstr "Debido a las diferencias en cómo Douban, IMDB y TMDB manejan la información de las temporadas, un pequeño número de series de TV y animaciones podrían no devolver un resultado correcto. Por favor, verifícalo manualmente y realiza una limpieza después de actualizarlo."
 
-#: catalog/templates/_sidebar_edit.html:173
+#: catalog/templates/_sidebar_edit.html:171
 msgid "Up to 250 episodes will be fetched for a season."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:176
-msgid ""
-"To fetch all episodes, season numbers and IMDB information are required. If "
-"filling this out is inconvenient, you can also manually create sub-entries."
-msgstr ""
-"Para obtener todos los episodios, se requiere el número de temporada e "
-"información de IMDB. Si lo prefieres, también puedes crear manualmente las "
-"sub-entradas."
+#: catalog/templates/_sidebar_edit.html:174
+msgid "To fetch all episodes, season numbers and IMDB information are required. If filling this out is inconvenient, you can also manually create sub-entries."
+msgstr "Para obtener todos los episodios, se requiere el número de temporada e información de IMDB. Si lo prefieres, también puedes crear manualmente las sub-entradas."
 
-#: catalog/templates/_sidebar_edit.html:182
-#: catalog/templates/_sidebar_edit.html:194
-#: catalog/templates/_sidebar_edit.html:213
+#: catalog/templates/_sidebar_edit.html:180
+#: catalog/templates/_sidebar_edit.html:191
+#: catalog/templates/_sidebar_edit.html:208
 msgid "switch category"
 msgstr "cambiar la categoría"
 
-#: catalog/templates/_sidebar_edit.html:185
-msgid "Switching may remove some metadata. Sure to proceed?"
-msgstr ""
-"Cambiar la categoría podría eliminar algunos metadatos. ¿Desea proceder?"
-
-#: catalog/templates/_sidebar_edit.html:188
+#: catalog/templates/_sidebar_edit.html:185 catalog/views/edit.py:383
 msgid "TV Show"
 msgstr "Serie de TV"
 
-#: catalog/templates/_sidebar_edit.html:227
+#: catalog/templates/_sidebar_edit.html:221
 msgid "Link to parent item"
 msgstr "Enlace al elemento superior"
 
 #: catalog/templates/_sidebar_edit.html:230
-msgid "Sure to link?"
-msgstr "¿Desea crear el enlace?"
-
-#: catalog/templates/_sidebar_edit.html:237
 msgid "Update link"
 msgstr "Actualizar el enlace"
 
-#: catalog/templates/_sidebar_edit.html:243
+#: catalog/templates/_sidebar_edit.html:236
 msgid "Cleanup seasons"
 msgstr "Limpiar temporadas"
 
-#: catalog/templates/_sidebar_edit.html:246
-#: catalog/templates/catalog_delete.html:45
-msgid "This operation cannot be undone. Sure to delete?"
-msgstr "Esta operación no podrá ser revertida. ¿Desea continuar?"
-
-#: catalog/templates/_sidebar_edit.html:250
+#: catalog/templates/_sidebar_edit.html:242
 msgid "remove seasons not marked"
 msgstr "eliminar temporada sin marcadores"
 
-#: catalog/templates/_sidebar_edit.html:256
-#: catalog/templates/catalog_merge.html:12
+#: catalog/templates/_sidebar_edit.html:248
 msgid "Merge"
 msgstr "Fusionar"
 
-#: catalog/templates/_sidebar_edit.html:262
+#: catalog/templates/_sidebar_edit.html:254
 msgid "URL of target item, or empty if undo merge"
 msgstr "URL del elemento destino o dejar vacío si estás deshaciendo una fusión"
 
-#: catalog/templates/_sidebar_edit.html:268
-#: catalog/templates/_sidebar_edit.html:348
+#: catalog/templates/_sidebar_edit.html:260
+#: catalog/templates/_sidebar_edit.html:350
 msgid "merge to another item"
 msgstr "fusionar con otro elemento"
 
-#: catalog/templates/_sidebar_edit.html:273
-#: catalog/templates/_sidebar_edit.html:277
-#: catalog/templates/catalog_delete.html:12
+#: catalog/templates/_sidebar_edit.html:265
+#: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
 #: journal/templates/article.html:199 journal/templates/collection.html:188
-#: journal/templates/mark.html:149 journal/templates/note.html:82
+#: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
 #: users/templates/users/account.html:254
 msgid "Delete"
 msgstr "Eliminar"
 
-#: catalog/templates/_sidebar_edit.html:287
+#: catalog/templates/_sidebar_edit.html:275
+#: catalog/templates/_sidebar_edit.html:279
+msgid "Undo delete"
+msgstr ""
+
+#: catalog/templates/_sidebar_edit.html:280
+msgid "Links to external sites and parent item were removed on delete and will not be restored."
+msgstr ""
+
+#: catalog/templates/_sidebar_edit.html:290
 msgid "This edition belongs to the following work"
 msgstr "Esta edición pertenece a las siguientes obras"
 
-#: catalog/templates/_sidebar_edit.html:292
-msgid "Sure to unlink?"
-msgstr "¿Desea desenlazarlo?"
-
-#: catalog/templates/_sidebar_edit.html:298
+#: catalog/templates/_sidebar_edit.html:300
 msgid "Unlink from work"
 msgstr "Desenlazar de la obra"
 
-#: catalog/templates/_sidebar_edit.html:304
+#: catalog/templates/_sidebar_edit.html:306
 msgid "Link"
 msgstr "Enlace"
 
-#: catalog/templates/_sidebar_edit.html:315
+#: catalog/templates/_sidebar_edit.html:317
 msgid "Link to another edition from same work"
 msgstr "Enlace a otra edición de la misma obra"
 
-#: catalog/templates/_sidebar_edit.html:324
+#: catalog/templates/_sidebar_edit.html:326
 #, fuzzy
 #| msgid "description"
 msgid "Restriction"
 msgstr "descripción"
 
-#: catalog/templates/_sidebar_edit.html:337
+#: catalog/templates/_sidebar_edit.html:339
 #: journal/templates/collection_update_item_note.html:4
 msgid "Update"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:342
+#: catalog/templates/_sidebar_edit.html:344
 msgid "Suggest Edits"
 msgstr "Sugerir edición"
 
-#: catalog/templates/_sidebar_edit.html:347
+#: catalog/templates/_sidebar_edit.html:349
 msgid "proposed action"
 msgstr "acción propuesta"
 
-#: catalog/templates/_sidebar_edit.html:349
+#: catalog/templates/_sidebar_edit.html:351
 msgid "link to another item"
 msgstr "enlazar a otro elemento"
 
-#: catalog/templates/_sidebar_edit.html:350
+#: catalog/templates/_sidebar_edit.html:352
 msgid "change item category"
 msgstr "modificar la categoría del elemento"
 
-#: catalog/templates/_sidebar_edit.html:351
+#: catalog/templates/_sidebar_edit.html:353
 msgid "change item metadata"
 msgstr "modificar los medatados del elemento"
 
-#: catalog/templates/_sidebar_edit.html:352
+#: catalog/templates/_sidebar_edit.html:354
 msgid "remove item"
 msgstr "eliminar elemento"
 
-#: catalog/templates/_sidebar_edit.html:353
+#: catalog/templates/_sidebar_edit.html:355
 msgid "other"
 msgstr "otro"
 
-#: catalog/templates/_sidebar_edit.html:357
-msgid ""
-"To suggest merging or association, please include the URL of the target item"
-msgstr ""
-"Para sugerir una fusión o asociación, por favor incluye la URL del elemento "
-"destino"
+#: catalog/templates/_sidebar_edit.html:359
+msgid "To suggest merging or association, please include the URL of the target item"
+msgstr "Para sugerir una fusión o asociación, por favor incluye la URL del elemento destino"
 
-#: catalog/templates/_sidebar_edit.html:358
+#: catalog/templates/_sidebar_edit.html:360
 #: catalog/templates/catalog_verify.html:116
 msgid "submit"
 msgstr "enviar"
 
-#: catalog/templates/_sidebar_edit.html:359
-msgid ""
-"As a user of this community, you may edit some metadata of items on this "
-"site. If you are unsure whether your edits are appropriate or are unable to "
-"make a certain change, you can make suggestions here. Moderators will "
-"consider each suggestion, although there is no guarantee that they will "
-"always be fully adopted; suggestions may also be viewed or discussed by "
-"other community users. If you have suggestions that are not related to a "
-"specific item, please contact us. Thank you for your support and "
-"contribution."
-msgstr ""
-"Como miembro de esta comunidad puedes modificar algunos de los metadatos de "
-"las entradas. Si no puedes o no tienes claro si tus cambios son apropiados "
-"puedes añadir una sugerencia aquí. El equipo de moderación la tendrán en "
-"cuenta, pero no hay garantías de que los cambios sean aplicados. Las "
-"sugerencias también podrán ser revisadas y discutidas por otros miembros del "
-"la comunidad. Si tienes alguna sugerencia que no esté relacionada con este "
-"elemento en particular, por favor contacta con nosotros. Gracias por tu "
-"contribución."
+#: catalog/templates/_sidebar_edit.html:361
+msgid "As a user of this community, you may edit some metadata of items on this site. If you are unsure whether your edits are appropriate or are unable to make a certain change, you can make suggestions here. Moderators will consider each suggestion, although there is no guarantee that they will always be fully adopted; suggestions may also be viewed or discussed by other community users. If you have suggestions that are not related to a specific item, please contact us. Thank you for your support and contribution."
+msgstr "Como miembro de esta comunidad puedes modificar algunos de los metadatos de las entradas. Si no puedes o no tienes claro si tus cambios son apropiados puedes añadir una sugerencia aquí. El equipo de moderación la tendrán en cuenta, pero no hay garantías de que los cambios sean aplicados. Las sugerencias también podrán ser revisadas y discutidas por otros miembros del la comunidad. Si tienes alguna sugerencia que no esté relacionada con este elemento en particular, por favor contacta con nosotros. Gracias por tu contribución."
 
 #: catalog/templates/_sidebar_search.html:5
 #: journal/templates/_sidebar_search_journal.html:4
@@ -1772,16 +1788,14 @@ msgid "matched"
 msgstr "visto"
 
 #: catalog/templates/_verify_status.html:21
-msgid ""
-"Sure to remove your creator verification? Anyone will be able to edit this "
-"item again."
+msgid "Sure to remove your creator verification? Anyone will be able to edit this item again."
 msgstr ""
 
 #: catalog/templates/_verify_status.html:26
 msgid "Remove my verification"
 msgstr ""
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:309
+#: catalog/templates/_verify_status.html:31 users/views/account.py:311
 msgid "Verification failed"
 msgstr ""
 
@@ -1822,43 +1836,11 @@ msgstr "código de barras"
 msgid "album media"
 msgstr "imágenes del disco"
 
-#: catalog/templates/catalog_delete.html:19
-msgid "Are you sure to delete?"
-msgstr "¿Confirmar la eliminación?"
-
-#: catalog/templates/catalog_delete.html:24
-#: catalog/templates/catalog_edit.html:52
-#: catalog/templates/catalog_merge.html:36
-#: catalog/templates/catalog_merge.html:64
-msgid "Item has been deleted."
-msgstr "El elemento ha sido eliminado."
-
-#: catalog/templates/catalog_delete.html:29
-#: catalog/templates/catalog_edit.html:55
-#: catalog/templates/catalog_merge.html:41
-#: catalog/templates/catalog_merge.html:69
-msgid "Item contains sub-items."
-msgstr "El elemento contiene sub-elementos."
-
-#: catalog/templates/catalog_delete.html:34
-#: catalog/templates/catalog_merge.html:46
-#: catalog/templates/catalog_merge.html:74
-msgid "Item has been merged to another item."
-msgstr "El elemento ha sido fusionado con otro."
-
-#: catalog/templates/catalog_delete.html:39
-#: catalog/templates/catalog_merge.html:51
-#: catalog/templates/catalog_merge.html:79
-msgid "Item has been marked by users."
-msgstr "El elemento ha sido marcado por los usuarios."
-
-#: catalog/templates/catalog_delete.html:48
-#: catalog/templates/catalog_merge.html:92 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:55 common/views_manage.py:139
 msgid "Yes"
 msgstr "Sí"
 
-#: catalog/templates/catalog_delete.html:49
-#: catalog/templates/catalog_merge.html:93 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:56 common/views_manage.py:139
 msgid "No"
 msgstr "No"
 
@@ -1867,36 +1849,18 @@ msgstr "No"
 msgid "Create"
 msgstr "Crear"
 
-#: catalog/templates/catalog_edit.html:68
+#: catalog/templates/catalog_edit.html:81
 #: journal/templates/collection_update_item_note.html:8
 #: journal/templates/piece_delete.html:38
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: catalog/templates/catalog_edit.html:104
+#: catalog/templates/catalog_edit.html:118
 msgid "open linked people page"
 msgstr ""
 
-#: catalog/templates/catalog_merge.html:22
-msgid "Are you sure to merge?"
-msgstr "¿Confirmar la fusión?"
-
-#: catalog/templates/catalog_merge.html:24
-msgid "Are you sure to cancel merge?"
-msgstr "¿Confirmar la cancelación de la fusión?"
-
-#: catalog/templates/catalog_merge.html:27
-msgid "Are you sure to link?"
-msgstr "¿Confirmar el enlace?"
-
-#: catalog/templates/catalog_merge.html:86
-msgid "This operation cannot be undone. Sure to merge?"
-msgstr "Esta operación no puede ser anulada. ¿Confirmar la fusión?"
-
 #: catalog/templates/catalog_verify.html:21
-msgid ""
-"If you are a creator of this podcast, you may verify the ownership, so that "
-"only you (and other verified creators) can edit its metadata on this site."
+msgid "If you are a creator of this podcast, you may verify the ownership, so that only you (and other verified creators) can edit its metadata on this site."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:22
@@ -1904,9 +1868,7 @@ msgid "Your recent episodes may also occasionally be featured in discovery."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:24
-msgid ""
-"To verify, prove you control one of the following identifiers of your "
-"account (click to copy):"
+msgid "To verify, prove you control one of the following identifiers of your account (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:30
@@ -1917,18 +1879,11 @@ msgid "copied"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:35
-msgid ""
-"You can prove this in a few ways, then start verification: add one of the "
-"identifiers above to the podcast feed's description; add a <code>rel=\"me\"</"
-"code> link back to one of them on the web page your feed links to (the link "
-"verification Mastodon uses); or point your feed's website at your Bluesky "
-"handle's own domain."
+msgid "You can prove this in a few ways, then start verification: add one of the identifiers above to the podcast feed's description; add a <code>rel=\"me\"</code> link back to one of them on the web page your feed links to (the link verification Mastodon uses); or point your feed's website at your Bluesky handle's own domain."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:44
-msgid ""
-"For example, add this rel=me link to the web page your feed links to (click "
-"to copy):"
+msgid "For example, add this rel=me link to the web page your feed links to (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:50
@@ -1936,9 +1891,7 @@ msgid "or, in the page's head:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:57
-msgid ""
-"Can't edit the website? Just add a line like this to your feed's description "
-"instead (click to copy):"
+msgid "Can't edit the website? Just add a line like this to your feed's description instead (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:62
@@ -1946,10 +1899,7 @@ msgid "Welcome to follow me on the Fediverse:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:66
-msgid ""
-"NeoDB does not re-check this periodically at the moment, but we recommend "
-"you keep it so that your audience can discover and connect with you in "
-"distributed social media."
+msgid "NeoDB does not re-check this periodically at the moment, but we recommend you keep it so that your audience can discover and connect with you in distributed social media."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:72
@@ -1979,12 +1929,11 @@ msgid "Send feedback"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:115
-msgid ""
-"Questions or issues with creator verification? Let the site moderators know."
+msgid "Questions or issues with creator verification? Let the site moderators know."
 msgstr ""
 
-#: catalog/templates/discover.html:28 common/views_manage.py:145
-#: common/views_manage.py:353 users/templates/users/preferences.html:34
+#: catalog/templates/discover.html:28 common/views_manage.py:35
+#: common/views_manage.py:431 users/templates/users/preferences.html:34
 msgid "Discover"
 msgstr "Descubrir"
 
@@ -2022,17 +1971,17 @@ msgstr "mostrar"
 msgid "hide"
 msgstr "ocultar"
 
-#: catalog/templates/discover.html:206 common/templates/_sidebar.html:14
+#: catalog/templates/discover.html:206 common/templates/_sidebar.html:13
 msgid "Unread Announcements"
 msgstr "Anuncios no leídos"
 
-#: catalog/templates/discover.html:212 common/templates/_sidebar.html:20
+#: catalog/templates/discover.html:212 common/templates/_sidebar.html:19
 #: social/templates/notification.html:67
 msgid "mark all as read"
 msgstr "marcar todo como leído"
 
 #: catalog/templates/discover.html:222
-#: common/templates/_sidebar_anonymous.html:55
+#: common/templates/_sidebar_anonymous.html:54
 msgid "Popular Tags"
 msgstr "Etiquetas destacadas"
 
@@ -2043,9 +1992,9 @@ msgstr "Etiquetas destacadas"
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
 #: catalog/templates/user_verified_works.html:23
-#: common/templates/_sidebar.html:127
-#: common/templates/_sidebar_anonymous.html:46
-#: common/templates/_sidebar_anonymous.html:62 journal/templates/posts.html:8
+#: common/templates/_sidebar.html:126
+#: common/templates/_sidebar_anonymous.html:45
+#: common/templates/_sidebar_anonymous.html:61 journal/templates/posts.html:7
 #: journal/templates/profile_articles.html:24
 #: journal/templates/profile_articles.html:26
 #: journal/templates/profile_items.html:65
@@ -2061,7 +2010,7 @@ msgstr "Etiquetas destacadas"
 msgid "nothing so far."
 msgstr "todavía nada."
 
-#: catalog/templates/discover.html:239 common/templates/_sidebar.html:269
+#: catalog/templates/discover.html:239 common/templates/_sidebar.html:268
 msgid "Recent Posts"
 msgstr "Publicaciones recientes"
 
@@ -2089,9 +2038,7 @@ msgid "Borrow or Buy"
 msgstr "Comprar o tomar prestado"
 
 #: catalog/templates/external_search_results.html:10
-msgid ""
-"Some items were found from other websites and instances, click their title "
-"to save them locally."
+msgid "Some items were found from other websites and instances, click their title to save them locally."
 msgstr ""
 
 #: catalog/templates/fetch_pending.html:13
@@ -2118,9 +2065,7 @@ msgstr "marcar, comentar y coleccionar"
 
 #: catalog/templates/item_base.html:142
 msgid "Login or register to review or add this item to your collection."
-msgstr ""
-"Inicia sesión o regístrate para reseñar o añadir este elemento a tu "
-"colección."
+msgstr "Inicia sesión o regístrate para reseñar o añadir este elemento a tu colección."
 
 #: catalog/templates/item_base.html:151
 msgid "Related Collections"
@@ -2195,14 +2140,14 @@ msgstr "número de Temporadas"
 msgid "number of Episodes"
 msgstr "número de Episodios"
 
-#: catalog/templates/people.html:13 common/templates/_sidebar.html:77
-#: common/templates/_sidebar.html:84 journal/models/shelf.py:326
+#: catalog/templates/people.html:13 common/templates/_sidebar.html:76
+#: common/templates/_sidebar.html:83 journal/models/shelf.py:328
 #, fuzzy
 #| msgid "following you"
 msgid "following"
 msgstr "te sigue"
 
-#: catalog/templates/people.html:15 journal/models/shelf.py:324
+#: catalog/templates/people.html:15 journal/models/shelf.py:326
 #: social/templates/notification.html:60
 msgid "follow"
 msgstr ""
@@ -2221,7 +2166,6 @@ msgstr ""
 #: journal/templates/_sidebar_collection_filter.html:14
 #: journal/templates/_sidebar_collection_filter.html:28
 #: journal/templates/_sidebar_user_mark_list.html:56
-#: social/templates/feed.html:42 social/templates/feed.html:44
 #: social/templates/notification.html:56
 msgid "all"
 msgstr "todo"
@@ -2247,7 +2191,7 @@ msgstr "libros terminados"
 msgid "production"
 msgstr "producción"
 
-#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:54
+#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:53
 #, fuzzy
 #| msgid "original creator"
 msgid "verified creator"
@@ -2332,14 +2276,8 @@ msgid "No items matching your search query."
 msgstr "No hay elementos que coincidan con tu búsqueda."
 
 #: catalog/templates/search_results.html:34
-msgid ""
-"If you have URL from one of these sites, please put the full URL (e.g. "
-"<code>https://www.imdb.com/title/tt2513074/</code>) to the search box and "
-"press Enter."
-msgstr ""
-"Si tienes la dirección de alguno de estos sitios, escribe el URL completo "
-"(p. ej., <code>https://www.imdb.com/title/tt2513074/</code>) en el cuadro de "
-"búsqueda y presiona Entrar."
+msgid "If you have URL from one of these sites, please put the full URL (e.g. <code>https://www.imdb.com/title/tt2513074/</code>) to the search box and press Enter."
+msgstr "Si tienes la dirección de alguno de estos sitios, escribe el URL completo (p. ej., <code>https://www.imdb.com/title/tt2513074/</code>) en el cuadro de búsqueda y presiona Entrar."
 
 #: catalog/templates/search_results.html:48
 msgid "Searching from other sites"
@@ -2347,8 +2285,7 @@ msgstr "Buscando en otros sitios"
 
 #: catalog/templates/search_results.html:51
 msgid "Logged in user may see search results from other sites."
-msgstr ""
-"Los usuarios que han iniciado sesión pueden ver resultados de otros sitios."
+msgstr "Los usuarios que han iniciado sesión pueden ver resultados de otros sitios."
 
 #: catalog/templates/search_results_people.html:12
 #: journal/templates/profile.html:200 journal/views/profile.py:614
@@ -2378,98 +2315,190 @@ msgstr ""
 msgid "Editions"
 msgstr "Ediciones"
 
-#: catalog/views/edit.py:202 catalog/views/edit.py:205
-#: catalog/views/edit.py:306 catalog/views/edit.py:309
-#: catalog/views/verify.py:197 journal/views/collection.py:77
-#: journal/views/collection.py:102 journal/views/collection.py:556
-#: journal/views/collection.py:651 journal/views/common.py:221
-#: journal/views/mark.py:196 journal/views/post.py:117
-#: journal/views/post.py:119 journal/views/post.py:166
-#: journal/views/post.py:185 journal/views/post.py:187
-#: journal/views/post.py:228 journal/views/post.py:241
+#: catalog/views/edit.py:293 catalog/views/edit.py:296
+#: catalog/views/edit.py:440 catalog/views/edit.py:443
+#: catalog/views/verify.py:197 journal/views/collection.py:75
+#: journal/views/collection.py:100 journal/views/collection.py:538
+#: journal/views/collection.py:634 journal/views/common.py:231
+#: journal/views/mark.py:244 journal/views/post.py:119
+#: journal/views/post.py:121 journal/views/post.py:168
+#: journal/views/post.py:187 journal/views/post.py:189
+#: journal/views/post.py:230 journal/views/post.py:243
 #: journal/views/review.py:154 journal/views/review.py:158
-#: users/views/actions.py:179
+#: users/views/actions.py:178
 msgid "Invalid parameter"
 msgstr "Parámetro no válido"
 
-#: catalog/views/edit.py:220
+#: catalog/views/edit.py:313
 msgid "Item in use."
 msgstr "El elemento se está utilizando."
 
-#: catalog/views/edit.py:222
+#: catalog/views/edit.py:315
 msgid "Item cannot be deleted."
 msgstr "El elemento no se puede eliminar."
 
-#: catalog/views/edit.py:247 catalog/views/edit.py:303
-#: catalog/views/edit.py:427 catalog/views/edit.py:519
-#: catalog/views/edit.py:552 catalog/views/verify.py:158
+#: catalog/views/edit.py:319 catalog/views/edit.py:515
+msgid "Are you sure to delete?"
+msgstr "¿Confirmar la eliminación?"
+
+#: catalog/views/edit.py:323 catalog/views/edit.py:518
+#: catalog/views/edit.py:617
+#, fuzzy
+#| msgid "This operation cannot be undone. Sure to merge?"
+msgid "This operation cannot be undone."
+msgstr "Esta operación no puede ser anulada. ¿Confirmar la fusión?"
+
+#: catalog/views/edit.py:344 catalog/views/edit.py:437
+#: catalog/views/edit.py:603 catalog/views/edit.py:705
+#: catalog/views/edit.py:752 catalog/views/verify.py:158
 #: catalog/views/verify.py:206 journal/views/article.py:44
 #: journal/views/article.py:133 journal/views/article.py:153
 #: journal/views/collection.py:248 journal/views/collection.py:341
-#: journal/views/collection.py:360 journal/views/collection.py:384
-#: journal/views/collection.py:457 journal/views/collection.py:500
-#: journal/views/collection.py:539 journal/views/collection.py:551
-#: journal/views/collection.py:576 journal/views/collection.py:613
-#: journal/views/common.py:300 journal/views/mark.py:281
-#: journal/views/post.py:58 journal/views/post.py:78 journal/views/post.py:100
-#: journal/views/post.py:170 journal/views/post.py:199
-#: journal/views/post.py:272 journal/views/post.py:287
-#: journal/views/post.py:394 journal/views/post.py:549
+#: journal/views/collection.py:354 journal/views/collection.py:372
+#: journal/views/collection.py:439 journal/views/collection.py:482
+#: journal/views/collection.py:521 journal/views/collection.py:533
+#: journal/views/collection.py:558 journal/views/collection.py:595
+#: journal/views/common.py:304 journal/views/mark.py:317
+#: journal/views/post.py:60 journal/views/post.py:80 journal/views/post.py:102
+#: journal/views/post.py:172 journal/views/post.py:201
+#: journal/views/post.py:274 journal/views/post.py:289
+#: journal/views/post.py:390 journal/views/post.py:539
 #: journal/views/review.py:64 journal/views/review.py:81
 #: journal/views/review.py:106
 msgid "Insufficient permission"
 msgstr "Permisos insuficientes"
 
-#: catalog/views/edit.py:374
+#: catalog/views/edit.py:346
+#, fuzzy
+#| msgid "Item has been deleted."
+msgid "Item is not deleted"
+msgstr "El elemento ha sido eliminado."
+
+#: catalog/views/edit.py:389
+#, fuzzy
+#| msgid "Switching may remove some metadata. Sure to proceed?"
+msgid "Switching may remove some metadata."
+msgstr "Cambiar la categoría podría eliminar algunos metadatos. ¿Desea proceder?"
+
+#: catalog/views/edit.py:395
+#, fuzzy
+#| msgid "The following items are merged into this item"
+msgid "The following seasons will be detached from this show"
+msgstr "Los siguientes elementos han sido fusionados con este elemento"
+
+#: catalog/views/edit.py:400
+msgid "Links to IMDB and TMDB will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:403
+#, fuzzy
+#| msgid "Are you sure to merge?"
+msgid "Are you sure to switch category?"
+msgstr "¿Confirmar la fusión?"
+
+#: catalog/views/edit.py:451
+#, fuzzy
+#| msgid "Are you sure to delete?"
+msgid "Are you sure to remove the link to this site?"
+msgstr "¿Confirmar la eliminación?"
+
+#: catalog/views/edit.py:457
+#, fuzzy
+#| msgid "You may not be able to undo this operation, sure to remove?"
+msgid "You may not be able to undo this operation."
+msgstr "Esta operación no podrá ser anulada, ¿desea eliminarlo?"
+
+#: catalog/views/edit.py:483
+#, fuzzy
+#| msgid "Link to parent item"
+msgid "Current parent item"
+msgstr "Enlace al elemento superior"
+
+#: catalog/views/edit.py:487
+msgid "The link to the parent item will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:490 catalog/views/edit.py:680
+msgid "Are you sure to link?"
+msgstr "¿Confirmar el enlace?"
+
+#: catalog/views/edit.py:521
+msgid "The following seasons will be deleted"
+msgstr ""
+
+#: catalog/views/edit.py:525
+msgid "The following seasons will be kept"
+msgstr ""
+
+#: catalog/views/edit.py:550
 msgid "TV Season with IMDB id and season number required."
 msgstr "Se necesita la temporada con su id de IMDB y su número de temporada."
 
-#: catalog/views/edit.py:380
+#: catalog/views/edit.py:556
 msgid "Updating episodes"
 msgstr "Actualizando episodios"
 
-#: catalog/views/edit.py:405
+#: catalog/views/edit.py:581
 msgid "This person has no supported source to fetch works from."
 msgstr ""
 
-#: catalog/views/edit.py:412
+#: catalog/views/edit.py:588
 msgid "Already pulling works for this person, try again later."
 msgstr ""
 
-#: catalog/views/edit.py:416
+#: catalog/views/edit.py:592
 msgid "Pulling works in background."
 msgstr ""
 
-#: catalog/views/edit.py:438
+#: catalog/views/edit.py:609
+msgid "Are you sure to merge?"
+msgstr "¿Confirmar la fusión?"
+
+#: catalog/views/edit.py:611
+msgid "Are you sure to cancel merge?"
+msgstr "¿Confirmar la cancelación de la fusión?"
+
+#: catalog/views/edit.py:622
 msgid "Cannot be merged to an item already deleted or merged"
 msgstr "No se puede fusionar con un elemento eliminado o ya fusionado."
 
-#: catalog/views/edit.py:443
+#: catalog/views/edit.py:627
 msgid "Cannot merge items in different categories"
-msgstr ""
-"No es posible fusionar elementos que pertenecen a categorías distintas."
+msgstr "No es posible fusionar elementos que pertenecen a categorías distintas."
 
-#: catalog/views/edit.py:447
+#: catalog/views/edit.py:631
 msgid "Cannot merge an item to itself"
 msgstr "No es posible fusionar un elemento consigo mismo"
 
-#: catalog/views/edit.py:488
+#: catalog/views/edit.py:672
 msgid "Cannot be linked to an item already deleted or merged"
 msgstr "No se puede asociar a una obra eliminada o fusionada"
 
-#: catalog/views/edit.py:492
+#: catalog/views/edit.py:676
 msgid "Cannot link items other than editions"
 msgstr "Solo es posible asociar ediciones"
 
-#: catalog/views/search.py:96
+#: catalog/views/edit.py:710
+#, fuzzy
+#| msgid "Are you sure to link?"
+msgid "Are you sure to unlink?"
+msgstr "¿Confirmar el enlace?"
+
+#: catalog/views/edit.py:715
+#, fuzzy
+#| msgid "This edition belongs to the following work"
+msgid "This edition will be unlinked from the following work"
+msgstr "Esta edición pertenece a las siguientes obras"
+
+#: catalog/views/search.py:113
 msgid "the internet"
 msgstr ""
 
-#: catalog/views/search.py:359
+#: catalog/views/search.py:410
 msgid "Invalid URL"
 msgstr "URL inválida"
 
-#: catalog/views/search.py:362
+#: catalog/views/search.py:413
 #, fuzzy
 #| msgid "Unsupported item type."
 msgid "Unsupported URL"
@@ -2495,9 +2524,9 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:122 common/utils.py:163
+#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
 #: journal/views/article.py:186 journal/views/review.py:182
-#: users/views/actions.py:45 users/views/actions.py:131
+#: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
 msgstr "Usuario no encontrado"
 
@@ -2509,15 +2538,15 @@ msgstr ""
 msgid "Creator verification removed."
 msgstr ""
 
-#: catalog/views/view.py:74 catalog/views/view.py:99
+#: catalog/views/view.py:77 catalog/views/view.py:102
 msgid "Item not found"
 msgstr "No se encontró el elemento"
 
-#: catalog/views/view.py:78 catalog/views/view.py:107 catalog/views/view.py:190
+#: catalog/views/view.py:81 catalog/views/view.py:110 catalog/views/view.py:193
 msgid "Item no longer exists"
 msgstr "El elemento ya no existe."
 
-#: catalog/views/view.py:187
+#: catalog/views/view.py:190
 #, fuzzy
 #| msgid "Invalid URL"
 msgid "Invalid role"
@@ -3055,759 +3084,759 @@ msgctxt "genre"
 msgid "Health"
 msgstr ""
 
-#: common/models/lang.py:54
+#: common/models/lang.py:56
 msgid "Afar"
 msgstr "Afar"
 
-#: common/models/lang.py:55
+#: common/models/lang.py:57
 msgid "Afrikaans"
 msgstr "Afrikaans"
 
-#: common/models/lang.py:56
+#: common/models/lang.py:58
 msgid "Akan"
 msgstr "Akan"
 
-#: common/models/lang.py:57
+#: common/models/lang.py:59
 msgid "Aragonese"
 msgstr "Aragonés"
 
-#: common/models/lang.py:58
+#: common/models/lang.py:60
 msgid "Assamese"
 msgstr "Asamés"
 
-#: common/models/lang.py:59
+#: common/models/lang.py:61
 msgid "Avaric"
 msgstr "Avar"
 
-#: common/models/lang.py:60
+#: common/models/lang.py:62
 msgid "Avestan"
 msgstr "Avéstico"
 
-#: common/models/lang.py:61
+#: common/models/lang.py:63
 msgid "Aymara"
 msgstr "Aymará"
 
-#: common/models/lang.py:62
+#: common/models/lang.py:64
 msgid "Azerbaijani"
 msgstr "Azerí"
 
-#: common/models/lang.py:63
+#: common/models/lang.py:65
 msgid "Bashkir"
 msgstr "Baskir"
 
-#: common/models/lang.py:64
+#: common/models/lang.py:66
 msgid "Bambara"
 msgstr "Bambara"
 
-#: common/models/lang.py:65
+#: common/models/lang.py:67
 msgid "Bislama"
 msgstr "Bislama"
 
-#: common/models/lang.py:66
+#: common/models/lang.py:68
 msgid "Tibetan"
 msgstr "Tibetano"
 
-#: common/models/lang.py:67
+#: common/models/lang.py:69
 msgid "Breton"
 msgstr "Bretón"
 
-#: common/models/lang.py:68
+#: common/models/lang.py:70
 msgid "Catalan"
 msgstr "Catalán"
 
-#: common/models/lang.py:69
+#: common/models/lang.py:71
 msgid "Czech"
 msgstr "Checo"
 
-#: common/models/lang.py:70
+#: common/models/lang.py:72
 msgid "Chechen"
 msgstr "Checheno"
 
-#: common/models/lang.py:71
+#: common/models/lang.py:73
 msgid "Slavic"
 msgstr "Eslavo"
 
-#: common/models/lang.py:72
+#: common/models/lang.py:74
 msgid "Chuvash"
 msgstr "Chuvasio"
 
-#: common/models/lang.py:73
+#: common/models/lang.py:75
 msgid "Cornish"
 msgstr "Córnico"
 
-#: common/models/lang.py:74
+#: common/models/lang.py:76
 msgid "Corsican"
 msgstr "Corso"
 
-#: common/models/lang.py:75
+#: common/models/lang.py:77
 msgid "Cree"
 msgstr "Cri"
 
-#: common/models/lang.py:76
+#: common/models/lang.py:78
 msgid "Welsh"
 msgstr "Galés"
 
-#: common/models/lang.py:79
+#: common/models/lang.py:81
 msgid "Divehi"
 msgstr "Maldivo"
 
-#: common/models/lang.py:80
+#: common/models/lang.py:82
 msgid "Dzongkha"
 msgstr "Dzongkha"
 
-#: common/models/lang.py:81
+#: common/models/lang.py:83
 msgid "Esperanto"
 msgstr "Esperanto"
 
-#: common/models/lang.py:82
+#: common/models/lang.py:84
 msgid "Estonian"
 msgstr "Estonio"
 
-#: common/models/lang.py:83
+#: common/models/lang.py:85
 msgid "Basque"
 msgstr "Euskera"
 
-#: common/models/lang.py:84
+#: common/models/lang.py:86
 msgid "Faroese"
 msgstr "Feroés"
 
-#: common/models/lang.py:85
+#: common/models/lang.py:87
 msgid "Fijian"
 msgstr "Fiyiano"
 
-#: common/models/lang.py:86
+#: common/models/lang.py:88
 msgid "Finnish"
 msgstr "Finés"
 
-#: common/models/lang.py:88
+#: common/models/lang.py:90
 msgid "Frisian"
 msgstr "Frisón"
 
-#: common/models/lang.py:89
+#: common/models/lang.py:91
 msgid "Fulah"
 msgstr "Fulani"
 
-#: common/models/lang.py:90
+#: common/models/lang.py:92
 msgid "Gaelic"
 msgstr "Gaélico"
 
-#: common/models/lang.py:91
+#: common/models/lang.py:93
 msgid "Irish"
 msgstr "Irlandés"
 
-#: common/models/lang.py:92
+#: common/models/lang.py:94
 msgid "Galician"
 msgstr "Gallego"
 
-#: common/models/lang.py:93
+#: common/models/lang.py:95
 msgid "Manx"
 msgstr "Manx"
 
-#: common/models/lang.py:94
+#: common/models/lang.py:96
 msgid "Guarani"
 msgstr "Guaraní"
 
-#: common/models/lang.py:95
+#: common/models/lang.py:97
 msgid "Gujarati"
 msgstr "Guyarati"
 
-#: common/models/lang.py:96
+#: common/models/lang.py:98
 msgid "Haitian; Haitian Creole"
 msgstr "Haitiano; Créole haitiano"
 
-#: common/models/lang.py:97
+#: common/models/lang.py:99
 msgid "Hausa"
 msgstr "Hausa"
 
-#: common/models/lang.py:98
+#: common/models/lang.py:100
 msgid "Serbo-Croatian"
 msgstr "Serbocroata"
 
-#: common/models/lang.py:99
+#: common/models/lang.py:101
 msgid "Herero"
 msgstr "Herero"
 
-#: common/models/lang.py:100
+#: common/models/lang.py:102
 msgid "Hiri Motu"
 msgstr "Hiri motu"
 
-#: common/models/lang.py:101
+#: common/models/lang.py:103
 msgid "Croatian"
 msgstr "Croata"
 
-#: common/models/lang.py:102
+#: common/models/lang.py:104
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: common/models/lang.py:103
+#: common/models/lang.py:105
 msgid "Igbo"
 msgstr "Igbó"
 
-#: common/models/lang.py:104
+#: common/models/lang.py:106
 msgid "Ido"
 msgstr "Ido"
 
-#: common/models/lang.py:105
+#: common/models/lang.py:107
 msgid "Yi"
 msgstr "Yi"
 
-#: common/models/lang.py:106
+#: common/models/lang.py:108
 msgid "Inuktitut"
 msgstr "Inuktitut"
 
-#: common/models/lang.py:107
+#: common/models/lang.py:109
 msgid "Interlingue"
 msgstr "Interlingue; Idioma occidental"
 
-#: common/models/lang.py:108
+#: common/models/lang.py:110
 msgid "Interlingua"
 msgstr "Interlingua"
 
-#: common/models/lang.py:109
+#: common/models/lang.py:111
 msgid "Indonesian"
 msgstr "Indonesio"
 
-#: common/models/lang.py:110
+#: common/models/lang.py:112
 msgid "Inupiaq"
 msgstr "Inupiaq"
 
-#: common/models/lang.py:111
+#: common/models/lang.py:113
 msgid "Icelandic"
 msgstr "Islandés"
 
-#: common/models/lang.py:113
+#: common/models/lang.py:115
 msgid "Javanese"
 msgstr "Javanés"
 
-#: common/models/lang.py:114
+#: common/models/lang.py:116
 msgid "Japanese"
 msgstr "Japonés"
 
-#: common/models/lang.py:115
+#: common/models/lang.py:117
 msgid "Kalaallisut"
 msgstr "Groenlandés"
 
-#: common/models/lang.py:116
+#: common/models/lang.py:118
 msgid "Kannada"
 msgstr "Canarés"
 
-#: common/models/lang.py:117
+#: common/models/lang.py:119
 msgid "Kashmiri"
 msgstr "Cachemir"
 
-#: common/models/lang.py:118
+#: common/models/lang.py:120
 msgid "Kanuri"
 msgstr "Kanuri"
 
-#: common/models/lang.py:119
+#: common/models/lang.py:121
 msgid "Kazakh"
 msgstr "Kazajo"
 
-#: common/models/lang.py:120
+#: common/models/lang.py:122
 msgid "Khmer"
 msgstr "Jemer; Camboyano"
 
-#: common/models/lang.py:121
+#: common/models/lang.py:123
 msgid "Kikuyu"
 msgstr "Kikuyu"
 
-#: common/models/lang.py:122
+#: common/models/lang.py:124
 msgid "Kinyarwanda"
 msgstr "Kiñaruanda"
 
-#: common/models/lang.py:123
+#: common/models/lang.py:125
 msgid "Kirghiz"
 msgstr "Kirguís"
 
-#: common/models/lang.py:124
+#: common/models/lang.py:126
 msgid "Komi"
 msgstr "Komi"
 
-#: common/models/lang.py:125
+#: common/models/lang.py:127
 msgid "Kongo"
 msgstr "Kikongo"
 
-#: common/models/lang.py:126
+#: common/models/lang.py:128
 msgid "Korean"
 msgstr "Coreano"
 
-#: common/models/lang.py:127
+#: common/models/lang.py:129
 msgid "Kuanyama"
 msgstr "Kuanyama"
 
-#: common/models/lang.py:128
+#: common/models/lang.py:130
 msgid "Kurdish"
 msgstr "Kurdo"
 
-#: common/models/lang.py:129
+#: common/models/lang.py:131
 msgid "Lao"
 msgstr "Lao; Laosiano"
 
-#: common/models/lang.py:130
+#: common/models/lang.py:132
 msgid "Latin"
 msgstr "Latín"
 
-#: common/models/lang.py:131
+#: common/models/lang.py:133
 msgid "Latvian"
 msgstr "Letón"
 
-#: common/models/lang.py:132
+#: common/models/lang.py:134
 msgid "Limburgish"
 msgstr "Limburgués"
 
-#: common/models/lang.py:133
+#: common/models/lang.py:135
 msgid "Lingala"
 msgstr "Lingala"
 
-#: common/models/lang.py:134
+#: common/models/lang.py:136
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: common/models/lang.py:135
+#: common/models/lang.py:137
 msgid "Letzeburgesch"
 msgstr "Luxemburgués"
 
-#: common/models/lang.py:136
+#: common/models/lang.py:138
 msgid "Luba-Katanga"
 msgstr "Luba-katanga; Kiluba"
 
-#: common/models/lang.py:137
+#: common/models/lang.py:139
 msgid "Ganda"
 msgstr "Luganda; Ganda"
 
-#: common/models/lang.py:138
+#: common/models/lang.py:140
 msgid "Marshall"
 msgstr "Marshalés; Ebon"
 
-#: common/models/lang.py:139
+#: common/models/lang.py:141
 msgid "Malayalam"
 msgstr "Malabar"
 
-#: common/models/lang.py:140
+#: common/models/lang.py:142
 msgid "Marathi"
 msgstr "Maratí"
 
-#: common/models/lang.py:141
+#: common/models/lang.py:143
 msgid "Malagasy"
 msgstr "Malgache"
 
-#: common/models/lang.py:142
+#: common/models/lang.py:144
 msgid "Maltese"
 msgstr "Maltés"
 
-#: common/models/lang.py:143
+#: common/models/lang.py:145
 msgid "Moldavian"
 msgstr "Moldavo"
 
-#: common/models/lang.py:144
+#: common/models/lang.py:146
 msgid "Mongolian"
 msgstr "Mongol"
 
-#: common/models/lang.py:145
+#: common/models/lang.py:147
 msgid "Maori"
 msgstr "Maorí"
 
-#: common/models/lang.py:146
+#: common/models/lang.py:148
 msgid "Malay"
 msgstr "Malayo"
 
-#: common/models/lang.py:147
+#: common/models/lang.py:149
 msgid "Burmese"
 msgstr "Birmano"
 
-#: common/models/lang.py:148
+#: common/models/lang.py:150
 msgid "Nauru"
 msgstr "Nauruano"
 
-#: common/models/lang.py:149
+#: common/models/lang.py:151
 msgid "Navajo"
 msgstr "Navajo"
 
-#: common/models/lang.py:150 common/models/lang.py:151
+#: common/models/lang.py:152 common/models/lang.py:153
 msgid "Ndebele"
 msgstr "Ndebele"
 
-#: common/models/lang.py:152
+#: common/models/lang.py:154
 msgid "Ndonga"
 msgstr "Ndonga"
 
-#: common/models/lang.py:153
+#: common/models/lang.py:155
 msgid "Nepali"
 msgstr "Nepalí"
 
-#: common/models/lang.py:154
+#: common/models/lang.py:156
 msgid "Dutch"
 msgstr "Neerlandés"
 
-#: common/models/lang.py:155
+#: common/models/lang.py:157
 msgid "Norwegian Nynorsk"
 msgstr "Noruego (Nynorsk)"
 
-#: common/models/lang.py:156
+#: common/models/lang.py:158
 msgid "Norwegian Bokmål"
 msgstr "Noruego (Bokmål)"
 
-#: common/models/lang.py:157
+#: common/models/lang.py:159
 msgid "Norwegian"
 msgstr "Noruego"
 
-#: common/models/lang.py:158
+#: common/models/lang.py:160
 msgid "Chichewa; Nyanja"
 msgstr "Chichewa"
 
-#: common/models/lang.py:159
+#: common/models/lang.py:161
 msgid "Occitan"
 msgstr "Occitano"
 
-#: common/models/lang.py:160
+#: common/models/lang.py:162
 msgid "Ojibwa"
 msgstr "Ojibwa"
 
-#: common/models/lang.py:161
+#: common/models/lang.py:163
 msgid "Oriya"
 msgstr "Oriya"
 
-#: common/models/lang.py:162
+#: common/models/lang.py:164
 msgid "Oromo"
 msgstr "Oromo"
 
-#: common/models/lang.py:163
+#: common/models/lang.py:165
 msgid "Ossetian; Ossetic"
 msgstr "Osetio"
 
-#: common/models/lang.py:164
+#: common/models/lang.py:166
 msgid "Pali"
 msgstr "Pali"
 
-#: common/models/lang.py:165
+#: common/models/lang.py:167
 msgid "Polish"
 msgstr "Polaco"
 
-#: common/models/lang.py:167
+#: common/models/lang.py:169
 msgid "Quechua"
 msgstr "Quechua"
 
-#: common/models/lang.py:168
+#: common/models/lang.py:170
 msgid "Raeto-Romance"
 msgstr "Retorrománico"
 
-#: common/models/lang.py:169
+#: common/models/lang.py:171
 msgid "Romanian"
 msgstr "Rumano"
 
-#: common/models/lang.py:170
+#: common/models/lang.py:172
 msgid "Rundi"
 msgstr "Kirundi"
 
-#: common/models/lang.py:171
+#: common/models/lang.py:173
 msgid "Russian"
 msgstr "Ruso"
 
-#: common/models/lang.py:172
+#: common/models/lang.py:174
 msgid "Sango"
 msgstr "Sango"
 
-#: common/models/lang.py:173
+#: common/models/lang.py:175
 msgid "Sanskrit"
 msgstr "Sánscrito"
 
-#: common/models/lang.py:174
+#: common/models/lang.py:176
 msgid "Sinhalese"
 msgstr "Singlés"
 
-#: common/models/lang.py:175
+#: common/models/lang.py:177
 msgid "Slovak"
 msgstr "Eslovaco"
 
-#: common/models/lang.py:176
+#: common/models/lang.py:178
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: common/models/lang.py:177
+#: common/models/lang.py:179
 msgid "Northern Sami"
 msgstr "Sami septentrional"
 
-#: common/models/lang.py:178
+#: common/models/lang.py:180
 msgid "Samoan"
 msgstr "Samoano"
 
-#: common/models/lang.py:179
+#: common/models/lang.py:181
 msgid "Shona"
 msgstr "Shona"
 
-#: common/models/lang.py:180
+#: common/models/lang.py:182
 msgid "Sindhi"
 msgstr "Sindi"
 
-#: common/models/lang.py:181
+#: common/models/lang.py:183
 msgid "Somali"
 msgstr "Somalí"
 
-#: common/models/lang.py:182
+#: common/models/lang.py:184
 msgid "Sotho"
 msgstr "Sotho"
 
-#: common/models/lang.py:184
+#: common/models/lang.py:186
 msgid "Albanian"
 msgstr "Albanés"
 
-#: common/models/lang.py:185
+#: common/models/lang.py:187
 msgid "Sardinian"
 msgstr "Sardo"
 
-#: common/models/lang.py:186
+#: common/models/lang.py:188
 msgid "Serbian"
 msgstr "Serbio"
 
-#: common/models/lang.py:187
+#: common/models/lang.py:189
 msgid "Swati"
 msgstr "Suazi"
 
-#: common/models/lang.py:188
+#: common/models/lang.py:190
 msgid "Sundanese"
 msgstr "Sudanés"
 
-#: common/models/lang.py:189
+#: common/models/lang.py:191
 msgid "Swahili"
 msgstr "Suajili"
 
-#: common/models/lang.py:190
+#: common/models/lang.py:192
 msgid "Swedish"
 msgstr "Sueco"
 
-#: common/models/lang.py:191
+#: common/models/lang.py:193
 msgid "Tahitian"
 msgstr "Tahitiano"
 
-#: common/models/lang.py:192
+#: common/models/lang.py:194
 msgid "Tamil"
 msgstr "Tamil"
 
-#: common/models/lang.py:193
+#: common/models/lang.py:195
 msgid "Tatar"
 msgstr "Tártaro"
 
-#: common/models/lang.py:194
+#: common/models/lang.py:196
 msgid "Telugu"
 msgstr "Télugu"
 
-#: common/models/lang.py:195
+#: common/models/lang.py:197
 msgid "Tajik"
 msgstr "Tayico"
 
-#: common/models/lang.py:196
+#: common/models/lang.py:198
 msgid "Tagalog"
 msgstr "Tagalo"
 
-#: common/models/lang.py:197
+#: common/models/lang.py:199
 msgid "Thai"
 msgstr "Tailandés"
 
-#: common/models/lang.py:198
+#: common/models/lang.py:200
 msgid "Tigrinya"
 msgstr "Tigriña"
 
-#: common/models/lang.py:199
+#: common/models/lang.py:201
 msgid "Tonga"
 msgstr "Tongano"
 
-#: common/models/lang.py:200
+#: common/models/lang.py:202
 msgid "Tswana"
 msgstr "Tsuana"
 
-#: common/models/lang.py:201
+#: common/models/lang.py:203
 msgid "Tsonga"
 msgstr "Tsonga"
 
-#: common/models/lang.py:202
+#: common/models/lang.py:204
 msgid "Turkmen"
 msgstr "Turcomano"
 
-#: common/models/lang.py:203
+#: common/models/lang.py:205
 msgid "Turkish"
 msgstr "Turco"
 
-#: common/models/lang.py:204
+#: common/models/lang.py:206
 msgid "Twi"
 msgstr "Twi; Chuí"
 
-#: common/models/lang.py:205
+#: common/models/lang.py:207
 msgid "Uighur"
 msgstr "Uigur"
 
-#: common/models/lang.py:206
+#: common/models/lang.py:208
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: common/models/lang.py:207
+#: common/models/lang.py:209
 msgid "Urdu"
 msgstr "Urdu"
 
-#: common/models/lang.py:208
+#: common/models/lang.py:210
 msgid "Uzbek"
 msgstr "Uzbeko"
 
-#: common/models/lang.py:209
+#: common/models/lang.py:211
 msgid "Venda"
 msgstr "Venda"
 
-#: common/models/lang.py:210
+#: common/models/lang.py:212
 msgid "Vietnamese"
 msgstr "Vietnamita"
 
-#: common/models/lang.py:211
+#: common/models/lang.py:213
 msgid "Volapük"
 msgstr "Volapük"
 
-#: common/models/lang.py:212
+#: common/models/lang.py:214
 msgid "Walloon"
 msgstr "Valón"
 
-#: common/models/lang.py:213
+#: common/models/lang.py:215
 msgid "Wolof"
 msgstr "Wólof"
 
-#: common/models/lang.py:214
+#: common/models/lang.py:216
 msgid "Xhosa"
 msgstr "Xhosa"
 
-#: common/models/lang.py:215
+#: common/models/lang.py:217
 msgid "Yiddish"
 msgstr "Yiddish"
 
-#: common/models/lang.py:216
+#: common/models/lang.py:218
 msgid "Zhuang"
 msgstr "Zhuang"
 
-#: common/models/lang.py:217
+#: common/models/lang.py:219
 msgid "Zulu"
 msgstr "Zulú"
 
-#: common/models/lang.py:218
+#: common/models/lang.py:220
 msgid "Abkhazian"
 msgstr "Abjasio"
 
-#: common/models/lang.py:219
+#: common/models/lang.py:221
 msgid "Chinese"
 msgstr "Chino"
 
-#: common/models/lang.py:220
+#: common/models/lang.py:222
 msgid "Pushto"
 msgstr "Pastún"
 
-#: common/models/lang.py:221
+#: common/models/lang.py:223
 msgid "Amharic"
 msgstr "Amhárico"
 
-#: common/models/lang.py:222
+#: common/models/lang.py:224
 msgid "Arabic"
 msgstr "Árabe"
 
-#: common/models/lang.py:223
+#: common/models/lang.py:225
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: common/models/lang.py:224
+#: common/models/lang.py:226
 msgid "Macedonian"
 msgstr "Macedonio"
 
-#: common/models/lang.py:225
+#: common/models/lang.py:227
 msgid "Greek"
 msgstr "Griego"
 
-#: common/models/lang.py:226
+#: common/models/lang.py:228
 msgid "Persian"
 msgstr "Persa"
 
-#: common/models/lang.py:227
+#: common/models/lang.py:229
 msgid "Hebrew"
 msgstr "Hebreo"
 
-#: common/models/lang.py:228
+#: common/models/lang.py:230
 msgid "Hindi"
 msgstr "Hindi"
 
-#: common/models/lang.py:229
+#: common/models/lang.py:231
 msgid "Armenian"
 msgstr "Armenio"
 
-#: common/models/lang.py:231
+#: common/models/lang.py:233
 msgid "Ewe"
 msgstr "Ewé"
 
-#: common/models/lang.py:232
+#: common/models/lang.py:234
 msgid "Georgian"
 msgstr "Georgiano"
 
-#: common/models/lang.py:233
+#: common/models/lang.py:235
 msgid "Punjabi"
 msgstr "Punyabí"
 
-#: common/models/lang.py:234
+#: common/models/lang.py:236
 msgid "Bengali"
 msgstr "Bengalí"
 
-#: common/models/lang.py:235
+#: common/models/lang.py:237
 msgid "Bosnian"
 msgstr "Bosnio"
 
-#: common/models/lang.py:236
+#: common/models/lang.py:238
 msgid "Chamorro"
 msgstr "Chamorro"
 
-#: common/models/lang.py:237
+#: common/models/lang.py:239
 msgid "Belarusian"
 msgstr "Bielorruso"
 
-#: common/models/lang.py:238
+#: common/models/lang.py:240
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: common/models/lang.py:300
+#: common/models/lang.py:302
 msgid "Simplified Chinese (Mainland)"
 msgstr "Chino simplificado (China continental)"
 
-#: common/models/lang.py:301
+#: common/models/lang.py:303
 msgid "Traditional Chinese (Taiwan)"
 msgstr "Chino tradicional (Taiwán)"
 
-#: common/models/lang.py:302
+#: common/models/lang.py:304
 msgid "Traditional Chinese (Hongkong)"
 msgstr "Chino tradicional (Hong Kong)"
 
-#: common/models/lang.py:310
+#: common/models/lang.py:312
 msgid "Portuguese (Brazil)"
 msgstr "Portugués (Brasil)"
 
-#: common/models/lang.py:313
+#: common/models/lang.py:315
 msgid "Simplified Chinese (Singapore)"
 msgstr "Chino simplificado (Singapur)"
 
-#: common/models/lang.py:314
+#: common/models/lang.py:316
 msgid "Simplified Chinese (Malaysia)"
 msgstr "Chino simplificado (Malasia)"
 
-#: common/models/lang.py:315
+#: common/models/lang.py:317
 msgid "Traditional Chinese (Macau)"
 msgstr "Chino tradicional (Macao)"
 
-#: common/models/lang.py:323
+#: common/models/lang.py:325
 msgid "Mandarin Chinese"
 msgstr "Chino mandarín"
 
-#: common/models/lang.py:324
+#: common/models/lang.py:326
 msgid "Yue Chinese"
 msgstr "Chino cantonés"
 
-#: common/models/lang.py:328
+#: common/models/lang.py:330
 msgid "Min Nan Chinese"
 msgstr "Chino Min"
 
-#: common/models/lang.py:329
+#: common/models/lang.py:331
 msgid "Wu Chinese"
 msgstr "Chino Wu"
 
-#: common/models/lang.py:330
+#: common/models/lang.py:332
 msgid "Hakka Chinese"
 msgstr "Chino Hakka"
 
@@ -3951,60 +3980,37 @@ msgid "VCD"
 msgstr ""
 
 #: common/templates/400.html:23
-msgid ""
-"You may have submitted invalid data, or the content may have been deleted by "
-"the author."
-msgstr ""
-"Parece que has introducido algún dato incorrecto. También es posible que el "
-"contenido haya sido eliminado por su autor(a)."
+msgid "You may have submitted invalid data, or the content may have been deleted by the author."
+msgstr "Parece que has introducido algún dato incorrecto. También es posible que el contenido haya sido eliminado por su autor(a)."
 
 #: common/templates/400.html:25 common/templates/403.html:24
 #: common/templates/404.html:24
-msgid ""
-"If you believe this is our mistake, please contact us through the link at "
-"the bottom of the page."
-msgstr ""
-"Si crees que se trata de un error nuestro, contáctanos a través del "
-"hipervínculo al final de la página."
+msgid "If you believe this is our mistake, please contact us through the link at the bottom of the page."
+msgstr "Si crees que se trata de un error nuestro, contáctanos a través del hipervínculo al final de la página."
 
 #: common/templates/403.html:22
-msgid ""
-"Author may require you to log in before accessing this content, or you do "
-"not have permission to view it."
-msgstr ""
-"Puede que se te pida iniciar sesión para acceder a este contenido. También "
-"es posible que no tengas los permisos necesarios para verlo."
+msgid "Author may require you to log in before accessing this content, or you do not have permission to view it."
+msgstr "Puede que se te pida iniciar sesión para acceder a este contenido. También es posible que no tengas los permisos necesarios para verlo."
 
 #: common/templates/404.html:20
 msgid "Something is missing"
 msgstr "Falta algo"
 
 #: common/templates/404.html:22
-msgid ""
-"You may have visited an incorrect URL, or the content you are looking for "
-"has been deleted by the author."
-msgstr ""
-"La dirección URL no es correcta o el contenido que buscas ha sido eliminado."
+msgid "You may have visited an incorrect URL, or the content you are looking for has been deleted by the author."
+msgstr "La dirección URL no es correcta o el contenido que buscas ha sido eliminado."
 
 #: common/templates/404.html:26
 msgid "Go to Home"
 msgstr "Ir al inicio"
 
 #: common/templates/500.html:22
-msgid ""
-"An internal error occurred. If this error occurs repeatedly, it will be "
-"recorded and handled by a human."
-msgstr ""
-"Se ha producido un error interno. Si este error se vuelve recurrente, será "
-"registrado y un humano se ocupará de él."
+msgid "An internal error occurred. If this error occurs repeatedly, it will be recorded and handled by a human."
+msgstr "Se ha producido un error interno. Si este error se vuelve recurrente, será registrado y un humano se ocupará de él."
 
 #: common/templates/500.html:24
-msgid ""
-"If you have an urgent situation or any questions, please contact us through "
-"the link at the bottom of the page."
-msgstr ""
-"Si tu situación es urgente o si tienes alguna pregunta, por favor, "
-"contáctanos a través del vínculo al final de la página."
+msgid "If you have an urgent situation or any questions, please contact us through the link at the bottom of the page."
+msgstr "Si tu situación es urgente o si tienes alguna pregunta, por favor, contáctanos a través del vínculo al final de la página."
 
 #: common/templates/_footer.html:6
 msgid "Rules"
@@ -4018,216 +4024,188 @@ msgstr "Términos y condiciones"
 msgid "About"
 msgstr ""
 
-#: common/templates/_footer.html:12 users/templates/users/login.html:265
+#: common/templates/_footer.html:12 users/templates/users/login.html:259
 #, python-format
-msgid ""
-"You are visiting an alternative domain for %(site_name)s, please always use "
-"<a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if "
-"possible."
-msgstr ""
-"Estás viendo un dominio alternativo para %(site_name)s; por favor, intenta "
-"utilizar la <a href=\"%(site_url)s%(request.get_full_path)s\">versión "
-"original</a> siempre que sea posible."
+msgid "You are visiting an alternative domain for %(site_name)s, please always use <a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if possible."
+msgstr "Estás viendo un dominio alternativo para %(site_name)s; por favor, intenta utilizar la <a href=\"%(site_url)s%(request.get_full_path)s\">versión original</a> siempre que sea posible."
 
-#: common/templates/_header.html:19 common/templates/_header.html:164
+#: common/templates/_header.html:19 common/templates/_header.html:177
 msgid "title, creator, ISBN, item url, @user, @user@instance"
 msgstr "Buscar por título, creador(a), ISBN, URL, @usuario, @usuario@instancia"
 
-#: common/templates/_header.html:24
+#: common/templates/_header.html:34
 msgid "All Items"
 msgstr "Todas las obras"
 
-#: common/templates/_header.html:31
+#: common/templates/_header.html:41
 msgid "Movie & TV"
 msgstr "Cine y TV"
 
-#: common/templates/_header.html:50
+#: common/templates/_header.html:60
 msgid "People & Organizations"
 msgstr ""
 
-#: common/templates/_header.html:52
+#: common/templates/_header.html:62
 msgid "Journal"
 msgstr "Diario"
 
-#: common/templates/_header.html:54 journal/templates/user_post_list.html:10
+#: common/templates/_header.html:64 journal/templates/user_post_list.html:10
 #: journal/templates/user_post_list.html:23
 msgid "Posts"
 msgstr "Publicaciones"
 
-#: common/templates/_header.html:89
+#: common/templates/_header.html:102
 msgid "Explore"
 msgstr "Explorar"
 
-#: common/templates/_header.html:93
+#: common/templates/_header.html:106 common/views_manage.py:36
 msgid "Feed"
 msgstr "Actividad"
 
-#: common/templates/_header.html:98 journal/templates/profile.html:13
+#: common/templates/_header.html:111 journal/templates/profile.html:13
 #: users/templates/users/preferences.html:46
 msgid "Home"
 msgstr "Inicio"
 
-#: common/templates/_header.html:114 common/templates/common/scan.html:9
+#: common/templates/_header.html:127 common/templates/common/scan.html:9
 #: common/templates/common/scan.html:42
 #, fuzzy
 #| msgid "barcode"
 msgid "Scan Barcode"
 msgstr "código de barras"
 
-#: common/templates/_header.html:118 social/templates/notification.html:12
+#: common/templates/_header.html:131 social/templates/notification.html:12
 #: social/templates/notification.html:53
 msgid "Notification"
 msgstr "Notificaciones"
 
-#: common/templates/_header.html:122 users/models/task.py:21
+#: common/templates/_header.html:135 users/models/task.py:23
 #: users/templates/users/account.html:219
 #: users/templates/users/crossposts.html:9
 msgid "Pending"
 msgstr ""
 
-#: common/templates/_header.html:125
+#: common/templates/_header.html:138
 msgid "Data"
 msgstr "Datos"
 
-#: common/templates/_header.html:128 common/templates/_header.html:146
+#: common/templates/_header.html:141 common/templates/_header.html:159
 #: users/templates/users/preferences.html:12
 #: users/templates/users/preferences.html:23
 #: users/templates/users/preferences_anonymous.html:13
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: common/templates/_header.html:131
+#: common/templates/_header.html:144
 msgid "Account"
 msgstr "Cuenta"
 
-#: common/templates/_header.html:135
+#: common/templates/_header.html:148
 msgid "Manage"
 msgstr "Administrar"
 
-#: common/templates/_header.html:139
+#: common/templates/_header.html:152
 msgid "Logout"
 msgstr "Cerrar sesión"
 
-#: common/templates/_header.html:143
+#: common/templates/_header.html:156
 msgid "Sign up or Login"
 msgstr "Crear cuenta o Iniciar sesión"
 
-#: common/templates/_header.html:160
-msgid ""
-"title or content  category:tv  status:complete  rating:8..10  "
-"date:2021-09-11..2022-02"
-msgstr ""
-"título o contenido. También puedes utilizar filtros, p. ej., category:tv, "
-"status:complete, rating:8..10, date:2021-09-11..2022-02"
+#: common/templates/_header.html:173
+msgid "title or content  category:tv  status:complete  rating:8..10  date:2021-09-11..2022-02"
+msgstr "título o contenido. También puedes utilizar filtros, p. ej., category:tv, status:complete, rating:8..10, date:2021-09-11..2022-02"
 
-#: common/templates/_header.html:162
+#: common/templates/_header.html:175
 msgid "name of a person or company"
 msgstr ""
 
-#: common/templates/_header.html:179
+#: common/templates/_header.html:192
 msgid "Open"
 msgstr "Abrir"
 
-#: common/templates/_sidebar.html:62
+#: common/templates/_sidebar.html:61
 #: users/templates/users/profile_actions.html:36
 msgid "approving followers manually"
 msgstr "aprobar manualmente las solicitudes de seguidores"
 
-#: common/templates/_sidebar.html:81 common/templates/_sidebar.html:86
+#: common/templates/_sidebar.html:80 common/templates/_sidebar.html:85
 #, fuzzy
 #| msgid "followed"
 msgid "followers"
 msgstr "seguido(a)"
 
-#: common/templates/_sidebar.html:112
+#: common/templates/_sidebar.html:111
 msgid "Current Targets"
 msgstr "Metas actuales"
 
-#: common/templates/_sidebar.html:125
+#: common/templates/_sidebar.html:124
 msgid "Set a collection as target, its progress will show up here."
 msgstr "Define una colección como meta y verás aquí el progreso."
 
-#: common/templates/_sidebar.html:138
+#: common/templates/_sidebar.html:137
 msgid "Recent podcast episodes"
 msgstr "Episodios recientes de podcasts"
 
-#: common/templates/_sidebar.html:173
+#: common/templates/_sidebar.html:172
 msgid "Currently reading"
 msgstr "Leyendo"
 
-#: common/templates/_sidebar.html:215
+#: common/templates/_sidebar.html:214
 msgid "Currently watching"
 msgstr "Viendo"
 
-#: common/templates/_sidebar.html:238 journal/forms.py:217
+#: common/templates/_sidebar.html:237 journal/forms.py:217
 #: journal/templates/user_tag_list.html:13
 #: journal/templates/user_tagmember_list.html:4
 msgid "Tags"
 msgstr "Etiquetas"
 
-#: common/templates/_sidebar.html:244 journal/templates/user_tag_list.html:28
+#: common/templates/_sidebar.html:243 journal/templates/user_tag_list.html:28
 #: journal/templates/user_tagmember_list.html:10
 msgid "featured tag"
 msgstr "Etiqueta destacada"
 
-#: common/templates/_sidebar.html:247 journal/templates/user_tag_list.html:31
+#: common/templates/_sidebar.html:246 journal/templates/user_tag_list.html:31
 #: journal/templates/user_tagmember_list.html:15
 msgid "personal tag"
 msgstr "etiqueta personal"
 
-#: common/templates/_sidebar.html:254 journal/templates/user_tag_list.html:39
+#: common/templates/_sidebar.html:253 journal/templates/user_tag_list.html:39
 msgid "no tags so far."
 msgstr "ninguna etiqueta por el momento."
 
-#: common/templates/_sidebar.html:258 common/templates/_sidebar.html:271
+#: common/templates/_sidebar.html:257 common/templates/_sidebar.html:270
 msgid "show all"
 msgstr "ver todo"
 
-#: common/templates/_sidebar_anonymous.html:16
+#: common/templates/_sidebar_anonymous.html:15
 #, python-format
 msgid ""
 "\n"
 "        <h3>Welcome 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is "
-"committed to creating a free, open, and interconnected space for collecting "
-"and reviewing books, movies, music, games, and podcasts. Here, you can "
-"manage your collections, share your thoughts, discover new content, and "
-"connect with others.\n"
+"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is committed to creating a free, open, and interconnected space for collecting and reviewing books, movies, music, games, and podcasts. Here, you can manage your collections, share your thoughts, discover new content, and connect with others.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in "
-"to %(site_name)s is through a Fediverse (a distributed social network, "
-"including Mastodon/Pleroma/etc) instance account. If you haven’t registered "
-"yet, you can <a href=\"https://joinmastodon.org/en/servers\" "
-"target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
+"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in to %(site_name)s is through a Fediverse (a distributed social network, including Mastodon/Pleroma/etc) instance account. If you haven’t registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log "
-"in is through a Bluesky (another distributed social network, also called "
-"ATProto) account. If you haven’t registered yet, you may <a href=\"https://"
-"bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
+"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log in is through a Bluesky (another distributed social network, also called ATProto) account. If you haven’t registered yet, you may <a href=\"https://bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready "
-"to join either Fediverse or Bluesky, that’s perfectly fine. You can create "
-"an account here using your email address, and link it to the Fediverse and "
-"Bluesky in settings whenever you’re ready.\n"
+"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready to join either Fediverse or Bluesky, that’s perfectly fine. You can create an account here using your email address, and link it to the Fediverse and Bluesky in settings whenever you’re ready.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have "
-"any questions or suggestions, please feel free to contact us via <a "
-"href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://"
-"discord.gg/uprvcH8gqD\">Discord</a>.\n"
+"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have any questions or suggestions, please feel free to contact us via <a href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-"href=\"%(login_url)s\">Click here</a> to register or log in.\n"
+"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Click here</a> to register or log in.\n"
 "        </p>\n"
 "        "
 msgstr ""
 
-#: common/templates/_sidebar_anonymous.html:43
+#: common/templates/_sidebar_anonymous.html:42
 #: users/templates/users/announcements.html:12
 #: users/templates/users/announcements.html:39
 msgid "Announcements"
@@ -4253,7 +4231,7 @@ msgstr "Código fuente"
 msgid "Registration"
 msgstr "descripción"
 
-#: common/templates/common/about.html:35 common/views_manage.py:493
+#: common/templates/common/about.html:35 common/views_manage.py:594
 #, fuzzy
 #| msgid "Mentioned Only"
 msgid "Invite Only"
@@ -4263,7 +4241,7 @@ msgstr "Solo cuentas mencionadas"
 msgid "Open Registration"
 msgstr ""
 
-#: common/templates/common/about.html:40 common/views_manage.py:556
+#: common/templates/common/about.html:40 common/views_manage.py:657
 #, fuzzy
 #| msgid "Preferences"
 msgid "Preferred Languages"
@@ -4312,9 +4290,7 @@ msgid "Error"
 msgstr "Error"
 
 #: common/templates/common/scan.html:45
-msgid ""
-"Point the camera at a book ISBN or product barcode (EAN / UPC). You will be "
-"redirected to the search once a code is detected."
+msgid "Point the camera at a book ISBN or product barcode (EAN / UPC). You will be redirected to the search once a code is detected."
 msgstr ""
 
 #: common/templates/common/scan.html:50
@@ -4325,7 +4301,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:628
+#: common/templates/common/scan.html:60 common/views_manage.py:738
 #, fuzzy
 #| msgid "Search results"
 msgid "Search"
@@ -4359,19 +4335,31 @@ msgstr ""
 msgid "Camera unavailable. Use manual entry below."
 msgstr ""
 
-#: common/templates/manage/settings.html:9
+#: common/templates/manage/base.html:9
 msgid "Site Settings"
 msgstr ""
 
-#: common/templates/manage/settings.html:109
+#: common/templates/manage/base.html:127
 msgid "Takahe Admin"
 msgstr ""
 
-#: common/templates/manage/settings.html:112
+#: common/templates/manage/base.html:130
 #, fuzzy
 #| msgid "Database"
 msgid "Database Admin"
 msgstr "Base de datos"
+
+#: common/templates/manage/environment.html:6
+msgid "These settings come from environment variables and cannot be changed here. Edit .env and restart the server to change them. Passwords and keys are hidden."
+msgstr ""
+
+#: common/templates/manage/environment.html:23
+msgid "(empty)"
+msgstr ""
+
+#: common/templates/manage/environment.html:26
+msgid "default"
+msgstr ""
 
 #: common/templatetags/duration.py:59
 msgid "just now"
@@ -4389,7 +4377,7 @@ msgstr "seguido(a)"
 msgid "following you"
 msgstr "te sigue"
 
-#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:95
+#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:90
 msgid "you"
 msgstr "tú"
 
@@ -4397,855 +4385,870 @@ msgstr "tú"
 msgid "unavailable"
 msgstr "no disponible"
 
-#: common/utils.py:126 common/utils.py:167 users/views/actions.py:134
+#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr "Este usuario ya no existe"
 
-#: common/utils.py:133 common/utils.py:135 common/utils.py:138
-#: common/utils.py:174 common/utils.py:178 journal/views/profile.py:499
+#: common/utils.py:135 common/utils.py:137 common/utils.py:140
+#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
 msgid "Access denied"
 msgstr "Acceso denegado"
 
-#: common/utils.py:141 common/utils.py:143 journal/views/article.py:204
+#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr ""
 
-#: common/views_manage.py:144 common/views_manage.py:295
+#: common/views_manage.py:34 common/views_manage.py:373
 #, fuzzy
 #| msgid "reading"
 msgid "Branding"
 msgstr "leyendo"
 
-#: common/views_manage.py:146
+#: common/views_manage.py:37
 #, fuzzy
 #| msgid "comments"
 msgid "Recommendations"
 msgstr "comentarios"
 
-#: common/views_manage.py:147
+#: common/views_manage.py:38
 #, fuzzy
 #| msgid "Access denied"
 msgid "Access"
 msgstr "Acceso denegado"
 
-#: common/views_manage.py:148 common/views_manage.py:623
+#: common/views_manage.py:39 common/views_manage.py:733
 #, fuzzy
 #| msgid "duration"
 msgid "Federation"
 msgstr "duración"
 
-#: common/views_manage.py:149
+#: common/views_manage.py:40
 #, fuzzy
 #| msgid "Catalan"
 msgid "Catalog"
 msgstr "Catalán"
 
-#: common/views_manage.py:150
+#: common/views_manage.py:41
 msgid "API Keys"
 msgstr ""
 
-#: common/views_manage.py:151
+#: common/views_manage.py:42
 #, fuzzy
 #| msgid "Downloadable Content"
 msgid "Downloader"
 msgstr "Contenido descargable"
 
-#: common/views_manage.py:152 common/views_manage.py:303
+#: common/views_manage.py:43 common/views_manage.py:381
 #: users/templates/users/steam_import.html:113
 msgid "Advanced"
 msgstr ""
 
-#: common/views_manage.py:202
+#: common/views_manage.py:44
+msgid "Environment"
+msgstr ""
+
+#: common/views_manage.py:280
 #, fuzzy
 #| msgid "Invalid parameter"
 msgid "Invalid value."
 msgstr "Parámetro no válido"
 
-#: common/views_manage.py:206
+#: common/views_manage.py:284
 msgid "Invalid configuration. Please check your input."
 msgstr ""
 
-#: common/views_manage.py:211
+#: common/views_manage.py:289
 msgid "Settings have been saved."
 msgstr ""
 
-#: common/views_manage.py:231
+#: common/views_manage.py:309
 msgid "Site Name"
 msgstr ""
 
-#: common/views_manage.py:234
+#: common/views_manage.py:312
 #, fuzzy
 #| msgid "description"
 msgid "Site Description"
 msgstr "descripción"
 
-#: common/views_manage.py:235
+#: common/views_manage.py:313
 msgid "Short description shown in metadata and about page."
 msgstr ""
 
-#: common/views_manage.py:238
+#: common/views_manage.py:316
 msgid "Site Logo URL"
 msgstr ""
 
-#: common/views_manage.py:239
+#: common/views_manage.py:317
 msgid "URL path to the site logo image."
 msgstr ""
 
-#: common/views_manage.py:242
+#: common/views_manage.py:320
 msgid "Site Icon URL"
 msgstr ""
 
-#: common/views_manage.py:243
+#: common/views_manage.py:321
 msgid "URL path to the site icon/favicon."
 msgstr ""
 
-#: common/views_manage.py:246
+#: common/views_manage.py:324
 msgid "Default User Avatar URL"
 msgstr ""
 
-#: common/views_manage.py:247
+#: common/views_manage.py:325
 msgid "URL path to the default user avatar."
 msgstr ""
 
-#: common/views_manage.py:250
+#: common/views_manage.py:328
 msgid "Site Color Theme"
 msgstr ""
 
-#: common/views_manage.py:251
+#: common/views_manage.py:329
 msgid "PicoCSS color theme."
 msgstr ""
 
-#: common/views_manage.py:276
+#: common/views_manage.py:354
 #, fuzzy
 #| msgid "Production"
 msgid "Site Introduction"
 msgstr "Producción"
 
-#: common/views_manage.py:277
+#: common/views_manage.py:355
 msgid "URL path for the intro/welcome sidebar page."
 msgstr ""
 
-#: common/views_manage.py:280
+#: common/views_manage.py:358
 msgid "Custom HTML Head"
 msgstr ""
 
-#: common/views_manage.py:281
+#: common/views_manage.py:359
 msgid "Extra HTML injected into the <head> of all pages."
 msgstr ""
 
-#: common/views_manage.py:285
+#: common/views_manage.py:363
 msgid "Footer Links"
 msgstr ""
 
-#: common/views_manage.py:286
+#: common/views_manage.py:364
 msgid "Link title mapped to URL."
 msgstr ""
 
-#: common/views_manage.py:315
+#: common/views_manage.py:393
 msgid "Minimum Marks for Discover"
 msgstr ""
 
-#: common/views_manage.py:317
+#: common/views_manage.py:395
 msgid "Number of marks required for an item to appear in discover."
 msgstr ""
 
-#: common/views_manage.py:322
+#: common/views_manage.py:400
 msgid "Update Interval (minutes)"
 msgstr ""
 
-#: common/views_manage.py:323
+#: common/views_manage.py:401
 msgid "How often to refresh the popular items list."
 msgstr ""
 
-#: common/views_manage.py:327
+#: common/views_manage.py:405
 msgid "Filter by Preferred Languages"
 msgstr ""
 
-#: common/views_manage.py:328
+#: common/views_manage.py:406
 msgid "Only show items with titles in the preferred languages."
 msgstr ""
 
-#: common/views_manage.py:331
+#: common/views_manage.py:409
 #, fuzzy
 #| msgid "show all"
 msgid "Show Local Only"
 msgstr "ver todo"
 
-#: common/views_manage.py:333
+#: common/views_manage.py:411
 msgid "Only show items marked by local users, not the entire network."
 msgstr ""
 
-#: common/views_manage.py:337
+#: common/views_manage.py:415
 #, fuzzy
 #| msgid "Popular Tags"
 msgid "Show Popular Posts"
 msgstr "Etiquetas destacadas"
 
-#: common/views_manage.py:338
+#: common/views_manage.py:416
 msgid "Show popular public posts instead of recent ones."
 msgstr ""
 
-#: common/views_manage.py:341
+#: common/views_manage.py:419
 #, fuzzy
 #| msgid "Popular Tags"
 msgid "Show Popular Tags"
 msgstr "Etiquetas destacadas"
 
-#: common/views_manage.py:342
+#: common/views_manage.py:420
 msgid "Show popular public tags on the discover page."
 msgstr ""
 
-#: common/views_manage.py:345
+#: common/views_manage.py:423
 #, fuzzy
 #| msgid "Spotify Podcast"
 msgid "Show Verified Podcasts"
 msgstr "Podcast de Spotify"
 
-#: common/views_manage.py:347
-msgid ""
-"Show a shelf of recent episodes from podcasts with a verified creator on the "
-"discover page."
+#: common/views_manage.py:425
+msgid "Show a shelf of recent episodes from podcasts with a verified creator on the discover page."
 msgstr ""
 
-#: common/views_manage.py:386
+#: common/views_manage.py:447
+#, fuzzy
+#| msgid "your timeline"
+msgid "Show World Timeline"
+msgstr "tu línea temporal"
+
+#: common/views_manage.py:449
+msgid "Offer a tab with public posts from this site and every server it federates with."
+msgstr ""
+
+#: common/views_manage.py:454
+#, fuzzy
+#| msgid "show all"
+msgid "Show Local Timeline"
+msgstr "ver todo"
+
+#: common/views_manage.py:455
+msgid "Offer a tab with public posts from this site only."
+msgstr ""
+
+#: common/views_manage.py:459
+#, fuzzy
+#| msgid "your timeline"
+msgid "Timelines"
+msgstr "tu línea temporal"
+
+#: common/views_manage.py:487
 msgid "Enable Recommendations"
 msgstr ""
 
-#: common/views_manage.py:388
-msgid ""
-"Master switch. When off, all recommendation surfaces are hidden and the cron "
-"jobs are not scheduled."
+#: common/views_manage.py:489
+msgid "Master switch. When off, all recommendation surfaces are hidden and the cron jobs are not scheduled."
 msgstr ""
 
-#: common/views_manage.py:393
+#: common/views_manage.py:494
 msgid "Source Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:395
-msgid ""
-"Minimum public marks an item needs before similarity rows are built for it."
+#: common/views_manage.py:496
+msgid "Minimum public marks an item needs before similarity rows are built for it."
 msgstr ""
 
-#: common/views_manage.py:401
+#: common/views_manage.py:502
 msgid "Target Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:403
-msgid ""
-"Minimum public marks an item needs to be eligible as a recommendation target."
+#: common/views_manage.py:504
+msgid "Minimum public marks an item needs to be eligible as a recommendation target."
 msgstr ""
 
-#: common/views_manage.py:409
+#: common/views_manage.py:510
 msgid "Top-K Similar Items per Source"
 msgstr ""
 
-#: common/views_manage.py:410
+#: common/views_manage.py:511
 msgid "Number of similar items stored per source item."
 msgstr ""
 
-#: common/views_manage.py:414
+#: common/views_manage.py:515
 msgid "Top-N Recommendations per User"
 msgstr ""
 
-#: common/views_manage.py:415
+#: common/views_manage.py:516
 msgid "Number of personalised rows stored per user."
 msgstr ""
 
-#: common/views_manage.py:419
+#: common/views_manage.py:520
 msgid "Dampen Heavy Shelvers"
 msgstr ""
 
-#: common/views_manage.py:421
-msgid ""
-"Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-"
-"shelvers in similarity scoring."
+#: common/views_manage.py:522
+msgid "Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-shelvers in similarity scoring."
 msgstr ""
 
-#: common/views_manage.py:426
+#: common/views_manage.py:527
 msgid "Per-User Mark Cap (training)"
 msgstr ""
 
-#: common/views_manage.py:428
-msgid ""
-"Truncate each user's contribution to their N most recent marks when building "
-"the similarity matrix."
+#: common/views_manage.py:529
+msgid "Truncate each user's contribution to their N most recent marks when building the similarity matrix."
 msgstr ""
 
-#: common/views_manage.py:434
+#: common/views_manage.py:535
 msgid "Active-User Window (days)"
 msgstr ""
 
-#: common/views_manage.py:436
-msgid ""
-"Refresh personalised recommendations for users with at least one public mark "
-"in the last N days."
+#: common/views_manage.py:537
+msgid "Refresh personalised recommendations for users with at least one public mark in the last N days."
 msgstr ""
 
-#: common/views_manage.py:442
+#: common/views_manage.py:543
 msgid "Per-User Seed Cap (serving)"
 msgstr ""
 
-#: common/views_manage.py:444
-msgid ""
-"Number of recent marks used as seeds when scoring personalised "
-"recommendations for one user."
+#: common/views_manage.py:545
+msgid "Number of recent marks used as seeds when scoring personalised recommendations for one user."
 msgstr ""
 
-#: common/views_manage.py:450
+#: common/views_manage.py:551
 msgid "Lazy Refresh TTL (days)"
 msgstr ""
 
-#: common/views_manage.py:452
-msgid ""
-"How long cached on-demand recommendations are valid before the next request "
-"triggers a refresh."
+#: common/views_manage.py:553
+msgid "How long cached on-demand recommendations are valid before the next request triggers a refresh."
 msgstr ""
 
-#: common/views_manage.py:458
+#: common/views_manage.py:559
 msgid "Circles Window (days)"
 msgstr ""
 
-#: common/views_manage.py:460
-msgid ""
-"Look back N days when finding items recently marked by people the viewer "
-"follows."
+#: common/views_manage.py:561
+msgid "Look back N days when finding items recently marked by people the viewer follows."
 msgstr ""
 
-#: common/views_manage.py:467
+#: common/views_manage.py:568
 msgid "Master Switch"
 msgstr ""
 
-#: common/views_manage.py:470
+#: common/views_manage.py:571
 msgid "Similarity Builder"
 msgstr ""
 
-#: common/views_manage.py:477
+#: common/views_manage.py:578
 #, fuzzy
 #| msgid "Persian"
 msgid "Personalisation"
 msgstr "Persa"
 
-#: common/views_manage.py:495
-msgid ""
-"Require an invite token to register. Invite tokens can be generated with "
-"neodb-manage invite --create."
+#: common/views_manage.py:596
+msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
 msgstr ""
 
-#: common/views_manage.py:500
+#: common/views_manage.py:601
 msgid "Enable Local-Only Posting"
 msgstr ""
 
-#: common/views_manage.py:501
+#: common/views_manage.py:602
 msgid "Allow users to create posts visible only to local users."
 msgstr ""
 
-#: common/views_manage.py:504
+#: common/views_manage.py:605
 msgid "Mastodon Login Whitelist"
 msgstr ""
 
-#: common/views_manage.py:505
+#: common/views_manage.py:606
 msgid "One domain per line. Leave empty to allow any instance."
 msgstr ""
 
-#: common/views_manage.py:508
+#: common/views_manage.py:609
 #, fuzzy
 #| msgid "description"
 msgid "Registration Captcha Items"
 msgstr "descripción"
 
-#: common/views_manage.py:512
-msgid ""
-"Number of item covers a new user must sort into two category rows before "
-"choosing a username. 0 disables the captcha; 5-6 is recommended. The covers "
-"carry no title text, so this cannot be solved with a screen reader: if you "
-"enable it, keep another way in, such as an invite link."
+#: common/views_manage.py:613
+msgid "Number of item covers a new user must sort into two category rows before choosing a username. 0 disables the captcha; 5-6 is recommended. The covers carry no title text, so this cannot be solved with a screen reader: if you enable it, keep another way in, such as an invite link."
 msgstr ""
 
-#: common/views_manage.py:520
+#: common/views_manage.py:621
 msgid "Registration Captcha Minimum Marks"
 msgstr ""
 
-#: common/views_manage.py:523
-msgid ""
-"Marks an item needs before the captcha treats it as well known enough to be "
-"recognizable. Categories with too few such items fall back to any item."
+#: common/views_manage.py:624
+msgid "Marks an item needs before the captcha treats it as well known enough to be recognizable. Categories with too few such items fall back to any item."
 msgstr ""
 
-#: common/views_manage.py:529
+#: common/views_manage.py:630
 msgid "Enable Mastodon Login"
 msgstr ""
 
-#: common/views_manage.py:532
+#: common/views_manage.py:633
 msgid "Enable Bluesky Login"
 msgstr ""
 
-#: common/views_manage.py:535
+#: common/views_manage.py:636
 msgid "Enable Threads Login"
 msgstr ""
 
-#: common/views_manage.py:538
+#: common/views_manage.py:639
 #, fuzzy
 #| msgid "Invalid URL"
 msgid "Email URL"
 msgstr "URL inválida"
 
-#: common/views_manage.py:540
+#: common/views_manage.py:641
 msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
 msgstr ""
 
-#: common/views_manage.py:544
+#: common/views_manage.py:645
 msgid "Email From"
 msgstr ""
 
-#: common/views_manage.py:545
+#: common/views_manage.py:646
 msgid "Sender name and address for outgoing email."
 msgstr ""
 
-#: common/views_manage.py:548
+#: common/views_manage.py:649
 #, fuzzy
 #| msgid "language"
 msgid "Default Language"
 msgstr "idioma"
 
-#: common/views_manage.py:551
-msgid ""
-"Interface language for visitors and for users who have not chosen one "
-"themselves."
+#: common/views_manage.py:652
+msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:558
-msgid ""
-"Language codes, one per line (e.g. en, zh, ja). First language is the "
-"default."
+#: common/views_manage.py:659
+msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:564
+#: common/views_manage.py:665
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:571
+#: common/views_manage.py:672
 msgid "Login Methods"
 msgstr ""
 
-#: common/views_manage.py:576 mastodon/models/common.py:28
+#: common/views_manage.py:677 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr ""
 
-#: common/views_manage.py:580
+#: common/views_manage.py:681
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:591
+#: common/views_manage.py:692
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:593
-msgid ""
-"Disable relay.neodb.net federation for sharing public ratings across "
-"instances."
+#: common/views_manage.py:694
+msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:598
+#: common/views_manage.py:699
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:599
+#: common/views_manage.py:700
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:603
+#: common/views_manage.py:704
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:605
+#: common/views_manage.py:706
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:610
+#: common/views_manage.py:711
 #, fuzzy
 #| msgid "Search results"
 msgid "Search Sites"
 msgstr "Resultados de la búsqueda"
 
-#: common/views_manage.py:611
+#: common/views_manage.py:712
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:614
+#: common/views_manage.py:715
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:615
+#: common/views_manage.py:716
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:618
+#: common/views_manage.py:719
 #, fuzzy
 #| msgid "Add tv series"
 msgid "Hidden Categories"
 msgstr "Añadir series de tv"
 
-#: common/views_manage.py:619
+#: common/views_manage.py:720
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:640
+#: common/views_manage.py:723
+msgid "Guest Search Page Limit"
+msgstr ""
+
+#: common/views_manage.py:725
+msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
+msgstr ""
+
+#: common/views_manage.py:751
 #, fuzzy
 #| msgid "Spotify Album"
 msgid "Spotify API Key"
 msgstr "Álbum de Spotify"
 
-#: common/views_manage.py:641
+#: common/views_manage.py:752
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:644
+#: common/views_manage.py:755
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:645
+#: common/views_manage.py:756
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:648
+#: common/views_manage.py:759
 #, fuzzy
 #| msgid "Google Books"
 msgid "Google Books API Key"
 msgstr "Google Books"
 
-#: common/views_manage.py:649
+#: common/views_manage.py:760
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:652
+#: common/views_manage.py:763
 #, fuzzy
 #| msgid "Discogs"
 msgid "Discogs API Key"
 msgstr "Discogs"
 
-#: common/views_manage.py:654
+#: common/views_manage.py:765
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:658
+#: common/views_manage.py:769
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:770
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:662
+#: common/views_manage.py:773
 msgid "IGDB Client Secret"
 msgstr ""
 
-#: common/views_manage.py:665
+#: common/views_manage.py:776
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:667
-msgid ""
-"Bearer token from https://boardgamegeek.com/applications (see https://"
-"boardgamegeek.com/using_the_xml_api#toc9)."
+#: common/views_manage.py:778
+msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:672 users/templates/users/steam_import.html:26
+#: common/views_manage.py:783
+msgid "MyAnimeList Client ID"
+msgstr ""
+
+#: common/views_manage.py:785
+msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
+msgstr ""
+
+#: common/views_manage.py:790 users/templates/users/steam_import.html:26
 #, fuzzy
 #| msgid "Steam Game"
 msgid "Steam API Key"
 msgstr "Juego de Steam"
 
-#: common/views_manage.py:674
-msgid ""
-"https://steamcommunity.com/dev - fallback key for Steam importer. Users can "
-"provide their own key when importing."
+#: common/views_manage.py:792
+msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:679
+#: common/views_manage.py:797
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:680
+#: common/views_manage.py:798
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:683
+#: common/views_manage.py:801
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:686
+#: common/views_manage.py:804
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:689
+#: common/views_manage.py:807
 msgid "Threads App ID"
 msgstr ""
 
-#: common/views_manage.py:690
+#: common/views_manage.py:808
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:693
+#: common/views_manage.py:811
 msgid "Threads App Secret"
 msgstr ""
 
-#: common/views_manage.py:696
+#: common/views_manage.py:814
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:698
-msgid ""
-"Webhook URLs keyed by channel (default, report, audit, suggest, system). All "
-"channels must be Discord forum or media channels (thread mode) because "
-"notifications are posted as threads."
+#: common/views_manage.py:816
+msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:715
+#: common/views_manage.py:833
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:844
 #, fuzzy
 #| msgid "translator"
 msgid "Translation"
 msgstr "traductor"
 
-#: common/views_manage.py:730
+#: common/views_manage.py:849
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:734 social/templates/feed.html:27
+#: common/views_manage.py:853 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr ""
 
-#: common/views_manage.py:744
+#: common/views_manage.py:863
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:745
+#: common/views_manage.py:864
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:748
+#: common/views_manage.py:867
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:749
+#: common/views_manage.py:868
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:752
+#: common/views_manage.py:871
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:874
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:758
+#: common/views_manage.py:877
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:761
+#: common/views_manage.py:880
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:764
+#: common/views_manage.py:883
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:767
+#: common/views_manage.py:886
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:768
+#: common/views_manage.py:887
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:771
+#: common/views_manage.py:890
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:775
+#: common/views_manage.py:894
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:779
+#: common/views_manage.py:898
 #, fuzzy
 #| msgid "series"
 msgid "Retries"
 msgstr "serie"
 
-#: common/views_manage.py:784
+#: common/views_manage.py:903
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:789
+#: common/views_manage.py:908
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:796
+#: common/views_manage.py:915
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:808
+#: common/views_manage.py:927
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:809
+#: common/views_manage.py:928
 msgid "One domain per line."
 msgstr ""
 
-#: common/views_manage.py:812
+#: common/views_manage.py:931
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:813
+#: common/views_manage.py:932
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:935
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:818
-msgid ""
-"Timeout for requests to Mastodon instances and remote fediverse servers."
+#: common/views_manage.py:937
+msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:824
+#: common/views_manage.py:943
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:825
+#: common/views_manage.py:944
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:828
+#: common/views_manage.py:947
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:829
+#: common/views_manage.py:948
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:839
+#: common/views_manage.py:958
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:841
-msgid ""
-"Delete import/export tasks and their files after this many days. Set to 0 to "
-"disable cleanup."
+#: common/views_manage.py:960
+msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:847
+#: common/views_manage.py:966
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:849
-msgid ""
-"Post-migration job keys to skip, one per line (e.g. normalize_genre). "
-"Checked by the worker at dequeue time; skipped jobs log a warning and notify "
-"the Discord system channel."
+#: common/views_manage.py:968
+msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:855
+#: common/views_manage.py:974
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:857
-msgid ""
-"Private key (JWK) identifying this site to ATProto authorization servers. "
-"Auto-generated on first Bluesky login; clear to regenerate."
+#: common/views_manage.py:976
+msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:983
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:986
 #, fuzzy
 #| msgid "optional"
 msgid "Operational"
 msgstr "opcional"
 
-#: common/views_manage.py:883
+#: common/views_manage.py:1002
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:885
-msgid ""
-"Genre codes offered in the Movie edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1004
+msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:1009
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:892
-msgid ""
-"Genre codes offered in the TV edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1011
+msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:897
+#: common/views_manage.py:1016
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:899
-msgid ""
-"Genre codes offered in the Music edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1018
+msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:904
+#: common/views_manage.py:1023
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:906
-msgid ""
-"Genre codes offered in the Game edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1025
+msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:911
+#: common/views_manage.py:1030
 #, fuzzy
 #| msgid "Podcast"
 msgid "Podcast Genres"
 msgstr "Podcast"
 
-#: common/views_manage.py:913
-msgid ""
-"Genre codes offered in the Podcast edit dropdown, one per line. Leave empty "
-"to use the built-in default."
+#: common/views_manage.py:1032
+msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:918
+#: common/views_manage.py:1037
 #, fuzzy
 #| msgid "Performance"
 msgid "Performance Genres"
 msgstr "Espectáculo"
 
-#: common/views_manage.py:920
-msgid ""
-"Genre codes offered in the Performance edit dropdown, one per line. Leave "
-"empty to use the built-in default."
+#: common/views_manage.py:1039
+msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:926
+#: common/views_manage.py:1045
 msgid "Genres by Category"
 msgstr ""
 
+#: common/views_manage.py:1069
+msgid "Site"
+msgstr ""
+
+#: common/views_manage.py:1079
+#, fuzzy
+#| msgid "Database"
+msgid "Database and Services"
+msgstr "Base de datos"
+
+#: common/views_manage.py:1089
+msgid "Media and Files"
+msgstr ""
+
+#: common/views_manage.py:1098
+msgid "Monitoring"
+msgstr ""
+
+#: common/views_manage.py:1102
+msgid "Security"
+msgstr ""
+
+#: common/views_manage.py:1111
+msgid "Other Environment Variables"
+msgstr ""
+
+#: common/views_manage.py:1113
+msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
+msgstr ""
+
 #: journal/forms.py:12
-msgid ""
-"Tips: use >!text!< for spoilers; some instances may not be able to show "
-"posts longer than 360 charactors."
+msgid "Tips: use >!text!< for spoilers; some instances may not be able to show posts longer than 360 charactors."
 msgstr ""
 
 #: journal/forms.py:29 journal/forms.py:31 journal/forms.py:80
@@ -5260,14 +5263,14 @@ msgid "Content (Markdown)"
 msgstr "Contenido (Markdown)"
 
 #: journal/forms.py:46 journal/forms.py:124 journal/forms.py:226
-#: journal/forms.py:288 journal/views/note.py:38
+#: journal/forms.py:288 journal/views/note.py:37
 #, fuzzy
 #| msgid "Crosspost to timeline"
 msgid "Crosspost"
 msgstr "Compartir en mi cuenta asociada"
 
 #: journal/forms.py:47 journal/forms.py:125 journal/forms.py:227
-#: journal/forms.py:289 journal/views/note.py:39
+#: journal/forms.py:289 journal/views/note.py:38
 msgid "Crosspost to your connected social networks"
 msgstr ""
 
@@ -5282,10 +5285,10 @@ msgstr ""
 #: journal/forms.py:59 journal/forms.py:137 journal/forms.py:162
 #: journal/forms.py:219 journal/forms.py:281
 #: journal/templates/collection_share.html:24
-#: journal/templates/wrapped_share.html:36 journal/views/note.py:31
-#: users/templates/users/data.html:45 users/templates/users/data.html:98
-#: users/templates/users/data.html:155 users/templates/users/data.html:206
-#: users/templates/users/data.html:269 users/templates/users/data.html:328
+#: journal/templates/wrapped_share.html:36 journal/views/note.py:30
+#: users/templates/users/data.html:60 users/templates/users/data.html:113
+#: users/templates/users/data.html:170 users/templates/users/data.html:221
+#: users/templates/users/data.html:284 users/templates/users/data.html:346
 #: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
@@ -5324,7 +5327,6 @@ msgid "Collaborative editing"
 msgstr "Edición colaborativa"
 
 #: journal/forms.py:204 users/templates/users/crossposts.html:51
-#: users/templates/users/data.html:483
 msgid "Status"
 msgstr ""
 
@@ -5338,48 +5340,46 @@ msgstr ""
 msgid "Rating"
 msgstr "puntuación"
 
-#: journal/importers/goodreads.py:196 journal/importers/letterboxd.py:144
-#: journal/importers/rym.py:442 journal/importers/storygraph.py:500
+#: journal/importers/goodreads.py:198 journal/importers/letterboxd.py:147
+#: journal/importers/rym.py:444 journal/importers/storygraph.py:504
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr "reseña de {item_title}"
 
-#: journal/importers/opml.py:45
+#: journal/importers/opml.py:49
 #, python-brace-format
 msgid "{username}'s podcast subscriptions"
 msgstr "podcasts a los que {username} se ha suscrito"
 
-#: journal/importers/rym.py:168 journal/importers/storygraph.py:128
+#: journal/importers/rym.py:170 journal/importers/storygraph.py:132
 #, python-brace-format
-msgid ""
-"Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
+msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:178 journal/importers/storygraph.py:138
+#: journal/importers/rym.py:180 journal/importers/storygraph.py:142
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/importers/rym.py:233 journal/importers/storygraph.py:184
+#: journal/importers/rym.py:235 journal/importers/storygraph.py:188
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:348 journal/importers/storygraph.py:389
+#: journal/importers/rym.py:350 journal/importers/storygraph.py:393
 msgid "Matched file missing; cannot import."
 msgstr ""
 
-#: journal/importers/rym.py:376 journal/importers/storygraph.py:412
+#: journal/importers/rym.py:378 journal/importers/storygraph.py:416
 #, python-brace-format
-msgid ""
-"Import complete: {imported} imported, {skipped} skipped, {failed} failed"
+msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:212 journal/views/article.py:218
+#: journal/models/article.py:215 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
-#: journal/models/collection.py:44 journal/templates/add_to_collection.html:39
+#: journal/models/collection.py:48 journal/templates/add_to_collection.html:39
 #: journal/templates/collection_edit.html:64
 #: journal/templates/collection_share.html:63
 #: journal/templates/collection_update_item_note.html:3
@@ -5387,73 +5387,73 @@ msgstr ""
 msgid "note"
 msgstr "nota"
 
-#: journal/models/collection.py:111
+#: journal/models/collection.py:115
 msgid "search query for dynamic collection"
 msgstr ""
 
-#: journal/models/collection.py:524 journal/templatetags/collection.py:35
+#: journal/models/collection.py:566 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:529 journal/templatetags/collection.py:43
+#: journal/models/collection.py:571 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:534 journal/templatetags/collection.py:51
+#: journal/models/collection.py:576 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:539 journal/templatetags/collection.py:59
+#: journal/models/collection.py:581 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:544 journal/templatetags/collection.py:67
+#: journal/models/collection.py:586 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:549 journal/templatetags/collection.py:75
+#: journal/models/collection.py:591 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:555 journal/templatetags/collection.py:83
+#: journal/models/collection.py:597 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:563 journal/templatetags/collection.py:91
+#: journal/models/collection.py:605 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/common.py:50 journal/templates/action_open_post.html:15
-#: journal/templates/collection_share.html:35 journal/templates/mark.html:84
+#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
-#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:54
-#: users/templates/users/data.html:107 users/templates/users/data.html:164
-#: users/templates/users/data.html:215 users/templates/users/data.html:277
-#: users/templates/users/data.html:337 users/templates/users/data.html:534
+#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
+#: users/templates/users/data.html:122 users/templates/users/data.html:179
+#: users/templates/users/data.html:230 users/templates/users/data.html:292
+#: users/templates/users/data.html:355 users/templates/users/data.html:534
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5461,13 +5461,13 @@ msgstr[1] ""
 msgid "Public"
 msgstr "Público"
 
-#: journal/models/common.py:51 journal/templates/action_open_post.html:9
-#: journal/templates/collection_share.html:46 journal/templates/mark.html:91
+#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
-#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
-#: users/templates/users/data.html:115 users/templates/users/data.html:172
-#: users/templates/users/data.html:223 users/templates/users/data.html:285
-#: users/templates/users/data.html:345 users/templates/users/data.html:542
+#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
+#: users/templates/users/data.html:130 users/templates/users/data.html:187
+#: users/templates/users/data.html:238 users/templates/users/data.html:300
+#: users/templates/users/data.html:363 users/templates/users/data.html:542
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5475,12 +5475,12 @@ msgstr "Público"
 msgid "Followers Only"
 msgstr "Solo seguidores"
 
-#: journal/models/common.py:52 journal/templates/collection_share.html:57
-#: journal/templates/mark.html:98 journal/templates/post_compose.html:72
-#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
-#: users/templates/users/data.html:123 users/templates/users/data.html:180
-#: users/templates/users/data.html:231 users/templates/users/data.html:293
-#: users/templates/users/data.html:353 users/templates/users/data.html:550
+#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/templates/mark.html:102 journal/templates/post_compose.html:72
+#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
+#: users/templates/users/data.html:138 users/templates/users/data.html:195
+#: users/templates/users/data.html:246 users/templates/users/data.html:308
+#: users/templates/users/data.html:371 users/templates/users/data.html:550
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5488,35 +5488,31 @@ msgstr "Solo seguidores"
 msgid "Mentioned Only"
 msgstr "Solo cuentas mencionadas"
 
-#: journal/models/common.py:790
-msgid ""
-"A recent post was not posted to Bluesky, please login NeoDB using ATProto "
-"again to re-authorize."
-msgstr ""
-"Una publicación reciente no se publicó en Bluesky. Por favor, vuelve a "
-"iniciar sesión en NeoDB con ATProto para renovar la autorización."
+#: journal/models/common.py:806
+msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
+msgstr "Una publicación reciente no se publicó en Bluesky. Por favor, vuelve a iniciar sesión en NeoDB con ATProto para renovar la autorización."
 
-#: journal/models/common.py:987
+#: journal/models/common.py:1003
 msgid "A recent post was not posted to Threads."
 msgstr "Falló la publicación en Threads."
 
-#: journal/models/common.py:1020
+#: journal/models/common.py:1036
 #, fuzzy
 #| msgid "A recent post was not posted to Mastodon."
 msgid "A recent post was not boosted on Mastodon."
 msgstr "Falló la publicación en Mastodon."
 
-#: journal/models/common.py:1030
+#: journal/models/common.py:1046
 #, fuzzy
 #| msgid "Item no longer exists"
 msgid "Original post no longer exists."
 msgstr "El elemento ya no existe."
 
-#: journal/models/common.py:1044
+#: journal/models/common.py:1060
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr "Falló la publicación en Mastodon. Por favor, renueva la autorización."
 
-#: journal/models/common.py:1053
+#: journal/models/common.py:1069
 msgid "A recent post was not posted to Mastodon."
 msgstr "Falló la publicación en Mastodon."
 
@@ -5524,7 +5520,7 @@ msgstr "Falló la publicación en Mastodon."
 msgid "Authorization expired"
 msgstr ""
 
-#: journal/models/crosspost.py:17 users/models/task.py:24
+#: journal/models/crosspost.py:17 users/models/task.py:26
 msgid "Failed"
 msgstr ""
 
@@ -5532,83 +5528,83 @@ msgstr ""
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:469
+#: journal/models/mark.py:475
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:473
+#: journal/models/mark.py:479
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:480
+#: journal/models/mark.py:486
 #, fuzzy
 #| msgid "Invalid parameter"
 msgid "Invalid progress type."
 msgstr "Parámetro no válido"
 
-#: journal/models/mark.py:482
+#: journal/models/mark.py:488
 msgid "Invalid progress type for this item."
 msgstr ""
 
-#: journal/models/note.py:34 users/templates/users/rym_import.html:73
+#: journal/models/note.py:47 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr "Página"
 
-#: journal/models/note.py:35
+#: journal/models/note.py:48
 msgid "Chapter"
 msgstr "Capítulo"
 
-#: journal/models/note.py:38
+#: journal/models/note.py:51
 msgid "Part"
 msgstr "Parte"
 
-#: journal/models/note.py:39
+#: journal/models/note.py:52
 msgid "Episode"
 msgstr "Episodio"
 
-#: journal/models/note.py:40
+#: journal/models/note.py:53
 msgid "Track"
 msgstr "Pista"
 
-#: journal/models/note.py:41
+#: journal/models/note.py:54
 msgid "Cycle"
 msgstr "Ciclo"
 
-#: journal/models/note.py:42
+#: journal/models/note.py:55
 msgid "Timestamp"
 msgstr "Marca de tiempo"
 
-#: journal/models/note.py:43
+#: journal/models/note.py:56
 msgid "Percentage"
 msgstr "Porcentaje"
 
-#: journal/models/note.py:60
+#: journal/models/note.py:77
 #, python-brace-format
 msgid "Page {value}"
 msgstr "Página {value}"
 
-#: journal/models/note.py:61
+#: journal/models/note.py:78
 #, python-brace-format
 msgid "Chapter {value}"
 msgstr "Capítulo {value}"
 
-#: journal/models/note.py:64
+#: journal/models/note.py:81
 #, python-brace-format
 msgid "Part {value}"
 msgstr "Parte {value}"
 
-#: journal/models/note.py:65
+#: journal/models/note.py:82
 #, python-brace-format
 msgid "Episode {value}"
 msgstr "Episodio {value}"
 
-#: journal/models/note.py:66
+#: journal/models/note.py:83
 #, python-brace-format
 msgid "Track {value}"
 msgstr "Pista {value}"
 
-#: journal/models/note.py:67
+#: journal/models/note.py:84
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr "Ciclo {value}"
@@ -5618,445 +5614,445 @@ msgstr "Ciclo {value}"
 msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr "acerca de {item_title}, puede contener espoilers o contenido chocante"
 
-#: journal/models/review.py:78
+#: journal/models/review.py:79
 #, fuzzy, python-brace-format
 #| msgid "a review of {item_title}"
 msgid "a review of {title}"
 msgstr "reseña de {item_title}"
 
-#: journal/models/review.py:80
+#: journal/models/review.py:81
 #, fuzzy
 #| msgid "Item contains sub-items."
 msgid "(may contain spoilers)"
 msgstr "El elemento contiene sub-elementos."
 
-#: journal/models/shelf.py:37
+#: journal/models/shelf.py:39
 msgid "WISHLIST"
 msgstr "LISTA DE DESEOS"
 
-#: journal/models/shelf.py:38
+#: journal/models/shelf.py:40
 msgid "PROGRESS"
 msgstr "PROGRESO"
 
-#: journal/models/shelf.py:39
+#: journal/models/shelf.py:41
 msgid "COMPLETE"
 msgstr "COMPLETO"
 
-#: journal/models/shelf.py:40
+#: journal/models/shelf.py:42
 msgid "DROPPED"
 msgstr "ABANDONADO"
 
-#: journal/models/shelf.py:49
+#: journal/models/shelf.py:51
 msgid "books to read"
 msgstr "libros por leer"
 
-#: journal/models/shelf.py:50
+#: journal/models/shelf.py:52
 msgid "want to read"
 msgstr "quiero leer"
 
-#: journal/models/shelf.py:51
+#: journal/models/shelf.py:53
 #, python-brace-format
 msgid "wants to read {item}"
 msgstr "quiere leer {item}"
 
-#: journal/models/shelf.py:52
+#: journal/models/shelf.py:54
 msgid "to read"
 msgstr "por leer"
 
-#: journal/models/shelf.py:57
+#: journal/models/shelf.py:59
 msgid "books reading"
 msgstr "leyendo"
 
-#: journal/models/shelf.py:58
+#: journal/models/shelf.py:60
 msgid "start reading"
 msgstr "comenzar a leer"
 
-#: journal/models/shelf.py:59
+#: journal/models/shelf.py:61
 #, python-brace-format
 msgid "started reading {item}"
 msgstr "comenzó a leer {item}"
 
-#: journal/models/shelf.py:60
+#: journal/models/shelf.py:62
 msgid "reading"
 msgstr "leyendo"
 
-#: journal/models/shelf.py:65
+#: journal/models/shelf.py:67
 msgid "books completed"
 msgstr "libros terminados"
 
-#: journal/models/shelf.py:66
+#: journal/models/shelf.py:68
 msgid "finish reading"
 msgstr "terminar de leer"
 
-#: journal/models/shelf.py:67
+#: journal/models/shelf.py:69
 #, python-brace-format
 msgid "finished reading {item}"
 msgstr "terminó de leer {item}"
 
-#: journal/models/shelf.py:68
+#: journal/models/shelf.py:70
 msgid "read"
 msgstr "leído"
 
-#: journal/models/shelf.py:73
+#: journal/models/shelf.py:75
 msgid "books dropped"
 msgstr "libros abandonados"
 
-#: journal/models/shelf.py:74
+#: journal/models/shelf.py:76
 msgid "stop reading"
 msgstr "dejar de leer"
 
-#: journal/models/shelf.py:75
+#: journal/models/shelf.py:77
 #, python-brace-format
 msgid "stopped reading {item}"
 msgstr "dejó de leer {item}"
 
-#: journal/models/shelf.py:76
+#: journal/models/shelf.py:78
 msgid "stopped reading"
 msgstr "abandonado"
 
-#: journal/models/shelf.py:81
+#: journal/models/shelf.py:83
 msgid "books reviewed"
 msgstr "reseñas de libros"
 
-#: journal/models/shelf.py:82 journal/models/shelf.py:122
-#: journal/models/shelf.py:162 journal/models/shelf.py:202
-#: journal/models/shelf.py:242 journal/models/shelf.py:282
-#: journal/models/shelf.py:316
+#: journal/models/shelf.py:84 journal/models/shelf.py:124
+#: journal/models/shelf.py:164 journal/models/shelf.py:204
+#: journal/models/shelf.py:244 journal/models/shelf.py:284
+#: journal/models/shelf.py:318
 msgid "review"
 msgstr "crítica"
 
-#: journal/models/shelf.py:83 journal/models/shelf.py:123
-#: journal/models/shelf.py:163 journal/models/shelf.py:203
-#: journal/models/shelf.py:243 journal/models/shelf.py:283
-#: journal/models/shelf.py:317
+#: journal/models/shelf.py:85 journal/models/shelf.py:125
+#: journal/models/shelf.py:165 journal/models/shelf.py:205
+#: journal/models/shelf.py:245 journal/models/shelf.py:285
+#: journal/models/shelf.py:319
 #, python-brace-format
 msgid "wrote a review of {item}"
 msgstr "escribió una reseña de {item}"
 
-#: journal/models/shelf.py:89
+#: journal/models/shelf.py:91
 msgid "movies to watch"
 msgstr "filmes por ver"
 
-#: journal/models/shelf.py:90 journal/models/shelf.py:130
+#: journal/models/shelf.py:92 journal/models/shelf.py:132
 msgid "want to watch"
 msgstr "quiero ver"
 
-#: journal/models/shelf.py:91 journal/models/shelf.py:131
+#: journal/models/shelf.py:93 journal/models/shelf.py:133
 #, python-brace-format
 msgid "wants to watch {item}"
 msgstr "quiere ver {item}"
 
-#: journal/models/shelf.py:92 journal/models/shelf.py:132
+#: journal/models/shelf.py:94 journal/models/shelf.py:134
 msgid "to watch"
 msgstr "por ver"
 
-#: journal/models/shelf.py:97
+#: journal/models/shelf.py:99
 msgid "movies watching"
 msgstr "viendo"
 
-#: journal/models/shelf.py:98 journal/models/shelf.py:138
+#: journal/models/shelf.py:100 journal/models/shelf.py:140
 msgid "start watching"
 msgstr "comenzar a ver"
 
-#: journal/models/shelf.py:99 journal/models/shelf.py:139
+#: journal/models/shelf.py:101 journal/models/shelf.py:141
 #, python-brace-format
 msgid "started watching {item}"
 msgstr "comenzó a ver {item}"
 
-#: journal/models/shelf.py:100 journal/models/shelf.py:140
+#: journal/models/shelf.py:102 journal/models/shelf.py:142
 msgid "watching"
 msgstr "viendo"
 
-#: journal/models/shelf.py:105
+#: journal/models/shelf.py:107
 msgid "movies watched"
 msgstr "películas vistas"
 
-#: journal/models/shelf.py:106 journal/models/shelf.py:146
+#: journal/models/shelf.py:108 journal/models/shelf.py:148
 msgid "finish watching"
 msgstr "terminar de ver"
 
-#: journal/models/shelf.py:107 journal/models/shelf.py:147
+#: journal/models/shelf.py:109 journal/models/shelf.py:149
 #, python-brace-format
 msgid "finished watching {item}"
 msgstr "terminó de ver {item}"
 
-#: journal/models/shelf.py:108 journal/models/shelf.py:148
+#: journal/models/shelf.py:110 journal/models/shelf.py:150
 msgid "watched"
 msgstr "visto"
 
-#: journal/models/shelf.py:113
+#: journal/models/shelf.py:115
 msgid "movies dropped"
 msgstr "películas abandonadas"
 
-#: journal/models/shelf.py:114 journal/models/shelf.py:154
+#: journal/models/shelf.py:116 journal/models/shelf.py:156
 msgid "stop watching"
 msgstr "dejar de ver"
 
-#: journal/models/shelf.py:115 journal/models/shelf.py:155
+#: journal/models/shelf.py:117 journal/models/shelf.py:157
 #, python-brace-format
 msgid "stopped watching {item}"
 msgstr "dejó de ver {item}"
 
-#: journal/models/shelf.py:116 journal/models/shelf.py:156
+#: journal/models/shelf.py:118 journal/models/shelf.py:158
 msgid "stopped watching"
 msgstr "dejó de ver"
 
-#: journal/models/shelf.py:121
+#: journal/models/shelf.py:123
 msgid "movies reviewed"
 msgstr "reseñas de películas"
 
-#: journal/models/shelf.py:129
+#: journal/models/shelf.py:131
 msgid "TV shows to watch"
 msgstr "series de TV por ver"
 
-#: journal/models/shelf.py:137
+#: journal/models/shelf.py:139
 msgid "TV shows watching"
 msgstr "viendo"
 
-#: journal/models/shelf.py:145
+#: journal/models/shelf.py:147
 msgid "TV shows watched"
 msgstr "series de TV vistas"
 
-#: journal/models/shelf.py:153
+#: journal/models/shelf.py:155
 msgid "TV shows dropped"
 msgstr "series abandonadas"
 
-#: journal/models/shelf.py:161
+#: journal/models/shelf.py:163
 msgid "TV shows reviewed"
 msgstr "reseñas de series"
 
-#: journal/models/shelf.py:169
+#: journal/models/shelf.py:171
 msgid "albums to listen"
 msgstr "álbumes para escuchar"
 
-#: journal/models/shelf.py:170 journal/models/shelf.py:250
+#: journal/models/shelf.py:172 journal/models/shelf.py:252
 msgid "want to listen"
 msgstr "quiero escuchar"
 
-#: journal/models/shelf.py:171 journal/models/shelf.py:251
+#: journal/models/shelf.py:173 journal/models/shelf.py:253
 #, python-brace-format
 msgid "wants to listen {item}"
 msgstr "quiere escuchar {item}"
 
-#: journal/models/shelf.py:172 journal/models/shelf.py:252
+#: journal/models/shelf.py:174 journal/models/shelf.py:254
 msgid "to listen"
 msgstr "escuchar"
 
-#: journal/models/shelf.py:177
+#: journal/models/shelf.py:179
 msgid "albums listening"
 msgstr "escuchando álbumes"
 
-#: journal/models/shelf.py:178 journal/models/shelf.py:258
+#: journal/models/shelf.py:180 journal/models/shelf.py:260
 msgid "start listening"
 msgstr "empieza a escuchar"
 
-#: journal/models/shelf.py:179 journal/models/shelf.py:259
+#: journal/models/shelf.py:181 journal/models/shelf.py:261
 #, python-brace-format
 msgid "started listening {item}"
 msgstr "comenzó a escuchar {item}"
 
-#: journal/models/shelf.py:180 journal/models/shelf.py:260
+#: journal/models/shelf.py:182 journal/models/shelf.py:262
 msgid "listening"
 msgstr "escuchando"
 
-#: journal/models/shelf.py:185
+#: journal/models/shelf.py:187
 msgid "albums listened"
 msgstr "álbumes escuchados"
 
-#: journal/models/shelf.py:186 journal/models/shelf.py:266
+#: journal/models/shelf.py:188 journal/models/shelf.py:268
 msgid "finish listening"
 msgstr "terminar de escuchar"
 
-#: journal/models/shelf.py:187 journal/models/shelf.py:267
+#: journal/models/shelf.py:189 journal/models/shelf.py:269
 #, python-brace-format
 msgid "finished listening {item}"
 msgstr "terminó de escuchar {item}"
 
-#: journal/models/shelf.py:188 journal/models/shelf.py:268
+#: journal/models/shelf.py:190 journal/models/shelf.py:270
 msgid "listened"
 msgstr "escuchado"
 
-#: journal/models/shelf.py:193
+#: journal/models/shelf.py:195
 msgid "albums dropped"
 msgstr ""
 
-#: journal/models/shelf.py:194 journal/models/shelf.py:274
+#: journal/models/shelf.py:196 journal/models/shelf.py:276
 msgid "stop listening"
 msgstr "deja de escuchar"
 
-#: journal/models/shelf.py:195 journal/models/shelf.py:275
+#: journal/models/shelf.py:197 journal/models/shelf.py:277
 #, python-brace-format
 msgid "stopped listening {item}"
 msgstr "dejó de escuchar {item}"
 
-#: journal/models/shelf.py:196 journal/models/shelf.py:276
+#: journal/models/shelf.py:198 journal/models/shelf.py:278
 msgid "stopped listening"
 msgstr "dejó de escuchar"
 
-#: journal/models/shelf.py:201
+#: journal/models/shelf.py:203
 msgid "albums reviewed"
 msgstr "álbumes reseñados"
 
-#: journal/models/shelf.py:209
+#: journal/models/shelf.py:211
 msgid "games to play"
 msgstr "juegos para jugar"
 
-#: journal/models/shelf.py:210
+#: journal/models/shelf.py:212
 msgid "want to play"
 msgstr "quiero jugar"
 
-#: journal/models/shelf.py:211
+#: journal/models/shelf.py:213
 #, python-brace-format
 msgid "wants to play {item}"
 msgstr "quiere jugar {item}"
 
-#: journal/models/shelf.py:212
+#: journal/models/shelf.py:214
 msgid "to play"
 msgstr "jugar"
 
-#: journal/models/shelf.py:217
+#: journal/models/shelf.py:219
 msgid "games playing"
 msgstr "jugando juegos"
 
-#: journal/models/shelf.py:218
+#: journal/models/shelf.py:220
 msgid "start playing"
 msgstr "empezar a jugar"
 
-#: journal/models/shelf.py:219
+#: journal/models/shelf.py:221
 #, python-brace-format
 msgid "started playing {item}"
 msgstr "comenzó a jugar {item}"
 
-#: journal/models/shelf.py:220
+#: journal/models/shelf.py:222
 msgid "playing"
 msgstr "jugando"
 
-#: journal/models/shelf.py:225
+#: journal/models/shelf.py:227
 msgid "games played"
 msgstr "juegos jugados"
 
-#: journal/models/shelf.py:226
+#: journal/models/shelf.py:228
 msgid "finish playing"
 msgstr "terminar de jugar"
 
-#: journal/models/shelf.py:227
+#: journal/models/shelf.py:229
 #, python-brace-format
 msgid "finished playing {item}"
 msgstr "terminó de jugar {item}"
 
-#: journal/models/shelf.py:228
+#: journal/models/shelf.py:230
 msgid "played"
 msgstr "jugado"
 
-#: journal/models/shelf.py:233
+#: journal/models/shelf.py:235
 msgid "games dropped"
 msgstr "juegos abandonados"
 
-#: journal/models/shelf.py:234
+#: journal/models/shelf.py:236
 msgid "stop playing"
 msgstr "deja de jugar"
 
-#: journal/models/shelf.py:235
+#: journal/models/shelf.py:237
 #, python-brace-format
 msgid "stopped playing {item}"
 msgstr "dejó de jugar {item}"
 
-#: journal/models/shelf.py:236
+#: journal/models/shelf.py:238
 msgid "stopped playing"
 msgstr "dejó de jugar"
 
-#: journal/models/shelf.py:241
+#: journal/models/shelf.py:243
 msgid "games reviewed"
 msgstr "juegos reseñados"
 
-#: journal/models/shelf.py:249
+#: journal/models/shelf.py:251
 msgid "podcasts to listen"
 msgstr ""
 
-#: journal/models/shelf.py:257
+#: journal/models/shelf.py:259
 msgid "podcasts listening"
 msgstr ""
 
-#: journal/models/shelf.py:265
+#: journal/models/shelf.py:267
 msgid "podcasts listened"
 msgstr ""
 
-#: journal/models/shelf.py:273
+#: journal/models/shelf.py:275
 msgid "podcasts dropped"
 msgstr ""
 
-#: journal/models/shelf.py:281
+#: journal/models/shelf.py:283
 msgid "podcasts reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:289
+#: journal/models/shelf.py:291
 msgid "performances to see"
 msgstr ""
 
-#: journal/models/shelf.py:290
+#: journal/models/shelf.py:292
 msgid "want to see"
 msgstr ""
 
-#: journal/models/shelf.py:291
+#: journal/models/shelf.py:293
 #, python-brace-format
 msgid "wants to see {item}"
 msgstr ""
 
-#: journal/models/shelf.py:292
+#: journal/models/shelf.py:294
 msgid "to see"
 msgstr ""
 
-#: journal/models/shelf.py:299
+#: journal/models/shelf.py:301
 msgid "performances saw"
 msgstr ""
 
-#: journal/models/shelf.py:300
+#: journal/models/shelf.py:302
 msgid "finish seeing"
 msgstr ""
 
-#: journal/models/shelf.py:301
+#: journal/models/shelf.py:303
 #, python-brace-format
 msgid "finished seeing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:302
+#: journal/models/shelf.py:304
 msgid "seen"
 msgstr ""
 
-#: journal/models/shelf.py:307
+#: journal/models/shelf.py:309
 msgid "performances dropped"
 msgstr ""
 
-#: journal/models/shelf.py:308
+#: journal/models/shelf.py:310
 msgid "stop seeing"
 msgstr ""
 
-#: journal/models/shelf.py:309
+#: journal/models/shelf.py:311
 #, python-brace-format
 msgid "stopped seeing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:310
+#: journal/models/shelf.py:312
 msgid "stopped seeing"
 msgstr ""
 
-#: journal/models/shelf.py:315
+#: journal/models/shelf.py:317
 msgid "performances reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:323
+#: journal/models/shelf.py:325
 #, fuzzy
 #| msgid "following you"
 msgid "people following"
 msgstr "te sigue"
 
-#: journal/models/shelf.py:325
+#: journal/models/shelf.py:327
 #, fuzzy, python-brace-format
 #| msgid "started playing {item}"
 msgid "started following {item}"
 msgstr "comenzó a jugar {item}"
 
-#: journal/models/shelf.py:921
+#: journal/models/shelf.py:923
 msgid "removed mark"
 msgstr ""
 
@@ -6086,30 +6082,20 @@ msgstr ""
 msgid "Remove from collection"
 msgstr ""
 
-#: journal/templates/_list_item.html:34
-msgid "add mark"
-msgstr ""
-
-#: journal/templates/_list_item.html:42
-msgid "update mark"
-msgstr ""
-
-#: journal/templates/_list_item.html:60
+#: journal/templates/_list_item.html:43
 #: journal/templates/collection_update_item_note_ok.html:3
 msgid "Update note"
 msgstr ""
 
-#: journal/templates/_list_item.html:100 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:123
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
 msgstr ""
 
-#: journal/templates/_list_item.html:133
+#: journal/templates/_list_item.html:91
 #, python-format
-msgid ""
-"%(dups)s item(s) are from the same work or have the same identifier, click "
-"here to display:"
+msgid "%(dups)s item(s) are from the same work or have the same identifier, click here to display:"
 msgstr ""
 
 #: journal/templates/_sidebar_collection_filter.html:32
@@ -6221,6 +6207,14 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
+#: journal/templates/action_mark_item.html:10
+msgid "add mark"
+msgstr ""
+
+#: journal/templates/action_mark_item.html:18
+msgid "update mark"
+msgstr ""
+
 #: journal/templates/action_open_post.html:7
 #, fuzzy
 #| msgid "Public"
@@ -6281,13 +6275,13 @@ msgstr ""
 msgid "Create a new collection"
 msgstr ""
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:81
+#: journal/templates/article.html:104 social/templates/_event_post.html:76
 #, fuzzy
 #| msgid "wrote a review of {item}"
 msgid "wrote a review"
 msgstr "escribió una reseña de {item}"
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:83
+#: journal/templates/article.html:106 social/templates/_event_post.html:78
 msgid "wrote an article"
 msgstr ""
 
@@ -6405,19 +6399,19 @@ msgstr ""
 msgid "Mark"
 msgstr ""
 
-#: journal/templates/mark.html:50
+#: journal/templates/mark.html:54
 msgid "not rated"
 msgstr ""
 
-#: journal/templates/mark.html:70
+#: journal/templates/mark.html:74
 msgid "add a tag and press Enter"
 msgstr ""
 
-#: journal/templates/mark.html:122
+#: journal/templates/mark.html:126
 msgid "change mark date"
 msgstr ""
 
-#: journal/templates/mark.html:148
+#: journal/templates/mark.html:156
 msgid "Sure to delete mark, comment and tags for this item?"
 msgstr ""
 
@@ -6460,12 +6454,11 @@ msgid ""
 "Content Cell  | Content Cell\n"
 "Content Cell  | Content Cell\n"
 "\n"
-"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/"
-"Wikipedia-logo-v2.svg)\n"
+"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 "\n"
 msgstr ""
 
-#: journal/templates/note.html:19 journal/views/note.py:23
+#: journal/templates/note.html:19 journal/views/note.py:22
 msgid "Note"
 msgstr ""
 
@@ -6492,9 +6485,7 @@ msgid "Are you sure to delete this entire content?"
 msgstr ""
 
 #: journal/templates/piece_delete.html:24
-msgid ""
-"By deleting it, you will also lose track of others' comments and feedbacks "
-"to your content."
+msgid "By deleting it, you will also lose track of others' comments and feedbacks to your content."
 msgstr ""
 
 #: journal/templates/piece_delete.html:25
@@ -6584,7 +6575,7 @@ msgstr ""
 msgid "Articles"
 msgstr ""
 
-#: journal/templates/profile.html:166 journal/views/collection.py:427
+#: journal/templates/profile.html:166 journal/views/collection.py:409
 #: journal/views/profile.py:401
 msgid "collection"
 msgstr ""
@@ -6618,9 +6609,7 @@ msgid "Personal"
 msgstr ""
 
 #: journal/templates/tag_edit.html:52
-msgid ""
-"Personal tags are not included in public index. However, if you use this tag "
-"when marking an item publicly, it might still be visible to others."
+msgid "Personal tags are not included in public index. However, if you use this tag when marking an item publicly, it might still be visible to others."
 msgstr ""
 
 #: journal/templates/tag_edit.html:55
@@ -6695,123 +6684,124 @@ msgstr ""
 msgid "Link invalid"
 msgstr ""
 
-#: journal/views/collection.py:58 journal/views/collection.py:96
+#: journal/views/collection.py:62 journal/views/collection.py:94
 #, python-brace-format
 msgid "Collection by {0}"
 msgstr ""
 
-#: journal/views/collection.py:432
+#: journal/views/collection.py:414
 msgid "shared my collection"
 msgstr ""
 
-#: journal/views/collection.py:435
+#: journal/views/collection.py:417
 #, python-brace-format
 msgid "shared {username}'s collection"
 msgstr ""
 
-#: journal/views/collection.py:502 journal/views/collection.py:541
-#: journal/views/collection.py:553 journal/views/collection.py:579
+#: journal/views/collection.py:484 journal/views/collection.py:523
+#: journal/views/collection.py:535 journal/views/collection.py:561
 msgid "Dynamic collection is not editable"
 msgstr ""
 
-#: journal/views/collection.py:518
+#: journal/views/collection.py:500
 msgid "The item is already in the collection."
 msgstr ""
 
-#: journal/views/collection.py:520
+#: journal/views/collection.py:502
 msgid "Unable to find the item, please use item url from this site."
 msgstr ""
 
-#: journal/views/collection.py:566
+#: journal/views/collection.py:548
 msgid "Saved."
 msgstr ""
 
-#: journal/views/common.py:119 journal/views/mark.py:225
-#: journal/views/mark.py:279 journal/views/note.py:175
+#: journal/views/common.py:126 journal/views/mark.py:273
+#: journal/views/mark.py:315 journal/views/note.py:167
 #: journal/views/profile.py:42 journal/views/review.py:59
 #: journal/views/review.py:79
 msgid "Content not found"
 msgstr ""
 
-#: journal/views/common.py:174 journal/views/mark.py:159
+#: journal/views/common.py:184 journal/views/mark.py:210
 msgid "Data saved but unable to crosspost to Fediverse instance."
 msgstr ""
 
-#: journal/views/common.py:176
+#: journal/views/common.py:186
 msgid "Redirecting to your Fediverse instance now to re-authenticate."
 msgstr ""
 
-#: journal/views/common.py:183
+#: journal/views/common.py:193
 msgid "List not found."
 msgstr ""
 
-#: journal/views/mark.py:150
+#: journal/views/mark.py:206
 msgid "Content too long for your Fediverse instance."
 msgstr ""
 
-#: journal/views/mark.py:178 journal/views/mark.py:238
+#: journal/views/mark.py:224 journal/views/mark.py:226
+#: journal/views/mark.py:280
 #, fuzzy
 #| msgid "Invalid URL"
 msgid "Invalid input"
 msgstr "URL inválida"
 
-#: journal/views/note.py:23
+#: journal/views/note.py:22
 msgid "Progress"
 msgstr ""
 
-#: journal/views/note.py:28
+#: journal/views/note.py:27
 #, fuzzy
 #| msgid "Updating episodes"
 msgid "Update progress"
 msgstr "Actualizando episodios"
 
-#: journal/views/note.py:59
+#: journal/views/note.py:58
 msgid "Progress (optional)"
 msgstr ""
 
-#: journal/views/note.py:61
+#: journal/views/note.py:60
 msgid "Note Content"
 msgstr ""
 
-#: journal/views/note.py:63
+#: journal/views/note.py:62
 msgid "Content Warning (optional)"
 msgstr ""
 
-#: journal/views/note.py:85
+#: journal/views/note.py:84
 msgid "Progress Type (optional)"
 msgstr ""
 
-#: journal/views/note.py:123 journal/views/note.py:183
+#: journal/views/note.py:115 journal/views/note.py:175
 msgid "Only in-progress items can have progress."
 msgstr ""
 
-#: journal/views/post.py:98 journal/views/post.py:392
+#: journal/views/post.py:100 journal/views/post.py:388
 msgid "Post not found"
 msgstr ""
 
-#: journal/views/post.py:189
+#: journal/views/post.py:191
 msgid "Visibility too high for quoting this post"
 msgstr ""
 
-#: journal/views/post.py:337 journal/views/post.py:418
+#: journal/views/post.py:339 journal/views/post.py:414
 #, fuzzy
 #| msgid "Item cannot be deleted."
 msgid "Content cannot be empty."
 msgstr "El elemento no se puede eliminar."
 
-#: journal/views/post.py:396
+#: journal/views/post.py:392
 #, fuzzy
 #| msgid "This operation cannot be undone. Sure to merge?"
 msgid "This post cannot be edited here"
 msgstr "Esta operación no puede ser anulada. ¿Confirmar la fusión?"
 
-#: journal/views/post.py:541
+#: journal/views/post.py:531
 #, fuzzy
 #| msgid "Invalid URL"
 msgid "Invalid choices"
 msgstr "URL inválida"
 
-#: journal/views/post.py:544
+#: journal/views/post.py:534
 #, fuzzy
 #| msgid "Invalid URL"
 msgid "Invalid post"
@@ -6833,56 +6823,54 @@ msgstr ""
 msgid "may contain spoiler or triggering content"
 msgstr "acerca de {item_title}, puede contener espoilers o contenido chocante"
 
-#: journal/views/tag.py:47 journal/views/tag.py:61
+#: journal/views/tag.py:46 journal/views/tag.py:60
 msgid "Invalid tag"
 msgstr ""
 
-#: journal/views/tag.py:50
+#: journal/views/tag.py:49
 msgid "Tag not found"
 msgstr ""
 
-#: journal/views/tag.py:72
+#: journal/views/tag.py:65
 msgid "Tag deleted."
 msgstr ""
 
-#: journal/views/tag.py:82
+#: journal/views/tag.py:75
 msgid "Duplicated tag."
 msgstr ""
 
-#: journal/views/tag.py:96
+#: journal/views/tag.py:83
 msgid "Tag updated."
 msgstr ""
 
-#: journal/views/wrapped.py:160
+#: journal/views/wrapped.py:161
 msgid "Summary posted to timeline."
 msgstr ""
 
-#: mastodon/models/common.py:29
+#: mastodon/models/common.py:31
 msgid "Mastodon"
 msgstr ""
 
-#: mastodon/models/common.py:30 users/templates/users/login.html:120
+#: mastodon/models/common.py:32 users/templates/users/login.html:114
 msgid "Threads"
 msgstr ""
 
-#: mastodon/models/common.py:31
+#: mastodon/models/common.py:33
 msgid "Bluesky"
 msgstr ""
 
-#: mastodon/models/email.py:59
+#: mastodon/models/email.py:63
 msgid ""
 "\n"
 "\n"
-"If you did not mean to register or login, please ignore this email. If you "
-"are concerned with your account security, please change the email linked "
-"with your account, or contact us."
+"If you did not mean to register or login, please ignore this email. If you are concerned with your account security, please change the email linked with your account, or contact us."
 msgstr ""
 
-#: mastodon/models/email.py:64 mastodon/models/email.py:69
+#: mastodon/models/email.py:68 mastodon/models/email.py:73
 msgid "Verification Code"
 msgstr ""
 
-#: mastodon/models/email.py:66
+#: mastodon/models/email.py:70
 #, python-brace-format
 msgid ""
 "Use this code to verify your email address {email}\n"
@@ -6890,7 +6878,7 @@ msgid ""
 "{code}"
 msgstr ""
 
-#: mastodon/models/email.py:70
+#: mastodon/models/email.py:74
 #, python-brace-format
 msgid ""
 "Use this code to login as {email}\n"
@@ -6898,23 +6886,21 @@ msgid ""
 "{code}"
 msgstr ""
 
-#: mastodon/models/email.py:74 users/templates/users/captcha.html:13
+#: mastodon/models/email.py:78 users/templates/users/captcha.html:13
 #: users/templates/users/captcha_solved.html:9
 #: users/templates/users/login.html:20 users/templates/users/register.html:9
 #: users/templates/users/welcome.html:10
 msgid "Register"
 msgstr ""
 
-#: mastodon/models/email.py:76
+#: mastodon/models/email.py:80
 #, python-brace-format
 msgid ""
 "There is no account registered with this email address yet: {email}\n"
 "\n"
-"If you already have an account with us, just login and add this email to you "
-"account.\n"
+"If you already have an account with us, just login and add this email to you account.\n"
 "\n"
-"If you prefer to register a new account with this email, please use this "
-"verification code: {code}"
+"If you prefer to register a new account with this email, please use this verification code: {code}"
 msgstr ""
 
 #: mastodon/models/mastodon.py:570
@@ -6957,46 +6943,51 @@ msgstr ""
 msgid "New Post"
 msgstr ""
 
-#: mastodon/views/bluesky.py:26 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:32 mastodon/views/bluesky.py:93
 msgid "Bluesky login is disabled."
 msgstr ""
 
-#: mastodon/views/bluesky.py:28 mastodon/views/email.py:35
-#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:29
-#: users/templates/users/login.html:6 users/views/webauthn.py:133
-msgid "Security check failed. Please try again."
-msgstr ""
-
-#: mastodon/views/bluesky.py:34 mastodon/views/bluesky.py:40
-#: mastodon/views/bluesky.py:64 mastodon/views/bluesky.py:72
-#: mastodon/views/bluesky.py:78 mastodon/views/common.py:36
-#: mastodon/views/mastodon.py:62 mastodon/views/mastodon.py:70
-#: mastodon/views/mastodon.py:77 mastodon/views/mastodon.py:87
-#: mastodon/views/mastodon.py:94 mastodon/views/threads.py:55
-#: mastodon/views/threads.py:63 mastodon/views/threads.py:69
-#: users/views/account.py:254 users/views/account.py:373
+#: mastodon/views/bluesky.py:47 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:65 mastodon/views/bluesky.py:98
+#: mastodon/views/bluesky.py:106 mastodon/views/bluesky.py:112
+#: mastodon/views/common.py:36 mastodon/views/mastodon.py:62
+#: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
+#: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
+#: mastodon/views/threads.py:57 mastodon/views/threads.py:65
+#: mastodon/views/threads.py:71 users/views/account.py:256
+#: users/views/account.py:375
 msgid "Authentication failed"
 msgstr ""
 
-#: mastodon/views/bluesky.py:35 mastodon/views/email.py:66
+#: mastodon/views/bluesky.py:47 mastodon/views/common.py:103
+msgid "Identity not found."
+msgstr ""
+
+#: mastodon/views/bluesky.py:53 mastodon/views/email.py:35
+#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:31
+#: users/templates/users/login.html:6 users/views/webauthn.py:136
+msgid "Security check failed. Please try again."
+msgstr ""
+
+#: mastodon/views/bluesky.py:60 mastodon/views/email.py:66
 #, fuzzy
 #| msgid "System busy, please try again in a minute."
 msgid "Too many attempts, please try again later."
 msgstr "El sistema está ocupado, por favor inténtalo de nuevo en un minuto."
 
-#: mastodon/views/bluesky.py:40
+#: mastodon/views/bluesky.py:65
 msgid "ATProto handle is required."
 msgstr ""
 
-#: mastodon/views/bluesky.py:50
+#: mastodon/views/bluesky.py:84
 msgid "Error connecting to your ATProto server"
 msgstr ""
 
-#: mastodon/views/bluesky.py:73
+#: mastodon/views/bluesky.py:107
 msgid "Invalid response from ATProto authorization server."
 msgstr ""
 
-#: mastodon/views/bluesky.py:78
+#: mastodon/views/bluesky.py:112
 msgid "Invalid account data from Bluesky."
 msgstr ""
 
@@ -7004,7 +6995,7 @@ msgstr ""
 msgid "Invalid user."
 msgstr ""
 
-#: mastodon/views/common.py:52 users/views/account.py:414
+#: mastodon/views/common.py:52 users/views/account.py:416
 msgid "Registration failed"
 msgstr ""
 
@@ -7034,10 +7025,6 @@ msgstr ""
 #: mastodon/views/common.py:103 mastodon/views/common.py:107
 #: mastodon/views/common.py:116
 msgid "Disconnect identity failed"
-msgstr ""
-
-#: mastodon/views/common.py:103
-msgid "Identity not found."
 msgstr ""
 
 #: mastodon/views/common.py:117
@@ -7081,7 +7068,7 @@ msgstr ""
 msgid "Invalid response from Fediverse instance."
 msgstr ""
 
-#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:64
+#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:66
 msgid "Invalid OAuth state. Please try again."
 msgstr ""
 
@@ -7101,19 +7088,17 @@ msgstr ""
 msgid "Invalid account data from Fediverse instance."
 msgstr ""
 
-#: mastodon/views/threads.py:69
+#: mastodon/views/threads.py:71
 msgid "Invalid account data from Threads."
 msgstr ""
 
-#: mastodon/views/threads.py:147
+#: mastodon/views/threads.py:149
 msgid "Data deletion completed"
 msgstr ""
 
-#: mastodon/views/threads.py:149
+#: mastodon/views/threads.py:151
 #, python-brace-format
-msgid ""
-"Data linked to your Threads account has been deleted. Confirmation code: "
-"{code}"
+msgid "Data linked to your Threads account has been deleted. Confirmation code: {code}"
 msgstr ""
 
 #: social/templates/_article_teaser.html:10
@@ -7147,15 +7132,11 @@ msgstr ""
 msgid "play"
 msgstr ""
 
-#: social/templates/_event_post.html:50
-msgid "mark"
-msgstr ""
-
-#: social/templates/_event_post.html:79
+#: social/templates/_event_post.html:74
 msgid "wrote a note"
 msgstr ""
 
-#: social/templates/_event_post.html:88
+#: social/templates/_event_post.html:83
 #, fuzzy
 #| msgid "playing"
 msgid "replying to"
@@ -7170,7 +7151,7 @@ msgstr ""
 msgid "Untitled article"
 msgstr ""
 
-#: social/templates/event/boosted.html:3
+#: social/templates/event/boosted.html:2
 msgid "boosted your post"
 msgstr ""
 
@@ -7213,8 +7194,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
 #: social/templates/event/boosted_shelfmember.html:3
@@ -7232,7 +7212,7 @@ msgstr ""
 msgid "followed you"
 msgstr ""
 
-#: social/templates/event/liked.html:3
+#: social/templates/event/liked.html:2
 msgid "liked your post"
 msgstr ""
 
@@ -7275,8 +7255,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
 #: social/templates/event/liked_shelfmember.html:3
@@ -7286,7 +7265,7 @@ msgid ""
 "liked your mark on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
-#: social/templates/event/mentioned.html:3
+#: social/templates/event/mentioned.html:2
 msgid "mentioned you"
 msgstr ""
 
@@ -7329,8 +7308,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
 #: social/templates/event/mentioned_shelfmember.html:3
@@ -7340,26 +7318,41 @@ msgid ""
 "replied to your mark on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
-#: social/templates/feed.html:12 social/templates/feed.html:39
-#: social/templates/search_feed.html:12
-msgid "Activities from those you follow"
+#: social/templates/feed.html:39 users/templates/users/preferences.html:40
+msgid "Activities"
 msgstr ""
 
-#: social/templates/feed.html:42 social/templates/feed.html:44
+#: social/templates/feed.html:43 social/templates/feed.html:45
+msgid "world"
+msgstr ""
+
+#: social/templates/feed.html:51 social/templates/feed.html:53
+#, fuzzy
+#| msgid "locale"
+msgid "local"
+msgstr "Localización"
+
+#: social/templates/feed.html:58 social/templates/feed.html:60
+#, fuzzy
+#| msgid "marks from who you follow"
+msgid "those you follow"
+msgstr "marcas de usuarios a los que sigues"
+
+#: social/templates/feed.html:64 social/templates/feed.html:66
 msgid "what they read/watch/..."
 msgstr ""
 
-#: social/templates/feed_events.html:30
+#: social/templates/feed_events.html:29
 msgid "no matching activities."
 msgstr ""
 
-#: social/templates/feed_events.html:33
+#: social/templates/feed_events.html:31
+msgid "no public activities yet."
+msgstr ""
+
+#: social/templates/feed_events.html:34
 #, python-format
-msgid ""
-"Find and mark some books/movies/podcasts/games, <a "
-"href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/"
-"Douban, follow some fellow %(site_name)s users on the fediverse, so their "
-"recent activities and yours will show up here."
+msgid "Find and mark some books/movies/podcasts/games, <a href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/Douban, follow some fellow %(site_name)s users on the fediverse, so their recent activities and yours will show up here."
 msgstr ""
 
 #: social/templates/notification.html:58
@@ -7396,6 +7389,10 @@ msgstr ""
 msgid "Poll ending at %(end_time)s"
 msgstr ""
 
+#: social/templates/search_feed.html:12 social/views.py:57 social/views.py:58
+msgid "Activities from those you follow"
+msgstr ""
+
 #: social/templates/single_post.html:13 social/templates/single_post.html:32
 #, fuzzy
 #| msgid "Posts"
@@ -7410,57 +7407,63 @@ msgstr ""
 msgid "Poll"
 msgstr ""
 
-#: takahe/models.py:453
+#: social/views.py:59
+msgid "Activities on this site"
+msgstr ""
+
+#: social/views.py:60
+msgid "Activities from the fediverse"
+msgstr ""
+
+#: takahe/models.py:445
 msgid "Display Name"
 msgstr ""
 
-#: takahe/models.py:455
+#: takahe/models.py:447
 msgid "Bio"
 msgstr ""
 
-#: takahe/models.py:457
+#: takahe/models.py:449
 msgid "Manually approve new followers"
 msgstr ""
 
-#: takahe/models.py:461
+#: takahe/models.py:453
 msgid "Include profile, marks and posts in discovery"
 msgstr ""
 
-#: takahe/models.py:464
+#: takahe/models.py:456
 msgid "Include posts in search results"
 msgstr ""
 
-#: takahe/models.py:482
+#: takahe/models.py:474
 msgid "Profile picture"
 msgstr ""
 
-#: takahe/models.py:489
+#: takahe/models.py:481
 msgid "Header picture"
 msgstr ""
 
-#: users/models/task.py:22
+#: users/models/task.py:24
 msgid "Started"
 msgstr ""
 
-#: users/models/task.py:23
+#: users/models/task.py:25
 msgid "Complete"
 msgstr ""
 
-#: users/models/user.py:69
-msgid ""
-"Enter a valid username. This value may contain only unaccented lowercase a-z "
-"and uppercase A-Z letters, numbers, and _ characters."
+#: users/models/user.py:71
+msgid "Enter a valid username. This value may contain only unaccented lowercase a-z and uppercase A-Z letters, numbers, and _ characters."
 msgstr ""
 
-#: users/models/user.py:130
+#: users/models/user.py:132
 msgid "username"
 msgstr ""
 
-#: users/models/user.py:135
+#: users/models/user.py:137
 msgid "Required. 50 characters or fewer. Letters, digits and _ only."
 msgstr ""
 
-#: users/models/user.py:138
+#: users/models/user.py:140
 msgid "A user with that username already exists."
 msgstr ""
 
@@ -7605,9 +7608,7 @@ msgid "Cancel import"
 msgstr "Cancelar"
 
 #: users/templates/users/_rym_section.html:29
-msgid ""
-"On RateYourMusic, go to your profile and use the <b>Export your music "
-"catalog</b> option to download your library as a CSV file."
+msgid "On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:31
@@ -7616,18 +7617,12 @@ msgid "Upload the downloaded CSV file below."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:33
-msgid ""
-"Albums are matched by title + artist (and year if present) — first against "
-"the local catalog, then MusicBrainz, then Spotify. After auto-matching, "
-"you'll preview the matches in a table, edit any link or shelf status, and "
-"confirm the import."
+msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:36
 #: users/templates/users/_storygraph_section.html:38
-msgid ""
-"You can also re-upload a previously-downloaded matched CSV — the existing "
-"<code>link</code> column will be honoured as the default match."
+msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:40
@@ -7654,18 +7649,11 @@ msgid "Cancel the StoryGraph import? Progress will be discarded."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:31
-msgid ""
-"On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to "
-"download your library as a CSV file."
+msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:35
-msgid ""
-"Books are matched by ISBN — first against the local catalog, then Google "
-"Books and OpenLibrary — with a title + author search as fallback. After auto-"
-"matching, you'll preview the matches in a table, edit any link or shelf "
-"status, and confirm the import."
+msgid "Books are matched by ISBN — first against the local catalog, then Google Books and OpenLibrary — with a title + author search as fallback. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/account.html:11
@@ -7677,9 +7665,7 @@ msgid "Display name, avatar and other information"
 msgstr ""
 
 #: users/templates/users/account.html:23
-msgid ""
-"Updating profile information here will turn off automatic sync of display "
-"name, bio and avatar from your Mastodon instance. Sure to continue?"
+msgid "Updating profile information here will turn off automatic sync of display name, bio and avatar from your Mastodon instance. Sure to continue?"
 msgstr ""
 
 #: users/templates/users/account.html:26
@@ -7692,16 +7678,11 @@ msgstr ""
 
 #: users/templates/users/account.html:59 users/templates/users/register.html:47
 #, python-format
-msgid ""
-"Please click the confirmation link in the email sent to %(pending_email)s; "
-"if you haven't received it for more than a few minutes, please input and "
-"save again."
+msgid "Please click the confirmation link in the email sent to %(pending_email)s; if you haven't received it for more than a few minutes, please input and save again."
 msgstr ""
 
 #: users/templates/users/account.html:61 users/templates/users/register.html:50
-msgid ""
-"Email is recommended as a backup login method, if you log in via a Fediverse "
-"instance"
+msgid "Email is recommended as a backup login method, if you log in via a Fediverse instance"
 msgstr ""
 
 #: users/templates/users/account.html:73 users/templates/users/login.html:84
@@ -7719,22 +7700,15 @@ msgid "Last updated"
 msgstr ""
 
 #: users/templates/users/account.html:92
-msgid ""
-"If you have not yet registered with any Federated instance, you may <a "
-"href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an "
-"instance</a> and register."
+msgid "If you have not yet registered with any Federated instance, you may <a href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an instance</a> and register."
 msgstr ""
 
 #: users/templates/users/account.html:97
-msgid ""
-"To associate with another federated identity, please enter the domain name "
-"of the instance where the new identity is located."
+msgid "To associate with another federated identity, please enter the domain name of the instance where the new identity is located."
 msgstr ""
 
 #: users/templates/users/account.html:99
-msgid ""
-"If you have registered with a Federated instance, please enter the instance "
-"domain name."
+msgid "If you have registered with a Federated instance, please enter the instance domain name."
 msgstr ""
 
 #: users/templates/users/account.html:104
@@ -7746,24 +7720,17 @@ msgid "Go to target instance and authorize with the identity"
 msgstr ""
 
 #: users/templates/users/account.html:113
-msgid ""
-"After replacing the association, you may use the new Fediverse identity to "
-"log in and control data visibility. Existing data such as tags, comments, "
-"and collections will not be affected."
+msgid "After replacing the association, you may use the new Fediverse identity to log in and control data visibility. Existing data such as tags, comments, and collections will not be affected."
 msgstr ""
 
 #: users/templates/users/account.html:115
-msgid ""
-"Once associated with Fediverse identity, you can discover more users and use "
-"the full features of this site."
+msgid "Once associated with Fediverse identity, you can discover more users and use the full features of this site."
 msgstr ""
 
 #: users/templates/users/account.html:123
 #: users/templates/users/account.html:160
 #: users/templates/users/account.html:206
-msgid ""
-"Once disconnected, you will no longer be able login with this identity. Are "
-"you sure to continue?"
+msgid "Once disconnected, you will no longer be able login with this identity. Are you sure to continue?"
 msgstr ""
 
 #: users/templates/users/account.html:126
@@ -7790,7 +7757,7 @@ msgstr ""
 msgid "Disconnect with Threads"
 msgstr ""
 
-#: users/templates/users/account.html:173 users/templates/users/login.html:112
+#: users/templates/users/account.html:173 users/templates/users/login.html:106
 msgid "Bluesky (ATProto)"
 msgstr ""
 
@@ -7798,7 +7765,7 @@ msgstr ""
 msgid "Verified ATProto identity"
 msgstr ""
 
-#: users/templates/users/account.html:194 users/templates/users/login.html:216
+#: users/templates/users/account.html:194 users/templates/users/login.html:210
 msgid "ATProto handle"
 msgstr ""
 
@@ -7823,7 +7790,7 @@ msgid "Name this passkey:"
 msgstr ""
 
 #: users/templates/users/account.html:227 users/templates/users/login.html:69
-#: users/templates/users/welcome.html:33 users/views/webauthn.py:106
+#: users/templates/users/welcome.html:33 users/views/webauthn.py:109
 msgid "Passkey"
 msgstr ""
 
@@ -7872,9 +7839,7 @@ msgid "Save sync settings"
 msgstr ""
 
 #: users/templates/users/account.html:297
-msgid ""
-"New follow, mute and blocks in the associated identity may be automatically "
-"imported; removal has to be done manually."
+msgid "New follow, mute and blocks in the associated identity may be automatically imported; removal has to be done manually."
 msgstr ""
 
 #: users/templates/users/account.html:304
@@ -7911,15 +7876,11 @@ msgid "Log out everywhere"
 msgstr ""
 
 #: users/templates/users/account.html:365
-msgid ""
-"This will log you out of all browsers and devices (including the current "
-"one), and revoke all API tokens. Continue?"
+msgid "This will log you out of all browsers and devices (including the current one), and revoke all API tokens. Continue?"
 msgstr ""
 
 #: users/templates/users/account.html:368
-msgid ""
-"If you notice any suspicious activity or have logged in on a shared "
-"computer, you can log out of all sessions and revoke all API tokens."
+msgid "If you notice any suspicious activity or have logged in on a shared computer, you can log out of all sessions and revoke all API tokens."
 msgstr ""
 
 #: users/templates/users/account.html:378
@@ -7988,10 +7949,10 @@ msgstr "escuchar"
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:74
-#: users/templates/users/data.html:126 users/templates/users/data.html:183
-#: users/templates/users/data.html:234 users/templates/users/data.html:298
-#: users/templates/users/data.html:358 users/templates/users/data.html:553
+#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/data.html:141 users/templates/users/data.html:198
+#: users/templates/users/data.html:249 users/templates/users/data.html:313
+#: users/templates/users/data.html:376 users/templates/users/data.html:553
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr ""
@@ -8018,9 +7979,7 @@ msgid "Migrate Account"
 msgstr ""
 
 #: users/templates/users/account.html:488
-msgid ""
-"Linking an email to your account is highly recommended before migrating from "
-"another Fediverse instance."
+msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
 msgstr ""
 
 #: users/templates/users/account.html:491
@@ -8042,9 +8001,7 @@ msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
 msgstr ""
 
 #: users/templates/users/account.html:507
-msgid ""
-"Enter full <code>username@instance.social</code> or <code>email@domain.com</"
-"code> to confirm deletion."
+msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
 msgstr ""
 
 #: users/templates/users/account.html:517
@@ -8102,9 +8059,7 @@ msgid "Token Created"
 msgstr "Crear"
 
 #: users/templates/users/authorized_app_created.html:22
-msgid ""
-"Your new personal access token has been created. Copy it now -- you will not "
-"be able to see it again."
+msgid "Your new personal access token has been created. Copy it now -- you will not be able to see it again."
 msgstr ""
 
 #: users/templates/users/authorized_app_created.html:25
@@ -8132,9 +8087,7 @@ msgid "One quick check"
 msgstr ""
 
 #: users/templates/users/captcha.html:28
-msgid ""
-"Put every cover into the row it belongs to. Drag it, or select a cover and "
-"then select a row."
+msgid "Put every cover into the row it belongs to. Drag it, or select a cover and then select a row."
 msgstr ""
 
 #: users/templates/users/captcha.html:41 users/templates/users/captcha.html:43
@@ -8167,7 +8120,7 @@ msgstr ""
 msgid "That is all we needed. Let's get you a username."
 msgstr ""
 
-#: users/templates/users/captcha_solved.html:34
+#: users/templates/users/captcha_solved.html:32
 #: users/templates/users/login.html:63
 #: users/templates/users/verify_email.html:25
 #: users/templates/users/welcome.html:51
@@ -8187,10 +8140,7 @@ msgid "Failed Crossposts"
 msgstr ""
 
 #: users/templates/users/crossposts.html:42
-msgid ""
-"These posts could not be crossposted to your linked social accounts. Re-"
-"authorize the account if needed, then retry. In rare cases retrying may "
-"create a duplicate post."
+msgid "These posts could not be crossposted to your linked social accounts. Re-authorize the account if needed, then retry. In rare cases retrying may create a duplicate post."
 msgstr ""
 
 #: users/templates/users/crossposts.html:48
@@ -8213,216 +8163,167 @@ msgstr ""
 msgid "Data Management"
 msgstr ""
 
-#: users/templates/users/data.html:27
+#: users/templates/users/data.html:39
 msgid "Import Marks and Reviews from Douban"
 msgstr ""
 
-#: users/templates/users/data.html:31
-msgid ""
-"Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
-"target=\"_blank\" rel=\"noopener\">Doufen</a>"
+#: users/templates/users/data.html:43
+msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr ""
 
 #: users/templates/users/data.html:45
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
-"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
-"NeoDB Archive</a> below."
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON format instead; upload it under <a href=\"#import-neodb-archive\">Import NeoDB Archive</a> below."
 msgstr ""
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:256
+#: users/templates/users/data.html:49 users/templates/users/data.html:271
 msgid "Import Method"
 msgstr ""
 
-#: users/templates/users/data.html:37
-msgid ""
-"Merge: only update when status changes from wishlist to in-progress, or from "
-"in-progress to complete."
+#: users/templates/users/data.html:52
+msgid "Merge: only update when status changes from wishlist to in-progress, or from in-progress to complete."
 msgstr ""
 
-#: users/templates/users/data.html:41
+#: users/templates/users/data.html:56
 msgid "Overwrite: update all imported status."
 msgstr ""
 
-#: users/templates/users/data.html:74
-msgid ""
-"Another import is in progress, starting a new import may cause issues, sure "
-"to import?"
+#: users/templates/users/data.html:89
+msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
 msgstr ""
 
-#: users/templates/users/data.html:74
+#: users/templates/users/data.html:89 users/views/data.py:1130
 msgid "Import in progress, please wait"
 msgstr ""
 
-#: users/templates/users/data.html:81
+#: users/templates/users/data.html:96
 #, fuzzy
 #| msgid "Goodreads"
 msgid "Import from Goodreads"
 msgstr "Goodreads"
 
-#: users/templates/users/data.html:87
-msgid ""
-"On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download "
-"your library as a CSV file."
+#: users/templates/users/data.html:102
+msgid "On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download your library as a CSV file."
 msgstr ""
 
-#: users/templates/users/data.html:90
-msgid ""
-"Upload the downloaded <code>goodreads_library_export.csv</code> file below."
+#: users/templates/users/data.html:105
+msgid "Upload the downloaded <code>goodreads_library_export.csv</code> file below."
 msgstr ""
 
-#: users/templates/users/data.html:93
-msgid ""
-"want-to-read / currently-reading / read / did-not-finish books and their "
-"reviews will be imported."
-msgstr ""
-
-#: users/templates/users/data.html:134
-msgid "Import from Letterboxd"
-msgstr ""
-
-#: users/templates/users/data.html:140
-msgid ""
-"on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" "
-"target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap "
-"Advanced Settings in Settings, tap EXPORT YOUR DATA"
-msgstr ""
-
-#: users/templates/users/data.html:143
-msgid ""
-"download file with name like <code>letterboxd-username-2018-03-11-07-52-"
-"utc.zip</code>, do not unzip"
-msgstr ""
-
-#: users/templates/users/data.html:146
-msgid ""
-"the following files in the zip file will be processed: <code>reviews.csv</"
-"code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</"
-"code> <code>lists/*.csv</code>"
+#: users/templates/users/data.html:108
+msgid "want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported."
 msgstr ""
 
 #: users/templates/users/data.html:149
-msgid ""
-"exported file does not indicate whether a list is private, unlisted or "
-"public, so all imported marks, reviews and collections will be created with "
-"the visibility selected below"
+msgid "Import from Letterboxd"
 msgstr ""
 
-#: users/templates/users/data.html:184 users/templates/users/data.html:235
+#: users/templates/users/data.html:155
+msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
+msgstr ""
+
+#: users/templates/users/data.html:158
+msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
+msgstr ""
+
+#: users/templates/users/data.html:161
+msgid "the following files in the zip file will be processed: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
+msgstr ""
+
+#: users/templates/users/data.html:164
+msgid "exported file does not indicate whether a list is private, unlisted or public, so all imported marks, reviews and collections will be created with the visibility selected below"
+msgstr ""
+
+#: users/templates/users/data.html:199 users/templates/users/data.html:250
 msgid "Only forward changes(none->to-watch->watched) will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:191
+#: users/templates/users/data.html:206
 msgid "Import from Trakt"
 msgstr ""
 
-#: users/templates/users/data.html:197
-msgid ""
-"On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" "
-"rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait "
-"for the download link to appear."
+#: users/templates/users/data.html:212
+msgid "On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait for the download link to appear."
 msgstr ""
 
-#: users/templates/users/data.html:200
+#: users/templates/users/data.html:215
 msgid "Upload the downloaded <code>.zip</code> file below, do not unzip."
 msgstr ""
 
-#: users/templates/users/data.html:202
+#: users/templates/users/data.html:217
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:243
+#: users/templates/users/data.html:258
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr ""
 
-#: users/templates/users/data.html:246
+#: users/templates/users/data.html:261
 msgid "Login with Steam"
 msgstr ""
 
-#: users/templates/users/data.html:252
+#: users/templates/users/data.html:267
 msgid "Import Podcast Subscriptions"
 msgstr ""
 
-#: users/templates/users/data.html:263
+#: users/templates/users/data.html:278
 msgid "Mark as listening"
 msgstr ""
 
-#: users/templates/users/data.html:267
+#: users/templates/users/data.html:282
 msgid "Import as a new collection"
 msgstr ""
 
-#: users/templates/users/data.html:296
+#: users/templates/users/data.html:311
 msgid "Select OPML file"
 msgstr ""
 
-#: users/templates/users/data.html:306
+#: users/templates/users/data.html:321
 msgid "Import NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:312
-msgid ""
-"Upload a <code>.zip</code> file containing <code>.csv</code> or "
-"<code>.ndjson</code> files exported from NeoDB."
+#: users/templates/users/data.html:327
+msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr ""
 
 #: users/templates/users/data.html:330
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
-"imported here."
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is imported here."
 msgstr ""
 
-#: users/templates/users/data.html:314
+#: users/templates/users/data.html:332
 #, fuzzy
 #| msgid "Existing metadata might get overwritten, sure to proceed?"
 msgid "Existing data may be overwritten."
-msgstr ""
-"Los metadatos existentes podrían ser sobreescritos, ¿estás seguro de "
-"continuar?"
+msgstr "Los metadatos existentes podrían ser sobreescritos, ¿estás seguro de continuar?"
 
-#: users/templates/users/data.html:324
+#: users/templates/users/data.html:342
 msgid "Detected format"
 msgstr ""
 
-#: users/templates/users/data.html:385
+#: users/templates/users/data.html:403
 msgid "Detecting format..."
 msgstr ""
 
-#: users/templates/users/data.html:411
+#: users/templates/users/data.html:429
 #, fuzzy
 #| msgid "Unknown"
 msgid "Unknown format"
 msgstr "Desconocido"
 
-#: users/templates/users/data.html:436
+#: users/templates/users/data.html:454
 msgid "Error detecting format"
 msgstr ""
 
-#: users/templates/users/data.html:460
+#: users/templates/users/data.html:478
 msgid "Export NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:464
+#: users/templates/users/data.html:482
 msgid "Export marks, reviews and notes in CSV"
 msgstr ""
 
-#: users/templates/users/data.html:471
+#: users/templates/users/data.html:489
 msgid "Export everything in NDJSON"
-msgstr ""
-
-#: users/templates/users/data.html:479
-msgid "Export marks and reviews in XLSX (Doufen format)"
-msgstr ""
-
-#: users/templates/users/data.html:482
-msgid "Last export"
-msgstr ""
-
-#: users/templates/users/data.html:487
-msgid "Download"
 msgstr ""
 
 #: users/templates/users/data.html:496
@@ -8430,22 +8331,15 @@ msgid "Import and Export Articles (WordPress)"
 msgstr ""
 
 #: users/templates/users/data.html:499
-msgid ""
-"Your articles are exchanged as WordPress posts in the WXR format, which "
-"WordPress and most blogging tools can read and write. Marks, reviews and "
-"notes are not included: use the NeoDB archive above for those."
+msgid "Your articles are exchanged as WordPress posts in the WXR format, which WordPress and most blogging tools can read and write. Marks, reviews and notes are not included: use the NeoDB archive above for those."
 msgstr ""
 
 #: users/templates/users/data.html:502
-msgid ""
-"Article title, body, excerpt, tags, dates and featured image are exchanged. "
-"Comments and custom fields are ignored."
+msgid "Article title, body, excerpt, tags, dates and featured image are exchanged. Comments and custom fields are ignored."
 msgstr ""
 
 #: users/templates/users/data.html:505
-msgid ""
-"The body is converted between Markdown and HTML, so formatting is kept but "
-"the text is not character-for-character identical."
+msgid "The body is converted between Markdown and HTML, so formatting is kept but the text is not character-for-character identical."
 msgstr ""
 
 #: users/templates/users/data.html:512
@@ -8453,16 +8347,11 @@ msgid "Export articles in WordPress format"
 msgstr ""
 
 #: users/templates/users/data.html:519
-msgid ""
-"In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download "
-"an <code>.xml</code> file, then upload it below."
+msgid "In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download an <code>.xml</code> file, then upload it below."
 msgstr ""
 
 #: users/templates/users/data.html:522
-msgid ""
-"Only published posts use the visibility below. Drafts, pending, private and "
-"password-protected posts are always imported as mentioned-only, so nothing "
-"unpublished becomes public."
+msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
 #: users/templates/users/data.html:560
@@ -8470,9 +8359,7 @@ msgid "View Annual Summary"
 msgstr ""
 
 #: users/templates/users/fetch_identity_failed.html:4
-msgid ""
-"Unable to find the user, please check your spelling; or the server may be "
-"busy, please try again later."
+msgid "Unable to find the user, please check your spelling; or the server may be busy, please try again later."
 msgstr ""
 
 #: users/templates/users/fetch_identity_pending.html:13
@@ -8492,94 +8379,76 @@ msgstr ""
 msgid "logo"
 msgstr ""
 
-#: users/templates/users/login.html:127
-msgid ""
-"Sign in with a passkey saved on this device or in your password manager."
+#: users/templates/users/login.html:121
+msgid "Sign in with a passkey saved on this device or in your password manager."
 msgstr ""
 
-#: users/templates/users/login.html:132
+#: users/templates/users/login.html:126
 msgid "Sign in with Passkey"
 msgstr ""
 
-#: users/templates/users/login.html:148
+#: users/templates/users/login.html:142
 msgid "Enter your email address"
 msgstr ""
 
-#: users/templates/users/login.html:152
+#: users/templates/users/login.html:146
 msgid "Send verification code"
 msgstr ""
 
-#: users/templates/users/login.html:171
+#: users/templates/users/login.html:165
 msgid "Domain of your instance, e.g. mastodon.social"
 msgstr ""
 
-#: users/templates/users/login.html:177
-msgid ""
-"Please enter domain of your instance; e.g. if your id is "
-"<i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
+#: users/templates/users/login.html:171
+msgid "Please enter domain of your instance; e.g. if your id is <i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
 msgstr ""
 
-#: users/templates/users/login.html:182 users/templates/users/login.html:246
+#: users/templates/users/login.html:176 users/templates/users/login.html:240
 msgid "Authorize via Fediverse instance"
 msgstr ""
 
-#: users/templates/users/login.html:187
-msgid ""
-"If you don't have a <a href=\"https://joinmastodon.org/servers\" "
-"target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or "
-"login with Email first, and link it with Fediverse (Mastodon) later in "
-"account settings."
+#: users/templates/users/login.html:181
+msgid "If you don't have a <a href=\"https://joinmastodon.org/servers\" target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or login with Email first, and link it with Fediverse (Mastodon) later in account settings."
 msgstr ""
 
-#: users/templates/users/login.html:200
+#: users/templates/users/login.html:194
 msgid "Authorize via Threads"
 msgstr ""
 
-#: users/templates/users/login.html:221
-msgid ""
-"Please input your ATProto handle (e.g. neodb.bsky.social, without the "
-"leading @), do not use email. If you changed handle recently, just use the "
-"latest one."
+#: users/templates/users/login.html:215
+msgid "Please input your ATProto handle (e.g. neodb.bsky.social, without the leading @), do not use email. If you changed handle recently, just use the latest one."
 msgstr ""
 
-#: users/templates/users/login.html:224
+#: users/templates/users/login.html:218
 msgid "Authorize via ATProto server"
 msgstr ""
 
-#: users/templates/users/login.html:231
+#: users/templates/users/login.html:225
 #, python-format
-msgid ""
-"Please choose one to register or login %(site_name)s. Have more than one of "
-"these identities? Don't worry, you may link them in account settings once "
-"logged in."
+msgid "Please choose one to register or login %(site_name)s. Have more than one of these identities? Don't worry, you may link them in account settings once logged in."
 msgstr ""
 
-#: users/templates/users/login.html:255
+#: users/templates/users/login.html:249
 msgid "Valid invitation code, please login or register."
 msgstr ""
 
-#: users/templates/users/login.html:257
-msgid ""
-"Please use invitation link to register a new account; existing user may "
-"login."
+#: users/templates/users/login.html:251
+msgid "Please use invitation link to register a new account; existing user may login."
 msgstr ""
 
-#: users/templates/users/login.html:259
+#: users/templates/users/login.html:253
 msgid "Invitation code invalid or expired."
 msgstr ""
 
-#: users/templates/users/login.html:267
+#: users/templates/users/login.html:261
 msgid "Loading timed out, please check your network (VPN) settings."
 msgstr ""
 
-#: users/templates/users/login.html:273
-msgid ""
-"Continue using this site implies consent to our <a href=\"/pages/rules/"
-"\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using "
-"cookies to provide necessary functionality."
+#: users/templates/users/login.html:267
+msgid "Continue using this site implies consent to our <a href=\"/pages/rules/\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using cookies to provide necessary functionality."
 msgstr ""
 
-#: users/templates/users/login.html:287
+#: users/templates/users/login.html:281
 msgid "Domain of your instance (excl. @)"
 msgstr ""
 
@@ -8589,9 +8458,7 @@ msgid "Migrate Here"
 msgstr ""
 
 #: users/templates/users/migrate_in.html:22
-msgid ""
-"To move another account to this one, first add it as an alias here, and then "
-"go to the server where it is hosted and initiate the move."
+msgid "To move another account to this one, first add it as an alias here, and then go to the server where it is hosted and initiate the move."
 msgstr ""
 
 #: users/templates/users/migrate_in.html:27
@@ -8641,16 +8508,11 @@ msgstr ""
 
 #: users/templates/users/migrate_out.html:46
 #, python-format
-msgid ""
-"To migrate to another account, first add <code>@%(handle)s</code> as an "
-"alias on the target server, and then type the target account below to start "
-"the migration."
+msgid "To migrate to another account, first add <code>@%(handle)s</code> as an alias on the target server, and then type the target account below to start the migration."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:50
-msgid ""
-"Are you sure you want to migrate your account? Your followers will be moved "
-"to the target account."
+msgid "Are you sure you want to migrate your account? Your followers will be moved to the target account."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:53
@@ -8665,10 +8527,6 @@ msgstr "comenzar a leer"
 
 #: users/templates/users/preferences.html:28
 msgid "Default view once logged in"
-msgstr ""
-
-#: users/templates/users/preferences.html:40
-msgid "Activities"
 msgstr ""
 
 #: users/templates/users/preferences.html:49
@@ -8698,9 +8556,7 @@ msgstr ""
 
 #: users/templates/users/preferences.html:111
 #: users/templates/users/register.html:88
-msgid ""
-"If a Mastodon account is linked with this identity, boosting a post will "
-"also make the same post boosted with that Mastodon account."
+msgid "If a Mastodon account is linked with this identity, boosting a post will also make the same post boosted with that Mastodon account."
 msgstr ""
 
 #: users/templates/users/preferences.html:115
@@ -8716,16 +8572,12 @@ msgid "Create a new post"
 msgstr ""
 
 #: users/templates/users/preferences.html:130
-msgid ""
-"this method is less optimal, may generate duplicated posts and miss "
-"reactions."
+msgid "this method is less optimal, may generate duplicated posts and miss reactions."
 msgstr ""
 
 #: users/templates/users/preferences.html:140
 #: users/templates/users/register.html:97
-msgid ""
-"Always publish my public marks, reviews and articles as data records to my "
-"PDS."
+msgid "Always publish my public marks, reviews and articles as data records to my PDS."
 msgstr ""
 
 #: users/templates/users/preferences.html:145
@@ -8745,12 +8597,7 @@ msgid "Automatic bookmark for these categories"
 msgstr ""
 
 #: users/templates/users/preferences.html:175
-msgid ""
-"When start to read/watch/play/... an item in these categories, a bookmark "
-"will be created automatically. Bookmarks can be viewed and managed in most "
-"<a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon "
-"compatible apps</a>; your replies to these posts will automatically become "
-"notes for the item."
+msgid "When start to read/watch/play/... an item in these categories, a bookmark will be created automatically. Bookmarks can be viewed and managed in most <a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon compatible apps</a>; your replies to these posts will automatically become notes for the item."
 msgstr ""
 
 #: users/templates/users/preferences.html:183
@@ -8770,9 +8617,7 @@ msgid "Profile visible to anonymous web visitors and search engines"
 msgstr ""
 
 #: users/templates/users/preferences.html:217
-msgid ""
-"this option limits web visits only; to limit fediverse visibility, choose "
-"followers only or mentioned only when posting"
+msgid "this option limits web visits only; to limit fediverse visibility, choose followers only or mentioned only when posting"
 msgstr ""
 
 #: users/templates/users/preferences.html:225
@@ -8784,17 +8629,7 @@ msgid "Do not show me item recommendations"
 msgstr ""
 
 #: users/templates/users/preferences.html:237
-msgid ""
-"Recommendations are generated only from public marks, processed in batch on "
-"this server. Your private and follower-only marks are never used as a signal "
-"for anyone, and we never share your data with third parties for this "
-"feature. When you share marks publicly and keep your profile discoverable, "
-"your marks help others here and across the Fediverse find things they might "
-"enjoy -- that voluntary contribution is what makes the feature work for "
-"everyone. If you'd rather not contribute, uncheck \"Include profile, marks "
-"and posts in discovery\" on your account page; this setting is published "
-"over ActivityPub, so other servers will also stop including you in their "
-"discovery features."
+msgid "Recommendations are generated only from public marks, processed in batch on this server. Your private and follower-only marks are never used as a signal for anyone, and we never share your data with third parties for this feature. When you share marks publicly and keep your profile discoverable, your marks help others here and across the Fediverse find things they might enjoy -- that voluntary contribution is what makes the feature work for everyone. If you'd rather not contribute, uncheck \"Include profile, marks and posts in discovery\" on your account page; this setting is published over ActivityPub, so other servers will also stop including you in their discovery features."
 msgstr ""
 
 #: users/templates/users/profile_actions.html:12
@@ -8895,19 +8730,11 @@ msgid "2-30 alphabets, numbers or underscore, can't be changed once saved"
 msgstr ""
 
 #: users/templates/users/register.html:72
-msgid ""
-"Use display name, bio and avatar from the social network you authenticated "
-"with"
+msgid "Use display name, bio and avatar from the social network you authenticated with"
 msgstr ""
 
 #: users/templates/users/register.html:80
-msgid ""
-"Add follow, mute and block list from the social network you authenticated "
-"with"
-msgstr ""
-
-#: users/templates/users/register.html:104
-msgid "Confirm and save"
+msgid "Add follow, mute and block list from the social network you authenticated with"
 msgstr ""
 
 #: users/templates/users/register.html:106
@@ -8936,8 +8763,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"              Matched %(local)s locally, %(external)s externally, "
-"%(unmatched)s unmatched out of %(total)s rows.\n"
+"              Matched %(local)s locally, %(external)s externally, %(unmatched)s unmatched out of %(total)s rows.\n"
 "            "
 msgstr ""
 
@@ -9064,9 +8890,7 @@ msgid "Played"
 msgstr "jugado"
 
 #: users/templates/users/steam_import.html:90
-msgid ""
-"Games in wishlist; or purchased in library but never played, mark date will "
-"be set as today"
+msgid "Games in wishlist; or purchased in library but never played, mark date will be set as today"
 msgstr ""
 
 #: users/templates/users/steam_import.html:91
@@ -9110,15 +8934,11 @@ msgid "Comma-separated Steam AppIDs"
 msgstr ""
 
 #: users/templates/users/steam_import.html:121
-msgid ""
-"Allow reverse override of status (e.g. playing -> want to, or played -> "
-"playing)"
+msgid "Allow reverse override of status (e.g. playing -> want to, or played -> playing)"
 msgstr ""
 
 #: users/templates/users/steam_import.html:139
-msgid ""
-"To import from Steam, your game details must be visible to public in Steam "
-"privacy settings."
+msgid "To import from Steam, your game details must be visible to public in Steam privacy settings."
 msgstr ""
 
 #: users/templates/users/storygraph_import.html:9
@@ -9163,23 +8983,16 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"              %(site_name)s is flourishing because of collaborations and "
-"contributions from users like you. Please read our <a href=\"/pages/"
-"rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</"
-"a> if you have any question or feedback.\n"
+"              %(site_name)s is flourishing because of collaborations and contributions from users like you. Please read our <a href=\"/pages/rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</a> if you have any question or feedback.\n"
 "        "
 msgstr ""
 
 #: users/templates/users/welcome.html:37
-msgid ""
-"Set up a passkey to sign in quickly next time using your fingerprint, face, "
-"or screen lock."
+msgid "Set up a passkey to sign in quickly next time using your fingerprint, face, or screen lock."
 msgstr ""
 
 #: users/templates/users/welcome.html:39
-msgid ""
-"Creating a passkey is highly recommended, as the website or email you use to "
-"create this account may not be always available."
+msgid "Creating a passkey is highly recommended, as the website or email you use to create this account may not be always available."
 msgstr ""
 
 #: users/templates/users/welcome.html:43
@@ -9196,269 +9009,231 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:124
+#: users/views/account.py:126
 msgid "This username is already in use."
 msgstr ""
 
-#: users/views/account.py:135
+#: users/views/account.py:137
 msgid "This email address is already in use."
 msgstr ""
 
-#: users/views/account.py:255 users/views/account.py:374
+#: users/views/account.py:257 users/views/account.py:376
 msgid "Registration is for invitation only"
 msgstr ""
 
-#: users/views/account.py:266 users/views/account.py:338
+#: users/views/account.py:268 users/views/account.py:340
 #, fuzzy
 #| msgid "Timestamp"
 msgid "Time is up"
 msgstr "Marca de tiempo"
 
-#: users/views/account.py:267 users/views/account.py:310
-#: users/views/account.py:339
+#: users/views/account.py:269 users/views/account.py:312
+#: users/views/account.py:341
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:313
+#: users/views/account.py:315
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:325
+#: users/views/account.py:327
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:326
+#: users/views/account.py:328
 #, fuzzy
 #| msgid "System busy, please try again in a minute."
 msgid "Please try again later."
 msgstr "El sistema está ocupado, por favor inténtalo de nuevo en un minuto."
 
-#: users/views/account.py:415
+#: users/views/account.py:417
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:445
+#: users/views/account.py:447
 msgid "Valid username required"
 msgstr ""
 
-#: users/views/account.py:526
+#: users/views/account.py:518
 msgid "Account is being deleted."
 msgstr ""
 
-#: users/views/account.py:529
+#: users/views/account.py:521
 msgid "Account mismatch."
 msgstr ""
 
-#: users/views/data.py:262 users/views/data.py:294
+#: users/views/data.py:264 users/views/data.py:296
 msgid "Export file not available."
 msgstr ""
 
-#: users/views/data.py:288
+#: users/views/data.py:290
 msgid "Generating exports."
 msgstr ""
 
-#: users/views/data.py:306
+#: users/views/data.py:308
 msgid "Export file expired. Please export again."
 msgstr ""
 
-#: users/views/data.py:321 users/views/data.py:342 users/views/data.py:363
+#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
 msgid "Recent export still in progress."
 msgstr ""
 
-#: users/views/data.py:379 users/views/data.py:513 users/views/data.py:547
-#: users/views/data.py:772 users/views/data.py:989 users/views/data.py:1015
-#: users/views/data.py:1040 users/views/data.py:1065
+#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
+#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
+#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
 msgid "Invalid file."
 msgstr ""
 
-#: users/views/data.py:403
+#: users/views/data.py:405
 msgid "Sync in progress."
 msgstr ""
 
-#: users/views/data.py:417
+#: users/views/data.py:419
 msgid "Settings saved."
 msgstr ""
 
-#: users/views/data.py:472
+#: users/views/data.py:474
 msgid "Account no longer linked."
 msgstr ""
 
-#: users/views/data.py:475
+#: users/views/data.py:477
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:503
+#: users/views/data.py:505
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:583 users/views/data.py:808
+#: users/views/data.py:585 users/views/data.py:810
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:608 users/views/data.py:837
+#: users/views/data.py:610 users/views/data.py:839
 #, fuzzy
 #| msgid "Cancel"
 msgid "Cancelled."
 msgstr "Cancelar"
 
-#: users/views/data.py:628
+#: users/views/data.py:630
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:636 users/views/data.py:746 users/views/data.py:867
-#: users/views/data.py:972
+#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
+#: users/views/data.py:974
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:732 users/views/data.py:958
+#: users/views/data.py:734 users/views/data.py:960
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:742 users/views/data.py:968
+#: users/views/data.py:744 users/views/data.py:970
 msgid "No matched file available."
 msgstr ""
 
-#: users/views/data.py:859
+#: users/views/data.py:861
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1188
+#: users/views/data.py:1226
 #, fuzzy
 #| msgid "games reviewed"
 msgid "Name is required."
 msgstr "juegos reseñados"
 
-#: users/views/data.py:1210
+#: users/views/data.py:1248
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1264
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1231
+#: users/views/data.py:1269
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1241 users/views/data.py:1292
+#: users/views/data.py:1279 users/views/data.py:1330
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:1248
+#: users/views/data.py:1286
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:1253
+#: users/views/data.py:1291
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:1279
+#: users/views/data.py:1317
 msgid "Migration cancelled."
 msgstr ""
 
-#: users/views/data.py:1284
+#: users/views/data.py:1322
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:1297
+#: users/views/data.py:1335
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:1308
+#: users/views/data.py:1346
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:1314
+#: users/views/data.py:1352
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr ""
 
-#: users/views/data.py:1372
+#: users/views/data.py:1410
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1388
+#: users/views/data.py:1426
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1392
+#: users/views/data.py:1430
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1402
+#: users/views/data.py:1440
 #, python-brace-format
-msgid ""
-"Import of {count} entries received. They will be processed in the background."
+msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""
 
-#: users/views/webauthn.py:103
+#: users/views/webauthn.py:106
 msgid "Passkey registration failed"
 msgstr ""
 
-#: users/views/webauthn.py:123
+#: users/views/webauthn.py:126
 msgid "Credential already registered"
 msgstr ""
 
-#: users/views/webauthn.py:165 users/views/webauthn.py:172
-#: users/views/webauthn.py:181
+#: users/views/webauthn.py:168 users/views/webauthn.py:175
+#: users/views/webauthn.py:184
 msgid "Passkey not recognized"
 msgstr ""
 
-#: users/views/webauthn.py:186
+#: users/views/webauthn.py:189
 msgid "Account is inactive"
 msgstr ""
 
-#: users/views/webauthn.py:202
+#: users/views/webauthn.py:205
 msgid "Passkey verification failed"
 msgstr ""
 
-#: users/views/webauthn.py:228 users/views/webauthn.py:250
+#: users/views/webauthn.py:231 users/views/webauthn.py:253
 #, fuzzy
 #| msgid "User not found"
 msgid "Passkey not found"
 msgstr "Usuario no encontrado"
 
-#: users/views/webauthn.py:244
+#: users/views/webauthn.py:247
 #, fuzzy
 #| msgid "required"
 msgid "Name is required"
 msgstr "requerido"
-
-#~ msgid "FanFic"
-#~ msgstr "FanFic"
-
-#~ msgid "year of publication"
-#~ msgstr "año de publicación"
-
-#~ msgid "YYYY-MM-DD"
-#~ msgstr "AAAA-MM-DD"
-
-#~ msgid "region or event"
-#~ msgstr "región o evento"
-
-#~ msgid "Germany or Toronto International Film Festival"
-#~ msgstr "Festival Internacional de Cine de Alemania o Toronto"
-
-#~ msgid "year"
-#~ msgstr "año"
-
-#~ msgctxt "music"
-#~ msgid "genre"
-#~ msgstr "género"
-
-#~ msgid "my notes"
-#~ msgstr "mis notas"
-
-#~ msgid "release year"
-#~ msgstr "año de lanzamiento"
-
-#~ msgid "episode Length"
-#~ msgstr "duración del episodio"
-
-#~ msgid "show time"
-#~ msgstr "primera emisión"
-
-#~ msgid "Region or Event"
-#~ msgstr "Región o Evento"

--- a/neodb/locale/eu/LC_MESSAGES/django.po
+++ b/neodb/locale/eu/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-23 15:40-0400\n"
+"POT-Creation-Date: 2026-09-06 20:04-0400\n"
 "PO-Revision-Date: 2026-08-09 06:31+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Basque <https://hosted.weblate.org/projects/neodb/neodb/eu/>\n"
@@ -18,159 +18,159 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: boofilsic/settings.py:472 common/models/lang.py:230
+#: boofilsic/settings.py:501 common/models/lang.py:232
 msgid "English"
 msgstr "Ingelesa"
 
-#: boofilsic/settings.py:473 common/models/lang.py:77
+#: boofilsic/settings.py:502 common/models/lang.py:79
 msgid "Danish"
 msgstr "Daniera"
 
-#: boofilsic/settings.py:474 common/models/lang.py:78
+#: boofilsic/settings.py:503 common/models/lang.py:80
 msgid "German"
 msgstr "Alemana"
 
-#: boofilsic/settings.py:475 common/models/lang.py:183
+#: boofilsic/settings.py:504 common/models/lang.py:185
 msgid "Spanish"
 msgstr ""
 
-#: boofilsic/settings.py:476 common/models/lang.py:87
+#: boofilsic/settings.py:505 common/models/lang.py:89
 msgid "French"
 msgstr "Frantsesa"
 
-#: boofilsic/settings.py:477 common/models/lang.py:112
+#: boofilsic/settings.py:506 common/models/lang.py:114
 msgid "Italian"
 msgstr "Italiera"
 
-#: boofilsic/settings.py:478 common/models/lang.py:166
-#: common/models/lang.py:305
+#: boofilsic/settings.py:507 common/models/lang.py:168
+#: common/models/lang.py:307
 msgid "Portuguese"
 msgstr "Portugesa"
 
-#: boofilsic/settings.py:479
+#: boofilsic/settings.py:508
 msgid "Brazilian Portuguese"
 msgstr "Brasilera"
 
-#: boofilsic/settings.py:480 common/models/lang.py:316
+#: boofilsic/settings.py:509 common/models/lang.py:318
 msgid "Simplified Chinese"
 msgstr "Txinera sinplifikatua"
 
-#: boofilsic/settings.py:481 common/models/lang.py:317
+#: boofilsic/settings.py:510 common/models/lang.py:319
 msgid "Traditional Chinese"
 msgstr "Txinera Tradizionala"
 
-#: catalog/forms.py:35 catalog/models/item.py:291
+#: catalog/forms.py:35 catalog/models/item.py:307
 msgid "Primary ID Type"
 msgstr ""
 
-#: catalog/forms.py:40 catalog/models/item.py:294
+#: catalog/forms.py:40 catalog/models/item.py:310
 msgid "Primary ID Value"
 msgstr ""
 
-#: catalog/forms.py:181
+#: catalog/forms.py:176
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
-#: catalog/models/book.py:139 catalog/models/book.py:158
-#: catalog/models/common.py:280 catalog/models/common.py:298
+#: catalog/models/book.py:141 catalog/models/book.py:160
+#: catalog/models/common.py:279 catalog/models/common.py:297
 msgid "locale"
 msgstr "lokala"
 
-#: catalog/models/book.py:142 catalog/models/book.py:161
-#: catalog/models/common.py:283 catalog/models/common.py:303
+#: catalog/models/book.py:144 catalog/models/book.py:163
+#: catalog/models/common.py:282 catalog/models/common.py:302
 msgid "text content"
 msgstr "testu edukia"
 
-#: catalog/models/book.py:177
+#: catalog/models/book.py:179
 msgid "Paperback"
 msgstr ""
 
-#: catalog/models/book.py:178
+#: catalog/models/book.py:180
 msgid "Hardcover"
 msgstr "Tapa gogorra"
 
-#: catalog/models/book.py:179
+#: catalog/models/book.py:181
 msgid "eBook"
 msgstr "eBook"
 
-#: catalog/models/book.py:180
+#: catalog/models/book.py:182
 msgid "Audiobook"
 msgstr "Audioliburua"
 
-#: catalog/models/book.py:182
+#: catalog/models/book.py:184
 msgid "Web Fiction"
 msgstr ""
 
-#: catalog/models/book.py:183 catalog/models/game.py:38
+#: catalog/models/book.py:185 catalog/models/game.py:38
 msgid "Other"
 msgstr "Besteak"
 
-#: catalog/models/book.py:260
+#: catalog/models/book.py:262
 msgid "subtitle"
 msgstr "azpitituluak"
 
-#: catalog/models/book.py:270 catalog/models/movie.py:120
-#: catalog/models/performance.py:385 catalog/models/tv.py:211
-#: catalog/models/tv.py:437
+#: catalog/models/book.py:272 catalog/models/movie.py:120
+#: catalog/models/performance.py:385 catalog/models/tv.py:213
+#: catalog/models/tv.py:439
 msgid "original title"
 msgstr "izenburu originala"
 
-#: catalog/models/book.py:274
+#: catalog/models/book.py:276
 msgid "other title"
 msgstr "beste izenburua"
 
-#: catalog/models/book.py:280 catalog/models/book.py:564
-#: catalog/models/item.py:123
+#: catalog/models/book.py:282 catalog/models/book.py:566
+#: catalog/models/item.py:119
 msgid "author"
 msgstr "autorea"
 
-#: catalog/models/book.py:287 catalog/models/item.py:124
+#: catalog/models/book.py:289 catalog/models/item.py:120
 msgid "translator"
 msgstr "itzultzailea"
 
-#: catalog/models/book.py:294 catalog/templates/edition.html:26
+#: catalog/models/book.py:296 catalog/templates/edition.html:26
 msgid "book format"
 msgstr "liburu formatua"
 
-#: catalog/models/book.py:301 catalog/models/game.py:135
-#: catalog/models/item.py:138 catalog/models/music.py:142
+#: catalog/models/book.py:303 catalog/models/game.py:135
+#: catalog/models/item.py:134 catalog/models/music.py:142
 msgid "publisher"
 msgstr ""
 
-#: catalog/models/book.py:308
+#: catalog/models/book.py:310
 msgid "publication year"
 msgstr "argitaratze urtea"
 
-#: catalog/models/book.py:314
+#: catalog/models/book.py:316
 msgid "publication month"
 msgstr "argitaratze hilabetea"
 
-#: catalog/models/book.py:319
+#: catalog/models/book.py:321
 msgid "binding"
 msgstr ""
 
-#: catalog/models/book.py:320
+#: catalog/models/book.py:322
 msgid "pages"
 msgstr "orrialdeak"
 
-#: catalog/models/book.py:321 catalog/templates/edition.html:45
+#: catalog/models/book.py:323 catalog/templates/edition.html:45
 msgid "series"
 msgstr "telesailak"
 
-#: catalog/models/book.py:322 catalog/templates/edition.html:65
+#: catalog/models/book.py:324 catalog/templates/edition.html:65
 msgid "contents"
 msgstr "edukiak"
 
-#: catalog/models/book.py:323 catalog/templates/edition.html:51
+#: catalog/models/book.py:325 catalog/templates/edition.html:51
 msgid "price"
 msgstr "prezioa"
 
-#: catalog/models/book.py:324 catalog/models/item.py:149
+#: catalog/models/book.py:326 catalog/models/item.py:145
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr ""
 
-#: catalog/models/common.py:26 common/models/lang.py:256
+#: catalog/models/common.py:26 common/models/lang.py:258
 msgid "Unknown"
 msgstr "Ezezaguna"
 
@@ -178,11 +178,11 @@ msgstr "Ezezaguna"
 msgid "Douban"
 msgstr ""
 
-#: catalog/models/common.py:28 catalog/models/common.py:79
+#: catalog/models/common.py:28 catalog/models/common.py:81
 msgid "Goodreads"
 msgstr "Goodreads"
 
-#: catalog/models/common.py:29 catalog/models/common.py:81
+#: catalog/models/common.py:29 catalog/models/common.py:83
 msgid "Google Books"
 msgstr "Google Liburuak"
 
@@ -190,16 +190,16 @@ msgstr "Google Liburuak"
 msgid "BooksTW"
 msgstr ""
 
-#: catalog/models/common.py:31 catalog/models/common.py:91
-#: catalog/models/common.py:93
+#: catalog/models/common.py:31 catalog/models/common.py:93
+#: catalog/models/common.py:95
 msgid "Bibliotek.dk"
 msgstr ""
 
-#: catalog/models/common.py:32 catalog/models/common.py:92
+#: catalog/models/common.py:32 catalog/models/common.py:94
 msgid "eReolen.dk"
 msgstr "eReolen.dk"
 
-#: catalog/models/common.py:33 catalog/models/common.py:74
+#: catalog/models/common.py:33 catalog/models/common.py:76
 #: catalog/templates/movie.html:41 catalog/templates/people.html:37
 #: catalog/templates/tvseason.html:58 catalog/templates/tvshow.html:53
 msgid "IMDb"
@@ -209,7 +209,7 @@ msgstr "IMDb"
 msgid "TMDB"
 msgstr "TMDB"
 
-#: catalog/models/common.py:35 catalog/models/common.py:94
+#: catalog/models/common.py:35 catalog/models/common.py:96
 msgid "Bandcamp"
 msgstr "Bandcamp"
 
@@ -225,11 +225,11 @@ msgstr "IGDB"
 msgid "Steam"
 msgstr "Steam"
 
-#: catalog/models/common.py:39 catalog/models/common.py:114
+#: catalog/models/common.py:39 catalog/models/common.py:116
 msgid "itch.io"
 msgstr ""
 
-#: catalog/models/common.py:40 catalog/models/common.py:115
+#: catalog/models/common.py:40 catalog/models/common.py:117
 msgid "Bangumi"
 msgstr "Bangumi"
 
@@ -237,7 +237,7 @@ msgstr "Bangumi"
 msgid "BGG"
 msgstr "BGG"
 
-#: catalog/models/common.py:42 catalog/models/common.py:116
+#: catalog/models/common.py:42 catalog/models/common.py:118
 msgid "Apple Podcast"
 msgstr "Apple Podcast"
 
@@ -249,35 +249,35 @@ msgstr "RSS"
 msgid "Discogs"
 msgstr "Discogs"
 
-#: catalog/models/common.py:45 catalog/models/common.py:117
+#: catalog/models/common.py:45 catalog/models/common.py:119
 msgid "Apple Music"
 msgstr "Apple Music"
 
-#: catalog/models/common.py:46 catalog/models/common.py:119
+#: catalog/models/common.py:46 catalog/models/common.py:121
 msgid "Fediverse"
 msgstr "Fedibertsoa"
 
-#: catalog/models/common.py:47 catalog/models/common.py:120
+#: catalog/models/common.py:47 catalog/models/common.py:122
 msgid "Qidian"
 msgstr "Qidian"
 
-#: catalog/models/common.py:48 catalog/models/common.py:121
+#: catalog/models/common.py:48 catalog/models/common.py:123
 msgid "Ypshuo"
 msgstr "Ypshuo"
 
-#: catalog/models/common.py:49 catalog/models/common.py:122
+#: catalog/models/common.py:49 catalog/models/common.py:124
 msgid "Archive of Our Own"
 msgstr ""
 
-#: catalog/models/common.py:50 catalog/models/common.py:123
+#: catalog/models/common.py:50 catalog/models/common.py:125
 msgid "JinJiang"
 msgstr ""
 
-#: catalog/models/common.py:51 catalog/models/common.py:64
+#: catalog/models/common.py:51 catalog/models/common.py:66
 msgid "WikiData"
 msgstr "WikiData"
 
-#: catalog/models/common.py:52 catalog/models/common.py:124
+#: catalog/models/common.py:52 catalog/models/common.py:126
 msgid "Open Library"
 msgstr ""
 
@@ -289,17 +289,17 @@ msgstr ""
 msgid "WorldCat"
 msgstr ""
 
-#: catalog/models/common.py:55 catalog/models/common.py:126
+#: catalog/models/common.py:55 catalog/models/common.py:128
 #, fuzzy
 #| msgid "Game"
 msgid "MobyGames"
 msgstr "Jokoa"
 
-#: catalog/models/common.py:56 catalog/models/common.py:127
+#: catalog/models/common.py:56 catalog/models/common.py:129
 msgid "StoryGraph"
 msgstr ""
 
-#: catalog/models/common.py:57 catalog/models/common.py:118
+#: catalog/models/common.py:57 catalog/models/common.py:120
 #, fuzzy
 #| msgid "Douban Music"
 msgid "YouTube Music"
@@ -317,351 +317,360 @@ msgstr ""
 msgid "Readmoo"
 msgstr ""
 
-#: catalog/models/common.py:65
-msgid "ISBN10"
+#: catalog/models/common.py:61
+msgid "MyAnimeList"
 msgstr ""
 
-#: catalog/models/common.py:66 catalog/templates/edition.html:19
-msgid "ISBN"
+#: catalog/models/common.py:62 catalog/models/common.py:140
+msgid "MangaUpdates"
 msgstr ""
 
 #: catalog/models/common.py:67
-msgid "ASIN"
+msgid "ISBN10"
 msgstr ""
 
-#: catalog/models/common.py:68
-msgid "ISSN"
+#: catalog/models/common.py:68 catalog/templates/edition.html:19
+msgid "ISBN"
 msgstr ""
 
 #: catalog/models/common.py:69
-msgid "CUBN"
+msgid "ASIN"
 msgstr ""
 
 #: catalog/models/common.py:70
-msgid "ISRC"
+msgid "ISSN"
 msgstr ""
 
 #: catalog/models/common.py:71
-msgid "GTIN UPC EAN"
+msgid "CUBN"
 msgstr ""
 
 #: catalog/models/common.py:72
-msgid "OCLC Number"
+msgid "ISRC"
 msgstr ""
 
 #: catalog/models/common.py:73
-msgid "RSS Feed URL"
+msgid "GTIN UPC EAN"
+msgstr ""
+
+#: catalog/models/common.py:74
+msgid "OCLC Number"
 msgstr ""
 
 #: catalog/models/common.py:75
+msgid "RSS Feed URL"
+msgstr ""
+
+#: catalog/models/common.py:77
 msgid "TMDB TV Series"
 msgstr ""
 
-#: catalog/models/common.py:76
+#: catalog/models/common.py:78
 msgid "TMDB TV Season"
 msgstr "TMDB TB Denboraldia"
 
-#: catalog/models/common.py:77
+#: catalog/models/common.py:79
 msgid "TMDB TV Episode"
 msgstr "TMDB TB Atala"
 
-#: catalog/models/common.py:78
+#: catalog/models/common.py:80
 msgid "TMDB Movie"
 msgstr "TMDB Filma"
 
-#: catalog/models/common.py:80
+#: catalog/models/common.py:82
 msgid "Goodreads Work"
 msgstr "Goodreadsen Lana"
 
-#: catalog/models/common.py:82
+#: catalog/models/common.py:84
 msgid "Douban Book"
 msgstr "Douban Book"
 
-#: catalog/models/common.py:83
+#: catalog/models/common.py:85
 msgid "Douban Book Work"
 msgstr "Douban Booken Lana"
 
-#: catalog/models/common.py:84
+#: catalog/models/common.py:86
 msgid "Douban Movie"
 msgstr "Douban Filma"
 
-#: catalog/models/common.py:85
+#: catalog/models/common.py:87
 msgid "Douban Music"
 msgstr "Douban Musika"
 
-#: catalog/models/common.py:86
+#: catalog/models/common.py:88
 msgid "Douban Game"
 msgstr "Douban Jokoa"
 
-#: catalog/models/common.py:87
+#: catalog/models/common.py:89
 msgid "Douban Drama"
 msgstr "Douban Drama"
 
-#: catalog/models/common.py:88
+#: catalog/models/common.py:90
 msgid "Douban Drama Version"
 msgstr "Douban Drama Bertsioa"
 
-#: catalog/models/common.py:89
+#: catalog/models/common.py:91
 msgid "BooksTW Book"
 msgstr "BooksTW Liburua"
 
-#: catalog/models/common.py:90
+#: catalog/models/common.py:92
 msgid "Readmoo Book"
 msgstr ""
 
-#: catalog/models/common.py:95
+#: catalog/models/common.py:97
 msgid "Spotify Album"
 msgstr "Spotify Albuma"
 
-#: catalog/models/common.py:96
+#: catalog/models/common.py:98
 msgid "Spotify Podcast"
 msgstr "Spotify Podkasta"
 
-#: catalog/models/common.py:97
+#: catalog/models/common.py:99
 msgid "Discogs Release"
 msgstr ""
 
-#: catalog/models/common.py:98
+#: catalog/models/common.py:100
 msgid "Discogs Master"
 msgstr ""
 
-#: catalog/models/common.py:101
+#: catalog/models/common.py:103
 msgid "MusicBrainz Release Group"
 msgstr ""
 
-#: catalog/models/common.py:103
+#: catalog/models/common.py:105
 msgid "MusicBrainz Release"
 msgstr "MusicBrainz Argitalpen"
 
-#: catalog/models/common.py:104
+#: catalog/models/common.py:106
 #, fuzzy
 #| msgid "MusicBrainz Release"
 msgid "MusicBrainz Artist"
 msgstr "MusicBrainz Argitalpen"
 
-#: catalog/models/common.py:105
+#: catalog/models/common.py:107
 #, fuzzy
 #| msgid "Douban Game"
 msgid "Douban Personage"
 msgstr "Douban Jokoa"
 
-#: catalog/models/common.py:106
+#: catalog/models/common.py:108
 #, fuzzy
 #| msgid "Goodreads Work"
 msgid "Goodreads Author"
 msgstr "Goodreadsen Lana"
 
-#: catalog/models/common.py:107
+#: catalog/models/common.py:109
 #, fuzzy
 #| msgid "Spotify Podcast"
 msgid "Spotify Artist"
 msgstr "Spotify Podkasta"
 
-#: catalog/models/common.py:108
+#: catalog/models/common.py:110
 #, fuzzy
 #| msgid "TMDB TV Season"
 msgid "TMDB Person"
 msgstr "TMDB TB Denboraldia"
 
-#: catalog/models/common.py:109
+#: catalog/models/common.py:111
 msgid "Open Library Author"
 msgstr ""
 
-#: catalog/models/common.py:110
+#: catalog/models/common.py:112
 msgid "IGDB Company"
 msgstr ""
 
-#: catalog/models/common.py:111
+#: catalog/models/common.py:113
 msgid "IGDB Game"
 msgstr "IGDB Jokoa"
 
-#: catalog/models/common.py:112
+#: catalog/models/common.py:114
 msgid "BGG Boardgame"
 msgstr "BGG Mahai-joko"
 
-#: catalog/models/common.py:113
+#: catalog/models/common.py:115
 msgid "Steam Game"
 msgstr "Steam Jokoa"
 
-#: catalog/models/common.py:125
+#: catalog/models/common.py:127
 msgid "Open Library Work"
 msgstr ""
 
-#: catalog/models/common.py:128
+#: catalog/models/common.py:130
 #, fuzzy
 #| msgid "MusicBrainz Release"
 msgid "RateYourMusic Release"
 msgstr "MusicBrainz Argitalpen"
 
-#: catalog/models/common.py:132
+#: catalog/models/common.py:134
 msgid "AniList Anime"
 msgstr ""
 
-#: catalog/models/common.py:133
+#: catalog/models/common.py:135
 msgid "AniList Manga"
 msgstr ""
 
-#: catalog/models/common.py:134
+#: catalog/models/common.py:136
 msgid "MyAnimeList Anime"
 msgstr ""
 
-#: catalog/models/common.py:135
+#: catalog/models/common.py:137
 msgid "MyAnimeList Manga"
 msgstr ""
 
-#: catalog/models/common.py:156
+#: catalog/models/common.py:161
 msgid "Edition"
 msgstr "Edizioa"
 
-#: catalog/models/common.py:157 catalog/templates/_sidebar_edit.html:286
+#: catalog/models/common.py:162 catalog/templates/_sidebar_edit.html:289
 msgid "Work"
 msgstr "Lana"
 
-#: catalog/models/common.py:158
+#: catalog/models/common.py:163
 msgid "TV Series"
 msgstr "TB Seriea"
 
-#: catalog/models/common.py:159 catalog/templates/_sidebar_edit.html:207
+#: catalog/models/common.py:164 catalog/templates/_sidebar_edit.html:202
+#: catalog/views/edit.py:385
 msgid "TV Season"
 msgstr "TB Denboraldia"
 
-#: catalog/models/common.py:160
+#: catalog/models/common.py:165
 msgid "TV Episode"
 msgstr "TB Atala"
 
-#: catalog/models/common.py:161 catalog/models/common.py:177
-#: catalog/models/common.py:191 catalog/templates/_sidebar_edit.html:200
-#: journal/templates/_sidebar_user_mark_list.html:35
+#: catalog/models/common.py:166 catalog/models/common.py:182
+#: catalog/models/common.py:196 catalog/templates/_sidebar_edit.html:196
+#: catalog/views/edit.py:384 journal/templates/_sidebar_user_mark_list.html:35
 #: journal/templates/_sidebar_user_tag_filter.html:27
 msgid "Movie"
 msgstr "Pelikula"
 
-#: catalog/models/common.py:162
+#: catalog/models/common.py:167
 msgid "Album"
 msgstr "Albuma"
 
-#: catalog/models/common.py:163 catalog/models/common.py:180
-#: catalog/models/common.py:194 common/templates/_header.html:43
+#: catalog/models/common.py:168 catalog/models/common.py:185
+#: catalog/models/common.py:199 common/templates/_header.html:53
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
 msgstr "Jokoa"
 
-#: catalog/models/common.py:164
+#: catalog/models/common.py:169
 msgid "Podcast Program"
 msgstr "Podkasta"
 
-#: catalog/models/common.py:165
+#: catalog/models/common.py:170
 msgid "Podcast Episode"
 msgstr "Podkast Atala"
 
-#: catalog/models/common.py:166 catalog/models/common.py:182
-#: catalog/models/common.py:196 common/templates/_header.html:47
+#: catalog/models/common.py:171 catalog/models/common.py:187
+#: catalog/models/common.py:201 common/templates/_header.html:57
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
 msgstr ""
 
-#: catalog/models/common.py:167
+#: catalog/models/common.py:172
 msgid "Production"
 msgstr "Produkzioa"
 
-#: catalog/models/common.py:168
+#: catalog/models/common.py:173
 msgid "Exhibition"
 msgstr ""
 
-#: catalog/models/common.py:169 catalog/models/common.py:186
+#: catalog/models/common.py:174 catalog/models/common.py:191
 #: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr "Kolekzio"
 
-#: catalog/models/common.py:172 catalog/models/common.py:185
+#: catalog/models/common.py:177 catalog/models/common.py:190
 msgid "Person / Organization"
 msgstr ""
 
-#: catalog/models/common.py:176 catalog/models/common.py:190
-#: common/templates/_header.html:27
+#: catalog/models/common.py:181 catalog/models/common.py:195
+#: common/templates/_header.html:37
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
 msgstr "Liburua"
 
-#: catalog/models/common.py:178 catalog/models/common.py:192
+#: catalog/models/common.py:183 catalog/models/common.py:197
 #: journal/templates/_sidebar_user_mark_list.html:38
 #: journal/templates/_sidebar_user_tag_filter.html:30
 msgid "TV"
 msgstr "TV"
 
-#: catalog/models/common.py:179 catalog/models/common.py:193
-#: common/templates/_header.html:39
+#: catalog/models/common.py:184 catalog/models/common.py:198
+#: common/templates/_header.html:49
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr "Musika"
 
-#: catalog/models/common.py:181 catalog/models/common.py:195
-#: catalog/templates/_sidebar_edit.html:219 common/templates/_header.html:35
+#: catalog/models/common.py:186 catalog/models/common.py:200
+#: catalog/templates/_sidebar_edit.html:213 common/templates/_header.html:45
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
 msgstr "Podkasta"
 
-#: catalog/models/common.py:346 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:345 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr "generoa"
 
-#: catalog/models/common.py:384
+#: catalog/models/common.py:383
 #, fuzzy
 #| msgid "original creator"
 msgid "origin country"
 msgstr "sortzaile originala"
 
-#: catalog/models/common.py:413 catalog/templates/album.html:33
+#: catalog/models/common.py:412 catalog/templates/album.html:33
 msgid "album type"
 msgstr "album mota"
 
-#: catalog/models/common.py:417 catalog/templates/_platform_list.html:5
+#: catalog/models/common.py:416 catalog/templates/_platform_list.html:5
 msgid "platform"
 msgstr "plataforma"
 
-#: catalog/models/common.py:421
+#: catalog/models/common.py:420
 #, fuzzy
 #| msgid "book format"
 msgid "media format"
 msgstr "liburu formatua"
 
-#: catalog/models/common.py:426 catalog/templates/_language_list.html:5
-#: users/models/user.py:142
+#: catalog/models/common.py:425 catalog/templates/_language_list.html:5
+#: users/models/user.py:144
 msgid "language"
 msgstr "hizkuntza"
 
-#: catalog/models/creator.py:24
+#: catalog/models/creator.py:26
 msgid "pending"
 msgstr ""
 
-#: catalog/models/creator.py:25
+#: catalog/models/creator.py:27
 msgid "verified"
 msgstr ""
 
-#: catalog/models/creator.py:26
+#: catalog/models/creator.py:28
 msgid "failed"
 msgstr ""
 
-#: catalog/models/creator.py:29
+#: catalog/models/creator.py:31
 msgid "no feed url available for this item"
 msgstr ""
 
-#: catalog/models/creator.py:30
+#: catalog/models/creator.py:32
 msgid "unable to fetch or parse the feed"
 msgstr ""
 
-#: catalog/models/creator.py:31
+#: catalog/models/creator.py:33
 msgid "no audio episode found in the feed"
 msgstr ""
 
-#: catalog/models/creator.py:34
+#: catalog/models/creator.py:36
 msgid "no matching identity found in the feed or its linked website"
 msgstr ""
 
@@ -697,16 +706,16 @@ msgstr ""
 msgid "Special Edition"
 msgstr "Edizio Berezia"
 
-#: catalog/models/game.py:111 catalog/models/item.py:130
+#: catalog/models/game.py:111 catalog/models/item.py:126
 msgid "designer"
 msgstr "diseinatzailea"
 
-#: catalog/models/game.py:119 catalog/models/item.py:129
+#: catalog/models/game.py:119 catalog/models/item.py:125
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr "artista"
 
-#: catalog/models/game.py:127 catalog/models/item.py:139
+#: catalog/models/game.py:127 catalog/models/item.py:135
 msgid "developer"
 msgstr "garatzailea"
 
@@ -715,8 +724,8 @@ msgid "date of publication"
 msgstr "publikatutako data"
 
 #: catalog/models/game.py:147 catalog/models/movie.py:156
-#: catalog/models/music.py:128 catalog/models/tv.py:247
-#: catalog/models/tv.py:473
+#: catalog/models/music.py:128 catalog/models/tv.py:249
+#: catalog/models/tv.py:475
 msgid "YYYY, YYYY-MM or YYYY-MM-DD"
 msgstr ""
 
@@ -727,7 +736,7 @@ msgstr ""
 #: catalog/models/game.py:180 catalog/models/movie.py:158
 #: catalog/models/people.py:178 catalog/models/performance.py:258
 #: catalog/models/performance.py:465 catalog/models/podcast.py:89
-#: catalog/models/tv.py:249 catalog/models/tv.py:476
+#: catalog/models/tv.py:251 catalog/models/tv.py:478
 #: catalog/templates/game.html:33 catalog/templates/movie.html:48
 #: catalog/templates/people.html:44 catalog/templates/performance.html:35
 #: catalog/templates/performanceproduction.html:35
@@ -736,152 +745,152 @@ msgstr ""
 msgid "website"
 msgstr "webgunea"
 
-#: catalog/models/item.py:125 catalog/models/movie.py:123
+#: catalog/models/item.py:121 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
-#: catalog/models/tv.py:214 catalog/models/tv.py:440
+#: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr "zuzendaria"
 
-#: catalog/models/item.py:126 catalog/models/movie.py:130
+#: catalog/models/item.py:122 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
-#: catalog/models/tv.py:221 catalog/models/tv.py:447
+#: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr ""
 
-#: catalog/models/item.py:127 catalog/models/movie.py:137
+#: catalog/models/item.py:123 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
-#: catalog/models/tv.py:228 catalog/models/tv.py:454
+#: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr "aktorea"
 
-#: catalog/models/item.py:128 catalog/models/movie.py:144
-#: catalog/models/tv.py:235 catalog/models/tv.py:461
+#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/tv.py:237 catalog/models/tv.py:463
 #, fuzzy
 #| msgid "production"
 msgid "producer"
 msgstr "produkzioa"
 
-#: catalog/models/item.py:131 catalog/models/performance.py:203
+#: catalog/models/item.py:127 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr "konpositorea"
 
-#: catalog/models/item.py:132 catalog/models/performance.py:210
+#: catalog/models/item.py:128 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr "koreografo"
 
-#: catalog/models/item.py:133 catalog/models/performance.py:224
+#: catalog/models/item.py:129 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr ""
 
-#: catalog/models/item.py:134 catalog/models/podcast.py:80
+#: catalog/models/item.py:130 catalog/models/podcast.py:80
 msgid "host"
 msgstr ""
 
-#: catalog/models/item.py:135 catalog/models/performance.py:196
+#: catalog/models/item.py:131 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr "sortzaile originala"
 
-#: catalog/models/item.py:136 catalog/models/performance.py:238
+#: catalog/models/item.py:132 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr "krew"
 
-#: catalog/models/item.py:140
+#: catalog/models/item.py:136
 #, fuzzy
 #| msgid "production"
 msgid "production company"
 msgstr "produkzioa"
 
-#: catalog/models/item.py:141
+#: catalog/models/item.py:137
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:142
+#: catalog/models/item.py:138
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:139
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:144 catalog/models/performance.py:231
+#: catalog/models/item.py:140 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr ""
 
-#: catalog/models/item.py:147
+#: catalog/models/item.py:143
 #, fuzzy
 #| msgid "director"
 msgid "voice actor"
 msgstr "zuzendaria"
 
-#: catalog/models/item.py:148 catalog/templates/edition.html:30
+#: catalog/models/item.py:144 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr ""
 
-#: catalog/models/item.py:173 catalog/models/people.py:476
+#: catalog/models/item.py:169 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr "rola"
 
-#: catalog/models/item.py:174 catalog/models/people.py:155
+#: catalog/models/item.py:170 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr "izena"
 
-#: catalog/models/item.py:176 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:288 catalog/models/item.py:320
-#: journal/models/collection.py:96
+#: catalog/models/item.py:304 catalog/models/item.py:336
+#: journal/models/collection.py:100
 msgid "title"
 msgstr "izenburua"
 
-#: catalog/models/item.py:289 catalog/models/item.py:328
-#: journal/models/collection.py:97
+#: catalog/models/item.py:305 catalog/models/item.py:344
+#: journal/models/collection.py:101
 msgid "description"
 msgstr "deskribapena"
 
-#: catalog/models/item.py:300 catalog/models/people.py:484
+#: catalog/models/item.py:316 catalog/models/people.py:484
 msgid "metadata"
 msgstr "metadatua"
 
-#: catalog/models/item.py:302 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
 msgid "cover"
 msgstr "azala"
 
-#: catalog/models/item.py:1485
+#: catalog/models/item.py:1526
 msgid "source site"
 msgstr "jatorrizko gunea"
 
-#: catalog/models/item.py:1487
+#: catalog/models/item.py:1528
 msgid "ID on source site"
 msgstr "IDa jatorrizko gunean"
 
-#: catalog/models/item.py:1489
+#: catalog/models/item.py:1530
 msgid "source url"
 msgstr "jatorrizko url-a"
 
-#: catalog/models/item.py:1505
+#: catalog/models/item.py:1546
 msgid "IdType of the source site"
 msgstr ""
 
-#: catalog/models/item.py:1511
+#: catalog/models/item.py:1552
 msgid "Primary Id on the source site"
 msgstr ""
 
-#: catalog/models/item.py:1514
+#: catalog/models/item.py:1555
 msgid "url to the resource"
 msgstr ""
 
 #: catalog/models/movie.py:152 catalog/models/music.py:124
-#: catalog/models/tv.py:243 catalog/models/tv.py:469
+#: catalog/models/tv.py:245 catalog/models/tv.py:471
 #: catalog/templates/_item_card_metadata_album.html:16
 #: catalog/templates/album.html:17 catalog/templates/game.html:22
 #: catalog/templates/movie.html:36 catalog/templates/tvseason.html:53
@@ -896,7 +905,7 @@ msgid "length"
 msgstr "luzera"
 
 #: catalog/models/movie.py:162 catalog/models/music.py:131
-#: catalog/models/tv.py:259 catalog/models/tv.py:486
+#: catalog/models/tv.py:261 catalog/models/tv.py:488
 #, fuzzy
 #| msgid "milliseconds"
 msgid "seconds"
@@ -1092,32 +1101,83 @@ msgstr "irekiera data"
 msgid "closing date"
 msgstr "itxiera data"
 
-#: catalog/models/tv.py:186 catalog/templates/tvseason.html:38
+#: catalog/models/tv.py:188 catalog/templates/tvseason.html:38
 #: catalog/templates/tvshow.html:33
 msgid "number of seasons"
 msgstr "denboraldi kopurua"
 
-#: catalog/models/tv.py:189 catalog/models/tv.py:415
+#: catalog/models/tv.py:191 catalog/models/tv.py:417
 #: catalog/templates/tvseason.html:43 catalog/templates/tvshow.html:38
 msgid "number of episodes"
 msgstr "atal kopurua"
 
-#: catalog/models/tv.py:256 catalog/models/tv.py:483
+#: catalog/models/tv.py:258 catalog/models/tv.py:485
 msgid "episode length"
 msgstr ""
 
-#: catalog/models/tv.py:412 catalog/templates/tvseason.html:33
+#: catalog/models/tv.py:414 catalog/templates/tvseason.html:33
 msgid "season number"
 msgstr ""
 
-#: catalog/models/tv.py:530
+#: catalog/models/tv.py:532
 #, python-brace-format
 msgid "{show_title} Season {season_number}"
 msgstr ""
 
-#: catalog/models/tv.py:684
+#: catalog/models/tv.py:686
 #, python-brace-format
 msgid "{season_title} E{episode_number}"
+msgstr ""
+
+#: catalog/templates/_catalog_confirm_item.html:7
+#: catalog/templates/catalog_edit.html:62
+msgid "Item has been deleted."
+msgstr ""
+
+#: catalog/templates/_catalog_confirm_item.html:12
+#: catalog/templates/catalog_edit.html:65
+msgid "Item contains sub-items."
+msgstr ""
+
+#: catalog/templates/_catalog_confirm_item.html:17
+msgid "Item has been merged to another item."
+msgstr ""
+
+#: catalog/templates/_catalog_confirm_item.html:22
+msgid "Item has been marked by users."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:11
+msgid "Confirm changes"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:16
+msgid "Please correct the errors below."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:24
+msgid "Field"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:25
+msgid "From"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:26
+msgid "To"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:45
+msgid "No changes detected."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:54
+#: users/templates/users/register.html:104
+msgid "Confirm and save"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:57
+msgid "Back to editing"
 msgstr ""
 
 #: catalog/templates/_country_list.html:5
@@ -1125,9 +1185,7 @@ msgid "region"
 msgstr "herrialdea"
 
 #: catalog/templates/_fetch_failed.html:4
-msgid ""
-"Unable to fetch from the link, please check again. Some sites may require "
-"login for certain links, please manually create them here."
+msgid "Unable to fetch from the link, please check again. Some sites may require login for certain links, please manually create them here."
 msgstr ""
 
 #: catalog/templates/_item_card_metadata_album.html:7
@@ -1183,7 +1241,7 @@ msgstr ""
 #: journal/templates/profile_posts.html:21
 #: journal/templates/user_follow_list_items.html:63
 #: journal/templates/user_post_list_items.html:24
-#: social/templates/events.html:43 social/templates/feed_events.html:28
+#: social/templates/events.html:43 social/templates/feed_events.html:27
 msgid "nothing more."
 msgstr ""
 
@@ -1272,7 +1330,7 @@ msgid "Add note"
 msgstr "oharrak"
 
 #: catalog/templates/_item_user_pieces.html:83
-#: common/templates/_sidebar.html:196 journal/templates/profile_items.html:46
+#: common/templates/_sidebar.html:195 journal/templates/profile_items.html:46
 msgid "Set progress"
 msgstr ""
 
@@ -1298,6 +1356,10 @@ msgstr ""
 
 #: catalog/templates/_item_user_pieces.html:214
 msgid "mark history"
+msgstr ""
+
+#: catalog/templates/_search_suggest.html:2
+msgid "Suggestions"
 msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:8
@@ -1329,15 +1391,15 @@ msgid "Edit Options"
 msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
-#: catalog/views/edit.py:82 catalog/views/edit.py:143 catalog/views/edit.py:197
-#: catalog/views/edit.py:218 catalog/views/edit.py:259
-#: catalog/views/edit.py:328 catalog/views/edit.py:332
-#: catalog/views/edit.py:351 catalog/views/edit.py:400
-#: catalog/views/edit.py:425 catalog/views/edit.py:440
-#: catalog/views/edit.py:480 catalog/views/edit.py:490
-#: catalog/views/edit.py:517 catalog/views/edit.py:582
-#: catalog/views/edit.py:637 catalog/views/edit.py:659
-#: catalog/views/search.py:367
+#: catalog/views/edit.py:160 catalog/views/edit.py:221
+#: catalog/views/edit.py:288 catalog/views/edit.py:309
+#: catalog/views/edit.py:364 catalog/views/edit.py:471
+#: catalog/views/edit.py:475 catalog/views/edit.py:509
+#: catalog/views/edit.py:576 catalog/views/edit.py:601
+#: catalog/views/edit.py:624 catalog/views/edit.py:664
+#: catalog/views/edit.py:674 catalog/views/edit.py:703
+#: catalog/views/edit.py:782 catalog/views/edit.py:837
+#: catalog/views/edit.py:859 catalog/views/search.py:418
 msgid "Editing this item is restricted."
 msgstr ""
 
@@ -1365,7 +1427,7 @@ msgstr ""
 msgid "The following items are merged into this item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:70
+#: catalog/templates/_sidebar_edit.html:70 catalog/views/edit.py:456
 msgid "External website"
 msgstr ""
 
@@ -1385,35 +1447,31 @@ msgstr ""
 msgid "Fetch again"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:97
-msgid "You may not be able to undo this operation, sure to remove?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:102
+#: catalog/templates/_sidebar_edit.html:100
 msgid "Remove link to site"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:110
+#: catalog/templates/_sidebar_edit.html:108
 msgid "Choose cover"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:119
+#: catalog/templates/_sidebar_edit.html:117
+#: catalog/templates/_sidebar_edit.html:118
 #: catalog/templates/_sidebar_edit.html:120
-#: catalog/templates/_sidebar_edit.html:122
 msgid "Current cover"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:139
+#: catalog/templates/_sidebar_edit.html:137
 msgid "Select an image to use as the cover of this item."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:140
-#: catalog/templates/catalog_edit.html:65
-#: common/templates/manage/settings.html:136
+#: catalog/templates/_sidebar_edit.html:138
+#: catalog/templates/catalog_edit.html:78
+#: common/templates/manage/settings.html:19
 #: journal/templates/add_to_collection.html:43
 #: journal/templates/article_edit.html:60
 #: journal/templates/collection_edit.html:39 journal/templates/comment.html:41
-#: journal/templates/mark.html:134 journal/templates/note.html:65
+#: journal/templates/mark.html:138 journal/templates/note.html:65
 #: journal/templates/post_compose.html:103
 #: journal/templates/review_edit.html:46 journal/templates/tag_edit.html:51
 #: users/templates/users/_pref_device.html:37
@@ -1422,181 +1480,157 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:147
+#: catalog/templates/_sidebar_edit.html:145
 msgid "Edit sub-items"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:160
+#: catalog/templates/_sidebar_edit.html:158
 msgid "create"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:166
+#: catalog/templates/_sidebar_edit.html:164
 msgid "Fetch all episodes"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:171
+#: catalog/templates/_sidebar_edit.html:169
 msgid "Fetch all"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:172
-msgid ""
-"Due to differences in how Douban, IMDB, and TMDB handle season data, a small "
-"number of TV shows and animations may not return correct results. Please "
-"manually verify and clean up after updating."
+#: catalog/templates/_sidebar_edit.html:170
+msgid "Due to differences in how Douban, IMDB, and TMDB handle season data, a small number of TV shows and animations may not return correct results. Please manually verify and clean up after updating."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:173
+#: catalog/templates/_sidebar_edit.html:171
 msgid "Up to 250 episodes will be fetched for a season."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:176
-msgid ""
-"To fetch all episodes, season numbers and IMDB information are required. If "
-"filling this out is inconvenient, you can also manually create sub-entries."
+#: catalog/templates/_sidebar_edit.html:174
+msgid "To fetch all episodes, season numbers and IMDB information are required. If filling this out is inconvenient, you can also manually create sub-entries."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:182
-#: catalog/templates/_sidebar_edit.html:194
-#: catalog/templates/_sidebar_edit.html:213
+#: catalog/templates/_sidebar_edit.html:180
+#: catalog/templates/_sidebar_edit.html:191
+#: catalog/templates/_sidebar_edit.html:208
 msgid "switch category"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:185
-msgid "Switching may remove some metadata. Sure to proceed?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:188
+#: catalog/templates/_sidebar_edit.html:185 catalog/views/edit.py:383
 msgid "TV Show"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:227
+#: catalog/templates/_sidebar_edit.html:221
 msgid "Link to parent item"
 msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:230
-msgid "Sure to link?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:237
 msgid "Update link"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:243
+#: catalog/templates/_sidebar_edit.html:236
 msgid "Cleanup seasons"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:246
-#: catalog/templates/catalog_delete.html:45
-msgid "This operation cannot be undone. Sure to delete?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:250
+#: catalog/templates/_sidebar_edit.html:242
 msgid "remove seasons not marked"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:256
-#: catalog/templates/catalog_merge.html:12
+#: catalog/templates/_sidebar_edit.html:248
 msgid "Merge"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:262
+#: catalog/templates/_sidebar_edit.html:254
 msgid "URL of target item, or empty if undo merge"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:268
-#: catalog/templates/_sidebar_edit.html:348
+#: catalog/templates/_sidebar_edit.html:260
+#: catalog/templates/_sidebar_edit.html:350
 msgid "merge to another item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:273
-#: catalog/templates/_sidebar_edit.html:277
-#: catalog/templates/catalog_delete.html:12
+#: catalog/templates/_sidebar_edit.html:265
+#: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
 #: journal/templates/article.html:199 journal/templates/collection.html:188
-#: journal/templates/mark.html:149 journal/templates/note.html:82
+#: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
 #: users/templates/users/account.html:254
 msgid "Delete"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:287
+#: catalog/templates/_sidebar_edit.html:275
+#: catalog/templates/_sidebar_edit.html:279
+msgid "Undo delete"
+msgstr ""
+
+#: catalog/templates/_sidebar_edit.html:280
+msgid "Links to external sites and parent item were removed on delete and will not be restored."
+msgstr ""
+
+#: catalog/templates/_sidebar_edit.html:290
 msgid "This edition belongs to the following work"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:292
-msgid "Sure to unlink?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:298
+#: catalog/templates/_sidebar_edit.html:300
 msgid "Unlink from work"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:304
+#: catalog/templates/_sidebar_edit.html:306
 msgid "Link"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:315
+#: catalog/templates/_sidebar_edit.html:317
 msgid "Link to another edition from same work"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:324
+#: catalog/templates/_sidebar_edit.html:326
 msgid "Restriction"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:337
+#: catalog/templates/_sidebar_edit.html:339
 #: journal/templates/collection_update_item_note.html:4
 msgid "Update"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:342
+#: catalog/templates/_sidebar_edit.html:344
 msgid "Suggest Edits"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:347
+#: catalog/templates/_sidebar_edit.html:349
 msgid "proposed action"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:349
+#: catalog/templates/_sidebar_edit.html:351
 msgid "link to another item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:350
+#: catalog/templates/_sidebar_edit.html:352
 msgid "change item category"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:351
+#: catalog/templates/_sidebar_edit.html:353
 msgid "change item metadata"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:352
+#: catalog/templates/_sidebar_edit.html:354
 msgid "remove item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:353
+#: catalog/templates/_sidebar_edit.html:355
 msgid "other"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:357
-msgid ""
-"To suggest merging or association, please include the URL of the target item"
+#: catalog/templates/_sidebar_edit.html:359
+msgid "To suggest merging or association, please include the URL of the target item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:358
+#: catalog/templates/_sidebar_edit.html:360
 #: catalog/templates/catalog_verify.html:116
 msgid "submit"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:359
-msgid ""
-"As a user of this community, you may edit some metadata of items on this "
-"site. If you are unsure whether your edits are appropriate or are unable to "
-"make a certain change, you can make suggestions here. Moderators will "
-"consider each suggestion, although there is no guarantee that they will "
-"always be fully adopted; suggestions may also be viewed or discussed by "
-"other community users. If you have suggestions that are not related to a "
-"specific item, please contact us. Thank you for your support and "
-"contribution."
+#: catalog/templates/_sidebar_edit.html:361
+msgid "As a user of this community, you may edit some metadata of items on this site. If you are unsure whether your edits are appropriate or are unable to make a certain change, you can make suggestions here. Moderators will consider each suggestion, although there is no guarantee that they will always be fully adopted; suggestions may also be viewed or discussed by other community users. If you have suggestions that are not related to a specific item, please contact us. Thank you for your support and contribution."
 msgstr ""
 
 #: catalog/templates/_sidebar_search.html:5
@@ -1694,16 +1728,14 @@ msgid "matched"
 msgstr ""
 
 #: catalog/templates/_verify_status.html:21
-msgid ""
-"Sure to remove your creator verification? Anyone will be able to edit this "
-"item again."
+msgid "Sure to remove your creator verification? Anyone will be able to edit this item again."
 msgstr ""
 
 #: catalog/templates/_verify_status.html:26
 msgid "Remove my verification"
 msgstr ""
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:309
+#: catalog/templates/_verify_status.html:31 users/views/account.py:311
 msgid "Verification failed"
 msgstr ""
 
@@ -1740,43 +1772,11 @@ msgstr ""
 msgid "album media"
 msgstr ""
 
-#: catalog/templates/catalog_delete.html:19
-msgid "Are you sure to delete?"
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:24
-#: catalog/templates/catalog_edit.html:52
-#: catalog/templates/catalog_merge.html:36
-#: catalog/templates/catalog_merge.html:64
-msgid "Item has been deleted."
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:29
-#: catalog/templates/catalog_edit.html:55
-#: catalog/templates/catalog_merge.html:41
-#: catalog/templates/catalog_merge.html:69
-msgid "Item contains sub-items."
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:34
-#: catalog/templates/catalog_merge.html:46
-#: catalog/templates/catalog_merge.html:74
-msgid "Item has been merged to another item."
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:39
-#: catalog/templates/catalog_merge.html:51
-#: catalog/templates/catalog_merge.html:79
-msgid "Item has been marked by users."
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:48
-#: catalog/templates/catalog_merge.html:92 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:55 common/views_manage.py:139
 msgid "Yes"
 msgstr ""
 
-#: catalog/templates/catalog_delete.html:49
-#: catalog/templates/catalog_merge.html:93 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:56 common/views_manage.py:139
 msgid "No"
 msgstr ""
 
@@ -1785,36 +1785,18 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: catalog/templates/catalog_edit.html:68
+#: catalog/templates/catalog_edit.html:81
 #: journal/templates/collection_update_item_note.html:8
 #: journal/templates/piece_delete.html:38
 msgid "Cancel"
 msgstr ""
 
-#: catalog/templates/catalog_edit.html:104
+#: catalog/templates/catalog_edit.html:118
 msgid "open linked people page"
 msgstr ""
 
-#: catalog/templates/catalog_merge.html:22
-msgid "Are you sure to merge?"
-msgstr ""
-
-#: catalog/templates/catalog_merge.html:24
-msgid "Are you sure to cancel merge?"
-msgstr ""
-
-#: catalog/templates/catalog_merge.html:27
-msgid "Are you sure to link?"
-msgstr ""
-
-#: catalog/templates/catalog_merge.html:86
-msgid "This operation cannot be undone. Sure to merge?"
-msgstr ""
-
 #: catalog/templates/catalog_verify.html:21
-msgid ""
-"If you are a creator of this podcast, you may verify the ownership, so that "
-"only you (and other verified creators) can edit its metadata on this site."
+msgid "If you are a creator of this podcast, you may verify the ownership, so that only you (and other verified creators) can edit its metadata on this site."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:22
@@ -1822,9 +1804,7 @@ msgid "Your recent episodes may also occasionally be featured in discovery."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:24
-msgid ""
-"To verify, prove you control one of the following identifiers of your "
-"account (click to copy):"
+msgid "To verify, prove you control one of the following identifiers of your account (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:30
@@ -1835,18 +1815,11 @@ msgid "copied"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:35
-msgid ""
-"You can prove this in a few ways, then start verification: add one of the "
-"identifiers above to the podcast feed's description; add a <code>rel=\"me\"</"
-"code> link back to one of them on the web page your feed links to (the link "
-"verification Mastodon uses); or point your feed's website at your Bluesky "
-"handle's own domain."
+msgid "You can prove this in a few ways, then start verification: add one of the identifiers above to the podcast feed's description; add a <code>rel=\"me\"</code> link back to one of them on the web page your feed links to (the link verification Mastodon uses); or point your feed's website at your Bluesky handle's own domain."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:44
-msgid ""
-"For example, add this rel=me link to the web page your feed links to (click "
-"to copy):"
+msgid "For example, add this rel=me link to the web page your feed links to (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:50
@@ -1854,9 +1827,7 @@ msgid "or, in the page's head:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:57
-msgid ""
-"Can't edit the website? Just add a line like this to your feed's description "
-"instead (click to copy):"
+msgid "Can't edit the website? Just add a line like this to your feed's description instead (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:62
@@ -1864,10 +1835,7 @@ msgid "Welcome to follow me on the Fediverse:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:66
-msgid ""
-"NeoDB does not re-check this periodically at the moment, but we recommend "
-"you keep it so that your audience can discover and connect with you in "
-"distributed social media."
+msgid "NeoDB does not re-check this periodically at the moment, but we recommend you keep it so that your audience can discover and connect with you in distributed social media."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:72
@@ -1897,12 +1865,11 @@ msgid "Send feedback"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:115
-msgid ""
-"Questions or issues with creator verification? Let the site moderators know."
+msgid "Questions or issues with creator verification? Let the site moderators know."
 msgstr ""
 
-#: catalog/templates/discover.html:28 common/views_manage.py:145
-#: common/views_manage.py:353 users/templates/users/preferences.html:34
+#: catalog/templates/discover.html:28 common/views_manage.py:35
+#: common/views_manage.py:431 users/templates/users/preferences.html:34
 msgid "Discover"
 msgstr ""
 
@@ -1940,17 +1907,17 @@ msgstr ""
 msgid "hide"
 msgstr ""
 
-#: catalog/templates/discover.html:206 common/templates/_sidebar.html:14
+#: catalog/templates/discover.html:206 common/templates/_sidebar.html:13
 msgid "Unread Announcements"
 msgstr ""
 
-#: catalog/templates/discover.html:212 common/templates/_sidebar.html:20
+#: catalog/templates/discover.html:212 common/templates/_sidebar.html:19
 #: social/templates/notification.html:67
 msgid "mark all as read"
 msgstr ""
 
 #: catalog/templates/discover.html:222
-#: common/templates/_sidebar_anonymous.html:55
+#: common/templates/_sidebar_anonymous.html:54
 msgid "Popular Tags"
 msgstr ""
 
@@ -1961,9 +1928,9 @@ msgstr ""
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
 #: catalog/templates/user_verified_works.html:23
-#: common/templates/_sidebar.html:127
-#: common/templates/_sidebar_anonymous.html:46
-#: common/templates/_sidebar_anonymous.html:62 journal/templates/posts.html:8
+#: common/templates/_sidebar.html:126
+#: common/templates/_sidebar_anonymous.html:45
+#: common/templates/_sidebar_anonymous.html:61 journal/templates/posts.html:7
 #: journal/templates/profile_articles.html:24
 #: journal/templates/profile_articles.html:26
 #: journal/templates/profile_items.html:65
@@ -1979,7 +1946,7 @@ msgstr ""
 msgid "nothing so far."
 msgstr ""
 
-#: catalog/templates/discover.html:239 common/templates/_sidebar.html:269
+#: catalog/templates/discover.html:239 common/templates/_sidebar.html:268
 msgid "Recent Posts"
 msgstr ""
 
@@ -2007,9 +1974,7 @@ msgid "Borrow or Buy"
 msgstr ""
 
 #: catalog/templates/external_search_results.html:10
-msgid ""
-"Some items were found from other websites and instances, click their title "
-"to save them locally."
+msgid "Some items were found from other websites and instances, click their title to save them locally."
 msgstr ""
 
 #: catalog/templates/fetch_pending.html:13
@@ -2109,12 +2074,12 @@ msgstr "denboraldi kopurua"
 msgid "number of Episodes"
 msgstr "atal kopurua"
 
-#: catalog/templates/people.html:13 common/templates/_sidebar.html:77
-#: common/templates/_sidebar.html:84 journal/models/shelf.py:326
+#: catalog/templates/people.html:13 common/templates/_sidebar.html:76
+#: common/templates/_sidebar.html:83 journal/models/shelf.py:328
 msgid "following"
 msgstr ""
 
-#: catalog/templates/people.html:15 journal/models/shelf.py:324
+#: catalog/templates/people.html:15 journal/models/shelf.py:326
 #: social/templates/notification.html:60
 msgid "follow"
 msgstr ""
@@ -2133,7 +2098,6 @@ msgstr ""
 #: journal/templates/_sidebar_collection_filter.html:14
 #: journal/templates/_sidebar_collection_filter.html:28
 #: journal/templates/_sidebar_user_mark_list.html:56
-#: social/templates/feed.html:42 social/templates/feed.html:44
 #: social/templates/notification.html:56
 msgid "all"
 msgstr "dena"
@@ -2159,7 +2123,7 @@ msgstr "konpositorea"
 msgid "production"
 msgstr "produkzioa"
 
-#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:54
+#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:53
 #, fuzzy
 #| msgid "original creator"
 msgid "verified creator"
@@ -2242,10 +2206,7 @@ msgid "No items matching your search query."
 msgstr ""
 
 #: catalog/templates/search_results.html:34
-msgid ""
-"If you have URL from one of these sites, please put the full URL (e.g. "
-"<code>https://www.imdb.com/title/tt2513074/</code>) to the search box and "
-"press Enter."
+msgid "If you have URL from one of these sites, please put the full URL (e.g. <code>https://www.imdb.com/title/tt2513074/</code>) to the search box and press Enter."
 msgstr ""
 
 #: catalog/templates/search_results.html:48
@@ -2282,97 +2243,170 @@ msgstr ""
 msgid "Editions"
 msgstr ""
 
-#: catalog/views/edit.py:202 catalog/views/edit.py:205
-#: catalog/views/edit.py:306 catalog/views/edit.py:309
-#: catalog/views/verify.py:197 journal/views/collection.py:77
-#: journal/views/collection.py:102 journal/views/collection.py:556
-#: journal/views/collection.py:651 journal/views/common.py:221
-#: journal/views/mark.py:196 journal/views/post.py:117
-#: journal/views/post.py:119 journal/views/post.py:166
-#: journal/views/post.py:185 journal/views/post.py:187
-#: journal/views/post.py:228 journal/views/post.py:241
+#: catalog/views/edit.py:293 catalog/views/edit.py:296
+#: catalog/views/edit.py:440 catalog/views/edit.py:443
+#: catalog/views/verify.py:197 journal/views/collection.py:75
+#: journal/views/collection.py:100 journal/views/collection.py:538
+#: journal/views/collection.py:634 journal/views/common.py:231
+#: journal/views/mark.py:244 journal/views/post.py:119
+#: journal/views/post.py:121 journal/views/post.py:168
+#: journal/views/post.py:187 journal/views/post.py:189
+#: journal/views/post.py:230 journal/views/post.py:243
 #: journal/views/review.py:154 journal/views/review.py:158
-#: users/views/actions.py:179
+#: users/views/actions.py:178
 msgid "Invalid parameter"
 msgstr ""
 
-#: catalog/views/edit.py:220
+#: catalog/views/edit.py:313
 msgid "Item in use."
 msgstr ""
 
-#: catalog/views/edit.py:222
+#: catalog/views/edit.py:315
 msgid "Item cannot be deleted."
 msgstr ""
 
-#: catalog/views/edit.py:247 catalog/views/edit.py:303
-#: catalog/views/edit.py:427 catalog/views/edit.py:519
-#: catalog/views/edit.py:552 catalog/views/verify.py:158
+#: catalog/views/edit.py:319 catalog/views/edit.py:515
+msgid "Are you sure to delete?"
+msgstr ""
+
+#: catalog/views/edit.py:323 catalog/views/edit.py:518
+#: catalog/views/edit.py:617
+msgid "This operation cannot be undone."
+msgstr ""
+
+#: catalog/views/edit.py:344 catalog/views/edit.py:437
+#: catalog/views/edit.py:603 catalog/views/edit.py:705
+#: catalog/views/edit.py:752 catalog/views/verify.py:158
 #: catalog/views/verify.py:206 journal/views/article.py:44
 #: journal/views/article.py:133 journal/views/article.py:153
 #: journal/views/collection.py:248 journal/views/collection.py:341
-#: journal/views/collection.py:360 journal/views/collection.py:384
-#: journal/views/collection.py:457 journal/views/collection.py:500
-#: journal/views/collection.py:539 journal/views/collection.py:551
-#: journal/views/collection.py:576 journal/views/collection.py:613
-#: journal/views/common.py:300 journal/views/mark.py:281
-#: journal/views/post.py:58 journal/views/post.py:78 journal/views/post.py:100
-#: journal/views/post.py:170 journal/views/post.py:199
-#: journal/views/post.py:272 journal/views/post.py:287
-#: journal/views/post.py:394 journal/views/post.py:549
+#: journal/views/collection.py:354 journal/views/collection.py:372
+#: journal/views/collection.py:439 journal/views/collection.py:482
+#: journal/views/collection.py:521 journal/views/collection.py:533
+#: journal/views/collection.py:558 journal/views/collection.py:595
+#: journal/views/common.py:304 journal/views/mark.py:317
+#: journal/views/post.py:60 journal/views/post.py:80 journal/views/post.py:102
+#: journal/views/post.py:172 journal/views/post.py:201
+#: journal/views/post.py:274 journal/views/post.py:289
+#: journal/views/post.py:390 journal/views/post.py:539
 #: journal/views/review.py:64 journal/views/review.py:81
 #: journal/views/review.py:106
 msgid "Insufficient permission"
 msgstr ""
 
-#: catalog/views/edit.py:374
+#: catalog/views/edit.py:346
+msgid "Item is not deleted"
+msgstr ""
+
+#: catalog/views/edit.py:389
+msgid "Switching may remove some metadata."
+msgstr ""
+
+#: catalog/views/edit.py:395
+msgid "The following seasons will be detached from this show"
+msgstr ""
+
+#: catalog/views/edit.py:400
+msgid "Links to IMDB and TMDB will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:403
+msgid "Are you sure to switch category?"
+msgstr ""
+
+#: catalog/views/edit.py:451
+msgid "Are you sure to remove the link to this site?"
+msgstr ""
+
+#: catalog/views/edit.py:457
+msgid "You may not be able to undo this operation."
+msgstr ""
+
+#: catalog/views/edit.py:483
+msgid "Current parent item"
+msgstr ""
+
+#: catalog/views/edit.py:487
+msgid "The link to the parent item will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:490 catalog/views/edit.py:680
+msgid "Are you sure to link?"
+msgstr ""
+
+#: catalog/views/edit.py:521
+msgid "The following seasons will be deleted"
+msgstr ""
+
+#: catalog/views/edit.py:525
+msgid "The following seasons will be kept"
+msgstr ""
+
+#: catalog/views/edit.py:550
 msgid "TV Season with IMDB id and season number required."
 msgstr ""
 
-#: catalog/views/edit.py:380
+#: catalog/views/edit.py:556
 msgid "Updating episodes"
 msgstr ""
 
-#: catalog/views/edit.py:405
+#: catalog/views/edit.py:581
 msgid "This person has no supported source to fetch works from."
 msgstr ""
 
-#: catalog/views/edit.py:412
+#: catalog/views/edit.py:588
 msgid "Already pulling works for this person, try again later."
 msgstr ""
 
-#: catalog/views/edit.py:416
+#: catalog/views/edit.py:592
 msgid "Pulling works in background."
 msgstr ""
 
-#: catalog/views/edit.py:438
+#: catalog/views/edit.py:609
+msgid "Are you sure to merge?"
+msgstr ""
+
+#: catalog/views/edit.py:611
+msgid "Are you sure to cancel merge?"
+msgstr ""
+
+#: catalog/views/edit.py:622
 msgid "Cannot be merged to an item already deleted or merged"
 msgstr ""
 
-#: catalog/views/edit.py:443
+#: catalog/views/edit.py:627
 msgid "Cannot merge items in different categories"
 msgstr ""
 
-#: catalog/views/edit.py:447
+#: catalog/views/edit.py:631
 msgid "Cannot merge an item to itself"
 msgstr ""
 
-#: catalog/views/edit.py:488
+#: catalog/views/edit.py:672
 msgid "Cannot be linked to an item already deleted or merged"
 msgstr ""
 
-#: catalog/views/edit.py:492
+#: catalog/views/edit.py:676
 msgid "Cannot link items other than editions"
 msgstr ""
 
-#: catalog/views/search.py:96
+#: catalog/views/edit.py:710
+msgid "Are you sure to unlink?"
+msgstr ""
+
+#: catalog/views/edit.py:715
+msgid "This edition will be unlinked from the following work"
+msgstr ""
+
+#: catalog/views/search.py:113
 msgid "the internet"
 msgstr ""
 
-#: catalog/views/search.py:359
+#: catalog/views/search.py:410
 msgid "Invalid URL"
 msgstr ""
 
-#: catalog/views/search.py:362
+#: catalog/views/search.py:413
 msgid "Unsupported URL"
 msgstr ""
 
@@ -2396,9 +2430,9 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:122 common/utils.py:163
+#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
 #: journal/views/article.py:186 journal/views/review.py:182
-#: users/views/actions.py:45 users/views/actions.py:131
+#: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
 msgstr ""
 
@@ -2410,15 +2444,15 @@ msgstr ""
 msgid "Creator verification removed."
 msgstr ""
 
-#: catalog/views/view.py:74 catalog/views/view.py:99
+#: catalog/views/view.py:77 catalog/views/view.py:102
 msgid "Item not found"
 msgstr ""
 
-#: catalog/views/view.py:78 catalog/views/view.py:107 catalog/views/view.py:190
+#: catalog/views/view.py:81 catalog/views/view.py:110 catalog/views/view.py:193
 msgid "Item no longer exists"
 msgstr ""
 
-#: catalog/views/view.py:187
+#: catalog/views/view.py:190
 msgid "Invalid role"
 msgstr ""
 
@@ -2938,760 +2972,760 @@ msgctxt "genre"
 msgid "Health"
 msgstr ""
 
-#: common/models/lang.py:54
+#: common/models/lang.py:56
 msgid "Afar"
 msgstr ""
 
-#: common/models/lang.py:55
+#: common/models/lang.py:57
 msgid "Afrikaans"
 msgstr ""
 
-#: common/models/lang.py:56
+#: common/models/lang.py:58
 msgid "Akan"
 msgstr ""
 
-#: common/models/lang.py:57
+#: common/models/lang.py:59
 msgid "Aragonese"
 msgstr ""
 
-#: common/models/lang.py:58
+#: common/models/lang.py:60
 msgid "Assamese"
 msgstr ""
 
-#: common/models/lang.py:59
+#: common/models/lang.py:61
 msgid "Avaric"
 msgstr ""
 
-#: common/models/lang.py:60
+#: common/models/lang.py:62
 msgid "Avestan"
 msgstr ""
 
-#: common/models/lang.py:61
+#: common/models/lang.py:63
 msgid "Aymara"
 msgstr ""
 
-#: common/models/lang.py:62
+#: common/models/lang.py:64
 msgid "Azerbaijani"
 msgstr ""
 
-#: common/models/lang.py:63
+#: common/models/lang.py:65
 msgid "Bashkir"
 msgstr ""
 
-#: common/models/lang.py:64
+#: common/models/lang.py:66
 msgid "Bambara"
 msgstr ""
 
-#: common/models/lang.py:65
+#: common/models/lang.py:67
 msgid "Bislama"
 msgstr ""
 
-#: common/models/lang.py:66
+#: common/models/lang.py:68
 msgid "Tibetan"
 msgstr ""
 
-#: common/models/lang.py:67
+#: common/models/lang.py:69
 msgid "Breton"
 msgstr ""
 
-#: common/models/lang.py:68
+#: common/models/lang.py:70
 msgid "Catalan"
 msgstr ""
 
-#: common/models/lang.py:69
+#: common/models/lang.py:71
 msgid "Czech"
 msgstr ""
 
-#: common/models/lang.py:70
+#: common/models/lang.py:72
 msgid "Chechen"
 msgstr ""
 
-#: common/models/lang.py:71
+#: common/models/lang.py:73
 msgid "Slavic"
 msgstr ""
 
-#: common/models/lang.py:72
+#: common/models/lang.py:74
 msgid "Chuvash"
 msgstr ""
 
-#: common/models/lang.py:73
+#: common/models/lang.py:75
 msgid "Cornish"
 msgstr ""
 
-#: common/models/lang.py:74
+#: common/models/lang.py:76
 msgid "Corsican"
 msgstr ""
 
-#: common/models/lang.py:75
+#: common/models/lang.py:77
 msgid "Cree"
 msgstr ""
 
-#: common/models/lang.py:76
+#: common/models/lang.py:78
 msgid "Welsh"
 msgstr ""
 
-#: common/models/lang.py:79
+#: common/models/lang.py:81
 msgid "Divehi"
 msgstr ""
 
-#: common/models/lang.py:80
+#: common/models/lang.py:82
 msgid "Dzongkha"
 msgstr ""
 
-#: common/models/lang.py:81
+#: common/models/lang.py:83
 msgid "Esperanto"
 msgstr ""
 
-#: common/models/lang.py:82
+#: common/models/lang.py:84
 msgid "Estonian"
 msgstr ""
 
-#: common/models/lang.py:83
+#: common/models/lang.py:85
 msgid "Basque"
 msgstr ""
 
-#: common/models/lang.py:84
+#: common/models/lang.py:86
 msgid "Faroese"
 msgstr ""
 
-#: common/models/lang.py:85
+#: common/models/lang.py:87
 msgid "Fijian"
 msgstr ""
 
-#: common/models/lang.py:86
+#: common/models/lang.py:88
 msgid "Finnish"
 msgstr ""
 
-#: common/models/lang.py:88
+#: common/models/lang.py:90
 msgid "Frisian"
 msgstr ""
 
-#: common/models/lang.py:89
+#: common/models/lang.py:91
 msgid "Fulah"
 msgstr ""
 
-#: common/models/lang.py:90
+#: common/models/lang.py:92
 msgid "Gaelic"
 msgstr ""
 
-#: common/models/lang.py:91
+#: common/models/lang.py:93
 msgid "Irish"
 msgstr ""
 
-#: common/models/lang.py:92
+#: common/models/lang.py:94
 msgid "Galician"
 msgstr ""
 
-#: common/models/lang.py:93
+#: common/models/lang.py:95
 msgid "Manx"
 msgstr ""
 
-#: common/models/lang.py:94
+#: common/models/lang.py:96
 msgid "Guarani"
 msgstr "Guarani"
 
-#: common/models/lang.py:95
+#: common/models/lang.py:97
 #, fuzzy
 msgid "Gujarati"
 msgstr "Gujarati"
 
-#: common/models/lang.py:96
+#: common/models/lang.py:98
 msgid "Haitian; Haitian Creole"
 msgstr "Haitiar; Haitian Creole"
 
-#: common/models/lang.py:97
+#: common/models/lang.py:99
 msgid "Hausa"
 msgstr "Hausa"
 
-#: common/models/lang.py:98
+#: common/models/lang.py:100
 msgid "Serbo-Croatian"
 msgstr "Serbo-Kroaziar"
 
-#: common/models/lang.py:99
+#: common/models/lang.py:101
 msgid "Herero"
 msgstr ""
 
-#: common/models/lang.py:100
+#: common/models/lang.py:102
 msgid "Hiri Motu"
 msgstr "Hiri Motu"
 
-#: common/models/lang.py:101
+#: common/models/lang.py:103
 msgid "Croatian"
 msgstr "Kroaziera"
 
-#: common/models/lang.py:102
+#: common/models/lang.py:104
 msgid "Hungarian"
 msgstr "Hungariera"
 
-#: common/models/lang.py:103
+#: common/models/lang.py:105
 msgid "Igbo"
 msgstr "Igbo"
 
-#: common/models/lang.py:104
+#: common/models/lang.py:106
 msgid "Ido"
 msgstr "Ido"
 
-#: common/models/lang.py:105
+#: common/models/lang.py:107
 msgid "Yi"
 msgstr "Yi"
 
-#: common/models/lang.py:106
+#: common/models/lang.py:108
 msgid "Inuktitut"
 msgstr "Inuktituera"
 
-#: common/models/lang.py:107
+#: common/models/lang.py:109
 msgid "Interlingue"
 msgstr ""
 
-#: common/models/lang.py:108
+#: common/models/lang.py:110
 msgid "Interlingua"
 msgstr ""
 
-#: common/models/lang.py:109
+#: common/models/lang.py:111
 msgid "Indonesian"
 msgstr "Indonesiera"
 
-#: common/models/lang.py:110
+#: common/models/lang.py:112
 msgid "Inupiaq"
 msgstr ""
 
-#: common/models/lang.py:111
+#: common/models/lang.py:113
 msgid "Icelandic"
 msgstr ""
 
-#: common/models/lang.py:113
+#: common/models/lang.py:115
 msgid "Javanese"
 msgstr ""
 
-#: common/models/lang.py:114
+#: common/models/lang.py:116
 msgid "Japanese"
 msgstr ""
 
-#: common/models/lang.py:115
+#: common/models/lang.py:117
 msgid "Kalaallisut"
 msgstr ""
 
-#: common/models/lang.py:116
+#: common/models/lang.py:118
 msgid "Kannada"
 msgstr ""
 
-#: common/models/lang.py:117
+#: common/models/lang.py:119
 msgid "Kashmiri"
 msgstr ""
 
-#: common/models/lang.py:118
+#: common/models/lang.py:120
 msgid "Kanuri"
 msgstr ""
 
-#: common/models/lang.py:119
+#: common/models/lang.py:121
 msgid "Kazakh"
 msgstr ""
 
-#: common/models/lang.py:120
+#: common/models/lang.py:122
 msgid "Khmer"
 msgstr ""
 
-#: common/models/lang.py:121
+#: common/models/lang.py:123
 msgid "Kikuyu"
 msgstr ""
 
-#: common/models/lang.py:122
+#: common/models/lang.py:124
 msgid "Kinyarwanda"
 msgstr ""
 
-#: common/models/lang.py:123
+#: common/models/lang.py:125
 msgid "Kirghiz"
 msgstr ""
 
-#: common/models/lang.py:124
+#: common/models/lang.py:126
 msgid "Komi"
 msgstr ""
 
-#: common/models/lang.py:125
+#: common/models/lang.py:127
 msgid "Kongo"
 msgstr ""
 
-#: common/models/lang.py:126
+#: common/models/lang.py:128
 msgid "Korean"
 msgstr ""
 
-#: common/models/lang.py:127
+#: common/models/lang.py:129
 msgid "Kuanyama"
 msgstr ""
 
-#: common/models/lang.py:128
+#: common/models/lang.py:130
 msgid "Kurdish"
 msgstr ""
 
-#: common/models/lang.py:129
+#: common/models/lang.py:131
 msgid "Lao"
 msgstr ""
 
-#: common/models/lang.py:130
+#: common/models/lang.py:132
 msgid "Latin"
 msgstr ""
 
-#: common/models/lang.py:131
+#: common/models/lang.py:133
 msgid "Latvian"
 msgstr ""
 
-#: common/models/lang.py:132
+#: common/models/lang.py:134
 msgid "Limburgish"
 msgstr ""
 
-#: common/models/lang.py:133
+#: common/models/lang.py:135
 msgid "Lingala"
 msgstr ""
 
-#: common/models/lang.py:134
+#: common/models/lang.py:136
 msgid "Lithuanian"
 msgstr ""
 
-#: common/models/lang.py:135
+#: common/models/lang.py:137
 msgid "Letzeburgesch"
 msgstr ""
 
-#: common/models/lang.py:136
+#: common/models/lang.py:138
 msgid "Luba-Katanga"
 msgstr ""
 
-#: common/models/lang.py:137
+#: common/models/lang.py:139
 msgid "Ganda"
 msgstr ""
 
-#: common/models/lang.py:138
+#: common/models/lang.py:140
 msgid "Marshall"
 msgstr ""
 
-#: common/models/lang.py:139
+#: common/models/lang.py:141
 msgid "Malayalam"
 msgstr ""
 
-#: common/models/lang.py:140
+#: common/models/lang.py:142
 msgid "Marathi"
 msgstr ""
 
-#: common/models/lang.py:141
+#: common/models/lang.py:143
 msgid "Malagasy"
 msgstr ""
 
-#: common/models/lang.py:142
+#: common/models/lang.py:144
 msgid "Maltese"
 msgstr ""
 
-#: common/models/lang.py:143
+#: common/models/lang.py:145
 msgid "Moldavian"
 msgstr ""
 
-#: common/models/lang.py:144
+#: common/models/lang.py:146
 msgid "Mongolian"
 msgstr ""
 
-#: common/models/lang.py:145
+#: common/models/lang.py:147
 msgid "Maori"
 msgstr ""
 
-#: common/models/lang.py:146
+#: common/models/lang.py:148
 msgid "Malay"
 msgstr ""
 
-#: common/models/lang.py:147
+#: common/models/lang.py:149
 msgid "Burmese"
 msgstr ""
 
-#: common/models/lang.py:148
+#: common/models/lang.py:150
 msgid "Nauru"
 msgstr ""
 
-#: common/models/lang.py:149
+#: common/models/lang.py:151
 msgid "Navajo"
 msgstr ""
 
-#: common/models/lang.py:150 common/models/lang.py:151
+#: common/models/lang.py:152 common/models/lang.py:153
 msgid "Ndebele"
 msgstr ""
 
-#: common/models/lang.py:152
+#: common/models/lang.py:154
 msgid "Ndonga"
 msgstr ""
 
-#: common/models/lang.py:153
+#: common/models/lang.py:155
 msgid "Nepali"
 msgstr ""
 
-#: common/models/lang.py:154
+#: common/models/lang.py:156
 msgid "Dutch"
 msgstr ""
 
-#: common/models/lang.py:155
+#: common/models/lang.py:157
 msgid "Norwegian Nynorsk"
 msgstr ""
 
-#: common/models/lang.py:156
+#: common/models/lang.py:158
 msgid "Norwegian Bokmål"
 msgstr ""
 
-#: common/models/lang.py:157
+#: common/models/lang.py:159
 msgid "Norwegian"
 msgstr "Norbegiera"
 
-#: common/models/lang.py:158
+#: common/models/lang.py:160
 msgid "Chichewa; Nyanja"
 msgstr ""
 
-#: common/models/lang.py:159
+#: common/models/lang.py:161
 msgid "Occitan"
 msgstr ""
 
-#: common/models/lang.py:160
+#: common/models/lang.py:162
 msgid "Ojibwa"
 msgstr ""
 
-#: common/models/lang.py:161
+#: common/models/lang.py:163
 msgid "Oriya"
 msgstr ""
 
-#: common/models/lang.py:162
+#: common/models/lang.py:164
 msgid "Oromo"
 msgstr ""
 
-#: common/models/lang.py:163
+#: common/models/lang.py:165
 msgid "Ossetian; Ossetic"
 msgstr ""
 
-#: common/models/lang.py:164
+#: common/models/lang.py:166
 msgid "Pali"
 msgstr ""
 
-#: common/models/lang.py:165
+#: common/models/lang.py:167
 msgid "Polish"
 msgstr ""
 
-#: common/models/lang.py:167
+#: common/models/lang.py:169
 msgid "Quechua"
 msgstr ""
 
-#: common/models/lang.py:168
+#: common/models/lang.py:170
 msgid "Raeto-Romance"
 msgstr ""
 
-#: common/models/lang.py:169
+#: common/models/lang.py:171
 msgid "Romanian"
 msgstr ""
 
-#: common/models/lang.py:170
+#: common/models/lang.py:172
 msgid "Rundi"
 msgstr ""
 
-#: common/models/lang.py:171
+#: common/models/lang.py:173
 msgid "Russian"
 msgstr ""
 
-#: common/models/lang.py:172
+#: common/models/lang.py:174
 msgid "Sango"
 msgstr ""
 
-#: common/models/lang.py:173
+#: common/models/lang.py:175
 msgid "Sanskrit"
 msgstr ""
 
-#: common/models/lang.py:174
+#: common/models/lang.py:176
 msgid "Sinhalese"
 msgstr ""
 
-#: common/models/lang.py:175
+#: common/models/lang.py:177
 msgid "Slovak"
 msgstr ""
 
-#: common/models/lang.py:176
+#: common/models/lang.py:178
 msgid "Slovenian"
 msgstr ""
 
-#: common/models/lang.py:177
+#: common/models/lang.py:179
 msgid "Northern Sami"
 msgstr ""
 
-#: common/models/lang.py:178
+#: common/models/lang.py:180
 msgid "Samoan"
 msgstr ""
 
-#: common/models/lang.py:179
+#: common/models/lang.py:181
 msgid "Shona"
 msgstr ""
 
-#: common/models/lang.py:180
+#: common/models/lang.py:182
 msgid "Sindhi"
 msgstr ""
 
-#: common/models/lang.py:181
+#: common/models/lang.py:183
 msgid "Somali"
 msgstr ""
 
-#: common/models/lang.py:182
+#: common/models/lang.py:184
 msgid "Sotho"
 msgstr ""
 
-#: common/models/lang.py:184
+#: common/models/lang.py:186
 msgid "Albanian"
 msgstr ""
 
-#: common/models/lang.py:185
+#: common/models/lang.py:187
 msgid "Sardinian"
 msgstr ""
 
-#: common/models/lang.py:186
+#: common/models/lang.py:188
 msgid "Serbian"
 msgstr ""
 
-#: common/models/lang.py:187
+#: common/models/lang.py:189
 msgid "Swati"
 msgstr ""
 
-#: common/models/lang.py:188
+#: common/models/lang.py:190
 msgid "Sundanese"
 msgstr ""
 
-#: common/models/lang.py:189
+#: common/models/lang.py:191
 msgid "Swahili"
 msgstr ""
 
-#: common/models/lang.py:190
+#: common/models/lang.py:192
 msgid "Swedish"
 msgstr ""
 
-#: common/models/lang.py:191
+#: common/models/lang.py:193
 msgid "Tahitian"
 msgstr ""
 
-#: common/models/lang.py:192
+#: common/models/lang.py:194
 msgid "Tamil"
 msgstr ""
 
-#: common/models/lang.py:193
+#: common/models/lang.py:195
 msgid "Tatar"
 msgstr ""
 
-#: common/models/lang.py:194
+#: common/models/lang.py:196
 msgid "Telugu"
 msgstr ""
 
-#: common/models/lang.py:195
+#: common/models/lang.py:197
 msgid "Tajik"
 msgstr ""
 
-#: common/models/lang.py:196
+#: common/models/lang.py:198
 msgid "Tagalog"
 msgstr ""
 
-#: common/models/lang.py:197
+#: common/models/lang.py:199
 msgid "Thai"
 msgstr ""
 
-#: common/models/lang.py:198
+#: common/models/lang.py:200
 msgid "Tigrinya"
 msgstr ""
 
-#: common/models/lang.py:199
+#: common/models/lang.py:201
 msgid "Tonga"
 msgstr ""
 
-#: common/models/lang.py:200
+#: common/models/lang.py:202
 msgid "Tswana"
 msgstr ""
 
-#: common/models/lang.py:201
+#: common/models/lang.py:203
 msgid "Tsonga"
 msgstr ""
 
-#: common/models/lang.py:202
+#: common/models/lang.py:204
 msgid "Turkmen"
 msgstr ""
 
-#: common/models/lang.py:203
+#: common/models/lang.py:205
 msgid "Turkish"
 msgstr ""
 
-#: common/models/lang.py:204
+#: common/models/lang.py:206
 msgid "Twi"
 msgstr ""
 
-#: common/models/lang.py:205
+#: common/models/lang.py:207
 msgid "Uighur"
 msgstr ""
 
-#: common/models/lang.py:206
+#: common/models/lang.py:208
 msgid "Ukrainian"
 msgstr ""
 
-#: common/models/lang.py:207
+#: common/models/lang.py:209
 msgid "Urdu"
 msgstr ""
 
-#: common/models/lang.py:208
+#: common/models/lang.py:210
 msgid "Uzbek"
 msgstr ""
 
-#: common/models/lang.py:209
+#: common/models/lang.py:211
 msgid "Venda"
 msgstr ""
 
-#: common/models/lang.py:210
+#: common/models/lang.py:212
 msgid "Vietnamese"
 msgstr ""
 
-#: common/models/lang.py:211
+#: common/models/lang.py:213
 msgid "Volapük"
 msgstr ""
 
-#: common/models/lang.py:212
+#: common/models/lang.py:214
 msgid "Walloon"
 msgstr ""
 
-#: common/models/lang.py:213
+#: common/models/lang.py:215
 msgid "Wolof"
 msgstr ""
 
-#: common/models/lang.py:214
+#: common/models/lang.py:216
 msgid "Xhosa"
 msgstr ""
 
-#: common/models/lang.py:215
+#: common/models/lang.py:217
 msgid "Yiddish"
 msgstr ""
 
-#: common/models/lang.py:216
+#: common/models/lang.py:218
 msgid "Zhuang"
 msgstr ""
 
-#: common/models/lang.py:217
+#: common/models/lang.py:219
 msgid "Zulu"
 msgstr ""
 
-#: common/models/lang.py:218
+#: common/models/lang.py:220
 msgid "Abkhazian"
 msgstr ""
 
-#: common/models/lang.py:219
+#: common/models/lang.py:221
 msgid "Chinese"
 msgstr "Txinera"
 
-#: common/models/lang.py:220
+#: common/models/lang.py:222
 msgid "Pushto"
 msgstr ""
 
-#: common/models/lang.py:221
+#: common/models/lang.py:223
 msgid "Amharic"
 msgstr ""
 
-#: common/models/lang.py:222
+#: common/models/lang.py:224
 msgid "Arabic"
 msgstr ""
 
-#: common/models/lang.py:223
+#: common/models/lang.py:225
 msgid "Bulgarian"
 msgstr ""
 
-#: common/models/lang.py:224
+#: common/models/lang.py:226
 msgid "Macedonian"
 msgstr ""
 
-#: common/models/lang.py:225
+#: common/models/lang.py:227
 msgid "Greek"
 msgstr ""
 
-#: common/models/lang.py:226
+#: common/models/lang.py:228
 msgid "Persian"
 msgstr ""
 
-#: common/models/lang.py:227
+#: common/models/lang.py:229
 msgid "Hebrew"
 msgstr ""
 
-#: common/models/lang.py:228
+#: common/models/lang.py:230
 msgid "Hindi"
 msgstr ""
 
-#: common/models/lang.py:229
+#: common/models/lang.py:231
 msgid "Armenian"
 msgstr ""
 
-#: common/models/lang.py:231
+#: common/models/lang.py:233
 msgid "Ewe"
 msgstr ""
 
-#: common/models/lang.py:232
+#: common/models/lang.py:234
 msgid "Georgian"
 msgstr ""
 
-#: common/models/lang.py:233
+#: common/models/lang.py:235
 msgid "Punjabi"
 msgstr ""
 
-#: common/models/lang.py:234
+#: common/models/lang.py:236
 msgid "Bengali"
 msgstr ""
 
-#: common/models/lang.py:235
+#: common/models/lang.py:237
 msgid "Bosnian"
 msgstr ""
 
-#: common/models/lang.py:236
+#: common/models/lang.py:238
 msgid "Chamorro"
 msgstr ""
 
-#: common/models/lang.py:237
+#: common/models/lang.py:239
 msgid "Belarusian"
 msgstr ""
 
-#: common/models/lang.py:238
+#: common/models/lang.py:240
 msgid "Yoruba"
 msgstr ""
 
-#: common/models/lang.py:300
+#: common/models/lang.py:302
 msgid "Simplified Chinese (Mainland)"
 msgstr ""
 
-#: common/models/lang.py:301
+#: common/models/lang.py:303
 msgid "Traditional Chinese (Taiwan)"
 msgstr ""
 
-#: common/models/lang.py:302
+#: common/models/lang.py:304
 msgid "Traditional Chinese (Hongkong)"
 msgstr ""
 
-#: common/models/lang.py:310
+#: common/models/lang.py:312
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: common/models/lang.py:313
+#: common/models/lang.py:315
 msgid "Simplified Chinese (Singapore)"
 msgstr ""
 
-#: common/models/lang.py:314
+#: common/models/lang.py:316
 msgid "Simplified Chinese (Malaysia)"
 msgstr ""
 
-#: common/models/lang.py:315
+#: common/models/lang.py:317
 msgid "Traditional Chinese (Macau)"
 msgstr ""
 
-#: common/models/lang.py:323
+#: common/models/lang.py:325
 msgid "Mandarin Chinese"
 msgstr ""
 
-#: common/models/lang.py:324
+#: common/models/lang.py:326
 msgid "Yue Chinese"
 msgstr ""
 
-#: common/models/lang.py:328
+#: common/models/lang.py:330
 msgid "Min Nan Chinese"
 msgstr ""
 
-#: common/models/lang.py:329
+#: common/models/lang.py:331
 msgid "Wu Chinese"
 msgstr ""
 
-#: common/models/lang.py:330
+#: common/models/lang.py:332
 msgid "Hakka Chinese"
 msgstr ""
 
@@ -3835,22 +3869,16 @@ msgid "VCD"
 msgstr ""
 
 #: common/templates/400.html:23
-msgid ""
-"You may have submitted invalid data, or the content may have been deleted by "
-"the author."
+msgid "You may have submitted invalid data, or the content may have been deleted by the author."
 msgstr ""
 
 #: common/templates/400.html:25 common/templates/403.html:24
 #: common/templates/404.html:24
-msgid ""
-"If you believe this is our mistake, please contact us through the link at "
-"the bottom of the page."
+msgid "If you believe this is our mistake, please contact us through the link at the bottom of the page."
 msgstr ""
 
 #: common/templates/403.html:22
-msgid ""
-"Author may require you to log in before accessing this content, or you do "
-"not have permission to view it."
+msgid "Author may require you to log in before accessing this content, or you do not have permission to view it."
 msgstr ""
 
 #: common/templates/404.html:20
@@ -3858,9 +3886,7 @@ msgid "Something is missing"
 msgstr ""
 
 #: common/templates/404.html:22
-msgid ""
-"You may have visited an incorrect URL, or the content you are looking for "
-"has been deleted by the author."
+msgid "You may have visited an incorrect URL, or the content you are looking for has been deleted by the author."
 msgstr ""
 
 #: common/templates/404.html:26
@@ -3868,15 +3894,11 @@ msgid "Go to Home"
 msgstr ""
 
 #: common/templates/500.html:22
-msgid ""
-"An internal error occurred. If this error occurs repeatedly, it will be "
-"recorded and handled by a human."
+msgid "An internal error occurred. If this error occurs repeatedly, it will be recorded and handled by a human."
 msgstr ""
 
 #: common/templates/500.html:24
-msgid ""
-"If you have an urgent situation or any questions, please contact us through "
-"the link at the bottom of the page."
+msgid "If you have an urgent situation or any questions, please contact us through the link at the bottom of the page."
 msgstr ""
 
 #: common/templates/_footer.html:6
@@ -3891,207 +3913,184 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: common/templates/_footer.html:12 users/templates/users/login.html:265
+#: common/templates/_footer.html:12 users/templates/users/login.html:259
 #, python-format
-msgid ""
-"You are visiting an alternative domain for %(site_name)s, please always use "
-"<a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if "
-"possible."
+msgid "You are visiting an alternative domain for %(site_name)s, please always use <a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if possible."
 msgstr ""
 
-#: common/templates/_header.html:19 common/templates/_header.html:164
+#: common/templates/_header.html:19 common/templates/_header.html:177
 msgid "title, creator, ISBN, item url, @user, @user@instance"
 msgstr ""
 
-#: common/templates/_header.html:24
+#: common/templates/_header.html:34
 msgid "All Items"
 msgstr ""
 
-#: common/templates/_header.html:31
+#: common/templates/_header.html:41
 msgid "Movie & TV"
 msgstr ""
 
-#: common/templates/_header.html:50
+#: common/templates/_header.html:60
 msgid "People & Organizations"
 msgstr ""
 
-#: common/templates/_header.html:52
+#: common/templates/_header.html:62
 msgid "Journal"
 msgstr ""
 
-#: common/templates/_header.html:54 journal/templates/user_post_list.html:10
+#: common/templates/_header.html:64 journal/templates/user_post_list.html:10
 #: journal/templates/user_post_list.html:23
 msgid "Posts"
 msgstr ""
 
-#: common/templates/_header.html:89
+#: common/templates/_header.html:102
 msgid "Explore"
 msgstr ""
 
-#: common/templates/_header.html:93
+#: common/templates/_header.html:106 common/views_manage.py:36
 msgid "Feed"
 msgstr ""
 
-#: common/templates/_header.html:98 journal/templates/profile.html:13
+#: common/templates/_header.html:111 journal/templates/profile.html:13
 #: users/templates/users/preferences.html:46
 msgid "Home"
 msgstr ""
 
-#: common/templates/_header.html:114 common/templates/common/scan.html:9
+#: common/templates/_header.html:127 common/templates/common/scan.html:9
 #: common/templates/common/scan.html:42
 msgid "Scan Barcode"
 msgstr ""
 
-#: common/templates/_header.html:118 social/templates/notification.html:12
+#: common/templates/_header.html:131 social/templates/notification.html:12
 #: social/templates/notification.html:53
 msgid "Notification"
 msgstr ""
 
-#: common/templates/_header.html:122 users/models/task.py:21
+#: common/templates/_header.html:135 users/models/task.py:23
 #: users/templates/users/account.html:219
 #: users/templates/users/crossposts.html:9
 msgid "Pending"
 msgstr ""
 
-#: common/templates/_header.html:125
+#: common/templates/_header.html:138
 msgid "Data"
 msgstr ""
 
-#: common/templates/_header.html:128 common/templates/_header.html:146
+#: common/templates/_header.html:141 common/templates/_header.html:159
 #: users/templates/users/preferences.html:12
 #: users/templates/users/preferences.html:23
 #: users/templates/users/preferences_anonymous.html:13
 msgid "Preferences"
 msgstr ""
 
-#: common/templates/_header.html:131
+#: common/templates/_header.html:144
 msgid "Account"
 msgstr ""
 
-#: common/templates/_header.html:135
+#: common/templates/_header.html:148
 msgid "Manage"
 msgstr ""
 
-#: common/templates/_header.html:139
+#: common/templates/_header.html:152
 msgid "Logout"
 msgstr ""
 
-#: common/templates/_header.html:143
+#: common/templates/_header.html:156
 msgid "Sign up or Login"
 msgstr ""
 
-#: common/templates/_header.html:160
-msgid ""
-"title or content  category:tv  status:complete  rating:8..10  "
-"date:2021-09-11..2022-02"
+#: common/templates/_header.html:173
+msgid "title or content  category:tv  status:complete  rating:8..10  date:2021-09-11..2022-02"
 msgstr ""
 
-#: common/templates/_header.html:162
+#: common/templates/_header.html:175
 msgid "name of a person or company"
 msgstr ""
 
-#: common/templates/_header.html:179
+#: common/templates/_header.html:192
 msgid "Open"
 msgstr ""
 
-#: common/templates/_sidebar.html:62
+#: common/templates/_sidebar.html:61
 #: users/templates/users/profile_actions.html:36
 msgid "approving followers manually"
 msgstr ""
 
-#: common/templates/_sidebar.html:81 common/templates/_sidebar.html:86
+#: common/templates/_sidebar.html:80 common/templates/_sidebar.html:85
 msgid "followers"
 msgstr ""
 
-#: common/templates/_sidebar.html:112
+#: common/templates/_sidebar.html:111
 msgid "Current Targets"
 msgstr ""
 
-#: common/templates/_sidebar.html:125
+#: common/templates/_sidebar.html:124
 msgid "Set a collection as target, its progress will show up here."
 msgstr ""
 
-#: common/templates/_sidebar.html:138
+#: common/templates/_sidebar.html:137
 msgid "Recent podcast episodes"
 msgstr ""
 
-#: common/templates/_sidebar.html:173
+#: common/templates/_sidebar.html:172
 msgid "Currently reading"
 msgstr ""
 
-#: common/templates/_sidebar.html:215
+#: common/templates/_sidebar.html:214
 msgid "Currently watching"
 msgstr ""
 
-#: common/templates/_sidebar.html:238 journal/forms.py:217
+#: common/templates/_sidebar.html:237 journal/forms.py:217
 #: journal/templates/user_tag_list.html:13
 #: journal/templates/user_tagmember_list.html:4
 msgid "Tags"
 msgstr ""
 
-#: common/templates/_sidebar.html:244 journal/templates/user_tag_list.html:28
+#: common/templates/_sidebar.html:243 journal/templates/user_tag_list.html:28
 #: journal/templates/user_tagmember_list.html:10
 msgid "featured tag"
 msgstr ""
 
-#: common/templates/_sidebar.html:247 journal/templates/user_tag_list.html:31
+#: common/templates/_sidebar.html:246 journal/templates/user_tag_list.html:31
 #: journal/templates/user_tagmember_list.html:15
 msgid "personal tag"
 msgstr ""
 
-#: common/templates/_sidebar.html:254 journal/templates/user_tag_list.html:39
+#: common/templates/_sidebar.html:253 journal/templates/user_tag_list.html:39
 msgid "no tags so far."
 msgstr ""
 
-#: common/templates/_sidebar.html:258 common/templates/_sidebar.html:271
+#: common/templates/_sidebar.html:257 common/templates/_sidebar.html:270
 msgid "show all"
 msgstr ""
 
-#: common/templates/_sidebar_anonymous.html:16
+#: common/templates/_sidebar_anonymous.html:15
 #, python-format
 msgid ""
 "\n"
 "        <h3>Welcome 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is "
-"committed to creating a free, open, and interconnected space for collecting "
-"and reviewing books, movies, music, games, and podcasts. Here, you can "
-"manage your collections, share your thoughts, discover new content, and "
-"connect with others.\n"
+"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is committed to creating a free, open, and interconnected space for collecting and reviewing books, movies, music, games, and podcasts. Here, you can manage your collections, share your thoughts, discover new content, and connect with others.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in "
-"to %(site_name)s is through a Fediverse (a distributed social network, "
-"including Mastodon/Pleroma/etc) instance account. If you haven’t registered "
-"yet, you can <a href=\"https://joinmastodon.org/en/servers\" "
-"target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
+"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in to %(site_name)s is through a Fediverse (a distributed social network, including Mastodon/Pleroma/etc) instance account. If you haven’t registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log "
-"in is through a Bluesky (another distributed social network, also called "
-"ATProto) account. If you haven’t registered yet, you may <a href=\"https://"
-"bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
+"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log in is through a Bluesky (another distributed social network, also called ATProto) account. If you haven’t registered yet, you may <a href=\"https://bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready "
-"to join either Fediverse or Bluesky, that’s perfectly fine. You can create "
-"an account here using your email address, and link it to the Fediverse and "
-"Bluesky in settings whenever you’re ready.\n"
+"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready to join either Fediverse or Bluesky, that’s perfectly fine. You can create an account here using your email address, and link it to the Fediverse and Bluesky in settings whenever you’re ready.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have "
-"any questions or suggestions, please feel free to contact us via <a "
-"href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://"
-"discord.gg/uprvcH8gqD\">Discord</a>.\n"
+"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have any questions or suggestions, please feel free to contact us via <a href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-"href=\"%(login_url)s\">Click here</a> to register or log in.\n"
+"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Click here</a> to register or log in.\n"
 "        </p>\n"
 "        "
 msgstr ""
 
-#: common/templates/_sidebar_anonymous.html:43
+#: common/templates/_sidebar_anonymous.html:42
 #: users/templates/users/announcements.html:12
 #: users/templates/users/announcements.html:39
 msgid "Announcements"
@@ -4113,7 +4112,7 @@ msgstr ""
 msgid "Registration"
 msgstr ""
 
-#: common/templates/common/about.html:35 common/views_manage.py:493
+#: common/templates/common/about.html:35 common/views_manage.py:594
 msgid "Invite Only"
 msgstr ""
 
@@ -4121,7 +4120,7 @@ msgstr ""
 msgid "Open Registration"
 msgstr ""
 
-#: common/templates/common/about.html:40 common/views_manage.py:556
+#: common/templates/common/about.html:40 common/views_manage.py:657
 msgid "Preferred Languages"
 msgstr ""
 
@@ -4166,9 +4165,7 @@ msgid "Error"
 msgstr ""
 
 #: common/templates/common/scan.html:45
-msgid ""
-"Point the camera at a book ISBN or product barcode (EAN / UPC). You will be "
-"redirected to the search once a code is detected."
+msgid "Point the camera at a book ISBN or product barcode (EAN / UPC). You will be redirected to the search once a code is detected."
 msgstr ""
 
 #: common/templates/common/scan.html:50
@@ -4179,7 +4176,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:628
+#: common/templates/common/scan.html:60 common/views_manage.py:738
 #, fuzzy
 #| msgid "Search results"
 msgid "Search"
@@ -4213,16 +4210,28 @@ msgstr ""
 msgid "Camera unavailable. Use manual entry below."
 msgstr ""
 
-#: common/templates/manage/settings.html:9
+#: common/templates/manage/base.html:9
 msgid "Site Settings"
 msgstr ""
 
-#: common/templates/manage/settings.html:109
+#: common/templates/manage/base.html:127
 msgid "Takahe Admin"
 msgstr ""
 
-#: common/templates/manage/settings.html:112
+#: common/templates/manage/base.html:130
 msgid "Database Admin"
+msgstr ""
+
+#: common/templates/manage/environment.html:6
+msgid "These settings come from environment variables and cannot be changed here. Edit .env and restart the server to change them. Passwords and keys are hidden."
+msgstr ""
+
+#: common/templates/manage/environment.html:23
+msgid "(empty)"
+msgstr ""
+
+#: common/templates/manage/environment.html:26
+msgid "default"
 msgstr ""
 
 #: common/templatetags/duration.py:59
@@ -4241,7 +4250,7 @@ msgstr ""
 msgid "following you"
 msgstr ""
 
-#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:95
+#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:90
 msgid "you"
 msgstr ""
 
@@ -4249,831 +4258,842 @@ msgstr ""
 msgid "unavailable"
 msgstr ""
 
-#: common/utils.py:126 common/utils.py:167 users/views/actions.py:134
+#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr ""
 
-#: common/utils.py:133 common/utils.py:135 common/utils.py:138
-#: common/utils.py:174 common/utils.py:178 journal/views/profile.py:499
+#: common/utils.py:135 common/utils.py:137 common/utils.py:140
+#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
 msgid "Access denied"
 msgstr ""
 
-#: common/utils.py:141 common/utils.py:143 journal/views/article.py:204
+#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr ""
 
-#: common/views_manage.py:144 common/views_manage.py:295
+#: common/views_manage.py:34 common/views_manage.py:373
 msgid "Branding"
 msgstr ""
 
-#: common/views_manage.py:146
+#: common/views_manage.py:37
 msgid "Recommendations"
 msgstr ""
 
-#: common/views_manage.py:147
+#: common/views_manage.py:38
 msgid "Access"
 msgstr ""
 
-#: common/views_manage.py:148 common/views_manage.py:623
+#: common/views_manage.py:39 common/views_manage.py:733
 #, fuzzy
 #| msgid "duration"
 msgid "Federation"
 msgstr "iraupena"
 
-#: common/views_manage.py:149
+#: common/views_manage.py:40
 msgid "Catalog"
 msgstr ""
 
-#: common/views_manage.py:150
+#: common/views_manage.py:41
 msgid "API Keys"
 msgstr ""
 
-#: common/views_manage.py:151
+#: common/views_manage.py:42
 msgid "Downloader"
 msgstr ""
 
-#: common/views_manage.py:152 common/views_manage.py:303
+#: common/views_manage.py:43 common/views_manage.py:381
 #: users/templates/users/steam_import.html:113
 msgid "Advanced"
 msgstr ""
 
-#: common/views_manage.py:202
+#: common/views_manage.py:44
+msgid "Environment"
+msgstr ""
+
+#: common/views_manage.py:280
 msgid "Invalid value."
 msgstr ""
 
-#: common/views_manage.py:206
+#: common/views_manage.py:284
 msgid "Invalid configuration. Please check your input."
 msgstr ""
 
-#: common/views_manage.py:211
+#: common/views_manage.py:289
 msgid "Settings have been saved."
 msgstr ""
 
-#: common/views_manage.py:231
+#: common/views_manage.py:309
 msgid "Site Name"
 msgstr ""
 
-#: common/views_manage.py:234
+#: common/views_manage.py:312
 #, fuzzy
 #| msgid "description"
 msgid "Site Description"
 msgstr "deskribapena"
 
-#: common/views_manage.py:235
+#: common/views_manage.py:313
 msgid "Short description shown in metadata and about page."
 msgstr ""
 
-#: common/views_manage.py:238
+#: common/views_manage.py:316
 msgid "Site Logo URL"
 msgstr ""
 
-#: common/views_manage.py:239
+#: common/views_manage.py:317
 msgid "URL path to the site logo image."
 msgstr ""
 
-#: common/views_manage.py:242
+#: common/views_manage.py:320
 msgid "Site Icon URL"
 msgstr ""
 
-#: common/views_manage.py:243
+#: common/views_manage.py:321
 msgid "URL path to the site icon/favicon."
 msgstr ""
 
-#: common/views_manage.py:246
+#: common/views_manage.py:324
 msgid "Default User Avatar URL"
 msgstr ""
 
-#: common/views_manage.py:247
+#: common/views_manage.py:325
 msgid "URL path to the default user avatar."
 msgstr ""
 
-#: common/views_manage.py:250
+#: common/views_manage.py:328
 msgid "Site Color Theme"
 msgstr ""
 
-#: common/views_manage.py:251
+#: common/views_manage.py:329
 msgid "PicoCSS color theme."
 msgstr ""
 
-#: common/views_manage.py:276
+#: common/views_manage.py:354
 #, fuzzy
 #| msgid "Production"
 msgid "Site Introduction"
 msgstr "Produkzioa"
 
-#: common/views_manage.py:277
+#: common/views_manage.py:355
 msgid "URL path for the intro/welcome sidebar page."
 msgstr ""
 
-#: common/views_manage.py:280
+#: common/views_manage.py:358
 msgid "Custom HTML Head"
 msgstr ""
 
-#: common/views_manage.py:281
+#: common/views_manage.py:359
 msgid "Extra HTML injected into the <head> of all pages."
 msgstr ""
 
-#: common/views_manage.py:285
+#: common/views_manage.py:363
 msgid "Footer Links"
 msgstr ""
 
-#: common/views_manage.py:286
+#: common/views_manage.py:364
 msgid "Link title mapped to URL."
 msgstr ""
 
-#: common/views_manage.py:315
+#: common/views_manage.py:393
 msgid "Minimum Marks for Discover"
 msgstr ""
 
-#: common/views_manage.py:317
+#: common/views_manage.py:395
 msgid "Number of marks required for an item to appear in discover."
 msgstr ""
 
-#: common/views_manage.py:322
+#: common/views_manage.py:400
 msgid "Update Interval (minutes)"
 msgstr ""
 
-#: common/views_manage.py:323
+#: common/views_manage.py:401
 msgid "How often to refresh the popular items list."
 msgstr ""
 
-#: common/views_manage.py:327
+#: common/views_manage.py:405
 #, fuzzy
 #| msgid "filter by year range"
 msgid "Filter by Preferred Languages"
 msgstr "urte tartearen arabera iragazi"
 
-#: common/views_manage.py:328
+#: common/views_manage.py:406
 msgid "Only show items with titles in the preferred languages."
 msgstr ""
 
-#: common/views_manage.py:331
+#: common/views_manage.py:409
 msgid "Show Local Only"
 msgstr ""
 
-#: common/views_manage.py:333
+#: common/views_manage.py:411
 msgid "Only show items marked by local users, not the entire network."
 msgstr ""
 
-#: common/views_manage.py:337
+#: common/views_manage.py:415
 msgid "Show Popular Posts"
 msgstr ""
 
-#: common/views_manage.py:338
+#: common/views_manage.py:416
 msgid "Show popular public posts instead of recent ones."
 msgstr ""
 
-#: common/views_manage.py:341
+#: common/views_manage.py:419
 msgid "Show Popular Tags"
 msgstr ""
 
-#: common/views_manage.py:342
+#: common/views_manage.py:420
 msgid "Show popular public tags on the discover page."
 msgstr ""
 
-#: common/views_manage.py:345
+#: common/views_manage.py:423
 #, fuzzy
 #| msgid "Spotify Podcast"
 msgid "Show Verified Podcasts"
 msgstr "Spotify Podkasta"
 
-#: common/views_manage.py:347
-msgid ""
-"Show a shelf of recent episodes from podcasts with a verified creator on the "
-"discover page."
+#: common/views_manage.py:425
+msgid "Show a shelf of recent episodes from podcasts with a verified creator on the discover page."
 msgstr ""
 
-#: common/views_manage.py:386
+#: common/views_manage.py:447
+#, fuzzy
+#| msgid "your timeline"
+msgid "Show World Timeline"
+msgstr "zure denbora-lerroa"
+
+#: common/views_manage.py:449
+msgid "Offer a tab with public posts from this site and every server it federates with."
+msgstr ""
+
+#: common/views_manage.py:454
+msgid "Show Local Timeline"
+msgstr ""
+
+#: common/views_manage.py:455
+msgid "Offer a tab with public posts from this site only."
+msgstr ""
+
+#: common/views_manage.py:459
+#, fuzzy
+#| msgid "your timeline"
+msgid "Timelines"
+msgstr "zure denbora-lerroa"
+
+#: common/views_manage.py:487
 msgid "Enable Recommendations"
 msgstr ""
 
-#: common/views_manage.py:388
-msgid ""
-"Master switch. When off, all recommendation surfaces are hidden and the cron "
-"jobs are not scheduled."
+#: common/views_manage.py:489
+msgid "Master switch. When off, all recommendation surfaces are hidden and the cron jobs are not scheduled."
 msgstr ""
 
-#: common/views_manage.py:393
+#: common/views_manage.py:494
 msgid "Source Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:395
-msgid ""
-"Minimum public marks an item needs before similarity rows are built for it."
+#: common/views_manage.py:496
+msgid "Minimum public marks an item needs before similarity rows are built for it."
 msgstr ""
 
-#: common/views_manage.py:401
+#: common/views_manage.py:502
 msgid "Target Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:403
-msgid ""
-"Minimum public marks an item needs to be eligible as a recommendation target."
+#: common/views_manage.py:504
+msgid "Minimum public marks an item needs to be eligible as a recommendation target."
 msgstr ""
 
-#: common/views_manage.py:409
+#: common/views_manage.py:510
 msgid "Top-K Similar Items per Source"
 msgstr ""
 
-#: common/views_manage.py:410
+#: common/views_manage.py:511
 msgid "Number of similar items stored per source item."
 msgstr ""
 
-#: common/views_manage.py:414
+#: common/views_manage.py:515
 msgid "Top-N Recommendations per User"
 msgstr ""
 
-#: common/views_manage.py:415
+#: common/views_manage.py:516
 msgid "Number of personalised rows stored per user."
 msgstr ""
 
-#: common/views_manage.py:419
+#: common/views_manage.py:520
 msgid "Dampen Heavy Shelvers"
 msgstr ""
 
-#: common/views_manage.py:421
-msgid ""
-"Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-"
-"shelvers in similarity scoring."
+#: common/views_manage.py:522
+msgid "Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-shelvers in similarity scoring."
 msgstr ""
 
-#: common/views_manage.py:426
+#: common/views_manage.py:527
 msgid "Per-User Mark Cap (training)"
 msgstr ""
 
-#: common/views_manage.py:428
-msgid ""
-"Truncate each user's contribution to their N most recent marks when building "
-"the similarity matrix."
-msgstr ""
-
-#: common/views_manage.py:434
-msgid "Active-User Window (days)"
-msgstr ""
-
-#: common/views_manage.py:436
-msgid ""
-"Refresh personalised recommendations for users with at least one public mark "
-"in the last N days."
-msgstr ""
-
-#: common/views_manage.py:442
-msgid "Per-User Seed Cap (serving)"
-msgstr ""
-
-#: common/views_manage.py:444
-msgid ""
-"Number of recent marks used as seeds when scoring personalised "
-"recommendations for one user."
-msgstr ""
-
-#: common/views_manage.py:450
-msgid "Lazy Refresh TTL (days)"
-msgstr ""
-
-#: common/views_manage.py:452
-msgid ""
-"How long cached on-demand recommendations are valid before the next request "
-"triggers a refresh."
-msgstr ""
-
-#: common/views_manage.py:458
-msgid "Circles Window (days)"
-msgstr ""
-
-#: common/views_manage.py:460
-msgid ""
-"Look back N days when finding items recently marked by people the viewer "
-"follows."
-msgstr ""
-
-#: common/views_manage.py:467
-msgid "Master Switch"
-msgstr ""
-
-#: common/views_manage.py:470
-msgid "Similarity Builder"
-msgstr ""
-
-#: common/views_manage.py:477
-msgid "Personalisation"
-msgstr ""
-
-#: common/views_manage.py:495
-msgid ""
-"Require an invite token to register. Invite tokens can be generated with "
-"neodb-manage invite --create."
-msgstr ""
-
-#: common/views_manage.py:500
-msgid "Enable Local-Only Posting"
-msgstr ""
-
-#: common/views_manage.py:501
-msgid "Allow users to create posts visible only to local users."
-msgstr ""
-
-#: common/views_manage.py:504
-msgid "Mastodon Login Whitelist"
-msgstr ""
-
-#: common/views_manage.py:505
-msgid "One domain per line. Leave empty to allow any instance."
-msgstr ""
-
-#: common/views_manage.py:508
-msgid "Registration Captcha Items"
-msgstr ""
-
-#: common/views_manage.py:512
-msgid ""
-"Number of item covers a new user must sort into two category rows before "
-"choosing a username. 0 disables the captcha; 5-6 is recommended. The covers "
-"carry no title text, so this cannot be solved with a screen reader: if you "
-"enable it, keep another way in, such as an invite link."
-msgstr ""
-
-#: common/views_manage.py:520
-msgid "Registration Captcha Minimum Marks"
-msgstr ""
-
-#: common/views_manage.py:523
-msgid ""
-"Marks an item needs before the captcha treats it as well known enough to be "
-"recognizable. Categories with too few such items fall back to any item."
-msgstr ""
-
 #: common/views_manage.py:529
-msgid "Enable Mastodon Login"
-msgstr ""
-
-#: common/views_manage.py:532
-msgid "Enable Bluesky Login"
+msgid "Truncate each user's contribution to their N most recent marks when building the similarity matrix."
 msgstr ""
 
 #: common/views_manage.py:535
-msgid "Enable Threads Login"
+msgid "Active-User Window (days)"
 msgstr ""
 
-#: common/views_manage.py:538
-msgid "Email URL"
+#: common/views_manage.py:537
+msgid "Refresh personalised recommendations for users with at least one public mark in the last N days."
 msgstr ""
 
-#: common/views_manage.py:540
-msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
-msgstr ""
-
-#: common/views_manage.py:544
-msgid "Email From"
+#: common/views_manage.py:543
+msgid "Per-User Seed Cap (serving)"
 msgstr ""
 
 #: common/views_manage.py:545
+msgid "Number of recent marks used as seeds when scoring personalised recommendations for one user."
+msgstr ""
+
+#: common/views_manage.py:551
+msgid "Lazy Refresh TTL (days)"
+msgstr ""
+
+#: common/views_manage.py:553
+msgid "How long cached on-demand recommendations are valid before the next request triggers a refresh."
+msgstr ""
+
+#: common/views_manage.py:559
+msgid "Circles Window (days)"
+msgstr ""
+
+#: common/views_manage.py:561
+msgid "Look back N days when finding items recently marked by people the viewer follows."
+msgstr ""
+
+#: common/views_manage.py:568
+msgid "Master Switch"
+msgstr ""
+
+#: common/views_manage.py:571
+msgid "Similarity Builder"
+msgstr ""
+
+#: common/views_manage.py:578
+msgid "Personalisation"
+msgstr ""
+
+#: common/views_manage.py:596
+msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
+msgstr ""
+
+#: common/views_manage.py:601
+msgid "Enable Local-Only Posting"
+msgstr ""
+
+#: common/views_manage.py:602
+msgid "Allow users to create posts visible only to local users."
+msgstr ""
+
+#: common/views_manage.py:605
+msgid "Mastodon Login Whitelist"
+msgstr ""
+
+#: common/views_manage.py:606
+msgid "One domain per line. Leave empty to allow any instance."
+msgstr ""
+
+#: common/views_manage.py:609
+msgid "Registration Captcha Items"
+msgstr ""
+
+#: common/views_manage.py:613
+msgid "Number of item covers a new user must sort into two category rows before choosing a username. 0 disables the captcha; 5-6 is recommended. The covers carry no title text, so this cannot be solved with a screen reader: if you enable it, keep another way in, such as an invite link."
+msgstr ""
+
+#: common/views_manage.py:621
+msgid "Registration Captcha Minimum Marks"
+msgstr ""
+
+#: common/views_manage.py:624
+msgid "Marks an item needs before the captcha treats it as well known enough to be recognizable. Categories with too few such items fall back to any item."
+msgstr ""
+
+#: common/views_manage.py:630
+msgid "Enable Mastodon Login"
+msgstr ""
+
+#: common/views_manage.py:633
+msgid "Enable Bluesky Login"
+msgstr ""
+
+#: common/views_manage.py:636
+msgid "Enable Threads Login"
+msgstr ""
+
+#: common/views_manage.py:639
+msgid "Email URL"
+msgstr ""
+
+#: common/views_manage.py:641
+msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
+msgstr ""
+
+#: common/views_manage.py:645
+msgid "Email From"
+msgstr ""
+
+#: common/views_manage.py:646
 msgid "Sender name and address for outgoing email."
 msgstr ""
 
-#: common/views_manage.py:548
+#: common/views_manage.py:649
 #, fuzzy
 #| msgid "language"
 msgid "Default Language"
 msgstr "hizkuntza"
 
-#: common/views_manage.py:551
-msgid ""
-"Interface language for visitors and for users who have not chosen one "
-"themselves."
+#: common/views_manage.py:652
+msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:558
-msgid ""
-"Language codes, one per line (e.g. en, zh, ja). First language is the "
-"default."
+#: common/views_manage.py:659
+msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:564
+#: common/views_manage.py:665
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:571
+#: common/views_manage.py:672
 msgid "Login Methods"
 msgstr ""
 
-#: common/views_manage.py:576 mastodon/models/common.py:28
+#: common/views_manage.py:677 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr ""
 
-#: common/views_manage.py:580
+#: common/views_manage.py:681
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:591
+#: common/views_manage.py:692
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:593
-msgid ""
-"Disable relay.neodb.net federation for sharing public ratings across "
-"instances."
+#: common/views_manage.py:694
+msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:598
+#: common/views_manage.py:699
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:599
+#: common/views_manage.py:700
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:603
+#: common/views_manage.py:704
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:605
+#: common/views_manage.py:706
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:610
+#: common/views_manage.py:711
 #, fuzzy
 #| msgid "Search results"
 msgid "Search Sites"
 msgstr "Emaitzak bilatu"
 
-#: common/views_manage.py:611
+#: common/views_manage.py:712
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:614
+#: common/views_manage.py:715
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:615
+#: common/views_manage.py:716
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:618
+#: common/views_manage.py:719
 msgid "Hidden Categories"
 msgstr ""
 
-#: common/views_manage.py:619
+#: common/views_manage.py:720
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:640
+#: common/views_manage.py:723
+msgid "Guest Search Page Limit"
+msgstr ""
+
+#: common/views_manage.py:725
+msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
+msgstr ""
+
+#: common/views_manage.py:751
 #, fuzzy
 #| msgid "Spotify Album"
 msgid "Spotify API Key"
 msgstr "Spotify Albuma"
 
-#: common/views_manage.py:641
+#: common/views_manage.py:752
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:644
+#: common/views_manage.py:755
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:645
+#: common/views_manage.py:756
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:648
+#: common/views_manage.py:759
 #, fuzzy
 #| msgid "Google Books"
 msgid "Google Books API Key"
 msgstr "Google Liburuak"
 
-#: common/views_manage.py:649
+#: common/views_manage.py:760
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:652
+#: common/views_manage.py:763
 #, fuzzy
 #| msgid "Discogs"
 msgid "Discogs API Key"
 msgstr "Discogs"
 
-#: common/views_manage.py:654
+#: common/views_manage.py:765
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:658
+#: common/views_manage.py:769
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:770
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:662
+#: common/views_manage.py:773
 msgid "IGDB Client Secret"
 msgstr ""
 
-#: common/views_manage.py:665
+#: common/views_manage.py:776
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:667
-msgid ""
-"Bearer token from https://boardgamegeek.com/applications (see https://"
-"boardgamegeek.com/using_the_xml_api#toc9)."
+#: common/views_manage.py:778
+msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:672 users/templates/users/steam_import.html:26
+#: common/views_manage.py:783
+msgid "MyAnimeList Client ID"
+msgstr ""
+
+#: common/views_manage.py:785
+msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
+msgstr ""
+
+#: common/views_manage.py:790 users/templates/users/steam_import.html:26
 #, fuzzy
 #| msgid "Steam Game"
 msgid "Steam API Key"
 msgstr "Steam Jokoa"
 
-#: common/views_manage.py:674
-msgid ""
-"https://steamcommunity.com/dev - fallback key for Steam importer. Users can "
-"provide their own key when importing."
+#: common/views_manage.py:792
+msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:679
+#: common/views_manage.py:797
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:680
+#: common/views_manage.py:798
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:683
+#: common/views_manage.py:801
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:686
+#: common/views_manage.py:804
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:689
+#: common/views_manage.py:807
 msgid "Threads App ID"
 msgstr ""
 
-#: common/views_manage.py:690
+#: common/views_manage.py:808
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:693
+#: common/views_manage.py:811
 msgid "Threads App Secret"
 msgstr ""
 
-#: common/views_manage.py:696
+#: common/views_manage.py:814
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:698
-msgid ""
-"Webhook URLs keyed by channel (default, report, audit, suggest, system). All "
-"channels must be Discord forum or media channels (thread mode) because "
-"notifications are posted as threads."
+#: common/views_manage.py:816
+msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:715
+#: common/views_manage.py:833
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:844
 #, fuzzy
 #| msgid "translator"
 msgid "Translation"
 msgstr "itzultzailea"
 
-#: common/views_manage.py:730
+#: common/views_manage.py:849
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:734 social/templates/feed.html:27
+#: common/views_manage.py:853 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr ""
 
-#: common/views_manage.py:744
+#: common/views_manage.py:863
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:745
+#: common/views_manage.py:864
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:748
+#: common/views_manage.py:867
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:749
+#: common/views_manage.py:868
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:752
+#: common/views_manage.py:871
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:874
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:758
+#: common/views_manage.py:877
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:761
+#: common/views_manage.py:880
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:764
+#: common/views_manage.py:883
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:767
+#: common/views_manage.py:886
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:768
+#: common/views_manage.py:887
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:771
+#: common/views_manage.py:890
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:775
+#: common/views_manage.py:894
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:779
+#: common/views_manage.py:898
 #, fuzzy
 #| msgid "series"
 msgid "Retries"
 msgstr "telesailak"
 
-#: common/views_manage.py:784
+#: common/views_manage.py:903
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:789
+#: common/views_manage.py:908
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:796
+#: common/views_manage.py:915
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:808
+#: common/views_manage.py:927
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:809
+#: common/views_manage.py:928
 msgid "One domain per line."
 msgstr ""
 
-#: common/views_manage.py:812
+#: common/views_manage.py:931
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:813
+#: common/views_manage.py:932
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:935
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:818
-msgid ""
-"Timeout for requests to Mastodon instances and remote fediverse servers."
+#: common/views_manage.py:937
+msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:824
+#: common/views_manage.py:943
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:825
+#: common/views_manage.py:944
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:828
+#: common/views_manage.py:947
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:829
+#: common/views_manage.py:948
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:839
+#: common/views_manage.py:958
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:841
-msgid ""
-"Delete import/export tasks and their files after this many days. Set to 0 to "
-"disable cleanup."
+#: common/views_manage.py:960
+msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:847
+#: common/views_manage.py:966
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:849
-msgid ""
-"Post-migration job keys to skip, one per line (e.g. normalize_genre). "
-"Checked by the worker at dequeue time; skipped jobs log a warning and notify "
-"the Discord system channel."
+#: common/views_manage.py:968
+msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:855
+#: common/views_manage.py:974
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:857
-msgid ""
-"Private key (JWK) identifying this site to ATProto authorization servers. "
-"Auto-generated on first Bluesky login; clear to regenerate."
+#: common/views_manage.py:976
+msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:983
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:986
 #, fuzzy
 #| msgid "optional"
 msgid "Operational"
 msgstr "aukerakoa"
 
-#: common/views_manage.py:883
+#: common/views_manage.py:1002
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:885
-msgid ""
-"Genre codes offered in the Movie edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1004
+msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:1009
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:892
-msgid ""
-"Genre codes offered in the TV edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1011
+msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:897
+#: common/views_manage.py:1016
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:899
-msgid ""
-"Genre codes offered in the Music edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1018
+msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:904
+#: common/views_manage.py:1023
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:906
-msgid ""
-"Genre codes offered in the Game edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1025
+msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:911
+#: common/views_manage.py:1030
 #, fuzzy
 #| msgid "Podcast"
 msgid "Podcast Genres"
 msgstr "Podkasta"
 
-#: common/views_manage.py:913
-msgid ""
-"Genre codes offered in the Podcast edit dropdown, one per line. Leave empty "
-"to use the built-in default."
+#: common/views_manage.py:1032
+msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:918
+#: common/views_manage.py:1037
 #, fuzzy
 #| msgid "performances"
 msgid "Performance Genres"
 msgstr "ikuskizunak"
 
-#: common/views_manage.py:920
-msgid ""
-"Genre codes offered in the Performance edit dropdown, one per line. Leave "
-"empty to use the built-in default."
+#: common/views_manage.py:1039
+msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:926
+#: common/views_manage.py:1045
 msgid "Genres by Category"
 msgstr ""
 
+#: common/views_manage.py:1069
+msgid "Site"
+msgstr ""
+
+#: common/views_manage.py:1079
+msgid "Database and Services"
+msgstr ""
+
+#: common/views_manage.py:1089
+msgid "Media and Files"
+msgstr ""
+
+#: common/views_manage.py:1098
+msgid "Monitoring"
+msgstr ""
+
+#: common/views_manage.py:1102
+msgid "Security"
+msgstr ""
+
+#: common/views_manage.py:1111
+msgid "Other Environment Variables"
+msgstr ""
+
+#: common/views_manage.py:1113
+msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
+msgstr ""
+
 #: journal/forms.py:12
-msgid ""
-"Tips: use >!text!< for spoilers; some instances may not be able to show "
-"posts longer than 360 charactors."
+msgid "Tips: use >!text!< for spoilers; some instances may not be able to show posts longer than 360 charactors."
 msgstr ""
 
 #: journal/forms.py:29 journal/forms.py:31 journal/forms.py:80
@@ -5088,12 +5108,12 @@ msgid "Content (Markdown)"
 msgstr ""
 
 #: journal/forms.py:46 journal/forms.py:124 journal/forms.py:226
-#: journal/forms.py:288 journal/views/note.py:38
+#: journal/forms.py:288 journal/views/note.py:37
 msgid "Crosspost"
 msgstr ""
 
 #: journal/forms.py:47 journal/forms.py:125 journal/forms.py:227
-#: journal/forms.py:289 journal/views/note.py:39
+#: journal/forms.py:289 journal/views/note.py:38
 msgid "Crosspost to your connected social networks"
 msgstr ""
 
@@ -5108,10 +5128,10 @@ msgstr ""
 #: journal/forms.py:59 journal/forms.py:137 journal/forms.py:162
 #: journal/forms.py:219 journal/forms.py:281
 #: journal/templates/collection_share.html:24
-#: journal/templates/wrapped_share.html:36 journal/views/note.py:31
-#: users/templates/users/data.html:45 users/templates/users/data.html:98
-#: users/templates/users/data.html:155 users/templates/users/data.html:206
-#: users/templates/users/data.html:269 users/templates/users/data.html:328
+#: journal/templates/wrapped_share.html:36 journal/views/note.py:30
+#: users/templates/users/data.html:60 users/templates/users/data.html:113
+#: users/templates/users/data.html:170 users/templates/users/data.html:221
+#: users/templates/users/data.html:284 users/templates/users/data.html:346
 #: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
@@ -5150,7 +5170,6 @@ msgid "Collaborative editing"
 msgstr ""
 
 #: journal/forms.py:204 users/templates/users/crossposts.html:51
-#: users/templates/users/data.html:483
 msgid "Status"
 msgstr ""
 
@@ -5162,48 +5181,46 @@ msgstr ""
 msgid "Rating"
 msgstr ""
 
-#: journal/importers/goodreads.py:196 journal/importers/letterboxd.py:144
-#: journal/importers/rym.py:442 journal/importers/storygraph.py:500
+#: journal/importers/goodreads.py:198 journal/importers/letterboxd.py:147
+#: journal/importers/rym.py:444 journal/importers/storygraph.py:504
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr ""
 
-#: journal/importers/opml.py:45
+#: journal/importers/opml.py:49
 #, python-brace-format
 msgid "{username}'s podcast subscriptions"
 msgstr ""
 
-#: journal/importers/rym.py:168 journal/importers/storygraph.py:128
+#: journal/importers/rym.py:170 journal/importers/storygraph.py:132
 #, python-brace-format
-msgid ""
-"Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
+msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:178 journal/importers/storygraph.py:138
+#: journal/importers/rym.py:180 journal/importers/storygraph.py:142
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/importers/rym.py:233 journal/importers/storygraph.py:184
+#: journal/importers/rym.py:235 journal/importers/storygraph.py:188
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:348 journal/importers/storygraph.py:389
+#: journal/importers/rym.py:350 journal/importers/storygraph.py:393
 msgid "Matched file missing; cannot import."
 msgstr ""
 
-#: journal/importers/rym.py:376 journal/importers/storygraph.py:412
+#: journal/importers/rym.py:378 journal/importers/storygraph.py:416
 #, python-brace-format
-msgid ""
-"Import complete: {imported} imported, {skipped} skipped, {failed} failed"
+msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:212 journal/views/article.py:218
+#: journal/models/article.py:215 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
-#: journal/models/collection.py:44 journal/templates/add_to_collection.html:39
+#: journal/models/collection.py:48 journal/templates/add_to_collection.html:39
 #: journal/templates/collection_edit.html:64
 #: journal/templates/collection_share.html:63
 #: journal/templates/collection_update_item_note.html:3
@@ -5211,73 +5228,73 @@ msgstr ""
 msgid "note"
 msgstr ""
 
-#: journal/models/collection.py:111
+#: journal/models/collection.py:115
 msgid "search query for dynamic collection"
 msgstr ""
 
-#: journal/models/collection.py:524 journal/templatetags/collection.py:35
+#: journal/models/collection.py:566 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:529 journal/templatetags/collection.py:43
+#: journal/models/collection.py:571 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:534 journal/templatetags/collection.py:51
+#: journal/models/collection.py:576 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:539 journal/templatetags/collection.py:59
+#: journal/models/collection.py:581 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:544 journal/templatetags/collection.py:67
+#: journal/models/collection.py:586 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:549 journal/templatetags/collection.py:75
+#: journal/models/collection.py:591 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:555 journal/templatetags/collection.py:83
+#: journal/models/collection.py:597 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:563 journal/templatetags/collection.py:91
+#: journal/models/collection.py:605 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/common.py:50 journal/templates/action_open_post.html:15
-#: journal/templates/collection_share.html:35 journal/templates/mark.html:84
+#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
-#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:54
-#: users/templates/users/data.html:107 users/templates/users/data.html:164
-#: users/templates/users/data.html:215 users/templates/users/data.html:277
-#: users/templates/users/data.html:337 users/templates/users/data.html:534
+#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
+#: users/templates/users/data.html:122 users/templates/users/data.html:179
+#: users/templates/users/data.html:230 users/templates/users/data.html:292
+#: users/templates/users/data.html:355 users/templates/users/data.html:534
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5285,13 +5302,13 @@ msgstr[1] ""
 msgid "Public"
 msgstr ""
 
-#: journal/models/common.py:51 journal/templates/action_open_post.html:9
-#: journal/templates/collection_share.html:46 journal/templates/mark.html:91
+#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
-#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
-#: users/templates/users/data.html:115 users/templates/users/data.html:172
-#: users/templates/users/data.html:223 users/templates/users/data.html:285
-#: users/templates/users/data.html:345 users/templates/users/data.html:542
+#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
+#: users/templates/users/data.html:130 users/templates/users/data.html:187
+#: users/templates/users/data.html:238 users/templates/users/data.html:300
+#: users/templates/users/data.html:363 users/templates/users/data.html:542
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5299,12 +5316,12 @@ msgstr ""
 msgid "Followers Only"
 msgstr ""
 
-#: journal/models/common.py:52 journal/templates/collection_share.html:57
-#: journal/templates/mark.html:98 journal/templates/post_compose.html:72
-#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
-#: users/templates/users/data.html:123 users/templates/users/data.html:180
-#: users/templates/users/data.html:231 users/templates/users/data.html:293
-#: users/templates/users/data.html:353 users/templates/users/data.html:550
+#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/templates/mark.html:102 journal/templates/post_compose.html:72
+#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
+#: users/templates/users/data.html:138 users/templates/users/data.html:195
+#: users/templates/users/data.html:246 users/templates/users/data.html:308
+#: users/templates/users/data.html:371 users/templates/users/data.html:550
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5312,29 +5329,27 @@ msgstr ""
 msgid "Mentioned Only"
 msgstr ""
 
-#: journal/models/common.py:790
-msgid ""
-"A recent post was not posted to Bluesky, please login NeoDB using ATProto "
-"again to re-authorize."
+#: journal/models/common.py:806
+msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr ""
 
-#: journal/models/common.py:987
+#: journal/models/common.py:1003
 msgid "A recent post was not posted to Threads."
 msgstr ""
 
-#: journal/models/common.py:1020
+#: journal/models/common.py:1036
 msgid "A recent post was not boosted on Mastodon."
 msgstr ""
 
-#: journal/models/common.py:1030
+#: journal/models/common.py:1046
 msgid "Original post no longer exists."
 msgstr ""
 
-#: journal/models/common.py:1044
+#: journal/models/common.py:1060
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr ""
 
-#: journal/models/common.py:1053
+#: journal/models/common.py:1069
 msgid "A recent post was not posted to Mastodon."
 msgstr ""
 
@@ -5342,7 +5357,7 @@ msgstr ""
 msgid "Authorization expired"
 msgstr ""
 
-#: journal/models/crosspost.py:17 users/models/task.py:24
+#: journal/models/crosspost.py:17 users/models/task.py:26
 msgid "Failed"
 msgstr ""
 
@@ -5350,81 +5365,81 @@ msgstr ""
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:469
+#: journal/models/mark.py:475
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:473
+#: journal/models/mark.py:479
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:480
+#: journal/models/mark.py:486
 msgid "Invalid progress type."
 msgstr ""
 
-#: journal/models/mark.py:482
+#: journal/models/mark.py:488
 msgid "Invalid progress type for this item."
 msgstr ""
 
-#: journal/models/note.py:34 users/templates/users/rym_import.html:73
+#: journal/models/note.py:47 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr ""
 
-#: journal/models/note.py:35
+#: journal/models/note.py:48
 msgid "Chapter"
 msgstr ""
 
-#: journal/models/note.py:38
+#: journal/models/note.py:51
 msgid "Part"
 msgstr ""
 
-#: journal/models/note.py:39
+#: journal/models/note.py:52
 msgid "Episode"
 msgstr ""
 
-#: journal/models/note.py:40
+#: journal/models/note.py:53
 msgid "Track"
 msgstr ""
 
-#: journal/models/note.py:41
+#: journal/models/note.py:54
 msgid "Cycle"
 msgstr ""
 
-#: journal/models/note.py:42
+#: journal/models/note.py:55
 msgid "Timestamp"
 msgstr ""
 
-#: journal/models/note.py:43
+#: journal/models/note.py:56
 msgid "Percentage"
 msgstr ""
 
-#: journal/models/note.py:60
+#: journal/models/note.py:77
 #, python-brace-format
 msgid "Page {value}"
 msgstr ""
 
-#: journal/models/note.py:61
+#: journal/models/note.py:78
 #, python-brace-format
 msgid "Chapter {value}"
 msgstr ""
 
-#: journal/models/note.py:64
+#: journal/models/note.py:81
 #, python-brace-format
 msgid "Part {value}"
 msgstr ""
 
-#: journal/models/note.py:65
+#: journal/models/note.py:82
 #, python-brace-format
 msgid "Episode {value}"
 msgstr ""
 
-#: journal/models/note.py:66
+#: journal/models/note.py:83
 #, python-brace-format
 msgid "Track {value}"
 msgstr ""
 
-#: journal/models/note.py:67
+#: journal/models/note.py:84
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr ""
@@ -5434,439 +5449,439 @@ msgstr ""
 msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr ""
 
-#: journal/models/review.py:78
+#: journal/models/review.py:79
 #, python-brace-format
 msgid "a review of {title}"
 msgstr ""
 
-#: journal/models/review.py:80
+#: journal/models/review.py:81
 msgid "(may contain spoilers)"
 msgstr ""
 
-#: journal/models/shelf.py:37
+#: journal/models/shelf.py:39
 msgid "WISHLIST"
 msgstr ""
 
-#: journal/models/shelf.py:38
+#: journal/models/shelf.py:40
 msgid "PROGRESS"
 msgstr ""
 
-#: journal/models/shelf.py:39
+#: journal/models/shelf.py:41
 msgid "COMPLETE"
 msgstr ""
 
-#: journal/models/shelf.py:40
+#: journal/models/shelf.py:42
 msgid "DROPPED"
 msgstr ""
 
-#: journal/models/shelf.py:49
+#: journal/models/shelf.py:51
 msgid "books to read"
 msgstr ""
 
-#: journal/models/shelf.py:50
+#: journal/models/shelf.py:52
 msgid "want to read"
 msgstr ""
 
-#: journal/models/shelf.py:51
+#: journal/models/shelf.py:53
 #, python-brace-format
 msgid "wants to read {item}"
 msgstr ""
 
-#: journal/models/shelf.py:52
+#: journal/models/shelf.py:54
 msgid "to read"
 msgstr ""
 
-#: journal/models/shelf.py:57
+#: journal/models/shelf.py:59
 msgid "books reading"
 msgstr ""
 
-#: journal/models/shelf.py:58
+#: journal/models/shelf.py:60
 msgid "start reading"
 msgstr ""
 
-#: journal/models/shelf.py:59
+#: journal/models/shelf.py:61
 #, python-brace-format
 msgid "started reading {item}"
 msgstr ""
 
-#: journal/models/shelf.py:60
+#: journal/models/shelf.py:62
 msgid "reading"
 msgstr ""
 
-#: journal/models/shelf.py:65
+#: journal/models/shelf.py:67
 msgid "books completed"
 msgstr ""
 
-#: journal/models/shelf.py:66
+#: journal/models/shelf.py:68
 msgid "finish reading"
 msgstr ""
 
-#: journal/models/shelf.py:67
+#: journal/models/shelf.py:69
 #, python-brace-format
 msgid "finished reading {item}"
 msgstr ""
 
-#: journal/models/shelf.py:68
+#: journal/models/shelf.py:70
 msgid "read"
 msgstr ""
 
-#: journal/models/shelf.py:73
+#: journal/models/shelf.py:75
 msgid "books dropped"
 msgstr ""
 
-#: journal/models/shelf.py:74
+#: journal/models/shelf.py:76
 msgid "stop reading"
 msgstr ""
 
-#: journal/models/shelf.py:75
+#: journal/models/shelf.py:77
 #, python-brace-format
 msgid "stopped reading {item}"
 msgstr ""
 
-#: journal/models/shelf.py:76
+#: journal/models/shelf.py:78
 msgid "stopped reading"
 msgstr ""
 
-#: journal/models/shelf.py:81
+#: journal/models/shelf.py:83
 msgid "books reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:82 journal/models/shelf.py:122
-#: journal/models/shelf.py:162 journal/models/shelf.py:202
-#: journal/models/shelf.py:242 journal/models/shelf.py:282
-#: journal/models/shelf.py:316
+#: journal/models/shelf.py:84 journal/models/shelf.py:124
+#: journal/models/shelf.py:164 journal/models/shelf.py:204
+#: journal/models/shelf.py:244 journal/models/shelf.py:284
+#: journal/models/shelf.py:318
 msgid "review"
 msgstr ""
 
-#: journal/models/shelf.py:83 journal/models/shelf.py:123
-#: journal/models/shelf.py:163 journal/models/shelf.py:203
-#: journal/models/shelf.py:243 journal/models/shelf.py:283
-#: journal/models/shelf.py:317
+#: journal/models/shelf.py:85 journal/models/shelf.py:125
+#: journal/models/shelf.py:165 journal/models/shelf.py:205
+#: journal/models/shelf.py:245 journal/models/shelf.py:285
+#: journal/models/shelf.py:319
 #, python-brace-format
 msgid "wrote a review of {item}"
 msgstr ""
 
-#: journal/models/shelf.py:89
+#: journal/models/shelf.py:91
 msgid "movies to watch"
 msgstr ""
 
-#: journal/models/shelf.py:90 journal/models/shelf.py:130
+#: journal/models/shelf.py:92 journal/models/shelf.py:132
 msgid "want to watch"
 msgstr ""
 
-#: journal/models/shelf.py:91 journal/models/shelf.py:131
+#: journal/models/shelf.py:93 journal/models/shelf.py:133
 #, python-brace-format
 msgid "wants to watch {item}"
 msgstr ""
 
-#: journal/models/shelf.py:92 journal/models/shelf.py:132
+#: journal/models/shelf.py:94 journal/models/shelf.py:134
 msgid "to watch"
 msgstr ""
 
-#: journal/models/shelf.py:97
+#: journal/models/shelf.py:99
 msgid "movies watching"
 msgstr ""
 
-#: journal/models/shelf.py:98 journal/models/shelf.py:138
+#: journal/models/shelf.py:100 journal/models/shelf.py:140
 msgid "start watching"
 msgstr ""
 
-#: journal/models/shelf.py:99 journal/models/shelf.py:139
+#: journal/models/shelf.py:101 journal/models/shelf.py:141
 #, python-brace-format
 msgid "started watching {item}"
 msgstr ""
 
-#: journal/models/shelf.py:100 journal/models/shelf.py:140
+#: journal/models/shelf.py:102 journal/models/shelf.py:142
 msgid "watching"
 msgstr ""
 
-#: journal/models/shelf.py:105
+#: journal/models/shelf.py:107
 msgid "movies watched"
 msgstr ""
 
-#: journal/models/shelf.py:106 journal/models/shelf.py:146
+#: journal/models/shelf.py:108 journal/models/shelf.py:148
 msgid "finish watching"
 msgstr ""
 
-#: journal/models/shelf.py:107 journal/models/shelf.py:147
+#: journal/models/shelf.py:109 journal/models/shelf.py:149
 #, python-brace-format
 msgid "finished watching {item}"
 msgstr ""
 
-#: journal/models/shelf.py:108 journal/models/shelf.py:148
+#: journal/models/shelf.py:110 journal/models/shelf.py:150
 msgid "watched"
 msgstr ""
 
-#: journal/models/shelf.py:113
+#: journal/models/shelf.py:115
 msgid "movies dropped"
 msgstr ""
 
-#: journal/models/shelf.py:114 journal/models/shelf.py:154
+#: journal/models/shelf.py:116 journal/models/shelf.py:156
 msgid "stop watching"
 msgstr ""
 
-#: journal/models/shelf.py:115 journal/models/shelf.py:155
+#: journal/models/shelf.py:117 journal/models/shelf.py:157
 #, python-brace-format
 msgid "stopped watching {item}"
 msgstr ""
 
-#: journal/models/shelf.py:116 journal/models/shelf.py:156
+#: journal/models/shelf.py:118 journal/models/shelf.py:158
 msgid "stopped watching"
 msgstr ""
 
-#: journal/models/shelf.py:121
+#: journal/models/shelf.py:123
 msgid "movies reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:129
+#: journal/models/shelf.py:131
 msgid "TV shows to watch"
 msgstr ""
 
-#: journal/models/shelf.py:137
+#: journal/models/shelf.py:139
 msgid "TV shows watching"
 msgstr ""
 
-#: journal/models/shelf.py:145
+#: journal/models/shelf.py:147
 msgid "TV shows watched"
 msgstr ""
 
-#: journal/models/shelf.py:153
+#: journal/models/shelf.py:155
 msgid "TV shows dropped"
 msgstr ""
 
-#: journal/models/shelf.py:161
+#: journal/models/shelf.py:163
 msgid "TV shows reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:169
+#: journal/models/shelf.py:171
 msgid "albums to listen"
 msgstr ""
 
-#: journal/models/shelf.py:170 journal/models/shelf.py:250
+#: journal/models/shelf.py:172 journal/models/shelf.py:252
 msgid "want to listen"
 msgstr ""
 
-#: journal/models/shelf.py:171 journal/models/shelf.py:251
+#: journal/models/shelf.py:173 journal/models/shelf.py:253
 #, python-brace-format
 msgid "wants to listen {item}"
 msgstr ""
 
-#: journal/models/shelf.py:172 journal/models/shelf.py:252
+#: journal/models/shelf.py:174 journal/models/shelf.py:254
 msgid "to listen"
 msgstr ""
 
-#: journal/models/shelf.py:177
+#: journal/models/shelf.py:179
 msgid "albums listening"
 msgstr ""
 
-#: journal/models/shelf.py:178 journal/models/shelf.py:258
+#: journal/models/shelf.py:180 journal/models/shelf.py:260
 msgid "start listening"
 msgstr ""
 
-#: journal/models/shelf.py:179 journal/models/shelf.py:259
+#: journal/models/shelf.py:181 journal/models/shelf.py:261
 #, python-brace-format
 msgid "started listening {item}"
 msgstr ""
 
-#: journal/models/shelf.py:180 journal/models/shelf.py:260
+#: journal/models/shelf.py:182 journal/models/shelf.py:262
 msgid "listening"
 msgstr ""
 
-#: journal/models/shelf.py:185
+#: journal/models/shelf.py:187
 msgid "albums listened"
 msgstr ""
 
-#: journal/models/shelf.py:186 journal/models/shelf.py:266
+#: journal/models/shelf.py:188 journal/models/shelf.py:268
 msgid "finish listening"
 msgstr ""
 
-#: journal/models/shelf.py:187 journal/models/shelf.py:267
+#: journal/models/shelf.py:189 journal/models/shelf.py:269
 #, python-brace-format
 msgid "finished listening {item}"
 msgstr ""
 
-#: journal/models/shelf.py:188 journal/models/shelf.py:268
+#: journal/models/shelf.py:190 journal/models/shelf.py:270
 msgid "listened"
 msgstr ""
 
-#: journal/models/shelf.py:193
+#: journal/models/shelf.py:195
 msgid "albums dropped"
 msgstr ""
 
-#: journal/models/shelf.py:194 journal/models/shelf.py:274
+#: journal/models/shelf.py:196 journal/models/shelf.py:276
 msgid "stop listening"
 msgstr ""
 
-#: journal/models/shelf.py:195 journal/models/shelf.py:275
+#: journal/models/shelf.py:197 journal/models/shelf.py:277
 #, python-brace-format
 msgid "stopped listening {item}"
 msgstr ""
 
-#: journal/models/shelf.py:196 journal/models/shelf.py:276
+#: journal/models/shelf.py:198 journal/models/shelf.py:278
 msgid "stopped listening"
 msgstr ""
 
-#: journal/models/shelf.py:201
+#: journal/models/shelf.py:203
 msgid "albums reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:209
+#: journal/models/shelf.py:211
 msgid "games to play"
 msgstr ""
 
-#: journal/models/shelf.py:210
+#: journal/models/shelf.py:212
 msgid "want to play"
 msgstr ""
 
-#: journal/models/shelf.py:211
+#: journal/models/shelf.py:213
 #, python-brace-format
 msgid "wants to play {item}"
 msgstr ""
 
-#: journal/models/shelf.py:212
+#: journal/models/shelf.py:214
 msgid "to play"
 msgstr ""
 
-#: journal/models/shelf.py:217
+#: journal/models/shelf.py:219
 msgid "games playing"
 msgstr ""
 
-#: journal/models/shelf.py:218
+#: journal/models/shelf.py:220
 msgid "start playing"
 msgstr ""
 
-#: journal/models/shelf.py:219
+#: journal/models/shelf.py:221
 #, python-brace-format
 msgid "started playing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:220
+#: journal/models/shelf.py:222
 msgid "playing"
 msgstr ""
 
-#: journal/models/shelf.py:225
+#: journal/models/shelf.py:227
 msgid "games played"
 msgstr ""
 
-#: journal/models/shelf.py:226
+#: journal/models/shelf.py:228
 msgid "finish playing"
 msgstr ""
 
-#: journal/models/shelf.py:227
+#: journal/models/shelf.py:229
 #, python-brace-format
 msgid "finished playing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:228
+#: journal/models/shelf.py:230
 msgid "played"
 msgstr ""
 
-#: journal/models/shelf.py:233
+#: journal/models/shelf.py:235
 msgid "games dropped"
 msgstr ""
 
-#: journal/models/shelf.py:234
+#: journal/models/shelf.py:236
 msgid "stop playing"
 msgstr ""
 
-#: journal/models/shelf.py:235
+#: journal/models/shelf.py:237
 #, python-brace-format
 msgid "stopped playing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:236
+#: journal/models/shelf.py:238
 msgid "stopped playing"
 msgstr ""
 
-#: journal/models/shelf.py:241
+#: journal/models/shelf.py:243
 msgid "games reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:249
+#: journal/models/shelf.py:251
 msgid "podcasts to listen"
 msgstr ""
 
-#: journal/models/shelf.py:257
+#: journal/models/shelf.py:259
 msgid "podcasts listening"
 msgstr ""
 
-#: journal/models/shelf.py:265
+#: journal/models/shelf.py:267
 msgid "podcasts listened"
 msgstr ""
 
-#: journal/models/shelf.py:273
+#: journal/models/shelf.py:275
 msgid "podcasts dropped"
 msgstr ""
 
-#: journal/models/shelf.py:281
+#: journal/models/shelf.py:283
 msgid "podcasts reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:289
+#: journal/models/shelf.py:291
 msgid "performances to see"
 msgstr ""
 
-#: journal/models/shelf.py:290
+#: journal/models/shelf.py:292
 msgid "want to see"
 msgstr ""
 
-#: journal/models/shelf.py:291
+#: journal/models/shelf.py:293
 #, python-brace-format
 msgid "wants to see {item}"
 msgstr ""
 
-#: journal/models/shelf.py:292
+#: journal/models/shelf.py:294
 msgid "to see"
 msgstr ""
 
-#: journal/models/shelf.py:299
+#: journal/models/shelf.py:301
 msgid "performances saw"
 msgstr ""
 
-#: journal/models/shelf.py:300
+#: journal/models/shelf.py:302
 msgid "finish seeing"
 msgstr ""
 
-#: journal/models/shelf.py:301
+#: journal/models/shelf.py:303
 #, python-brace-format
 msgid "finished seeing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:302
+#: journal/models/shelf.py:304
 msgid "seen"
 msgstr ""
 
-#: journal/models/shelf.py:307
+#: journal/models/shelf.py:309
 msgid "performances dropped"
 msgstr ""
 
-#: journal/models/shelf.py:308
+#: journal/models/shelf.py:310
 msgid "stop seeing"
 msgstr ""
 
-#: journal/models/shelf.py:309
+#: journal/models/shelf.py:311
 #, python-brace-format
 msgid "stopped seeing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:310
+#: journal/models/shelf.py:312
 msgid "stopped seeing"
 msgstr ""
 
-#: journal/models/shelf.py:315
+#: journal/models/shelf.py:317
 msgid "performances reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:323
+#: journal/models/shelf.py:325
 msgid "people following"
 msgstr ""
 
-#: journal/models/shelf.py:325
+#: journal/models/shelf.py:327
 #, python-brace-format
 msgid "started following {item}"
 msgstr ""
 
-#: journal/models/shelf.py:921
+#: journal/models/shelf.py:923
 msgid "removed mark"
 msgstr ""
 
@@ -5894,30 +5909,20 @@ msgstr ""
 msgid "Remove from collection"
 msgstr ""
 
-#: journal/templates/_list_item.html:34
-msgid "add mark"
-msgstr ""
-
-#: journal/templates/_list_item.html:42
-msgid "update mark"
-msgstr ""
-
-#: journal/templates/_list_item.html:60
+#: journal/templates/_list_item.html:43
 #: journal/templates/collection_update_item_note_ok.html:3
 msgid "Update note"
 msgstr ""
 
-#: journal/templates/_list_item.html:100 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:123
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
 msgstr ""
 
-#: journal/templates/_list_item.html:133
+#: journal/templates/_list_item.html:91
 #, python-format
-msgid ""
-"%(dups)s item(s) are from the same work or have the same identifier, click "
-"here to display:"
+msgid "%(dups)s item(s) are from the same work or have the same identifier, click here to display:"
 msgstr ""
 
 #: journal/templates/_sidebar_collection_filter.html:32
@@ -6025,6 +6030,14 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
+#: journal/templates/action_mark_item.html:10
+msgid "add mark"
+msgstr ""
+
+#: journal/templates/action_mark_item.html:18
+msgid "update mark"
+msgstr ""
+
 #: journal/templates/action_open_post.html:7
 msgid "Quiet Public"
 msgstr ""
@@ -6079,13 +6092,13 @@ msgstr ""
 msgid "Create a new collection"
 msgstr ""
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:81
+#: journal/templates/article.html:104 social/templates/_event_post.html:76
 #, fuzzy
 #| msgid "write a review"
 msgid "wrote a review"
 msgstr "idatzi kritika"
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:83
+#: journal/templates/article.html:106 social/templates/_event_post.html:78
 #, fuzzy
 #| msgid "write a review"
 msgid "wrote an article"
@@ -6203,19 +6216,19 @@ msgstr ""
 msgid "Mark"
 msgstr ""
 
-#: journal/templates/mark.html:50
+#: journal/templates/mark.html:54
 msgid "not rated"
 msgstr ""
 
-#: journal/templates/mark.html:70
+#: journal/templates/mark.html:74
 msgid "add a tag and press Enter"
 msgstr ""
 
-#: journal/templates/mark.html:122
+#: journal/templates/mark.html:126
 msgid "change mark date"
 msgstr ""
 
-#: journal/templates/mark.html:148
+#: journal/templates/mark.html:156
 msgid "Sure to delete mark, comment and tags for this item?"
 msgstr ""
 
@@ -6258,12 +6271,11 @@ msgid ""
 "Content Cell  | Content Cell\n"
 "Content Cell  | Content Cell\n"
 "\n"
-"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/"
-"Wikipedia-logo-v2.svg)\n"
+"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 "\n"
 msgstr ""
 
-#: journal/templates/note.html:19 journal/views/note.py:23
+#: journal/templates/note.html:19 journal/views/note.py:22
 msgid "Note"
 msgstr ""
 
@@ -6288,9 +6300,7 @@ msgid "Are you sure to delete this entire content?"
 msgstr ""
 
 #: journal/templates/piece_delete.html:24
-msgid ""
-"By deleting it, you will also lose track of others' comments and feedbacks "
-"to your content."
+msgid "By deleting it, you will also lose track of others' comments and feedbacks to your content."
 msgstr ""
 
 #: journal/templates/piece_delete.html:25
@@ -6372,7 +6382,7 @@ msgstr ""
 msgid "Articles"
 msgstr ""
 
-#: journal/templates/profile.html:166 journal/views/collection.py:427
+#: journal/templates/profile.html:166 journal/views/collection.py:409
 #: journal/views/profile.py:401
 msgid "collection"
 msgstr ""
@@ -6406,9 +6416,7 @@ msgid "Personal"
 msgstr ""
 
 #: journal/templates/tag_edit.html:52
-msgid ""
-"Personal tags are not included in public index. However, if you use this tag "
-"when marking an item publicly, it might still be visible to others."
+msgid "Personal tags are not included in public index. However, if you use this tag when marking an item publicly, it might still be visible to others."
 msgstr ""
 
 #: journal/templates/tag_edit.html:55
@@ -6477,113 +6485,114 @@ msgstr ""
 msgid "Link invalid"
 msgstr ""
 
-#: journal/views/collection.py:58 journal/views/collection.py:96
+#: journal/views/collection.py:62 journal/views/collection.py:94
 #, python-brace-format
 msgid "Collection by {0}"
 msgstr ""
 
-#: journal/views/collection.py:432
+#: journal/views/collection.py:414
 msgid "shared my collection"
 msgstr ""
 
-#: journal/views/collection.py:435
+#: journal/views/collection.py:417
 #, python-brace-format
 msgid "shared {username}'s collection"
 msgstr ""
 
-#: journal/views/collection.py:502 journal/views/collection.py:541
-#: journal/views/collection.py:553 journal/views/collection.py:579
+#: journal/views/collection.py:484 journal/views/collection.py:523
+#: journal/views/collection.py:535 journal/views/collection.py:561
 msgid "Dynamic collection is not editable"
 msgstr ""
 
-#: journal/views/collection.py:518
+#: journal/views/collection.py:500
 msgid "The item is already in the collection."
 msgstr ""
 
-#: journal/views/collection.py:520
+#: journal/views/collection.py:502
 msgid "Unable to find the item, please use item url from this site."
 msgstr ""
 
-#: journal/views/collection.py:566
+#: journal/views/collection.py:548
 msgid "Saved."
 msgstr ""
 
-#: journal/views/common.py:119 journal/views/mark.py:225
-#: journal/views/mark.py:279 journal/views/note.py:175
+#: journal/views/common.py:126 journal/views/mark.py:273
+#: journal/views/mark.py:315 journal/views/note.py:167
 #: journal/views/profile.py:42 journal/views/review.py:59
 #: journal/views/review.py:79
 msgid "Content not found"
 msgstr ""
 
-#: journal/views/common.py:174 journal/views/mark.py:159
+#: journal/views/common.py:184 journal/views/mark.py:210
 msgid "Data saved but unable to crosspost to Fediverse instance."
 msgstr ""
 
-#: journal/views/common.py:176
+#: journal/views/common.py:186
 msgid "Redirecting to your Fediverse instance now to re-authenticate."
 msgstr ""
 
-#: journal/views/common.py:183
+#: journal/views/common.py:193
 msgid "List not found."
 msgstr ""
 
-#: journal/views/mark.py:150
+#: journal/views/mark.py:206
 msgid "Content too long for your Fediverse instance."
 msgstr ""
 
-#: journal/views/mark.py:178 journal/views/mark.py:238
+#: journal/views/mark.py:224 journal/views/mark.py:226
+#: journal/views/mark.py:280
 msgid "Invalid input"
 msgstr ""
 
-#: journal/views/note.py:23
+#: journal/views/note.py:22
 msgid "Progress"
 msgstr ""
 
-#: journal/views/note.py:28
+#: journal/views/note.py:27
 msgid "Update progress"
 msgstr ""
 
-#: journal/views/note.py:59
+#: journal/views/note.py:58
 msgid "Progress (optional)"
 msgstr ""
 
-#: journal/views/note.py:61
+#: journal/views/note.py:60
 msgid "Note Content"
 msgstr ""
 
-#: journal/views/note.py:63
+#: journal/views/note.py:62
 msgid "Content Warning (optional)"
 msgstr ""
 
-#: journal/views/note.py:85
+#: journal/views/note.py:84
 msgid "Progress Type (optional)"
 msgstr ""
 
-#: journal/views/note.py:123 journal/views/note.py:183
+#: journal/views/note.py:115 journal/views/note.py:175
 msgid "Only in-progress items can have progress."
 msgstr ""
 
-#: journal/views/post.py:98 journal/views/post.py:392
+#: journal/views/post.py:100 journal/views/post.py:388
 msgid "Post not found"
 msgstr ""
 
-#: journal/views/post.py:189
+#: journal/views/post.py:191
 msgid "Visibility too high for quoting this post"
 msgstr ""
 
-#: journal/views/post.py:337 journal/views/post.py:418
+#: journal/views/post.py:339 journal/views/post.py:414
 msgid "Content cannot be empty."
 msgstr ""
 
-#: journal/views/post.py:396
+#: journal/views/post.py:392
 msgid "This post cannot be edited here"
 msgstr ""
 
-#: journal/views/post.py:541
+#: journal/views/post.py:531
 msgid "Invalid choices"
 msgstr ""
 
-#: journal/views/post.py:544
+#: journal/views/post.py:534
 msgid "Invalid post"
 msgstr ""
 
@@ -6601,56 +6610,54 @@ msgstr ""
 msgid "may contain spoiler or triggering content"
 msgstr ""
 
-#: journal/views/tag.py:47 journal/views/tag.py:61
+#: journal/views/tag.py:46 journal/views/tag.py:60
 msgid "Invalid tag"
 msgstr ""
 
-#: journal/views/tag.py:50
+#: journal/views/tag.py:49
 msgid "Tag not found"
 msgstr ""
 
-#: journal/views/tag.py:72
+#: journal/views/tag.py:65
 msgid "Tag deleted."
 msgstr ""
 
-#: journal/views/tag.py:82
+#: journal/views/tag.py:75
 msgid "Duplicated tag."
 msgstr ""
 
-#: journal/views/tag.py:96
+#: journal/views/tag.py:83
 msgid "Tag updated."
 msgstr ""
 
-#: journal/views/wrapped.py:160
+#: journal/views/wrapped.py:161
 msgid "Summary posted to timeline."
 msgstr ""
 
-#: mastodon/models/common.py:29
+#: mastodon/models/common.py:31
 msgid "Mastodon"
 msgstr ""
 
-#: mastodon/models/common.py:30 users/templates/users/login.html:120
+#: mastodon/models/common.py:32 users/templates/users/login.html:114
 msgid "Threads"
 msgstr ""
 
-#: mastodon/models/common.py:31
+#: mastodon/models/common.py:33
 msgid "Bluesky"
 msgstr ""
 
-#: mastodon/models/email.py:59
+#: mastodon/models/email.py:63
 msgid ""
 "\n"
 "\n"
-"If you did not mean to register or login, please ignore this email. If you "
-"are concerned with your account security, please change the email linked "
-"with your account, or contact us."
+"If you did not mean to register or login, please ignore this email. If you are concerned with your account security, please change the email linked with your account, or contact us."
 msgstr ""
 
-#: mastodon/models/email.py:64 mastodon/models/email.py:69
+#: mastodon/models/email.py:68 mastodon/models/email.py:73
 msgid "Verification Code"
 msgstr ""
 
-#: mastodon/models/email.py:66
+#: mastodon/models/email.py:70
 #, python-brace-format
 msgid ""
 "Use this code to verify your email address {email}\n"
@@ -6658,7 +6665,7 @@ msgid ""
 "{code}"
 msgstr ""
 
-#: mastodon/models/email.py:70
+#: mastodon/models/email.py:74
 #, python-brace-format
 msgid ""
 "Use this code to login as {email}\n"
@@ -6666,23 +6673,21 @@ msgid ""
 "{code}"
 msgstr ""
 
-#: mastodon/models/email.py:74 users/templates/users/captcha.html:13
+#: mastodon/models/email.py:78 users/templates/users/captcha.html:13
 #: users/templates/users/captcha_solved.html:9
 #: users/templates/users/login.html:20 users/templates/users/register.html:9
 #: users/templates/users/welcome.html:10
 msgid "Register"
 msgstr ""
 
-#: mastodon/models/email.py:76
+#: mastodon/models/email.py:80
 #, python-brace-format
 msgid ""
 "There is no account registered with this email address yet: {email}\n"
 "\n"
-"If you already have an account with us, just login and add this email to you "
-"account.\n"
+"If you already have an account with us, just login and add this email to you account.\n"
 "\n"
-"If you prefer to register a new account with this email, please use this "
-"verification code: {code}"
+"If you prefer to register a new account with this email, please use this verification code: {code}"
 msgstr ""
 
 #: mastodon/models/mastodon.py:570
@@ -6725,44 +6730,49 @@ msgstr ""
 msgid "New Post"
 msgstr ""
 
-#: mastodon/views/bluesky.py:26 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:32 mastodon/views/bluesky.py:93
 msgid "Bluesky login is disabled."
 msgstr ""
 
-#: mastodon/views/bluesky.py:28 mastodon/views/email.py:35
-#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:29
-#: users/templates/users/login.html:6 users/views/webauthn.py:133
-msgid "Security check failed. Please try again."
-msgstr ""
-
-#: mastodon/views/bluesky.py:34 mastodon/views/bluesky.py:40
-#: mastodon/views/bluesky.py:64 mastodon/views/bluesky.py:72
-#: mastodon/views/bluesky.py:78 mastodon/views/common.py:36
-#: mastodon/views/mastodon.py:62 mastodon/views/mastodon.py:70
-#: mastodon/views/mastodon.py:77 mastodon/views/mastodon.py:87
-#: mastodon/views/mastodon.py:94 mastodon/views/threads.py:55
-#: mastodon/views/threads.py:63 mastodon/views/threads.py:69
-#: users/views/account.py:254 users/views/account.py:373
+#: mastodon/views/bluesky.py:47 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:65 mastodon/views/bluesky.py:98
+#: mastodon/views/bluesky.py:106 mastodon/views/bluesky.py:112
+#: mastodon/views/common.py:36 mastodon/views/mastodon.py:62
+#: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
+#: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
+#: mastodon/views/threads.py:57 mastodon/views/threads.py:65
+#: mastodon/views/threads.py:71 users/views/account.py:256
+#: users/views/account.py:375
 msgid "Authentication failed"
 msgstr ""
 
-#: mastodon/views/bluesky.py:35 mastodon/views/email.py:66
+#: mastodon/views/bluesky.py:47 mastodon/views/common.py:103
+msgid "Identity not found."
+msgstr ""
+
+#: mastodon/views/bluesky.py:53 mastodon/views/email.py:35
+#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:31
+#: users/templates/users/login.html:6 users/views/webauthn.py:136
+msgid "Security check failed. Please try again."
+msgstr ""
+
+#: mastodon/views/bluesky.py:60 mastodon/views/email.py:66
 msgid "Too many attempts, please try again later."
 msgstr ""
 
-#: mastodon/views/bluesky.py:40
+#: mastodon/views/bluesky.py:65
 msgid "ATProto handle is required."
 msgstr ""
 
-#: mastodon/views/bluesky.py:50
+#: mastodon/views/bluesky.py:84
 msgid "Error connecting to your ATProto server"
 msgstr ""
 
-#: mastodon/views/bluesky.py:73
+#: mastodon/views/bluesky.py:107
 msgid "Invalid response from ATProto authorization server."
 msgstr ""
 
-#: mastodon/views/bluesky.py:78
+#: mastodon/views/bluesky.py:112
 msgid "Invalid account data from Bluesky."
 msgstr ""
 
@@ -6770,7 +6780,7 @@ msgstr ""
 msgid "Invalid user."
 msgstr ""
 
-#: mastodon/views/common.py:52 users/views/account.py:414
+#: mastodon/views/common.py:52 users/views/account.py:416
 msgid "Registration failed"
 msgstr ""
 
@@ -6800,10 +6810,6 @@ msgstr ""
 #: mastodon/views/common.py:103 mastodon/views/common.py:107
 #: mastodon/views/common.py:116
 msgid "Disconnect identity failed"
-msgstr ""
-
-#: mastodon/views/common.py:103
-msgid "Identity not found."
 msgstr ""
 
 #: mastodon/views/common.py:117
@@ -6847,7 +6853,7 @@ msgstr ""
 msgid "Invalid response from Fediverse instance."
 msgstr ""
 
-#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:64
+#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:66
 msgid "Invalid OAuth state. Please try again."
 msgstr ""
 
@@ -6867,19 +6873,17 @@ msgstr ""
 msgid "Invalid account data from Fediverse instance."
 msgstr ""
 
-#: mastodon/views/threads.py:69
+#: mastodon/views/threads.py:71
 msgid "Invalid account data from Threads."
 msgstr ""
 
-#: mastodon/views/threads.py:147
+#: mastodon/views/threads.py:149
 msgid "Data deletion completed"
 msgstr ""
 
-#: mastodon/views/threads.py:149
+#: mastodon/views/threads.py:151
 #, python-brace-format
-msgid ""
-"Data linked to your Threads account has been deleted. Confirmation code: "
-"{code}"
+msgid "Data linked to your Threads account has been deleted. Confirmation code: {code}"
 msgstr ""
 
 #: social/templates/_article_teaser.html:10
@@ -6912,15 +6916,11 @@ msgstr ""
 msgid "play"
 msgstr ""
 
-#: social/templates/_event_post.html:50
-msgid "mark"
-msgstr ""
-
-#: social/templates/_event_post.html:79
+#: social/templates/_event_post.html:74
 msgid "wrote a note"
 msgstr ""
 
-#: social/templates/_event_post.html:88
+#: social/templates/_event_post.html:83
 msgid "replying to"
 msgstr ""
 
@@ -6933,7 +6933,7 @@ msgstr ""
 msgid "Untitled article"
 msgstr ""
 
-#: social/templates/event/boosted.html:3
+#: social/templates/event/boosted.html:2
 msgid "boosted your post"
 msgstr ""
 
@@ -6976,8 +6976,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
 #: social/templates/event/boosted_shelfmember.html:3
@@ -6995,7 +6994,7 @@ msgstr ""
 msgid "followed you"
 msgstr ""
 
-#: social/templates/event/liked.html:3
+#: social/templates/event/liked.html:2
 msgid "liked your post"
 msgstr ""
 
@@ -7038,8 +7037,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
 #: social/templates/event/liked_shelfmember.html:3
@@ -7049,7 +7047,7 @@ msgid ""
 "liked your mark on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
-#: social/templates/event/mentioned.html:3
+#: social/templates/event/mentioned.html:2
 msgid "mentioned you"
 msgstr ""
 
@@ -7092,8 +7090,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
 #: social/templates/event/mentioned_shelfmember.html:3
@@ -7103,26 +7100,39 @@ msgid ""
 "replied to your mark on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
-#: social/templates/feed.html:12 social/templates/feed.html:39
-#: social/templates/search_feed.html:12
-msgid "Activities from those you follow"
+#: social/templates/feed.html:39 users/templates/users/preferences.html:40
+msgid "Activities"
 msgstr ""
 
-#: social/templates/feed.html:42 social/templates/feed.html:44
+#: social/templates/feed.html:43 social/templates/feed.html:45
+msgid "world"
+msgstr ""
+
+#: social/templates/feed.html:51 social/templates/feed.html:53
+#, fuzzy
+#| msgid "locale"
+msgid "local"
+msgstr "lokala"
+
+#: social/templates/feed.html:58 social/templates/feed.html:60
+msgid "those you follow"
+msgstr ""
+
+#: social/templates/feed.html:64 social/templates/feed.html:66
 msgid "what they read/watch/..."
 msgstr ""
 
-#: social/templates/feed_events.html:30
+#: social/templates/feed_events.html:29
 msgid "no matching activities."
 msgstr ""
 
-#: social/templates/feed_events.html:33
+#: social/templates/feed_events.html:31
+msgid "no public activities yet."
+msgstr ""
+
+#: social/templates/feed_events.html:34
 #, python-format
-msgid ""
-"Find and mark some books/movies/podcasts/games, <a "
-"href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/"
-"Douban, follow some fellow %(site_name)s users on the fediverse, so their "
-"recent activities and yours will show up here."
+msgid "Find and mark some books/movies/podcasts/games, <a href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/Douban, follow some fellow %(site_name)s users on the fediverse, so their recent activities and yours will show up here."
 msgstr ""
 
 #: social/templates/notification.html:58
@@ -7157,6 +7167,10 @@ msgstr ""
 msgid "Poll ending at %(end_time)s"
 msgstr ""
 
+#: social/templates/search_feed.html:12 social/views.py:57 social/views.py:58
+msgid "Activities from those you follow"
+msgstr ""
+
 #: social/templates/single_post.html:13 social/templates/single_post.html:32
 msgid "Post"
 msgstr ""
@@ -7169,57 +7183,63 @@ msgstr ""
 msgid "Poll"
 msgstr ""
 
-#: takahe/models.py:453
+#: social/views.py:59
+msgid "Activities on this site"
+msgstr ""
+
+#: social/views.py:60
+msgid "Activities from the fediverse"
+msgstr ""
+
+#: takahe/models.py:445
 msgid "Display Name"
 msgstr ""
 
-#: takahe/models.py:455
+#: takahe/models.py:447
 msgid "Bio"
 msgstr ""
 
-#: takahe/models.py:457
+#: takahe/models.py:449
 msgid "Manually approve new followers"
 msgstr ""
 
-#: takahe/models.py:461
+#: takahe/models.py:453
 msgid "Include profile, marks and posts in discovery"
 msgstr ""
 
-#: takahe/models.py:464
+#: takahe/models.py:456
 msgid "Include posts in search results"
 msgstr ""
 
-#: takahe/models.py:482
+#: takahe/models.py:474
 msgid "Profile picture"
 msgstr ""
 
-#: takahe/models.py:489
+#: takahe/models.py:481
 msgid "Header picture"
 msgstr ""
 
-#: users/models/task.py:22
+#: users/models/task.py:24
 msgid "Started"
 msgstr ""
 
-#: users/models/task.py:23
+#: users/models/task.py:25
 msgid "Complete"
 msgstr ""
 
-#: users/models/user.py:69
-msgid ""
-"Enter a valid username. This value may contain only unaccented lowercase a-z "
-"and uppercase A-Z letters, numbers, and _ characters."
+#: users/models/user.py:71
+msgid "Enter a valid username. This value may contain only unaccented lowercase a-z and uppercase A-Z letters, numbers, and _ characters."
 msgstr ""
 
-#: users/models/user.py:130
+#: users/models/user.py:132
 msgid "username"
 msgstr ""
 
-#: users/models/user.py:135
+#: users/models/user.py:137
 msgid "Required. 50 characters or fewer. Letters, digits and _ only."
 msgstr ""
 
-#: users/models/user.py:138
+#: users/models/user.py:140
 msgid "A user with that username already exists."
 msgstr ""
 
@@ -7356,9 +7376,7 @@ msgid "Cancel import"
 msgstr ""
 
 #: users/templates/users/_rym_section.html:29
-msgid ""
-"On RateYourMusic, go to your profile and use the <b>Export your music "
-"catalog</b> option to download your library as a CSV file."
+msgid "On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:31
@@ -7367,18 +7385,12 @@ msgid "Upload the downloaded CSV file below."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:33
-msgid ""
-"Albums are matched by title + artist (and year if present) — first against "
-"the local catalog, then MusicBrainz, then Spotify. After auto-matching, "
-"you'll preview the matches in a table, edit any link or shelf status, and "
-"confirm the import."
+msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:36
 #: users/templates/users/_storygraph_section.html:38
-msgid ""
-"You can also re-upload a previously-downloaded matched CSV — the existing "
-"<code>link</code> column will be honoured as the default match."
+msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:40
@@ -7405,18 +7417,11 @@ msgid "Cancel the StoryGraph import? Progress will be discarded."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:31
-msgid ""
-"On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to "
-"download your library as a CSV file."
+msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:35
-msgid ""
-"Books are matched by ISBN — first against the local catalog, then Google "
-"Books and OpenLibrary — with a title + author search as fallback. After auto-"
-"matching, you'll preview the matches in a table, edit any link or shelf "
-"status, and confirm the import."
+msgid "Books are matched by ISBN — first against the local catalog, then Google Books and OpenLibrary — with a title + author search as fallback. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/account.html:11
@@ -7428,9 +7433,7 @@ msgid "Display name, avatar and other information"
 msgstr ""
 
 #: users/templates/users/account.html:23
-msgid ""
-"Updating profile information here will turn off automatic sync of display "
-"name, bio and avatar from your Mastodon instance. Sure to continue?"
+msgid "Updating profile information here will turn off automatic sync of display name, bio and avatar from your Mastodon instance. Sure to continue?"
 msgstr ""
 
 #: users/templates/users/account.html:26
@@ -7443,16 +7446,11 @@ msgstr ""
 
 #: users/templates/users/account.html:59 users/templates/users/register.html:47
 #, python-format
-msgid ""
-"Please click the confirmation link in the email sent to %(pending_email)s; "
-"if you haven't received it for more than a few minutes, please input and "
-"save again."
+msgid "Please click the confirmation link in the email sent to %(pending_email)s; if you haven't received it for more than a few minutes, please input and save again."
 msgstr ""
 
 #: users/templates/users/account.html:61 users/templates/users/register.html:50
-msgid ""
-"Email is recommended as a backup login method, if you log in via a Fediverse "
-"instance"
+msgid "Email is recommended as a backup login method, if you log in via a Fediverse instance"
 msgstr ""
 
 #: users/templates/users/account.html:73 users/templates/users/login.html:84
@@ -7470,22 +7468,15 @@ msgid "Last updated"
 msgstr ""
 
 #: users/templates/users/account.html:92
-msgid ""
-"If you have not yet registered with any Federated instance, you may <a "
-"href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an "
-"instance</a> and register."
+msgid "If you have not yet registered with any Federated instance, you may <a href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an instance</a> and register."
 msgstr ""
 
 #: users/templates/users/account.html:97
-msgid ""
-"To associate with another federated identity, please enter the domain name "
-"of the instance where the new identity is located."
+msgid "To associate with another federated identity, please enter the domain name of the instance where the new identity is located."
 msgstr ""
 
 #: users/templates/users/account.html:99
-msgid ""
-"If you have registered with a Federated instance, please enter the instance "
-"domain name."
+msgid "If you have registered with a Federated instance, please enter the instance domain name."
 msgstr ""
 
 #: users/templates/users/account.html:104
@@ -7497,24 +7488,17 @@ msgid "Go to target instance and authorize with the identity"
 msgstr ""
 
 #: users/templates/users/account.html:113
-msgid ""
-"After replacing the association, you may use the new Fediverse identity to "
-"log in and control data visibility. Existing data such as tags, comments, "
-"and collections will not be affected."
+msgid "After replacing the association, you may use the new Fediverse identity to log in and control data visibility. Existing data such as tags, comments, and collections will not be affected."
 msgstr ""
 
 #: users/templates/users/account.html:115
-msgid ""
-"Once associated with Fediverse identity, you can discover more users and use "
-"the full features of this site."
+msgid "Once associated with Fediverse identity, you can discover more users and use the full features of this site."
 msgstr ""
 
 #: users/templates/users/account.html:123
 #: users/templates/users/account.html:160
 #: users/templates/users/account.html:206
-msgid ""
-"Once disconnected, you will no longer be able login with this identity. Are "
-"you sure to continue?"
+msgid "Once disconnected, you will no longer be able login with this identity. Are you sure to continue?"
 msgstr ""
 
 #: users/templates/users/account.html:126
@@ -7541,7 +7525,7 @@ msgstr ""
 msgid "Disconnect with Threads"
 msgstr ""
 
-#: users/templates/users/account.html:173 users/templates/users/login.html:112
+#: users/templates/users/account.html:173 users/templates/users/login.html:106
 msgid "Bluesky (ATProto)"
 msgstr ""
 
@@ -7549,7 +7533,7 @@ msgstr ""
 msgid "Verified ATProto identity"
 msgstr ""
 
-#: users/templates/users/account.html:194 users/templates/users/login.html:216
+#: users/templates/users/account.html:194 users/templates/users/login.html:210
 msgid "ATProto handle"
 msgstr ""
 
@@ -7574,7 +7558,7 @@ msgid "Name this passkey:"
 msgstr ""
 
 #: users/templates/users/account.html:227 users/templates/users/login.html:69
-#: users/templates/users/welcome.html:33 users/views/webauthn.py:106
+#: users/templates/users/welcome.html:33 users/views/webauthn.py:109
 msgid "Passkey"
 msgstr ""
 
@@ -7617,9 +7601,7 @@ msgid "Save sync settings"
 msgstr ""
 
 #: users/templates/users/account.html:297
-msgid ""
-"New follow, mute and blocks in the associated identity may be automatically "
-"imported; removal has to be done manually."
+msgid "New follow, mute and blocks in the associated identity may be automatically imported; removal has to be done manually."
 msgstr ""
 
 #: users/templates/users/account.html:304
@@ -7656,15 +7638,11 @@ msgid "Log out everywhere"
 msgstr ""
 
 #: users/templates/users/account.html:365
-msgid ""
-"This will log you out of all browsers and devices (including the current "
-"one), and revoke all API tokens. Continue?"
+msgid "This will log you out of all browsers and devices (including the current one), and revoke all API tokens. Continue?"
 msgstr ""
 
 #: users/templates/users/account.html:368
-msgid ""
-"If you notice any suspicious activity or have logged in on a shared "
-"computer, you can log out of all sessions and revoke all API tokens."
+msgid "If you notice any suspicious activity or have logged in on a shared computer, you can log out of all sessions and revoke all API tokens."
 msgstr ""
 
 #: users/templates/users/account.html:378
@@ -7727,10 +7705,10 @@ msgstr ""
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:74
-#: users/templates/users/data.html:126 users/templates/users/data.html:183
-#: users/templates/users/data.html:234 users/templates/users/data.html:298
-#: users/templates/users/data.html:358 users/templates/users/data.html:553
+#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/data.html:141 users/templates/users/data.html:198
+#: users/templates/users/data.html:249 users/templates/users/data.html:313
+#: users/templates/users/data.html:376 users/templates/users/data.html:553
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr ""
@@ -7755,9 +7733,7 @@ msgid "Migrate Account"
 msgstr ""
 
 #: users/templates/users/account.html:488
-msgid ""
-"Linking an email to your account is highly recommended before migrating from "
-"another Fediverse instance."
+msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
 msgstr ""
 
 #: users/templates/users/account.html:491
@@ -7777,9 +7753,7 @@ msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
 msgstr ""
 
 #: users/templates/users/account.html:507
-msgid ""
-"Enter full <code>username@instance.social</code> or <code>email@domain.com</"
-"code> to confirm deletion."
+msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
 msgstr ""
 
 #: users/templates/users/account.html:517
@@ -7831,9 +7805,7 @@ msgid "Token Created"
 msgstr ""
 
 #: users/templates/users/authorized_app_created.html:22
-msgid ""
-"Your new personal access token has been created. Copy it now -- you will not "
-"be able to see it again."
+msgid "Your new personal access token has been created. Copy it now -- you will not be able to see it again."
 msgstr ""
 
 #: users/templates/users/authorized_app_created.html:25
@@ -7861,9 +7833,7 @@ msgid "One quick check"
 msgstr ""
 
 #: users/templates/users/captcha.html:28
-msgid ""
-"Put every cover into the row it belongs to. Drag it, or select a cover and "
-"then select a row."
+msgid "Put every cover into the row it belongs to. Drag it, or select a cover and then select a row."
 msgstr ""
 
 #: users/templates/users/captcha.html:41 users/templates/users/captcha.html:43
@@ -7896,7 +7866,7 @@ msgstr ""
 msgid "That is all we needed. Let's get you a username."
 msgstr ""
 
-#: users/templates/users/captcha_solved.html:34
+#: users/templates/users/captcha_solved.html:32
 #: users/templates/users/login.html:63
 #: users/templates/users/verify_email.html:25
 #: users/templates/users/welcome.html:51
@@ -7916,10 +7886,7 @@ msgid "Failed Crossposts"
 msgstr ""
 
 #: users/templates/users/crossposts.html:42
-msgid ""
-"These posts could not be crossposted to your linked social accounts. Re-"
-"authorize the account if needed, then retry. In rare cases retrying may "
-"create a duplicate post."
+msgid "These posts could not be crossposted to your linked social accounts. Re-authorize the account if needed, then retry. In rare cases retrying may create a duplicate post."
 msgstr ""
 
 #: users/templates/users/crossposts.html:48
@@ -7940,210 +7907,163 @@ msgstr ""
 msgid "Data Management"
 msgstr ""
 
-#: users/templates/users/data.html:27
+#: users/templates/users/data.html:39
 msgid "Import Marks and Reviews from Douban"
 msgstr ""
 
-#: users/templates/users/data.html:31
-msgid ""
-"Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
-"target=\"_blank\" rel=\"noopener\">Doufen</a>"
+#: users/templates/users/data.html:43
+msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr ""
 
 #: users/templates/users/data.html:45
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
-"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
-"NeoDB Archive</a> below."
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON format instead; upload it under <a href=\"#import-neodb-archive\">Import NeoDB Archive</a> below."
 msgstr ""
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:256
+#: users/templates/users/data.html:49 users/templates/users/data.html:271
 msgid "Import Method"
 msgstr ""
 
-#: users/templates/users/data.html:37
-msgid ""
-"Merge: only update when status changes from wishlist to in-progress, or from "
-"in-progress to complete."
+#: users/templates/users/data.html:52
+msgid "Merge: only update when status changes from wishlist to in-progress, or from in-progress to complete."
 msgstr ""
 
-#: users/templates/users/data.html:41
+#: users/templates/users/data.html:56
 msgid "Overwrite: update all imported status."
 msgstr ""
 
-#: users/templates/users/data.html:74
-msgid ""
-"Another import is in progress, starting a new import may cause issues, sure "
-"to import?"
+#: users/templates/users/data.html:89
+msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
 msgstr ""
 
-#: users/templates/users/data.html:74
+#: users/templates/users/data.html:89 users/views/data.py:1130
 msgid "Import in progress, please wait"
 msgstr ""
 
-#: users/templates/users/data.html:81
+#: users/templates/users/data.html:96
 #, fuzzy
 #| msgid "Goodreads"
 msgid "Import from Goodreads"
 msgstr "Goodreads"
 
-#: users/templates/users/data.html:87
-msgid ""
-"On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download "
-"your library as a CSV file."
+#: users/templates/users/data.html:102
+msgid "On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download your library as a CSV file."
 msgstr ""
 
-#: users/templates/users/data.html:90
-msgid ""
-"Upload the downloaded <code>goodreads_library_export.csv</code> file below."
+#: users/templates/users/data.html:105
+msgid "Upload the downloaded <code>goodreads_library_export.csv</code> file below."
 msgstr ""
 
-#: users/templates/users/data.html:93
-msgid ""
-"want-to-read / currently-reading / read / did-not-finish books and their "
-"reviews will be imported."
-msgstr ""
-
-#: users/templates/users/data.html:134
-msgid "Import from Letterboxd"
-msgstr ""
-
-#: users/templates/users/data.html:140
-msgid ""
-"on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" "
-"target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap "
-"Advanced Settings in Settings, tap EXPORT YOUR DATA"
-msgstr ""
-
-#: users/templates/users/data.html:143
-msgid ""
-"download file with name like <code>letterboxd-username-2018-03-11-07-52-"
-"utc.zip</code>, do not unzip"
-msgstr ""
-
-#: users/templates/users/data.html:146
-msgid ""
-"the following files in the zip file will be processed: <code>reviews.csv</"
-"code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</"
-"code> <code>lists/*.csv</code>"
+#: users/templates/users/data.html:108
+msgid "want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported."
 msgstr ""
 
 #: users/templates/users/data.html:149
-msgid ""
-"exported file does not indicate whether a list is private, unlisted or "
-"public, so all imported marks, reviews and collections will be created with "
-"the visibility selected below"
+msgid "Import from Letterboxd"
 msgstr ""
 
-#: users/templates/users/data.html:184 users/templates/users/data.html:235
+#: users/templates/users/data.html:155
+msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
+msgstr ""
+
+#: users/templates/users/data.html:158
+msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
+msgstr ""
+
+#: users/templates/users/data.html:161
+msgid "the following files in the zip file will be processed: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
+msgstr ""
+
+#: users/templates/users/data.html:164
+msgid "exported file does not indicate whether a list is private, unlisted or public, so all imported marks, reviews and collections will be created with the visibility selected below"
+msgstr ""
+
+#: users/templates/users/data.html:199 users/templates/users/data.html:250
 msgid "Only forward changes(none->to-watch->watched) will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:191
+#: users/templates/users/data.html:206
 msgid "Import from Trakt"
 msgstr ""
 
-#: users/templates/users/data.html:197
-msgid ""
-"On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" "
-"rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait "
-"for the download link to appear."
+#: users/templates/users/data.html:212
+msgid "On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait for the download link to appear."
 msgstr ""
 
-#: users/templates/users/data.html:200
+#: users/templates/users/data.html:215
 msgid "Upload the downloaded <code>.zip</code> file below, do not unzip."
 msgstr ""
 
-#: users/templates/users/data.html:202
+#: users/templates/users/data.html:217
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:243
+#: users/templates/users/data.html:258
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr ""
 
-#: users/templates/users/data.html:246
+#: users/templates/users/data.html:261
 msgid "Login with Steam"
 msgstr ""
 
-#: users/templates/users/data.html:252
+#: users/templates/users/data.html:267
 msgid "Import Podcast Subscriptions"
 msgstr ""
 
-#: users/templates/users/data.html:263
+#: users/templates/users/data.html:278
 msgid "Mark as listening"
 msgstr ""
 
-#: users/templates/users/data.html:267
+#: users/templates/users/data.html:282
 msgid "Import as a new collection"
 msgstr ""
 
-#: users/templates/users/data.html:296
+#: users/templates/users/data.html:311
 msgid "Select OPML file"
 msgstr ""
 
-#: users/templates/users/data.html:306
+#: users/templates/users/data.html:321
 msgid "Import NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:312
-msgid ""
-"Upload a <code>.zip</code> file containing <code>.csv</code> or "
-"<code>.ndjson</code> files exported from NeoDB."
+#: users/templates/users/data.html:327
+msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr ""
 
 #: users/templates/users/data.html:330
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
-"imported here."
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is imported here."
 msgstr ""
 
-#: users/templates/users/data.html:314
+#: users/templates/users/data.html:332
 msgid "Existing data may be overwritten."
 msgstr ""
 
-#: users/templates/users/data.html:324
+#: users/templates/users/data.html:342
 msgid "Detected format"
 msgstr ""
 
-#: users/templates/users/data.html:385
+#: users/templates/users/data.html:403
 msgid "Detecting format..."
 msgstr ""
 
-#: users/templates/users/data.html:411
+#: users/templates/users/data.html:429
 msgid "Unknown format"
 msgstr ""
 
-#: users/templates/users/data.html:436
+#: users/templates/users/data.html:454
 msgid "Error detecting format"
 msgstr ""
 
-#: users/templates/users/data.html:460
+#: users/templates/users/data.html:478
 msgid "Export NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:464
+#: users/templates/users/data.html:482
 msgid "Export marks, reviews and notes in CSV"
 msgstr ""
 
-#: users/templates/users/data.html:471
+#: users/templates/users/data.html:489
 msgid "Export everything in NDJSON"
-msgstr ""
-
-#: users/templates/users/data.html:479
-msgid "Export marks and reviews in XLSX (Doufen format)"
-msgstr ""
-
-#: users/templates/users/data.html:482
-msgid "Last export"
-msgstr ""
-
-#: users/templates/users/data.html:487
-msgid "Download"
 msgstr ""
 
 #: users/templates/users/data.html:496
@@ -8151,22 +8071,15 @@ msgid "Import and Export Articles (WordPress)"
 msgstr ""
 
 #: users/templates/users/data.html:499
-msgid ""
-"Your articles are exchanged as WordPress posts in the WXR format, which "
-"WordPress and most blogging tools can read and write. Marks, reviews and "
-"notes are not included: use the NeoDB archive above for those."
+msgid "Your articles are exchanged as WordPress posts in the WXR format, which WordPress and most blogging tools can read and write. Marks, reviews and notes are not included: use the NeoDB archive above for those."
 msgstr ""
 
 #: users/templates/users/data.html:502
-msgid ""
-"Article title, body, excerpt, tags, dates and featured image are exchanged. "
-"Comments and custom fields are ignored."
+msgid "Article title, body, excerpt, tags, dates and featured image are exchanged. Comments and custom fields are ignored."
 msgstr ""
 
 #: users/templates/users/data.html:505
-msgid ""
-"The body is converted between Markdown and HTML, so formatting is kept but "
-"the text is not character-for-character identical."
+msgid "The body is converted between Markdown and HTML, so formatting is kept but the text is not character-for-character identical."
 msgstr ""
 
 #: users/templates/users/data.html:512
@@ -8174,16 +8087,11 @@ msgid "Export articles in WordPress format"
 msgstr ""
 
 #: users/templates/users/data.html:519
-msgid ""
-"In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download "
-"an <code>.xml</code> file, then upload it below."
+msgid "In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download an <code>.xml</code> file, then upload it below."
 msgstr ""
 
 #: users/templates/users/data.html:522
-msgid ""
-"Only published posts use the visibility below. Drafts, pending, private and "
-"password-protected posts are always imported as mentioned-only, so nothing "
-"unpublished becomes public."
+msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
 #: users/templates/users/data.html:560
@@ -8191,9 +8099,7 @@ msgid "View Annual Summary"
 msgstr ""
 
 #: users/templates/users/fetch_identity_failed.html:4
-msgid ""
-"Unable to find the user, please check your spelling; or the server may be "
-"busy, please try again later."
+msgid "Unable to find the user, please check your spelling; or the server may be busy, please try again later."
 msgstr ""
 
 #: users/templates/users/fetch_identity_pending.html:13
@@ -8213,94 +8119,76 @@ msgstr ""
 msgid "logo"
 msgstr ""
 
-#: users/templates/users/login.html:127
-msgid ""
-"Sign in with a passkey saved on this device or in your password manager."
+#: users/templates/users/login.html:121
+msgid "Sign in with a passkey saved on this device or in your password manager."
 msgstr ""
 
-#: users/templates/users/login.html:132
+#: users/templates/users/login.html:126
 msgid "Sign in with Passkey"
 msgstr ""
 
-#: users/templates/users/login.html:148
+#: users/templates/users/login.html:142
 msgid "Enter your email address"
 msgstr ""
 
-#: users/templates/users/login.html:152
+#: users/templates/users/login.html:146
 msgid "Send verification code"
 msgstr ""
 
-#: users/templates/users/login.html:171
+#: users/templates/users/login.html:165
 msgid "Domain of your instance, e.g. mastodon.social"
 msgstr ""
 
-#: users/templates/users/login.html:177
-msgid ""
-"Please enter domain of your instance; e.g. if your id is "
-"<i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
+#: users/templates/users/login.html:171
+msgid "Please enter domain of your instance; e.g. if your id is <i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
 msgstr ""
 
-#: users/templates/users/login.html:182 users/templates/users/login.html:246
+#: users/templates/users/login.html:176 users/templates/users/login.html:240
 msgid "Authorize via Fediverse instance"
 msgstr ""
 
-#: users/templates/users/login.html:187
-msgid ""
-"If you don't have a <a href=\"https://joinmastodon.org/servers\" "
-"target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or "
-"login with Email first, and link it with Fediverse (Mastodon) later in "
-"account settings."
+#: users/templates/users/login.html:181
+msgid "If you don't have a <a href=\"https://joinmastodon.org/servers\" target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or login with Email first, and link it with Fediverse (Mastodon) later in account settings."
 msgstr ""
 
-#: users/templates/users/login.html:200
+#: users/templates/users/login.html:194
 msgid "Authorize via Threads"
 msgstr ""
 
-#: users/templates/users/login.html:221
-msgid ""
-"Please input your ATProto handle (e.g. neodb.bsky.social, without the "
-"leading @), do not use email. If you changed handle recently, just use the "
-"latest one."
+#: users/templates/users/login.html:215
+msgid "Please input your ATProto handle (e.g. neodb.bsky.social, without the leading @), do not use email. If you changed handle recently, just use the latest one."
 msgstr ""
 
-#: users/templates/users/login.html:224
+#: users/templates/users/login.html:218
 msgid "Authorize via ATProto server"
 msgstr ""
 
-#: users/templates/users/login.html:231
+#: users/templates/users/login.html:225
 #, python-format
-msgid ""
-"Please choose one to register or login %(site_name)s. Have more than one of "
-"these identities? Don't worry, you may link them in account settings once "
-"logged in."
+msgid "Please choose one to register or login %(site_name)s. Have more than one of these identities? Don't worry, you may link them in account settings once logged in."
 msgstr ""
 
-#: users/templates/users/login.html:255
+#: users/templates/users/login.html:249
 msgid "Valid invitation code, please login or register."
 msgstr ""
 
-#: users/templates/users/login.html:257
-msgid ""
-"Please use invitation link to register a new account; existing user may "
-"login."
+#: users/templates/users/login.html:251
+msgid "Please use invitation link to register a new account; existing user may login."
 msgstr ""
 
-#: users/templates/users/login.html:259
+#: users/templates/users/login.html:253
 msgid "Invitation code invalid or expired."
 msgstr ""
 
-#: users/templates/users/login.html:267
+#: users/templates/users/login.html:261
 msgid "Loading timed out, please check your network (VPN) settings."
 msgstr ""
 
-#: users/templates/users/login.html:273
-msgid ""
-"Continue using this site implies consent to our <a href=\"/pages/rules/"
-"\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using "
-"cookies to provide necessary functionality."
+#: users/templates/users/login.html:267
+msgid "Continue using this site implies consent to our <a href=\"/pages/rules/\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using cookies to provide necessary functionality."
 msgstr ""
 
-#: users/templates/users/login.html:287
+#: users/templates/users/login.html:281
 msgid "Domain of your instance (excl. @)"
 msgstr ""
 
@@ -8310,9 +8198,7 @@ msgid "Migrate Here"
 msgstr ""
 
 #: users/templates/users/migrate_in.html:22
-msgid ""
-"To move another account to this one, first add it as an alias here, and then "
-"go to the server where it is hosted and initiate the move."
+msgid "To move another account to this one, first add it as an alias here, and then go to the server where it is hosted and initiate the move."
 msgstr ""
 
 #: users/templates/users/migrate_in.html:27
@@ -8356,16 +8242,11 @@ msgstr ""
 
 #: users/templates/users/migrate_out.html:46
 #, python-format
-msgid ""
-"To migrate to another account, first add <code>@%(handle)s</code> as an "
-"alias on the target server, and then type the target account below to start "
-"the migration."
+msgid "To migrate to another account, first add <code>@%(handle)s</code> as an alias on the target server, and then type the target account below to start the migration."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:50
-msgid ""
-"Are you sure you want to migrate your account? Your followers will be moved "
-"to the target account."
+msgid "Are you sure you want to migrate your account? Your followers will be moved to the target account."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:53
@@ -8378,10 +8259,6 @@ msgstr ""
 
 #: users/templates/users/preferences.html:28
 msgid "Default view once logged in"
-msgstr ""
-
-#: users/templates/users/preferences.html:40
-msgid "Activities"
 msgstr ""
 
 #: users/templates/users/preferences.html:49
@@ -8411,9 +8288,7 @@ msgstr ""
 
 #: users/templates/users/preferences.html:111
 #: users/templates/users/register.html:88
-msgid ""
-"If a Mastodon account is linked with this identity, boosting a post will "
-"also make the same post boosted with that Mastodon account."
+msgid "If a Mastodon account is linked with this identity, boosting a post will also make the same post boosted with that Mastodon account."
 msgstr ""
 
 #: users/templates/users/preferences.html:115
@@ -8429,16 +8304,12 @@ msgid "Create a new post"
 msgstr ""
 
 #: users/templates/users/preferences.html:130
-msgid ""
-"this method is less optimal, may generate duplicated posts and miss "
-"reactions."
+msgid "this method is less optimal, may generate duplicated posts and miss reactions."
 msgstr ""
 
 #: users/templates/users/preferences.html:140
 #: users/templates/users/register.html:97
-msgid ""
-"Always publish my public marks, reviews and articles as data records to my "
-"PDS."
+msgid "Always publish my public marks, reviews and articles as data records to my PDS."
 msgstr ""
 
 #: users/templates/users/preferences.html:145
@@ -8458,12 +8329,7 @@ msgid "Automatic bookmark for these categories"
 msgstr ""
 
 #: users/templates/users/preferences.html:175
-msgid ""
-"When start to read/watch/play/... an item in these categories, a bookmark "
-"will be created automatically. Bookmarks can be viewed and managed in most "
-"<a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon "
-"compatible apps</a>; your replies to these posts will automatically become "
-"notes for the item."
+msgid "When start to read/watch/play/... an item in these categories, a bookmark will be created automatically. Bookmarks can be viewed and managed in most <a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon compatible apps</a>; your replies to these posts will automatically become notes for the item."
 msgstr ""
 
 #: users/templates/users/preferences.html:183
@@ -8483,9 +8349,7 @@ msgid "Profile visible to anonymous web visitors and search engines"
 msgstr ""
 
 #: users/templates/users/preferences.html:217
-msgid ""
-"this option limits web visits only; to limit fediverse visibility, choose "
-"followers only or mentioned only when posting"
+msgid "this option limits web visits only; to limit fediverse visibility, choose followers only or mentioned only when posting"
 msgstr ""
 
 #: users/templates/users/preferences.html:225
@@ -8497,17 +8361,7 @@ msgid "Do not show me item recommendations"
 msgstr ""
 
 #: users/templates/users/preferences.html:237
-msgid ""
-"Recommendations are generated only from public marks, processed in batch on "
-"this server. Your private and follower-only marks are never used as a signal "
-"for anyone, and we never share your data with third parties for this "
-"feature. When you share marks publicly and keep your profile discoverable, "
-"your marks help others here and across the Fediverse find things they might "
-"enjoy -- that voluntary contribution is what makes the feature work for "
-"everyone. If you'd rather not contribute, uncheck \"Include profile, marks "
-"and posts in discovery\" on your account page; this setting is published "
-"over ActivityPub, so other servers will also stop including you in their "
-"discovery features."
+msgid "Recommendations are generated only from public marks, processed in batch on this server. Your private and follower-only marks are never used as a signal for anyone, and we never share your data with third parties for this feature. When you share marks publicly and keep your profile discoverable, your marks help others here and across the Fediverse find things they might enjoy -- that voluntary contribution is what makes the feature work for everyone. If you'd rather not contribute, uncheck \"Include profile, marks and posts in discovery\" on your account page; this setting is published over ActivityPub, so other servers will also stop including you in their discovery features."
 msgstr ""
 
 #: users/templates/users/profile_actions.html:12
@@ -8608,19 +8462,11 @@ msgid "2-30 alphabets, numbers or underscore, can't be changed once saved"
 msgstr ""
 
 #: users/templates/users/register.html:72
-msgid ""
-"Use display name, bio and avatar from the social network you authenticated "
-"with"
+msgid "Use display name, bio and avatar from the social network you authenticated with"
 msgstr ""
 
 #: users/templates/users/register.html:80
-msgid ""
-"Add follow, mute and block list from the social network you authenticated "
-"with"
-msgstr ""
-
-#: users/templates/users/register.html:104
-msgid "Confirm and save"
+msgid "Add follow, mute and block list from the social network you authenticated with"
 msgstr ""
 
 #: users/templates/users/register.html:106
@@ -8649,8 +8495,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"              Matched %(local)s locally, %(external)s externally, "
-"%(unmatched)s unmatched out of %(total)s rows.\n"
+"              Matched %(local)s locally, %(external)s externally, %(unmatched)s unmatched out of %(total)s rows.\n"
 "            "
 msgstr ""
 
@@ -8769,9 +8614,7 @@ msgid "Played"
 msgstr ""
 
 #: users/templates/users/steam_import.html:90
-msgid ""
-"Games in wishlist; or purchased in library but never played, mark date will "
-"be set as today"
+msgid "Games in wishlist; or purchased in library but never played, mark date will be set as today"
 msgstr ""
 
 #: users/templates/users/steam_import.html:91
@@ -8811,15 +8654,11 @@ msgid "Comma-separated Steam AppIDs"
 msgstr ""
 
 #: users/templates/users/steam_import.html:121
-msgid ""
-"Allow reverse override of status (e.g. playing -> want to, or played -> "
-"playing)"
+msgid "Allow reverse override of status (e.g. playing -> want to, or played -> playing)"
 msgstr ""
 
 #: users/templates/users/steam_import.html:139
-msgid ""
-"To import from Steam, your game details must be visible to public in Steam "
-"privacy settings."
+msgid "To import from Steam, your game details must be visible to public in Steam privacy settings."
 msgstr ""
 
 #: users/templates/users/storygraph_import.html:9
@@ -8864,23 +8703,16 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"              %(site_name)s is flourishing because of collaborations and "
-"contributions from users like you. Please read our <a href=\"/pages/"
-"rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</"
-"a> if you have any question or feedback.\n"
+"              %(site_name)s is flourishing because of collaborations and contributions from users like you. Please read our <a href=\"/pages/rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</a> if you have any question or feedback.\n"
 "        "
 msgstr ""
 
 #: users/templates/users/welcome.html:37
-msgid ""
-"Set up a passkey to sign in quickly next time using your fingerprint, face, "
-"or screen lock."
+msgid "Set up a passkey to sign in quickly next time using your fingerprint, face, or screen lock."
 msgstr ""
 
 #: users/templates/users/welcome.html:39
-msgid ""
-"Creating a passkey is highly recommended, as the website or email you use to "
-"create this account may not be always available."
+msgid "Creating a passkey is highly recommended, as the website or email you use to create this account may not be always available."
 msgstr ""
 
 #: users/templates/users/welcome.html:43
@@ -8895,237 +8727,223 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:124
+#: users/views/account.py:126
 msgid "This username is already in use."
 msgstr ""
 
-#: users/views/account.py:135
+#: users/views/account.py:137
 msgid "This email address is already in use."
 msgstr ""
 
-#: users/views/account.py:255 users/views/account.py:374
+#: users/views/account.py:257 users/views/account.py:376
 msgid "Registration is for invitation only"
 msgstr ""
 
-#: users/views/account.py:266 users/views/account.py:338
+#: users/views/account.py:268 users/views/account.py:340
 msgid "Time is up"
 msgstr ""
 
-#: users/views/account.py:267 users/views/account.py:310
-#: users/views/account.py:339
+#: users/views/account.py:269 users/views/account.py:312
+#: users/views/account.py:341
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:313
+#: users/views/account.py:315
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:325
+#: users/views/account.py:327
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:326
+#: users/views/account.py:328
 msgid "Please try again later."
 msgstr ""
 
-#: users/views/account.py:415
+#: users/views/account.py:417
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:445
+#: users/views/account.py:447
 msgid "Valid username required"
 msgstr ""
 
-#: users/views/account.py:526
+#: users/views/account.py:518
 msgid "Account is being deleted."
 msgstr ""
 
-#: users/views/account.py:529
+#: users/views/account.py:521
 msgid "Account mismatch."
 msgstr ""
 
-#: users/views/data.py:262 users/views/data.py:294
+#: users/views/data.py:264 users/views/data.py:296
 msgid "Export file not available."
 msgstr ""
 
-#: users/views/data.py:288
+#: users/views/data.py:290
 msgid "Generating exports."
 msgstr ""
 
-#: users/views/data.py:306
+#: users/views/data.py:308
 msgid "Export file expired. Please export again."
 msgstr ""
 
-#: users/views/data.py:321 users/views/data.py:342 users/views/data.py:363
+#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
 msgid "Recent export still in progress."
 msgstr ""
 
-#: users/views/data.py:379 users/views/data.py:513 users/views/data.py:547
-#: users/views/data.py:772 users/views/data.py:989 users/views/data.py:1015
-#: users/views/data.py:1040 users/views/data.py:1065
+#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
+#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
+#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
 msgid "Invalid file."
 msgstr ""
 
-#: users/views/data.py:403
+#: users/views/data.py:405
 msgid "Sync in progress."
 msgstr ""
 
-#: users/views/data.py:417
+#: users/views/data.py:419
 msgid "Settings saved."
 msgstr ""
 
-#: users/views/data.py:472
+#: users/views/data.py:474
 msgid "Account no longer linked."
 msgstr ""
 
-#: users/views/data.py:475
+#: users/views/data.py:477
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:503
+#: users/views/data.py:505
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:583 users/views/data.py:808
+#: users/views/data.py:585 users/views/data.py:810
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:608 users/views/data.py:837
+#: users/views/data.py:610 users/views/data.py:839
 msgid "Cancelled."
 msgstr ""
 
-#: users/views/data.py:628
+#: users/views/data.py:630
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:636 users/views/data.py:746 users/views/data.py:867
-#: users/views/data.py:972
+#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
+#: users/views/data.py:974
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:732 users/views/data.py:958
+#: users/views/data.py:734 users/views/data.py:960
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:742 users/views/data.py:968
+#: users/views/data.py:744 users/views/data.py:970
 msgid "No matched file available."
 msgstr ""
 
-#: users/views/data.py:859
+#: users/views/data.py:861
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1188
+#: users/views/data.py:1226
 #, fuzzy
 #| msgid "required"
 msgid "Name is required."
 msgstr "derrigorrezkoa"
 
-#: users/views/data.py:1210
+#: users/views/data.py:1248
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1264
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1231
+#: users/views/data.py:1269
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1241 users/views/data.py:1292
+#: users/views/data.py:1279 users/views/data.py:1330
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:1248
+#: users/views/data.py:1286
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:1253
+#: users/views/data.py:1291
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:1279
+#: users/views/data.py:1317
 msgid "Migration cancelled."
 msgstr ""
 
-#: users/views/data.py:1284
+#: users/views/data.py:1322
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:1297
+#: users/views/data.py:1335
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:1308
+#: users/views/data.py:1346
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:1314
+#: users/views/data.py:1352
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr ""
 
-#: users/views/data.py:1372
+#: users/views/data.py:1410
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1388
+#: users/views/data.py:1426
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1392
+#: users/views/data.py:1430
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1402
+#: users/views/data.py:1440
 #, python-brace-format
-msgid ""
-"Import of {count} entries received. They will be processed in the background."
+msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""
 
-#: users/views/webauthn.py:103
+#: users/views/webauthn.py:106
 msgid "Passkey registration failed"
 msgstr ""
 
-#: users/views/webauthn.py:123
+#: users/views/webauthn.py:126
 msgid "Credential already registered"
 msgstr ""
 
-#: users/views/webauthn.py:165 users/views/webauthn.py:172
-#: users/views/webauthn.py:181
+#: users/views/webauthn.py:168 users/views/webauthn.py:175
+#: users/views/webauthn.py:184
 msgid "Passkey not recognized"
 msgstr ""
 
-#: users/views/webauthn.py:186
+#: users/views/webauthn.py:189
 msgid "Account is inactive"
 msgstr ""
 
-#: users/views/webauthn.py:202
+#: users/views/webauthn.py:205
 msgid "Passkey verification failed"
 msgstr ""
 
-#: users/views/webauthn.py:228 users/views/webauthn.py:250
+#: users/views/webauthn.py:231 users/views/webauthn.py:253
 msgid "Passkey not found"
 msgstr ""
 
-#: users/views/webauthn.py:244
+#: users/views/webauthn.py:247
 #, fuzzy
 #| msgid "required"
 msgid "Name is required"
 msgstr "derrigorrezkoa"
-
-#~ msgid "YYYY-MM-DD"
-#~ msgstr "UUUU-HH-DD"
-
-#~ msgid "year"
-#~ msgstr "urtea"
-
-#~ msgctxt "music"
-#~ msgid "genre"
-#~ msgstr "generoa"
-
-#~ msgid "episode Length"
-#~ msgstr "atalaren luzera"

--- a/neodb/locale/fa/LC_MESSAGES/django.po
+++ b/neodb/locale/fa/LC_MESSAGES/django.po
@@ -7,11 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-23 15:40-0400\n"
+"POT-Creation-Date: 2026-09-06 20:04-0400\n"
 "PO-Revision-Date: 2026-08-09 06:31+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Persian <https://hosted.weblate.org/projects/neodb/neodb/fa/"
-">\n"
+"Language-Team: Persian <https://hosted.weblate.org/projects/neodb/neodb/fa/>\n"
 "Language: fa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,163 +18,163 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: boofilsic/settings.py:472 common/models/lang.py:230
+#: boofilsic/settings.py:501 common/models/lang.py:232
 msgid "English"
 msgstr "انگلیسی"
 
-#: boofilsic/settings.py:473 common/models/lang.py:77
+#: boofilsic/settings.py:502 common/models/lang.py:79
 msgid "Danish"
 msgstr "دانمارکی"
 
-#: boofilsic/settings.py:474 common/models/lang.py:78
+#: boofilsic/settings.py:503 common/models/lang.py:80
 msgid "German"
 msgstr "آلمانی"
 
-#: boofilsic/settings.py:475 common/models/lang.py:183
+#: boofilsic/settings.py:504 common/models/lang.py:185
 msgid "Spanish"
 msgstr ""
 
-#: boofilsic/settings.py:476 common/models/lang.py:87
+#: boofilsic/settings.py:505 common/models/lang.py:89
 msgid "French"
 msgstr "فرانسوی"
 
-#: boofilsic/settings.py:477 common/models/lang.py:112
+#: boofilsic/settings.py:506 common/models/lang.py:114
 msgid "Italian"
 msgstr "ایتالیایی"
 
-#: boofilsic/settings.py:478 common/models/lang.py:166
-#: common/models/lang.py:305
+#: boofilsic/settings.py:507 common/models/lang.py:168
+#: common/models/lang.py:307
 msgid "Portuguese"
 msgstr "پرتغالی"
 
-#: boofilsic/settings.py:479
+#: boofilsic/settings.py:508
 msgid "Brazilian Portuguese"
 msgstr "پرتغالی برزیلی"
 
-#: boofilsic/settings.py:480 common/models/lang.py:316
+#: boofilsic/settings.py:509 common/models/lang.py:318
 msgid "Simplified Chinese"
 msgstr "چینی ساده‌شده"
 
-#: boofilsic/settings.py:481 common/models/lang.py:317
+#: boofilsic/settings.py:510 common/models/lang.py:319
 msgid "Traditional Chinese"
 msgstr "چینی سنتی"
 
-#: catalog/forms.py:35 catalog/models/item.py:291
+#: catalog/forms.py:35 catalog/models/item.py:307
 #, fuzzy
 msgid "Primary ID Type"
 msgstr "نوع شناسهٔ اصلی"
 
-#: catalog/forms.py:40 catalog/models/item.py:294
+#: catalog/forms.py:40 catalog/models/item.py:310
 #, fuzzy
 msgid "Primary ID Value"
 msgstr "مقدار شناسهٔ اصلی"
 
-#: catalog/forms.py:181
+#: catalog/forms.py:176
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
-#: catalog/models/book.py:139 catalog/models/book.py:158
-#: catalog/models/common.py:280 catalog/models/common.py:298
+#: catalog/models/book.py:141 catalog/models/book.py:160
+#: catalog/models/common.py:279 catalog/models/common.py:297
 msgid "locale"
 msgstr "محلی"
 
-#: catalog/models/book.py:142 catalog/models/book.py:161
-#: catalog/models/common.py:283 catalog/models/common.py:303
+#: catalog/models/book.py:144 catalog/models/book.py:163
+#: catalog/models/common.py:282 catalog/models/common.py:302
 msgid "text content"
 msgstr "محتوای متنی"
 
-#: catalog/models/book.py:177
+#: catalog/models/book.py:179
 msgid "Paperback"
 msgstr "جلد کاغذی"
 
-#: catalog/models/book.py:178
+#: catalog/models/book.py:180
 msgid "Hardcover"
 msgstr "جلد سخت"
 
-#: catalog/models/book.py:179
+#: catalog/models/book.py:181
 #, fuzzy
 msgid "eBook"
 msgstr "کتاب الکترونیکی"
 
-#: catalog/models/book.py:180
+#: catalog/models/book.py:182
 msgid "Audiobook"
 msgstr "کتاب صوتی"
 
-#: catalog/models/book.py:182
+#: catalog/models/book.py:184
 msgid "Web Fiction"
 msgstr "رمان اینترنتی"
 
-#: catalog/models/book.py:183 catalog/models/game.py:38
+#: catalog/models/book.py:185 catalog/models/game.py:38
 msgid "Other"
 msgstr "دیگر"
 
-#: catalog/models/book.py:260
+#: catalog/models/book.py:262
 msgid "subtitle"
 msgstr "زیرنویس"
 
-#: catalog/models/book.py:270 catalog/models/movie.py:120
-#: catalog/models/performance.py:385 catalog/models/tv.py:211
-#: catalog/models/tv.py:437
+#: catalog/models/book.py:272 catalog/models/movie.py:120
+#: catalog/models/performance.py:385 catalog/models/tv.py:213
+#: catalog/models/tv.py:439
 msgid "original title"
 msgstr "عنوان اصلی"
 
-#: catalog/models/book.py:274
+#: catalog/models/book.py:276
 msgid "other title"
 msgstr "عنوان دیگر"
 
-#: catalog/models/book.py:280 catalog/models/book.py:564
-#: catalog/models/item.py:123
+#: catalog/models/book.py:282 catalog/models/book.py:566
+#: catalog/models/item.py:119
 msgid "author"
 msgstr "نویسنده"
 
-#: catalog/models/book.py:287 catalog/models/item.py:124
+#: catalog/models/book.py:289 catalog/models/item.py:120
 msgid "translator"
 msgstr "ترجمه‌کننده"
 
-#: catalog/models/book.py:294 catalog/templates/edition.html:26
+#: catalog/models/book.py:296 catalog/templates/edition.html:26
 #, fuzzy
 msgid "book format"
 msgstr "قالب‌ کتاب"
 
-#: catalog/models/book.py:301 catalog/models/game.py:135
-#: catalog/models/item.py:138 catalog/models/music.py:142
+#: catalog/models/book.py:303 catalog/models/game.py:135
+#: catalog/models/item.py:134 catalog/models/music.py:142
 msgid "publisher"
 msgstr "ناشر"
 
-#: catalog/models/book.py:308
+#: catalog/models/book.py:310
 msgid "publication year"
 msgstr "سال انتشار"
 
-#: catalog/models/book.py:314
+#: catalog/models/book.py:316
 msgid "publication month"
 msgstr "ماه انتشار"
 
-#: catalog/models/book.py:319
+#: catalog/models/book.py:321
 msgid "binding"
 msgstr "صحافی"
 
-#: catalog/models/book.py:320
+#: catalog/models/book.py:322
 msgid "pages"
 msgstr "برگه‌ها"
 
-#: catalog/models/book.py:321 catalog/templates/edition.html:45
+#: catalog/models/book.py:323 catalog/templates/edition.html:45
 msgid "series"
 msgstr "دنباله‌ها"
 
-#: catalog/models/book.py:322 catalog/templates/edition.html:65
+#: catalog/models/book.py:324 catalog/templates/edition.html:65
 msgid "contents"
 msgstr "محتویات"
 
-#: catalog/models/book.py:323 catalog/templates/edition.html:51
+#: catalog/models/book.py:325 catalog/templates/edition.html:51
 msgid "price"
 msgstr "قیمت"
 
-#: catalog/models/book.py:324 catalog/models/item.py:149
+#: catalog/models/book.py:326 catalog/models/item.py:145
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr ""
 
-#: catalog/models/common.py:26 common/models/lang.py:256
+#: catalog/models/common.py:26 common/models/lang.py:258
 msgid "Unknown"
 msgstr "ناشناخته"
 
@@ -183,11 +182,11 @@ msgstr "ناشناخته"
 msgid "Douban"
 msgstr ""
 
-#: catalog/models/common.py:28 catalog/models/common.py:79
+#: catalog/models/common.py:28 catalog/models/common.py:81
 msgid "Goodreads"
 msgstr "گودریدز"
 
-#: catalog/models/common.py:29 catalog/models/common.py:81
+#: catalog/models/common.py:29 catalog/models/common.py:83
 msgid "Google Books"
 msgstr "کتاب‌های گوگل"
 
@@ -196,16 +195,16 @@ msgstr "کتاب‌های گوگل"
 msgid "BooksTW"
 msgstr "کتاب‌های TW"
 
-#: catalog/models/common.py:31 catalog/models/common.py:91
-#: catalog/models/common.py:93
+#: catalog/models/common.py:31 catalog/models/common.py:93
+#: catalog/models/common.py:95
 msgid "Bibliotek.dk"
 msgstr ""
 
-#: catalog/models/common.py:32 catalog/models/common.py:92
+#: catalog/models/common.py:32 catalog/models/common.py:94
 msgid "eReolen.dk"
 msgstr ""
 
-#: catalog/models/common.py:33 catalog/models/common.py:74
+#: catalog/models/common.py:33 catalog/models/common.py:76
 #: catalog/templates/movie.html:41 catalog/templates/people.html:37
 #: catalog/templates/tvseason.html:58 catalog/templates/tvshow.html:53
 msgid "IMDb"
@@ -215,7 +214,7 @@ msgstr "ای ام دی بی"
 msgid "TMDB"
 msgstr ""
 
-#: catalog/models/common.py:35 catalog/models/common.py:94
+#: catalog/models/common.py:35 catalog/models/common.py:96
 msgid "Bandcamp"
 msgstr "بندکمپ"
 
@@ -231,11 +230,11 @@ msgstr ""
 msgid "Steam"
 msgstr ""
 
-#: catalog/models/common.py:39 catalog/models/common.py:114
+#: catalog/models/common.py:39 catalog/models/common.py:116
 msgid "itch.io"
 msgstr ""
 
-#: catalog/models/common.py:40 catalog/models/common.py:115
+#: catalog/models/common.py:40 catalog/models/common.py:117
 msgid "Bangumi"
 msgstr ""
 
@@ -243,7 +242,7 @@ msgstr ""
 msgid "BGG"
 msgstr ""
 
-#: catalog/models/common.py:42 catalog/models/common.py:116
+#: catalog/models/common.py:42 catalog/models/common.py:118
 msgid "Apple Podcast"
 msgstr "پادپخش اپل"
 
@@ -255,35 +254,35 @@ msgstr "آ‌راس‌اس"
 msgid "Discogs"
 msgstr ""
 
-#: catalog/models/common.py:45 catalog/models/common.py:117
+#: catalog/models/common.py:45 catalog/models/common.py:119
 msgid "Apple Music"
 msgstr "اپل موزیک"
 
-#: catalog/models/common.py:46 catalog/models/common.py:119
+#: catalog/models/common.py:46 catalog/models/common.py:121
 msgid "Fediverse"
 msgstr "فدیورس"
 
-#: catalog/models/common.py:47 catalog/models/common.py:120
+#: catalog/models/common.py:47 catalog/models/common.py:122
 msgid "Qidian"
 msgstr ""
 
-#: catalog/models/common.py:48 catalog/models/common.py:121
+#: catalog/models/common.py:48 catalog/models/common.py:123
 msgid "Ypshuo"
 msgstr ""
 
-#: catalog/models/common.py:49 catalog/models/common.py:122
+#: catalog/models/common.py:49 catalog/models/common.py:124
 msgid "Archive of Our Own"
 msgstr ""
 
-#: catalog/models/common.py:50 catalog/models/common.py:123
+#: catalog/models/common.py:50 catalog/models/common.py:125
 msgid "JinJiang"
 msgstr ""
 
-#: catalog/models/common.py:51 catalog/models/common.py:64
+#: catalog/models/common.py:51 catalog/models/common.py:66
 msgid "WikiData"
 msgstr "ویکی‌داده"
 
-#: catalog/models/common.py:52 catalog/models/common.py:124
+#: catalog/models/common.py:52 catalog/models/common.py:126
 msgid "Open Library"
 msgstr ""
 
@@ -295,17 +294,17 @@ msgstr ""
 msgid "WorldCat"
 msgstr ""
 
-#: catalog/models/common.py:55 catalog/models/common.py:126
+#: catalog/models/common.py:55 catalog/models/common.py:128
 #, fuzzy
 #| msgid "Game"
 msgid "MobyGames"
 msgstr "بازی"
 
-#: catalog/models/common.py:56 catalog/models/common.py:127
+#: catalog/models/common.py:56 catalog/models/common.py:129
 msgid "StoryGraph"
 msgstr ""
 
-#: catalog/models/common.py:57 catalog/models/common.py:118
+#: catalog/models/common.py:57 catalog/models/common.py:120
 #, fuzzy
 msgid "YouTube Music"
 msgstr "آهنگ دوبان"
@@ -322,359 +321,368 @@ msgstr ""
 msgid "Readmoo"
 msgstr ""
 
-#: catalog/models/common.py:65
+#: catalog/models/common.py:61
+msgid "MyAnimeList"
+msgstr ""
+
+#: catalog/models/common.py:62 catalog/models/common.py:140
+msgid "MangaUpdates"
+msgstr ""
+
+#: catalog/models/common.py:67
 msgid "ISBN10"
 msgstr ""
 
-#: catalog/models/common.py:66 catalog/templates/edition.html:19
+#: catalog/models/common.py:68 catalog/templates/edition.html:19
 msgid "ISBN"
 msgstr "شابک"
 
-#: catalog/models/common.py:67
+#: catalog/models/common.py:69
 msgid "ASIN"
 msgstr ""
 
-#: catalog/models/common.py:68
+#: catalog/models/common.py:70
 msgid "ISSN"
 msgstr ""
 
-#: catalog/models/common.py:69
+#: catalog/models/common.py:71
 msgid "CUBN"
 msgstr ""
 
-#: catalog/models/common.py:70
+#: catalog/models/common.py:72
 msgid "ISRC"
 msgstr ""
 
-#: catalog/models/common.py:71
+#: catalog/models/common.py:73
 msgid "GTIN UPC EAN"
 msgstr ""
 
-#: catalog/models/common.py:72
+#: catalog/models/common.py:74
 msgid "OCLC Number"
 msgstr ""
 
-#: catalog/models/common.py:73
+#: catalog/models/common.py:75
 #, fuzzy
 msgid "RSS Feed URL"
 msgstr "نشانی خوراک‌وب"
 
-#: catalog/models/common.py:75
+#: catalog/models/common.py:77
 msgid "TMDB TV Series"
 msgstr ""
 
-#: catalog/models/common.py:76
+#: catalog/models/common.py:78
 msgid "TMDB TV Season"
 msgstr ""
 
-#: catalog/models/common.py:77
+#: catalog/models/common.py:79
 msgid "TMDB TV Episode"
 msgstr ""
 
-#: catalog/models/common.py:78
+#: catalog/models/common.py:80
 msgid "TMDB Movie"
 msgstr ""
 
-#: catalog/models/common.py:80
+#: catalog/models/common.py:82
 msgid "Goodreads Work"
 msgstr ""
 
-#: catalog/models/common.py:82
+#: catalog/models/common.py:84
 msgid "Douban Book"
 msgstr ""
 
-#: catalog/models/common.py:83
+#: catalog/models/common.py:85
 msgid "Douban Book Work"
 msgstr ""
 
-#: catalog/models/common.py:84
+#: catalog/models/common.py:86
 #, fuzzy
 msgid "Douban Movie"
 msgstr "فیلم دوبان"
 
-#: catalog/models/common.py:85
+#: catalog/models/common.py:87
 #, fuzzy
 msgid "Douban Music"
 msgstr "آهنگ دوبان"
 
-#: catalog/models/common.py:86
+#: catalog/models/common.py:88
 #, fuzzy
 msgid "Douban Game"
 msgstr "بازی دوبان"
 
-#: catalog/models/common.py:87
+#: catalog/models/common.py:89
 msgid "Douban Drama"
 msgstr "درام دوبان"
 
-#: catalog/models/common.py:88
+#: catalog/models/common.py:90
 msgid "Douban Drama Version"
 msgstr "دوبان ورژن درام"
 
-#: catalog/models/common.py:89
+#: catalog/models/common.py:91
 msgid "BooksTW Book"
 msgstr "کتابهای کتاب تلویزیون"
 
-#: catalog/models/common.py:90
+#: catalog/models/common.py:92
 msgid "Readmoo Book"
 msgstr ""
 
-#: catalog/models/common.py:95
+#: catalog/models/common.py:97
 #, fuzzy
 msgid "Spotify Album"
 msgstr "آلبوم اسپاتیفای"
 
-#: catalog/models/common.py:96
+#: catalog/models/common.py:98
 #, fuzzy
 msgid "Spotify Podcast"
 msgstr "پادکست اسپاتیفای"
 
-#: catalog/models/common.py:97
+#: catalog/models/common.py:99
 #, fuzzy
 msgid "Discogs Release"
 msgstr "انتشار دیسکاگ ها"
 
-#: catalog/models/common.py:98
+#: catalog/models/common.py:100
 msgid "Discogs Master"
 msgstr "استاد دیسکاگ ها"
 
-#: catalog/models/common.py:101
+#: catalog/models/common.py:103
 msgid "MusicBrainz Release Group"
 msgstr "گروه انتشار موزیک‌برینز"
 
-#: catalog/models/common.py:103
+#: catalog/models/common.py:105
 msgid "MusicBrainz Release"
 msgstr "انتشار موزیک‌برینزش"
 
-#: catalog/models/common.py:104
+#: catalog/models/common.py:106
 #, fuzzy
 #| msgid "MusicBrainz Release"
 msgid "MusicBrainz Artist"
 msgstr "انتشار موزیک‌برینزش"
 
-#: catalog/models/common.py:105
+#: catalog/models/common.py:107
 #, fuzzy
 msgid "Douban Personage"
 msgstr "بازی دوبان"
 
-#: catalog/models/common.py:106
+#: catalog/models/common.py:108
 #, fuzzy
 #| msgid "Goodreads"
 msgid "Goodreads Author"
 msgstr "گودریدز"
 
-#: catalog/models/common.py:107
+#: catalog/models/common.py:109
 #, fuzzy
 msgid "Spotify Artist"
 msgstr "پادکست اسپاتیفای"
 
-#: catalog/models/common.py:108
+#: catalog/models/common.py:110
 msgid "TMDB Person"
 msgstr ""
 
-#: catalog/models/common.py:109
+#: catalog/models/common.py:111
 #, fuzzy
 #| msgid "Open Library Work"
 msgid "Open Library Author"
 msgstr "کتابخانه کار را بازکنید"
 
-#: catalog/models/common.py:110
+#: catalog/models/common.py:112
 msgid "IGDB Company"
 msgstr ""
 
-#: catalog/models/common.py:111
+#: catalog/models/common.py:113
 msgid "IGDB Game"
 msgstr "بازی آی جی دی بی"
 
-#: catalog/models/common.py:112
+#: catalog/models/common.py:114
 msgid "BGG Boardgame"
 msgstr "بازی رو میزی بی جی جی"
 
-#: catalog/models/common.py:113
+#: catalog/models/common.py:115
 msgid "Steam Game"
 msgstr "بازی استیم"
 
-#: catalog/models/common.py:125
+#: catalog/models/common.py:127
 msgid "Open Library Work"
 msgstr "کتابخانه کار را بازکنید"
 
-#: catalog/models/common.py:128
+#: catalog/models/common.py:130
 #, fuzzy
 #| msgid "MusicBrainz Release"
 msgid "RateYourMusic Release"
 msgstr "انتشار موزیک‌برینزش"
 
-#: catalog/models/common.py:132
+#: catalog/models/common.py:134
 msgid "AniList Anime"
 msgstr ""
 
-#: catalog/models/common.py:133
+#: catalog/models/common.py:135
 msgid "AniList Manga"
 msgstr ""
 
-#: catalog/models/common.py:134
+#: catalog/models/common.py:136
 msgid "MyAnimeList Anime"
 msgstr ""
 
-#: catalog/models/common.py:135
+#: catalog/models/common.py:137
 msgid "MyAnimeList Manga"
 msgstr ""
 
-#: catalog/models/common.py:156
+#: catalog/models/common.py:161
 msgid "Edition"
 msgstr "ویرایش"
 
-#: catalog/models/common.py:157 catalog/templates/_sidebar_edit.html:286
+#: catalog/models/common.py:162 catalog/templates/_sidebar_edit.html:289
 msgid "Work"
 msgstr "کار"
 
-#: catalog/models/common.py:158
+#: catalog/models/common.py:163
 msgid "TV Series"
 msgstr "دنبالهٔ تلویزیونی"
 
-#: catalog/models/common.py:159 catalog/templates/_sidebar_edit.html:207
+#: catalog/models/common.py:164 catalog/templates/_sidebar_edit.html:202
+#: catalog/views/edit.py:385
 msgid "TV Season"
 msgstr "فصل تلویزیون"
 
-#: catalog/models/common.py:160
+#: catalog/models/common.py:165
 #, fuzzy
 msgid "TV Episode"
 msgstr "اپیزود تلویزیونی"
 
-#: catalog/models/common.py:161 catalog/models/common.py:177
-#: catalog/models/common.py:191 catalog/templates/_sidebar_edit.html:200
-#: journal/templates/_sidebar_user_mark_list.html:35
+#: catalog/models/common.py:166 catalog/models/common.py:182
+#: catalog/models/common.py:196 catalog/templates/_sidebar_edit.html:196
+#: catalog/views/edit.py:384 journal/templates/_sidebar_user_mark_list.html:35
 #: journal/templates/_sidebar_user_tag_filter.html:27
 msgid "Movie"
 msgstr "فیلم"
 
-#: catalog/models/common.py:162
+#: catalog/models/common.py:167
 #, fuzzy
 msgid "Album"
 msgstr "آلبم"
 
-#: catalog/models/common.py:163 catalog/models/common.py:180
-#: catalog/models/common.py:194 common/templates/_header.html:43
+#: catalog/models/common.py:168 catalog/models/common.py:185
+#: catalog/models/common.py:199 common/templates/_header.html:53
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
 msgstr "بازی"
 
-#: catalog/models/common.py:164
+#: catalog/models/common.py:169
 #, fuzzy
 msgid "Podcast Program"
 msgstr "برنامه پادکست"
 
-#: catalog/models/common.py:165
+#: catalog/models/common.py:170
 msgid "Podcast Episode"
 msgstr "قسمت پادپخش"
 
-#: catalog/models/common.py:166 catalog/models/common.py:182
-#: catalog/models/common.py:196 common/templates/_header.html:47
+#: catalog/models/common.py:171 catalog/models/common.py:187
+#: catalog/models/common.py:201 common/templates/_header.html:57
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
 msgstr "عملکرد"
 
-#: catalog/models/common.py:167
+#: catalog/models/common.py:172
 #, fuzzy
 msgid "Production"
 msgstr "تولید"
 
-#: catalog/models/common.py:168
+#: catalog/models/common.py:173
 msgid "Exhibition"
 msgstr "نمایشگاه"
 
-#: catalog/models/common.py:169 catalog/models/common.py:186
+#: catalog/models/common.py:174 catalog/models/common.py:191
 #: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr "مجموعه"
 
-#: catalog/models/common.py:172 catalog/models/common.py:185
+#: catalog/models/common.py:177 catalog/models/common.py:190
 msgid "Person / Organization"
 msgstr ""
 
-#: catalog/models/common.py:176 catalog/models/common.py:190
-#: common/templates/_header.html:27
+#: catalog/models/common.py:181 catalog/models/common.py:195
+#: common/templates/_header.html:37
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
 msgstr "کتاب"
 
-#: catalog/models/common.py:178 catalog/models/common.py:192
+#: catalog/models/common.py:183 catalog/models/common.py:197
 #: journal/templates/_sidebar_user_mark_list.html:38
 #: journal/templates/_sidebar_user_tag_filter.html:30
 msgid "TV"
 msgstr "تی‌وی"
 
-#: catalog/models/common.py:179 catalog/models/common.py:193
-#: common/templates/_header.html:39
+#: catalog/models/common.py:184 catalog/models/common.py:198
+#: common/templates/_header.html:49
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr "موسیقی"
 
-#: catalog/models/common.py:181 catalog/models/common.py:195
-#: catalog/templates/_sidebar_edit.html:219 common/templates/_header.html:35
+#: catalog/models/common.py:186 catalog/models/common.py:200
+#: catalog/templates/_sidebar_edit.html:213 common/templates/_header.html:45
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
 msgstr "پادپخش"
 
-#: catalog/models/common.py:346 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:345 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr ""
 
-#: catalog/models/common.py:384
+#: catalog/models/common.py:383
 msgid "origin country"
 msgstr ""
 
-#: catalog/models/common.py:413 catalog/templates/album.html:33
+#: catalog/models/common.py:412 catalog/templates/album.html:33
 msgid "album type"
 msgstr ""
 
-#: catalog/models/common.py:417 catalog/templates/_platform_list.html:5
+#: catalog/models/common.py:416 catalog/templates/_platform_list.html:5
 msgid "platform"
 msgstr "بُن‌سازه"
 
-#: catalog/models/common.py:421
+#: catalog/models/common.py:420
 #, fuzzy
 msgid "media format"
 msgstr "قالب‌ کتاب"
 
-#: catalog/models/common.py:426 catalog/templates/_language_list.html:5
-#: users/models/user.py:142
+#: catalog/models/common.py:425 catalog/templates/_language_list.html:5
+#: users/models/user.py:144
 msgid "language"
 msgstr "زبان"
 
-#: catalog/models/creator.py:24
+#: catalog/models/creator.py:26
 #, fuzzy
 #| msgid "binding"
 msgid "pending"
 msgstr "صحافی"
 
-#: catalog/models/creator.py:25
+#: catalog/models/creator.py:27
 msgid "verified"
 msgstr ""
 
-#: catalog/models/creator.py:26
+#: catalog/models/creator.py:28
 msgid "failed"
 msgstr ""
 
-#: catalog/models/creator.py:29
+#: catalog/models/creator.py:31
 msgid "no feed url available for this item"
 msgstr ""
 
-#: catalog/models/creator.py:30
+#: catalog/models/creator.py:32
 msgid "unable to fetch or parse the feed"
 msgstr ""
 
-#: catalog/models/creator.py:31
+#: catalog/models/creator.py:33
 msgid "no audio episode found in the feed"
 msgstr ""
 
-#: catalog/models/creator.py:34
+#: catalog/models/creator.py:36
 msgid "no matching identity found in the feed or its linked website"
 msgstr ""
 
@@ -711,16 +719,16 @@ msgstr ""
 msgid "Special Edition"
 msgstr ""
 
-#: catalog/models/game.py:111 catalog/models/item.py:130
+#: catalog/models/game.py:111 catalog/models/item.py:126
 msgid "designer"
 msgstr "طراح"
 
-#: catalog/models/game.py:119 catalog/models/item.py:129
+#: catalog/models/game.py:119 catalog/models/item.py:125
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr "هنرمند"
 
-#: catalog/models/game.py:127 catalog/models/item.py:139
+#: catalog/models/game.py:127 catalog/models/item.py:135
 msgid "developer"
 msgstr "توسعه‌دهنده"
 
@@ -729,8 +737,8 @@ msgid "date of publication"
 msgstr ""
 
 #: catalog/models/game.py:147 catalog/models/movie.py:156
-#: catalog/models/music.py:128 catalog/models/tv.py:247
-#: catalog/models/tv.py:473
+#: catalog/models/music.py:128 catalog/models/tv.py:249
+#: catalog/models/tv.py:475
 msgid "YYYY, YYYY-MM or YYYY-MM-DD"
 msgstr ""
 
@@ -741,7 +749,7 @@ msgstr ""
 #: catalog/models/game.py:180 catalog/models/movie.py:158
 #: catalog/models/people.py:178 catalog/models/performance.py:258
 #: catalog/models/performance.py:465 catalog/models/podcast.py:89
-#: catalog/models/tv.py:249 catalog/models/tv.py:476
+#: catalog/models/tv.py:251 catalog/models/tv.py:478
 #: catalog/templates/game.html:33 catalog/templates/movie.html:48
 #: catalog/templates/people.html:44 catalog/templates/performance.html:35
 #: catalog/templates/performanceproduction.html:35
@@ -750,149 +758,149 @@ msgstr ""
 msgid "website"
 msgstr "وبگاه"
 
-#: catalog/models/item.py:125 catalog/models/movie.py:123
+#: catalog/models/item.py:121 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
-#: catalog/models/tv.py:214 catalog/models/tv.py:440
+#: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr ""
 
-#: catalog/models/item.py:126 catalog/models/movie.py:130
+#: catalog/models/item.py:122 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
-#: catalog/models/tv.py:221 catalog/models/tv.py:447
+#: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr ""
 
-#: catalog/models/item.py:127 catalog/models/movie.py:137
+#: catalog/models/item.py:123 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
-#: catalog/models/tv.py:228 catalog/models/tv.py:454
+#: catalog/models/tv.py:230 catalog/models/tv.py:456
 #, fuzzy
 msgid "actor"
 msgstr "بازیگر"
 
-#: catalog/models/item.py:128 catalog/models/movie.py:144
-#: catalog/models/tv.py:235 catalog/models/tv.py:461
+#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/tv.py:237 catalog/models/tv.py:463
 msgid "producer"
 msgstr ""
 
-#: catalog/models/item.py:131 catalog/models/performance.py:203
+#: catalog/models/item.py:127 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr ""
 
-#: catalog/models/item.py:132 catalog/models/performance.py:210
+#: catalog/models/item.py:128 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr ""
 
-#: catalog/models/item.py:133 catalog/models/performance.py:224
+#: catalog/models/item.py:129 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr ""
 
-#: catalog/models/item.py:134 catalog/models/podcast.py:80
+#: catalog/models/item.py:130 catalog/models/podcast.py:80
 msgid "host"
 msgstr ""
 
-#: catalog/models/item.py:135 catalog/models/performance.py:196
+#: catalog/models/item.py:131 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr ""
 
-#: catalog/models/item.py:136 catalog/models/performance.py:238
+#: catalog/models/item.py:132 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr ""
 
-#: catalog/models/item.py:140
+#: catalog/models/item.py:136
 #, fuzzy
 msgid "production company"
 msgstr "تولید"
 
-#: catalog/models/item.py:141
+#: catalog/models/item.py:137
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:142
+#: catalog/models/item.py:138
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:139
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:144 catalog/models/performance.py:231
+#: catalog/models/item.py:140 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr ""
 
-#: catalog/models/item.py:147
+#: catalog/models/item.py:143
 #, fuzzy
 msgid "voice actor"
 msgstr "بازیگر"
 
-#: catalog/models/item.py:148 catalog/templates/edition.html:30
+#: catalog/models/item.py:144 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr ""
 
-#: catalog/models/item.py:173 catalog/models/people.py:476
+#: catalog/models/item.py:169 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr ""
 
-#: catalog/models/item.py:174 catalog/models/people.py:155
+#: catalog/models/item.py:170 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr ""
 
-#: catalog/models/item.py:176 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:288 catalog/models/item.py:320
-#: journal/models/collection.py:96
+#: catalog/models/item.py:304 catalog/models/item.py:336
+#: journal/models/collection.py:100
 msgid "title"
 msgstr "عنوان"
 
-#: catalog/models/item.py:289 catalog/models/item.py:328
-#: journal/models/collection.py:97
+#: catalog/models/item.py:305 catalog/models/item.py:344
+#: journal/models/collection.py:101
 msgid "description"
 msgstr "توضیحات"
 
-#: catalog/models/item.py:300 catalog/models/people.py:484
+#: catalog/models/item.py:316 catalog/models/people.py:484
 msgid "metadata"
 msgstr "فراداده"
 
-#: catalog/models/item.py:302 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
 msgid "cover"
 msgstr "جلد"
 
-#: catalog/models/item.py:1485
+#: catalog/models/item.py:1526
 msgid "source site"
 msgstr "وبگاه منبع"
 
-#: catalog/models/item.py:1487
+#: catalog/models/item.py:1528
 msgid "ID on source site"
 msgstr ""
 
-#: catalog/models/item.py:1489
+#: catalog/models/item.py:1530
 msgid "source url"
 msgstr ""
 
-#: catalog/models/item.py:1505
+#: catalog/models/item.py:1546
 msgid "IdType of the source site"
 msgstr ""
 
-#: catalog/models/item.py:1511
+#: catalog/models/item.py:1552
 msgid "Primary Id on the source site"
 msgstr ""
 
-#: catalog/models/item.py:1514
+#: catalog/models/item.py:1555
 msgid "url to the resource"
 msgstr ""
 
 #: catalog/models/movie.py:152 catalog/models/music.py:124
-#: catalog/models/tv.py:243 catalog/models/tv.py:469
+#: catalog/models/tv.py:245 catalog/models/tv.py:471
 #: catalog/templates/_item_card_metadata_album.html:16
 #: catalog/templates/album.html:17 catalog/templates/game.html:22
 #: catalog/templates/movie.html:36 catalog/templates/tvseason.html:53
@@ -907,7 +915,7 @@ msgid "length"
 msgstr ""
 
 #: catalog/models/movie.py:162 catalog/models/music.py:131
-#: catalog/models/tv.py:259 catalog/models/tv.py:486
+#: catalog/models/tv.py:261 catalog/models/tv.py:488
 msgid "seconds"
 msgstr ""
 
@@ -1087,32 +1095,83 @@ msgstr ""
 msgid "closing date"
 msgstr ""
 
-#: catalog/models/tv.py:186 catalog/templates/tvseason.html:38
+#: catalog/models/tv.py:188 catalog/templates/tvseason.html:38
 #: catalog/templates/tvshow.html:33
 msgid "number of seasons"
 msgstr ""
 
-#: catalog/models/tv.py:189 catalog/models/tv.py:415
+#: catalog/models/tv.py:191 catalog/models/tv.py:417
 #: catalog/templates/tvseason.html:43 catalog/templates/tvshow.html:38
 msgid "number of episodes"
 msgstr ""
 
-#: catalog/models/tv.py:256 catalog/models/tv.py:483
+#: catalog/models/tv.py:258 catalog/models/tv.py:485
 msgid "episode length"
 msgstr ""
 
-#: catalog/models/tv.py:412 catalog/templates/tvseason.html:33
+#: catalog/models/tv.py:414 catalog/templates/tvseason.html:33
 msgid "season number"
 msgstr ""
 
-#: catalog/models/tv.py:530
+#: catalog/models/tv.py:532
 #, python-brace-format
 msgid "{show_title} Season {season_number}"
 msgstr ""
 
-#: catalog/models/tv.py:684
+#: catalog/models/tv.py:686
 #, python-brace-format
 msgid "{season_title} E{episode_number}"
+msgstr ""
+
+#: catalog/templates/_catalog_confirm_item.html:7
+#: catalog/templates/catalog_edit.html:62
+msgid "Item has been deleted."
+msgstr ""
+
+#: catalog/templates/_catalog_confirm_item.html:12
+#: catalog/templates/catalog_edit.html:65
+msgid "Item contains sub-items."
+msgstr ""
+
+#: catalog/templates/_catalog_confirm_item.html:17
+msgid "Item has been merged to another item."
+msgstr ""
+
+#: catalog/templates/_catalog_confirm_item.html:22
+msgid "Item has been marked by users."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:11
+msgid "Confirm changes"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:16
+msgid "Please correct the errors below."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:24
+msgid "Field"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:25
+msgid "From"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:26
+msgid "To"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:45
+msgid "No changes detected."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:54
+#: users/templates/users/register.html:104
+msgid "Confirm and save"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:57
+msgid "Back to editing"
 msgstr ""
 
 #: catalog/templates/_country_list.html:5
@@ -1120,9 +1179,7 @@ msgid "region"
 msgstr ""
 
 #: catalog/templates/_fetch_failed.html:4
-msgid ""
-"Unable to fetch from the link, please check again. Some sites may require "
-"login for certain links, please manually create them here."
+msgid "Unable to fetch from the link, please check again. Some sites may require login for certain links, please manually create them here."
 msgstr ""
 
 #: catalog/templates/_item_card_metadata_album.html:7
@@ -1178,7 +1235,7 @@ msgstr ""
 #: journal/templates/profile_posts.html:21
 #: journal/templates/user_follow_list_items.html:63
 #: journal/templates/user_post_list_items.html:24
-#: social/templates/events.html:43 social/templates/feed_events.html:28
+#: social/templates/events.html:43 social/templates/feed_events.html:27
 msgid "nothing more."
 msgstr ""
 
@@ -1267,7 +1324,7 @@ msgid "Add note"
 msgstr "اضافه کردن پادپخش‌ها"
 
 #: catalog/templates/_item_user_pieces.html:83
-#: common/templates/_sidebar.html:196 journal/templates/profile_items.html:46
+#: common/templates/_sidebar.html:195 journal/templates/profile_items.html:46
 msgid "Set progress"
 msgstr ""
 
@@ -1293,6 +1350,10 @@ msgstr ""
 
 #: catalog/templates/_item_user_pieces.html:214
 msgid "mark history"
+msgstr ""
+
+#: catalog/templates/_search_suggest.html:2
+msgid "Suggestions"
 msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:8
@@ -1322,15 +1383,15 @@ msgid "Edit Options"
 msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
-#: catalog/views/edit.py:82 catalog/views/edit.py:143 catalog/views/edit.py:197
-#: catalog/views/edit.py:218 catalog/views/edit.py:259
-#: catalog/views/edit.py:328 catalog/views/edit.py:332
-#: catalog/views/edit.py:351 catalog/views/edit.py:400
-#: catalog/views/edit.py:425 catalog/views/edit.py:440
-#: catalog/views/edit.py:480 catalog/views/edit.py:490
-#: catalog/views/edit.py:517 catalog/views/edit.py:582
-#: catalog/views/edit.py:637 catalog/views/edit.py:659
-#: catalog/views/search.py:367
+#: catalog/views/edit.py:160 catalog/views/edit.py:221
+#: catalog/views/edit.py:288 catalog/views/edit.py:309
+#: catalog/views/edit.py:364 catalog/views/edit.py:471
+#: catalog/views/edit.py:475 catalog/views/edit.py:509
+#: catalog/views/edit.py:576 catalog/views/edit.py:601
+#: catalog/views/edit.py:624 catalog/views/edit.py:664
+#: catalog/views/edit.py:674 catalog/views/edit.py:703
+#: catalog/views/edit.py:782 catalog/views/edit.py:837
+#: catalog/views/edit.py:859 catalog/views/search.py:418
 msgid "Editing this item is restricted."
 msgstr ""
 
@@ -1358,7 +1419,7 @@ msgstr ""
 msgid "The following items are merged into this item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:70
+#: catalog/templates/_sidebar_edit.html:70 catalog/views/edit.py:456
 msgid "External website"
 msgstr ""
 
@@ -1378,35 +1439,31 @@ msgstr ""
 msgid "Fetch again"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:97
-msgid "You may not be able to undo this operation, sure to remove?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:102
+#: catalog/templates/_sidebar_edit.html:100
 msgid "Remove link to site"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:110
+#: catalog/templates/_sidebar_edit.html:108
 msgid "Choose cover"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:119
+#: catalog/templates/_sidebar_edit.html:117
+#: catalog/templates/_sidebar_edit.html:118
 #: catalog/templates/_sidebar_edit.html:120
-#: catalog/templates/_sidebar_edit.html:122
 msgid "Current cover"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:139
+#: catalog/templates/_sidebar_edit.html:137
 msgid "Select an image to use as the cover of this item."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:140
-#: catalog/templates/catalog_edit.html:65
-#: common/templates/manage/settings.html:136
+#: catalog/templates/_sidebar_edit.html:138
+#: catalog/templates/catalog_edit.html:78
+#: common/templates/manage/settings.html:19
 #: journal/templates/add_to_collection.html:43
 #: journal/templates/article_edit.html:60
 #: journal/templates/collection_edit.html:39 journal/templates/comment.html:41
-#: journal/templates/mark.html:134 journal/templates/note.html:65
+#: journal/templates/mark.html:138 journal/templates/note.html:65
 #: journal/templates/post_compose.html:103
 #: journal/templates/review_edit.html:46 journal/templates/tag_edit.html:51
 #: users/templates/users/_pref_device.html:37
@@ -1415,181 +1472,157 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:147
+#: catalog/templates/_sidebar_edit.html:145
 msgid "Edit sub-items"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:160
+#: catalog/templates/_sidebar_edit.html:158
 msgid "create"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:166
+#: catalog/templates/_sidebar_edit.html:164
 msgid "Fetch all episodes"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:171
+#: catalog/templates/_sidebar_edit.html:169
 msgid "Fetch all"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:172
-msgid ""
-"Due to differences in how Douban, IMDB, and TMDB handle season data, a small "
-"number of TV shows and animations may not return correct results. Please "
-"manually verify and clean up after updating."
+#: catalog/templates/_sidebar_edit.html:170
+msgid "Due to differences in how Douban, IMDB, and TMDB handle season data, a small number of TV shows and animations may not return correct results. Please manually verify and clean up after updating."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:173
+#: catalog/templates/_sidebar_edit.html:171
 msgid "Up to 250 episodes will be fetched for a season."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:176
-msgid ""
-"To fetch all episodes, season numbers and IMDB information are required. If "
-"filling this out is inconvenient, you can also manually create sub-entries."
+#: catalog/templates/_sidebar_edit.html:174
+msgid "To fetch all episodes, season numbers and IMDB information are required. If filling this out is inconvenient, you can also manually create sub-entries."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:182
-#: catalog/templates/_sidebar_edit.html:194
-#: catalog/templates/_sidebar_edit.html:213
+#: catalog/templates/_sidebar_edit.html:180
+#: catalog/templates/_sidebar_edit.html:191
+#: catalog/templates/_sidebar_edit.html:208
 msgid "switch category"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:185
-msgid "Switching may remove some metadata. Sure to proceed?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:188
+#: catalog/templates/_sidebar_edit.html:185 catalog/views/edit.py:383
 msgid "TV Show"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:227
+#: catalog/templates/_sidebar_edit.html:221
 msgid "Link to parent item"
 msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:230
-msgid "Sure to link?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:237
 msgid "Update link"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:243
+#: catalog/templates/_sidebar_edit.html:236
 msgid "Cleanup seasons"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:246
-#: catalog/templates/catalog_delete.html:45
-msgid "This operation cannot be undone. Sure to delete?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:250
+#: catalog/templates/_sidebar_edit.html:242
 msgid "remove seasons not marked"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:256
-#: catalog/templates/catalog_merge.html:12
+#: catalog/templates/_sidebar_edit.html:248
 msgid "Merge"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:262
+#: catalog/templates/_sidebar_edit.html:254
 msgid "URL of target item, or empty if undo merge"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:268
-#: catalog/templates/_sidebar_edit.html:348
+#: catalog/templates/_sidebar_edit.html:260
+#: catalog/templates/_sidebar_edit.html:350
 msgid "merge to another item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:273
-#: catalog/templates/_sidebar_edit.html:277
-#: catalog/templates/catalog_delete.html:12
+#: catalog/templates/_sidebar_edit.html:265
+#: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
 #: journal/templates/article.html:199 journal/templates/collection.html:188
-#: journal/templates/mark.html:149 journal/templates/note.html:82
+#: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
 #: users/templates/users/account.html:254
 msgid "Delete"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:287
+#: catalog/templates/_sidebar_edit.html:275
+#: catalog/templates/_sidebar_edit.html:279
+msgid "Undo delete"
+msgstr ""
+
+#: catalog/templates/_sidebar_edit.html:280
+msgid "Links to external sites and parent item were removed on delete and will not be restored."
+msgstr ""
+
+#: catalog/templates/_sidebar_edit.html:290
 msgid "This edition belongs to the following work"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:292
-msgid "Sure to unlink?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:298
+#: catalog/templates/_sidebar_edit.html:300
 msgid "Unlink from work"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:304
+#: catalog/templates/_sidebar_edit.html:306
 msgid "Link"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:315
+#: catalog/templates/_sidebar_edit.html:317
 msgid "Link to another edition from same work"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:324
+#: catalog/templates/_sidebar_edit.html:326
 msgid "Restriction"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:337
+#: catalog/templates/_sidebar_edit.html:339
 #: journal/templates/collection_update_item_note.html:4
 msgid "Update"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:342
+#: catalog/templates/_sidebar_edit.html:344
 msgid "Suggest Edits"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:347
+#: catalog/templates/_sidebar_edit.html:349
 msgid "proposed action"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:349
+#: catalog/templates/_sidebar_edit.html:351
 msgid "link to another item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:350
+#: catalog/templates/_sidebar_edit.html:352
 msgid "change item category"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:351
+#: catalog/templates/_sidebar_edit.html:353
 msgid "change item metadata"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:352
+#: catalog/templates/_sidebar_edit.html:354
 msgid "remove item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:353
+#: catalog/templates/_sidebar_edit.html:355
 msgid "other"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:357
-msgid ""
-"To suggest merging or association, please include the URL of the target item"
+#: catalog/templates/_sidebar_edit.html:359
+msgid "To suggest merging or association, please include the URL of the target item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:358
+#: catalog/templates/_sidebar_edit.html:360
 #: catalog/templates/catalog_verify.html:116
 msgid "submit"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:359
-msgid ""
-"As a user of this community, you may edit some metadata of items on this "
-"site. If you are unsure whether your edits are appropriate or are unable to "
-"make a certain change, you can make suggestions here. Moderators will "
-"consider each suggestion, although there is no guarantee that they will "
-"always be fully adopted; suggestions may also be viewed or discussed by "
-"other community users. If you have suggestions that are not related to a "
-"specific item, please contact us. Thank you for your support and "
-"contribution."
+#: catalog/templates/_sidebar_edit.html:361
+msgid "As a user of this community, you may edit some metadata of items on this site. If you are unsure whether your edits are appropriate or are unable to make a certain change, you can make suggestions here. Moderators will consider each suggestion, although there is no guarantee that they will always be fully adopted; suggestions may also be viewed or discussed by other community users. If you have suggestions that are not related to a specific item, please contact us. Thank you for your support and contribution."
 msgstr ""
 
 #: catalog/templates/_sidebar_search.html:5
@@ -1687,16 +1720,14 @@ msgid "matched"
 msgstr ""
 
 #: catalog/templates/_verify_status.html:21
-msgid ""
-"Sure to remove your creator verification? Anyone will be able to edit this "
-"item again."
+msgid "Sure to remove your creator verification? Anyone will be able to edit this item again."
 msgstr ""
 
 #: catalog/templates/_verify_status.html:26
 msgid "Remove my verification"
 msgstr ""
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:309
+#: catalog/templates/_verify_status.html:31 users/views/account.py:311
 msgid "Verification failed"
 msgstr ""
 
@@ -1733,43 +1764,11 @@ msgstr ""
 msgid "album media"
 msgstr ""
 
-#: catalog/templates/catalog_delete.html:19
-msgid "Are you sure to delete?"
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:24
-#: catalog/templates/catalog_edit.html:52
-#: catalog/templates/catalog_merge.html:36
-#: catalog/templates/catalog_merge.html:64
-msgid "Item has been deleted."
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:29
-#: catalog/templates/catalog_edit.html:55
-#: catalog/templates/catalog_merge.html:41
-#: catalog/templates/catalog_merge.html:69
-msgid "Item contains sub-items."
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:34
-#: catalog/templates/catalog_merge.html:46
-#: catalog/templates/catalog_merge.html:74
-msgid "Item has been merged to another item."
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:39
-#: catalog/templates/catalog_merge.html:51
-#: catalog/templates/catalog_merge.html:79
-msgid "Item has been marked by users."
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:48
-#: catalog/templates/catalog_merge.html:92 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:55 common/views_manage.py:139
 msgid "Yes"
 msgstr ""
 
-#: catalog/templates/catalog_delete.html:49
-#: catalog/templates/catalog_merge.html:93 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:56 common/views_manage.py:139
 msgid "No"
 msgstr ""
 
@@ -1778,36 +1777,18 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: catalog/templates/catalog_edit.html:68
+#: catalog/templates/catalog_edit.html:81
 #: journal/templates/collection_update_item_note.html:8
 #: journal/templates/piece_delete.html:38
 msgid "Cancel"
 msgstr ""
 
-#: catalog/templates/catalog_edit.html:104
+#: catalog/templates/catalog_edit.html:118
 msgid "open linked people page"
 msgstr ""
 
-#: catalog/templates/catalog_merge.html:22
-msgid "Are you sure to merge?"
-msgstr ""
-
-#: catalog/templates/catalog_merge.html:24
-msgid "Are you sure to cancel merge?"
-msgstr ""
-
-#: catalog/templates/catalog_merge.html:27
-msgid "Are you sure to link?"
-msgstr ""
-
-#: catalog/templates/catalog_merge.html:86
-msgid "This operation cannot be undone. Sure to merge?"
-msgstr ""
-
 #: catalog/templates/catalog_verify.html:21
-msgid ""
-"If you are a creator of this podcast, you may verify the ownership, so that "
-"only you (and other verified creators) can edit its metadata on this site."
+msgid "If you are a creator of this podcast, you may verify the ownership, so that only you (and other verified creators) can edit its metadata on this site."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:22
@@ -1815,9 +1796,7 @@ msgid "Your recent episodes may also occasionally be featured in discovery."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:24
-msgid ""
-"To verify, prove you control one of the following identifiers of your "
-"account (click to copy):"
+msgid "To verify, prove you control one of the following identifiers of your account (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:30
@@ -1828,18 +1807,11 @@ msgid "copied"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:35
-msgid ""
-"You can prove this in a few ways, then start verification: add one of the "
-"identifiers above to the podcast feed's description; add a <code>rel=\"me\"</"
-"code> link back to one of them on the web page your feed links to (the link "
-"verification Mastodon uses); or point your feed's website at your Bluesky "
-"handle's own domain."
+msgid "You can prove this in a few ways, then start verification: add one of the identifiers above to the podcast feed's description; add a <code>rel=\"me\"</code> link back to one of them on the web page your feed links to (the link verification Mastodon uses); or point your feed's website at your Bluesky handle's own domain."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:44
-msgid ""
-"For example, add this rel=me link to the web page your feed links to (click "
-"to copy):"
+msgid "For example, add this rel=me link to the web page your feed links to (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:50
@@ -1847,9 +1819,7 @@ msgid "or, in the page's head:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:57
-msgid ""
-"Can't edit the website? Just add a line like this to your feed's description "
-"instead (click to copy):"
+msgid "Can't edit the website? Just add a line like this to your feed's description instead (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:62
@@ -1857,10 +1827,7 @@ msgid "Welcome to follow me on the Fediverse:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:66
-msgid ""
-"NeoDB does not re-check this periodically at the moment, but we recommend "
-"you keep it so that your audience can discover and connect with you in "
-"distributed social media."
+msgid "NeoDB does not re-check this periodically at the moment, but we recommend you keep it so that your audience can discover and connect with you in distributed social media."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:72
@@ -1888,12 +1855,11 @@ msgid "Send feedback"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:115
-msgid ""
-"Questions or issues with creator verification? Let the site moderators know."
+msgid "Questions or issues with creator verification? Let the site moderators know."
 msgstr ""
 
-#: catalog/templates/discover.html:28 common/views_manage.py:145
-#: common/views_manage.py:353 users/templates/users/preferences.html:34
+#: catalog/templates/discover.html:28 common/views_manage.py:35
+#: common/views_manage.py:431 users/templates/users/preferences.html:34
 msgid "Discover"
 msgstr ""
 
@@ -1931,17 +1897,17 @@ msgstr ""
 msgid "hide"
 msgstr ""
 
-#: catalog/templates/discover.html:206 common/templates/_sidebar.html:14
+#: catalog/templates/discover.html:206 common/templates/_sidebar.html:13
 msgid "Unread Announcements"
 msgstr ""
 
-#: catalog/templates/discover.html:212 common/templates/_sidebar.html:20
+#: catalog/templates/discover.html:212 common/templates/_sidebar.html:19
 #: social/templates/notification.html:67
 msgid "mark all as read"
 msgstr ""
 
 #: catalog/templates/discover.html:222
-#: common/templates/_sidebar_anonymous.html:55
+#: common/templates/_sidebar_anonymous.html:54
 msgid "Popular Tags"
 msgstr ""
 
@@ -1952,9 +1918,9 @@ msgstr ""
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
 #: catalog/templates/user_verified_works.html:23
-#: common/templates/_sidebar.html:127
-#: common/templates/_sidebar_anonymous.html:46
-#: common/templates/_sidebar_anonymous.html:62 journal/templates/posts.html:8
+#: common/templates/_sidebar.html:126
+#: common/templates/_sidebar_anonymous.html:45
+#: common/templates/_sidebar_anonymous.html:61 journal/templates/posts.html:7
 #: journal/templates/profile_articles.html:24
 #: journal/templates/profile_articles.html:26
 #: journal/templates/profile_items.html:65
@@ -1970,7 +1936,7 @@ msgstr ""
 msgid "nothing so far."
 msgstr ""
 
-#: catalog/templates/discover.html:239 common/templates/_sidebar.html:269
+#: catalog/templates/discover.html:239 common/templates/_sidebar.html:268
 msgid "Recent Posts"
 msgstr ""
 
@@ -1998,9 +1964,7 @@ msgid "Borrow or Buy"
 msgstr ""
 
 #: catalog/templates/external_search_results.html:10
-msgid ""
-"Some items were found from other websites and instances, click their title "
-"to save them locally."
+msgid "Some items were found from other websites and instances, click their title to save them locally."
 msgstr ""
 
 #: catalog/templates/fetch_pending.html:13
@@ -2100,12 +2064,12 @@ msgstr ""
 msgid "number of Episodes"
 msgstr ""
 
-#: catalog/templates/people.html:13 common/templates/_sidebar.html:77
-#: common/templates/_sidebar.html:84 journal/models/shelf.py:326
+#: catalog/templates/people.html:13 common/templates/_sidebar.html:76
+#: common/templates/_sidebar.html:83 journal/models/shelf.py:328
 msgid "following"
 msgstr ""
 
-#: catalog/templates/people.html:15 journal/models/shelf.py:324
+#: catalog/templates/people.html:15 journal/models/shelf.py:326
 #: social/templates/notification.html:60
 msgid "follow"
 msgstr ""
@@ -2124,7 +2088,6 @@ msgstr ""
 #: journal/templates/_sidebar_collection_filter.html:14
 #: journal/templates/_sidebar_collection_filter.html:28
 #: journal/templates/_sidebar_user_mark_list.html:56
-#: social/templates/feed.html:42 social/templates/feed.html:44
 #: social/templates/notification.html:56
 msgid "all"
 msgstr ""
@@ -2148,7 +2111,7 @@ msgstr ""
 msgid "production"
 msgstr ""
 
-#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:54
+#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:53
 msgid "verified creator"
 msgstr ""
 
@@ -2229,10 +2192,7 @@ msgid "No items matching your search query."
 msgstr ""
 
 #: catalog/templates/search_results.html:34
-msgid ""
-"If you have URL from one of these sites, please put the full URL (e.g. "
-"<code>https://www.imdb.com/title/tt2513074/</code>) to the search box and "
-"press Enter."
+msgid "If you have URL from one of these sites, please put the full URL (e.g. <code>https://www.imdb.com/title/tt2513074/</code>) to the search box and press Enter."
 msgstr ""
 
 #: catalog/templates/search_results.html:48
@@ -2269,97 +2229,170 @@ msgstr ""
 msgid "Editions"
 msgstr ""
 
-#: catalog/views/edit.py:202 catalog/views/edit.py:205
-#: catalog/views/edit.py:306 catalog/views/edit.py:309
-#: catalog/views/verify.py:197 journal/views/collection.py:77
-#: journal/views/collection.py:102 journal/views/collection.py:556
-#: journal/views/collection.py:651 journal/views/common.py:221
-#: journal/views/mark.py:196 journal/views/post.py:117
-#: journal/views/post.py:119 journal/views/post.py:166
-#: journal/views/post.py:185 journal/views/post.py:187
-#: journal/views/post.py:228 journal/views/post.py:241
+#: catalog/views/edit.py:293 catalog/views/edit.py:296
+#: catalog/views/edit.py:440 catalog/views/edit.py:443
+#: catalog/views/verify.py:197 journal/views/collection.py:75
+#: journal/views/collection.py:100 journal/views/collection.py:538
+#: journal/views/collection.py:634 journal/views/common.py:231
+#: journal/views/mark.py:244 journal/views/post.py:119
+#: journal/views/post.py:121 journal/views/post.py:168
+#: journal/views/post.py:187 journal/views/post.py:189
+#: journal/views/post.py:230 journal/views/post.py:243
 #: journal/views/review.py:154 journal/views/review.py:158
-#: users/views/actions.py:179
+#: users/views/actions.py:178
 msgid "Invalid parameter"
 msgstr ""
 
-#: catalog/views/edit.py:220
+#: catalog/views/edit.py:313
 msgid "Item in use."
 msgstr ""
 
-#: catalog/views/edit.py:222
+#: catalog/views/edit.py:315
 msgid "Item cannot be deleted."
 msgstr ""
 
-#: catalog/views/edit.py:247 catalog/views/edit.py:303
-#: catalog/views/edit.py:427 catalog/views/edit.py:519
-#: catalog/views/edit.py:552 catalog/views/verify.py:158
+#: catalog/views/edit.py:319 catalog/views/edit.py:515
+msgid "Are you sure to delete?"
+msgstr ""
+
+#: catalog/views/edit.py:323 catalog/views/edit.py:518
+#: catalog/views/edit.py:617
+msgid "This operation cannot be undone."
+msgstr ""
+
+#: catalog/views/edit.py:344 catalog/views/edit.py:437
+#: catalog/views/edit.py:603 catalog/views/edit.py:705
+#: catalog/views/edit.py:752 catalog/views/verify.py:158
 #: catalog/views/verify.py:206 journal/views/article.py:44
 #: journal/views/article.py:133 journal/views/article.py:153
 #: journal/views/collection.py:248 journal/views/collection.py:341
-#: journal/views/collection.py:360 journal/views/collection.py:384
-#: journal/views/collection.py:457 journal/views/collection.py:500
-#: journal/views/collection.py:539 journal/views/collection.py:551
-#: journal/views/collection.py:576 journal/views/collection.py:613
-#: journal/views/common.py:300 journal/views/mark.py:281
-#: journal/views/post.py:58 journal/views/post.py:78 journal/views/post.py:100
-#: journal/views/post.py:170 journal/views/post.py:199
-#: journal/views/post.py:272 journal/views/post.py:287
-#: journal/views/post.py:394 journal/views/post.py:549
+#: journal/views/collection.py:354 journal/views/collection.py:372
+#: journal/views/collection.py:439 journal/views/collection.py:482
+#: journal/views/collection.py:521 journal/views/collection.py:533
+#: journal/views/collection.py:558 journal/views/collection.py:595
+#: journal/views/common.py:304 journal/views/mark.py:317
+#: journal/views/post.py:60 journal/views/post.py:80 journal/views/post.py:102
+#: journal/views/post.py:172 journal/views/post.py:201
+#: journal/views/post.py:274 journal/views/post.py:289
+#: journal/views/post.py:390 journal/views/post.py:539
 #: journal/views/review.py:64 journal/views/review.py:81
 #: journal/views/review.py:106
 msgid "Insufficient permission"
 msgstr ""
 
-#: catalog/views/edit.py:374
+#: catalog/views/edit.py:346
+msgid "Item is not deleted"
+msgstr ""
+
+#: catalog/views/edit.py:389
+msgid "Switching may remove some metadata."
+msgstr ""
+
+#: catalog/views/edit.py:395
+msgid "The following seasons will be detached from this show"
+msgstr ""
+
+#: catalog/views/edit.py:400
+msgid "Links to IMDB and TMDB will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:403
+msgid "Are you sure to switch category?"
+msgstr ""
+
+#: catalog/views/edit.py:451
+msgid "Are you sure to remove the link to this site?"
+msgstr ""
+
+#: catalog/views/edit.py:457
+msgid "You may not be able to undo this operation."
+msgstr ""
+
+#: catalog/views/edit.py:483
+msgid "Current parent item"
+msgstr ""
+
+#: catalog/views/edit.py:487
+msgid "The link to the parent item will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:490 catalog/views/edit.py:680
+msgid "Are you sure to link?"
+msgstr ""
+
+#: catalog/views/edit.py:521
+msgid "The following seasons will be deleted"
+msgstr ""
+
+#: catalog/views/edit.py:525
+msgid "The following seasons will be kept"
+msgstr ""
+
+#: catalog/views/edit.py:550
 msgid "TV Season with IMDB id and season number required."
 msgstr ""
 
-#: catalog/views/edit.py:380
+#: catalog/views/edit.py:556
 msgid "Updating episodes"
 msgstr ""
 
-#: catalog/views/edit.py:405
+#: catalog/views/edit.py:581
 msgid "This person has no supported source to fetch works from."
 msgstr ""
 
-#: catalog/views/edit.py:412
+#: catalog/views/edit.py:588
 msgid "Already pulling works for this person, try again later."
 msgstr ""
 
-#: catalog/views/edit.py:416
+#: catalog/views/edit.py:592
 msgid "Pulling works in background."
 msgstr ""
 
-#: catalog/views/edit.py:438
+#: catalog/views/edit.py:609
+msgid "Are you sure to merge?"
+msgstr ""
+
+#: catalog/views/edit.py:611
+msgid "Are you sure to cancel merge?"
+msgstr ""
+
+#: catalog/views/edit.py:622
 msgid "Cannot be merged to an item already deleted or merged"
 msgstr ""
 
-#: catalog/views/edit.py:443
+#: catalog/views/edit.py:627
 msgid "Cannot merge items in different categories"
 msgstr ""
 
-#: catalog/views/edit.py:447
+#: catalog/views/edit.py:631
 msgid "Cannot merge an item to itself"
 msgstr ""
 
-#: catalog/views/edit.py:488
+#: catalog/views/edit.py:672
 msgid "Cannot be linked to an item already deleted or merged"
 msgstr ""
 
-#: catalog/views/edit.py:492
+#: catalog/views/edit.py:676
 msgid "Cannot link items other than editions"
 msgstr ""
 
-#: catalog/views/search.py:96
+#: catalog/views/edit.py:710
+msgid "Are you sure to unlink?"
+msgstr ""
+
+#: catalog/views/edit.py:715
+msgid "This edition will be unlinked from the following work"
+msgstr ""
+
+#: catalog/views/search.py:113
 msgid "the internet"
 msgstr ""
 
-#: catalog/views/search.py:359
+#: catalog/views/search.py:410
 msgid "Invalid URL"
 msgstr ""
 
-#: catalog/views/search.py:362
+#: catalog/views/search.py:413
 msgid "Unsupported URL"
 msgstr ""
 
@@ -2383,9 +2416,9 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:122 common/utils.py:163
+#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
 #: journal/views/article.py:186 journal/views/review.py:182
-#: users/views/actions.py:45 users/views/actions.py:131
+#: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
 msgstr ""
 
@@ -2397,15 +2430,15 @@ msgstr ""
 msgid "Creator verification removed."
 msgstr ""
 
-#: catalog/views/view.py:74 catalog/views/view.py:99
+#: catalog/views/view.py:77 catalog/views/view.py:102
 msgid "Item not found"
 msgstr ""
 
-#: catalog/views/view.py:78 catalog/views/view.py:107 catalog/views/view.py:190
+#: catalog/views/view.py:81 catalog/views/view.py:110 catalog/views/view.py:193
 msgid "Item no longer exists"
 msgstr ""
 
-#: catalog/views/view.py:187
+#: catalog/views/view.py:190
 msgid "Invalid role"
 msgstr ""
 
@@ -2919,759 +2952,759 @@ msgctxt "genre"
 msgid "Health"
 msgstr ""
 
-#: common/models/lang.py:54
+#: common/models/lang.py:56
 msgid "Afar"
 msgstr ""
 
-#: common/models/lang.py:55
+#: common/models/lang.py:57
 msgid "Afrikaans"
 msgstr ""
 
-#: common/models/lang.py:56
+#: common/models/lang.py:58
 msgid "Akan"
 msgstr ""
 
-#: common/models/lang.py:57
+#: common/models/lang.py:59
 msgid "Aragonese"
 msgstr ""
 
-#: common/models/lang.py:58
+#: common/models/lang.py:60
 msgid "Assamese"
 msgstr ""
 
-#: common/models/lang.py:59
+#: common/models/lang.py:61
 msgid "Avaric"
 msgstr ""
 
-#: common/models/lang.py:60
+#: common/models/lang.py:62
 msgid "Avestan"
 msgstr ""
 
-#: common/models/lang.py:61
+#: common/models/lang.py:63
 msgid "Aymara"
 msgstr ""
 
-#: common/models/lang.py:62
+#: common/models/lang.py:64
 msgid "Azerbaijani"
 msgstr ""
 
-#: common/models/lang.py:63
+#: common/models/lang.py:65
 msgid "Bashkir"
 msgstr ""
 
-#: common/models/lang.py:64
+#: common/models/lang.py:66
 msgid "Bambara"
 msgstr ""
 
-#: common/models/lang.py:65
+#: common/models/lang.py:67
 msgid "Bislama"
 msgstr ""
 
-#: common/models/lang.py:66
+#: common/models/lang.py:68
 msgid "Tibetan"
 msgstr ""
 
-#: common/models/lang.py:67
+#: common/models/lang.py:69
 msgid "Breton"
 msgstr ""
 
-#: common/models/lang.py:68
+#: common/models/lang.py:70
 msgid "Catalan"
 msgstr ""
 
-#: common/models/lang.py:69
+#: common/models/lang.py:71
 msgid "Czech"
 msgstr ""
 
-#: common/models/lang.py:70
+#: common/models/lang.py:72
 msgid "Chechen"
 msgstr ""
 
-#: common/models/lang.py:71
+#: common/models/lang.py:73
 msgid "Slavic"
 msgstr ""
 
-#: common/models/lang.py:72
+#: common/models/lang.py:74
 msgid "Chuvash"
 msgstr ""
 
-#: common/models/lang.py:73
+#: common/models/lang.py:75
 msgid "Cornish"
 msgstr ""
 
-#: common/models/lang.py:74
+#: common/models/lang.py:76
 msgid "Corsican"
 msgstr ""
 
-#: common/models/lang.py:75
+#: common/models/lang.py:77
 msgid "Cree"
 msgstr ""
 
-#: common/models/lang.py:76
+#: common/models/lang.py:78
 msgid "Welsh"
 msgstr ""
 
-#: common/models/lang.py:79
+#: common/models/lang.py:81
 msgid "Divehi"
 msgstr ""
 
-#: common/models/lang.py:80
+#: common/models/lang.py:82
 msgid "Dzongkha"
 msgstr ""
 
-#: common/models/lang.py:81
+#: common/models/lang.py:83
 msgid "Esperanto"
 msgstr ""
 
-#: common/models/lang.py:82
+#: common/models/lang.py:84
 msgid "Estonian"
 msgstr ""
 
-#: common/models/lang.py:83
+#: common/models/lang.py:85
 msgid "Basque"
 msgstr ""
 
-#: common/models/lang.py:84
+#: common/models/lang.py:86
 msgid "Faroese"
 msgstr ""
 
-#: common/models/lang.py:85
+#: common/models/lang.py:87
 msgid "Fijian"
 msgstr ""
 
-#: common/models/lang.py:86
+#: common/models/lang.py:88
 msgid "Finnish"
 msgstr ""
 
-#: common/models/lang.py:88
+#: common/models/lang.py:90
 msgid "Frisian"
 msgstr ""
 
-#: common/models/lang.py:89
+#: common/models/lang.py:91
 msgid "Fulah"
 msgstr ""
 
-#: common/models/lang.py:90
+#: common/models/lang.py:92
 msgid "Gaelic"
 msgstr ""
 
-#: common/models/lang.py:91
+#: common/models/lang.py:93
 msgid "Irish"
 msgstr ""
 
-#: common/models/lang.py:92
+#: common/models/lang.py:94
 msgid "Galician"
 msgstr ""
 
-#: common/models/lang.py:93
+#: common/models/lang.py:95
 msgid "Manx"
 msgstr ""
 
-#: common/models/lang.py:94
+#: common/models/lang.py:96
 msgid "Guarani"
 msgstr ""
 
-#: common/models/lang.py:95
+#: common/models/lang.py:97
 msgid "Gujarati"
 msgstr ""
 
-#: common/models/lang.py:96
+#: common/models/lang.py:98
 msgid "Haitian; Haitian Creole"
 msgstr ""
 
-#: common/models/lang.py:97
+#: common/models/lang.py:99
 msgid "Hausa"
 msgstr ""
 
-#: common/models/lang.py:98
+#: common/models/lang.py:100
 msgid "Serbo-Croatian"
 msgstr ""
 
-#: common/models/lang.py:99
+#: common/models/lang.py:101
 msgid "Herero"
 msgstr ""
 
-#: common/models/lang.py:100
+#: common/models/lang.py:102
 msgid "Hiri Motu"
 msgstr ""
 
-#: common/models/lang.py:101
+#: common/models/lang.py:103
 msgid "Croatian"
 msgstr ""
 
-#: common/models/lang.py:102
+#: common/models/lang.py:104
 msgid "Hungarian"
 msgstr ""
 
-#: common/models/lang.py:103
+#: common/models/lang.py:105
 msgid "Igbo"
 msgstr ""
 
-#: common/models/lang.py:104
+#: common/models/lang.py:106
 msgid "Ido"
 msgstr ""
 
-#: common/models/lang.py:105
+#: common/models/lang.py:107
 msgid "Yi"
 msgstr ""
 
-#: common/models/lang.py:106
+#: common/models/lang.py:108
 msgid "Inuktitut"
 msgstr ""
 
-#: common/models/lang.py:107
+#: common/models/lang.py:109
 msgid "Interlingue"
 msgstr ""
 
-#: common/models/lang.py:108
+#: common/models/lang.py:110
 msgid "Interlingua"
 msgstr ""
 
-#: common/models/lang.py:109
+#: common/models/lang.py:111
 msgid "Indonesian"
 msgstr ""
 
-#: common/models/lang.py:110
+#: common/models/lang.py:112
 msgid "Inupiaq"
 msgstr ""
 
-#: common/models/lang.py:111
+#: common/models/lang.py:113
 msgid "Icelandic"
 msgstr ""
 
-#: common/models/lang.py:113
+#: common/models/lang.py:115
 msgid "Javanese"
 msgstr ""
 
-#: common/models/lang.py:114
+#: common/models/lang.py:116
 msgid "Japanese"
 msgstr ""
 
-#: common/models/lang.py:115
+#: common/models/lang.py:117
 msgid "Kalaallisut"
 msgstr ""
 
-#: common/models/lang.py:116
+#: common/models/lang.py:118
 msgid "Kannada"
 msgstr ""
 
-#: common/models/lang.py:117
+#: common/models/lang.py:119
 msgid "Kashmiri"
 msgstr ""
 
-#: common/models/lang.py:118
+#: common/models/lang.py:120
 msgid "Kanuri"
 msgstr ""
 
-#: common/models/lang.py:119
+#: common/models/lang.py:121
 msgid "Kazakh"
 msgstr ""
 
-#: common/models/lang.py:120
+#: common/models/lang.py:122
 msgid "Khmer"
 msgstr ""
 
-#: common/models/lang.py:121
+#: common/models/lang.py:123
 msgid "Kikuyu"
 msgstr ""
 
-#: common/models/lang.py:122
+#: common/models/lang.py:124
 msgid "Kinyarwanda"
 msgstr ""
 
-#: common/models/lang.py:123
+#: common/models/lang.py:125
 msgid "Kirghiz"
 msgstr ""
 
-#: common/models/lang.py:124
+#: common/models/lang.py:126
 msgid "Komi"
 msgstr ""
 
-#: common/models/lang.py:125
+#: common/models/lang.py:127
 msgid "Kongo"
 msgstr ""
 
-#: common/models/lang.py:126
+#: common/models/lang.py:128
 msgid "Korean"
 msgstr ""
 
-#: common/models/lang.py:127
+#: common/models/lang.py:129
 msgid "Kuanyama"
 msgstr ""
 
-#: common/models/lang.py:128
+#: common/models/lang.py:130
 msgid "Kurdish"
 msgstr ""
 
-#: common/models/lang.py:129
+#: common/models/lang.py:131
 msgid "Lao"
 msgstr ""
 
-#: common/models/lang.py:130
+#: common/models/lang.py:132
 msgid "Latin"
 msgstr ""
 
-#: common/models/lang.py:131
+#: common/models/lang.py:133
 msgid "Latvian"
 msgstr ""
 
-#: common/models/lang.py:132
+#: common/models/lang.py:134
 msgid "Limburgish"
 msgstr ""
 
-#: common/models/lang.py:133
+#: common/models/lang.py:135
 msgid "Lingala"
 msgstr ""
 
-#: common/models/lang.py:134
+#: common/models/lang.py:136
 msgid "Lithuanian"
 msgstr ""
 
-#: common/models/lang.py:135
+#: common/models/lang.py:137
 msgid "Letzeburgesch"
 msgstr ""
 
-#: common/models/lang.py:136
+#: common/models/lang.py:138
 msgid "Luba-Katanga"
 msgstr ""
 
-#: common/models/lang.py:137
+#: common/models/lang.py:139
 msgid "Ganda"
 msgstr ""
 
-#: common/models/lang.py:138
+#: common/models/lang.py:140
 msgid "Marshall"
 msgstr ""
 
-#: common/models/lang.py:139
+#: common/models/lang.py:141
 msgid "Malayalam"
 msgstr ""
 
-#: common/models/lang.py:140
+#: common/models/lang.py:142
 msgid "Marathi"
 msgstr ""
 
-#: common/models/lang.py:141
+#: common/models/lang.py:143
 msgid "Malagasy"
 msgstr ""
 
-#: common/models/lang.py:142
+#: common/models/lang.py:144
 msgid "Maltese"
 msgstr ""
 
-#: common/models/lang.py:143
+#: common/models/lang.py:145
 msgid "Moldavian"
 msgstr ""
 
-#: common/models/lang.py:144
+#: common/models/lang.py:146
 msgid "Mongolian"
 msgstr ""
 
-#: common/models/lang.py:145
+#: common/models/lang.py:147
 msgid "Maori"
 msgstr ""
 
-#: common/models/lang.py:146
+#: common/models/lang.py:148
 msgid "Malay"
 msgstr ""
 
-#: common/models/lang.py:147
+#: common/models/lang.py:149
 msgid "Burmese"
 msgstr ""
 
-#: common/models/lang.py:148
+#: common/models/lang.py:150
 msgid "Nauru"
 msgstr ""
 
-#: common/models/lang.py:149
+#: common/models/lang.py:151
 msgid "Navajo"
 msgstr ""
 
-#: common/models/lang.py:150 common/models/lang.py:151
+#: common/models/lang.py:152 common/models/lang.py:153
 msgid "Ndebele"
 msgstr ""
 
-#: common/models/lang.py:152
+#: common/models/lang.py:154
 msgid "Ndonga"
 msgstr ""
 
-#: common/models/lang.py:153
+#: common/models/lang.py:155
 msgid "Nepali"
 msgstr ""
 
-#: common/models/lang.py:154
+#: common/models/lang.py:156
 msgid "Dutch"
 msgstr ""
 
-#: common/models/lang.py:155
+#: common/models/lang.py:157
 msgid "Norwegian Nynorsk"
 msgstr ""
 
-#: common/models/lang.py:156
+#: common/models/lang.py:158
 msgid "Norwegian Bokmål"
 msgstr ""
 
-#: common/models/lang.py:157
+#: common/models/lang.py:159
 msgid "Norwegian"
 msgstr ""
 
-#: common/models/lang.py:158
+#: common/models/lang.py:160
 msgid "Chichewa; Nyanja"
 msgstr ""
 
-#: common/models/lang.py:159
+#: common/models/lang.py:161
 msgid "Occitan"
 msgstr ""
 
-#: common/models/lang.py:160
+#: common/models/lang.py:162
 msgid "Ojibwa"
 msgstr ""
 
-#: common/models/lang.py:161
+#: common/models/lang.py:163
 msgid "Oriya"
 msgstr ""
 
-#: common/models/lang.py:162
+#: common/models/lang.py:164
 msgid "Oromo"
 msgstr ""
 
-#: common/models/lang.py:163
+#: common/models/lang.py:165
 msgid "Ossetian; Ossetic"
 msgstr ""
 
-#: common/models/lang.py:164
+#: common/models/lang.py:166
 msgid "Pali"
 msgstr ""
 
-#: common/models/lang.py:165
+#: common/models/lang.py:167
 msgid "Polish"
 msgstr ""
 
-#: common/models/lang.py:167
+#: common/models/lang.py:169
 msgid "Quechua"
 msgstr ""
 
-#: common/models/lang.py:168
+#: common/models/lang.py:170
 msgid "Raeto-Romance"
 msgstr ""
 
-#: common/models/lang.py:169
+#: common/models/lang.py:171
 msgid "Romanian"
 msgstr ""
 
-#: common/models/lang.py:170
+#: common/models/lang.py:172
 msgid "Rundi"
 msgstr ""
 
-#: common/models/lang.py:171
+#: common/models/lang.py:173
 msgid "Russian"
 msgstr ""
 
-#: common/models/lang.py:172
+#: common/models/lang.py:174
 msgid "Sango"
 msgstr ""
 
-#: common/models/lang.py:173
+#: common/models/lang.py:175
 msgid "Sanskrit"
 msgstr ""
 
-#: common/models/lang.py:174
+#: common/models/lang.py:176
 msgid "Sinhalese"
 msgstr ""
 
-#: common/models/lang.py:175
+#: common/models/lang.py:177
 msgid "Slovak"
 msgstr ""
 
-#: common/models/lang.py:176
+#: common/models/lang.py:178
 msgid "Slovenian"
 msgstr ""
 
-#: common/models/lang.py:177
+#: common/models/lang.py:179
 msgid "Northern Sami"
 msgstr ""
 
-#: common/models/lang.py:178
+#: common/models/lang.py:180
 msgid "Samoan"
 msgstr ""
 
-#: common/models/lang.py:179
+#: common/models/lang.py:181
 msgid "Shona"
 msgstr ""
 
-#: common/models/lang.py:180
+#: common/models/lang.py:182
 msgid "Sindhi"
 msgstr ""
 
-#: common/models/lang.py:181
+#: common/models/lang.py:183
 msgid "Somali"
 msgstr ""
 
-#: common/models/lang.py:182
+#: common/models/lang.py:184
 msgid "Sotho"
 msgstr ""
 
-#: common/models/lang.py:184
+#: common/models/lang.py:186
 msgid "Albanian"
 msgstr ""
 
-#: common/models/lang.py:185
+#: common/models/lang.py:187
 msgid "Sardinian"
 msgstr ""
 
-#: common/models/lang.py:186
+#: common/models/lang.py:188
 msgid "Serbian"
 msgstr ""
 
-#: common/models/lang.py:187
+#: common/models/lang.py:189
 msgid "Swati"
 msgstr ""
 
-#: common/models/lang.py:188
+#: common/models/lang.py:190
 msgid "Sundanese"
 msgstr ""
 
-#: common/models/lang.py:189
+#: common/models/lang.py:191
 msgid "Swahili"
 msgstr ""
 
-#: common/models/lang.py:190
+#: common/models/lang.py:192
 msgid "Swedish"
 msgstr ""
 
-#: common/models/lang.py:191
+#: common/models/lang.py:193
 msgid "Tahitian"
 msgstr ""
 
-#: common/models/lang.py:192
+#: common/models/lang.py:194
 msgid "Tamil"
 msgstr ""
 
-#: common/models/lang.py:193
+#: common/models/lang.py:195
 msgid "Tatar"
 msgstr ""
 
-#: common/models/lang.py:194
+#: common/models/lang.py:196
 msgid "Telugu"
 msgstr ""
 
-#: common/models/lang.py:195
+#: common/models/lang.py:197
 msgid "Tajik"
 msgstr ""
 
-#: common/models/lang.py:196
+#: common/models/lang.py:198
 msgid "Tagalog"
 msgstr ""
 
-#: common/models/lang.py:197
+#: common/models/lang.py:199
 msgid "Thai"
 msgstr ""
 
-#: common/models/lang.py:198
+#: common/models/lang.py:200
 msgid "Tigrinya"
 msgstr ""
 
-#: common/models/lang.py:199
+#: common/models/lang.py:201
 msgid "Tonga"
 msgstr ""
 
-#: common/models/lang.py:200
+#: common/models/lang.py:202
 msgid "Tswana"
 msgstr ""
 
-#: common/models/lang.py:201
+#: common/models/lang.py:203
 msgid "Tsonga"
 msgstr ""
 
-#: common/models/lang.py:202
+#: common/models/lang.py:204
 msgid "Turkmen"
 msgstr ""
 
-#: common/models/lang.py:203
+#: common/models/lang.py:205
 msgid "Turkish"
 msgstr ""
 
-#: common/models/lang.py:204
+#: common/models/lang.py:206
 msgid "Twi"
 msgstr ""
 
-#: common/models/lang.py:205
+#: common/models/lang.py:207
 msgid "Uighur"
 msgstr ""
 
-#: common/models/lang.py:206
+#: common/models/lang.py:208
 msgid "Ukrainian"
 msgstr ""
 
-#: common/models/lang.py:207
+#: common/models/lang.py:209
 msgid "Urdu"
 msgstr ""
 
-#: common/models/lang.py:208
+#: common/models/lang.py:210
 msgid "Uzbek"
 msgstr ""
 
-#: common/models/lang.py:209
+#: common/models/lang.py:211
 msgid "Venda"
 msgstr ""
 
-#: common/models/lang.py:210
+#: common/models/lang.py:212
 msgid "Vietnamese"
 msgstr ""
 
-#: common/models/lang.py:211
+#: common/models/lang.py:213
 msgid "Volapük"
 msgstr ""
 
-#: common/models/lang.py:212
+#: common/models/lang.py:214
 msgid "Walloon"
 msgstr ""
 
-#: common/models/lang.py:213
+#: common/models/lang.py:215
 msgid "Wolof"
 msgstr ""
 
-#: common/models/lang.py:214
+#: common/models/lang.py:216
 msgid "Xhosa"
 msgstr ""
 
-#: common/models/lang.py:215
+#: common/models/lang.py:217
 msgid "Yiddish"
 msgstr ""
 
-#: common/models/lang.py:216
+#: common/models/lang.py:218
 msgid "Zhuang"
 msgstr ""
 
-#: common/models/lang.py:217
+#: common/models/lang.py:219
 msgid "Zulu"
 msgstr ""
 
-#: common/models/lang.py:218
+#: common/models/lang.py:220
 msgid "Abkhazian"
 msgstr ""
 
-#: common/models/lang.py:219
+#: common/models/lang.py:221
 msgid "Chinese"
 msgstr ""
 
-#: common/models/lang.py:220
+#: common/models/lang.py:222
 msgid "Pushto"
 msgstr ""
 
-#: common/models/lang.py:221
+#: common/models/lang.py:223
 msgid "Amharic"
 msgstr ""
 
-#: common/models/lang.py:222
+#: common/models/lang.py:224
 msgid "Arabic"
 msgstr ""
 
-#: common/models/lang.py:223
+#: common/models/lang.py:225
 msgid "Bulgarian"
 msgstr ""
 
-#: common/models/lang.py:224
+#: common/models/lang.py:226
 msgid "Macedonian"
 msgstr ""
 
-#: common/models/lang.py:225
+#: common/models/lang.py:227
 msgid "Greek"
 msgstr ""
 
-#: common/models/lang.py:226
+#: common/models/lang.py:228
 msgid "Persian"
 msgstr ""
 
-#: common/models/lang.py:227
+#: common/models/lang.py:229
 msgid "Hebrew"
 msgstr ""
 
-#: common/models/lang.py:228
+#: common/models/lang.py:230
 msgid "Hindi"
 msgstr ""
 
-#: common/models/lang.py:229
+#: common/models/lang.py:231
 msgid "Armenian"
 msgstr ""
 
-#: common/models/lang.py:231
+#: common/models/lang.py:233
 msgid "Ewe"
 msgstr ""
 
-#: common/models/lang.py:232
+#: common/models/lang.py:234
 msgid "Georgian"
 msgstr ""
 
-#: common/models/lang.py:233
+#: common/models/lang.py:235
 msgid "Punjabi"
 msgstr ""
 
-#: common/models/lang.py:234
+#: common/models/lang.py:236
 msgid "Bengali"
 msgstr ""
 
-#: common/models/lang.py:235
+#: common/models/lang.py:237
 msgid "Bosnian"
 msgstr ""
 
-#: common/models/lang.py:236
+#: common/models/lang.py:238
 msgid "Chamorro"
 msgstr ""
 
-#: common/models/lang.py:237
+#: common/models/lang.py:239
 msgid "Belarusian"
 msgstr ""
 
-#: common/models/lang.py:238
+#: common/models/lang.py:240
 msgid "Yoruba"
 msgstr ""
 
-#: common/models/lang.py:300
+#: common/models/lang.py:302
 msgid "Simplified Chinese (Mainland)"
 msgstr ""
 
-#: common/models/lang.py:301
+#: common/models/lang.py:303
 msgid "Traditional Chinese (Taiwan)"
 msgstr ""
 
-#: common/models/lang.py:302
+#: common/models/lang.py:304
 msgid "Traditional Chinese (Hongkong)"
 msgstr ""
 
-#: common/models/lang.py:310
+#: common/models/lang.py:312
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: common/models/lang.py:313
+#: common/models/lang.py:315
 msgid "Simplified Chinese (Singapore)"
 msgstr ""
 
-#: common/models/lang.py:314
+#: common/models/lang.py:316
 msgid "Simplified Chinese (Malaysia)"
 msgstr ""
 
-#: common/models/lang.py:315
+#: common/models/lang.py:317
 msgid "Traditional Chinese (Macau)"
 msgstr ""
 
-#: common/models/lang.py:323
+#: common/models/lang.py:325
 msgid "Mandarin Chinese"
 msgstr ""
 
-#: common/models/lang.py:324
+#: common/models/lang.py:326
 msgid "Yue Chinese"
 msgstr ""
 
-#: common/models/lang.py:328
+#: common/models/lang.py:330
 msgid "Min Nan Chinese"
 msgstr ""
 
-#: common/models/lang.py:329
+#: common/models/lang.py:331
 msgid "Wu Chinese"
 msgstr ""
 
-#: common/models/lang.py:330
+#: common/models/lang.py:332
 msgid "Hakka Chinese"
 msgstr ""
 
@@ -3810,22 +3843,16 @@ msgid "VCD"
 msgstr ""
 
 #: common/templates/400.html:23
-msgid ""
-"You may have submitted invalid data, or the content may have been deleted by "
-"the author."
+msgid "You may have submitted invalid data, or the content may have been deleted by the author."
 msgstr ""
 
 #: common/templates/400.html:25 common/templates/403.html:24
 #: common/templates/404.html:24
-msgid ""
-"If you believe this is our mistake, please contact us through the link at "
-"the bottom of the page."
+msgid "If you believe this is our mistake, please contact us through the link at the bottom of the page."
 msgstr ""
 
 #: common/templates/403.html:22
-msgid ""
-"Author may require you to log in before accessing this content, or you do "
-"not have permission to view it."
+msgid "Author may require you to log in before accessing this content, or you do not have permission to view it."
 msgstr ""
 
 #: common/templates/404.html:20
@@ -3833,9 +3860,7 @@ msgid "Something is missing"
 msgstr ""
 
 #: common/templates/404.html:22
-msgid ""
-"You may have visited an incorrect URL, or the content you are looking for "
-"has been deleted by the author."
+msgid "You may have visited an incorrect URL, or the content you are looking for has been deleted by the author."
 msgstr ""
 
 #: common/templates/404.html:26
@@ -3843,15 +3868,11 @@ msgid "Go to Home"
 msgstr ""
 
 #: common/templates/500.html:22
-msgid ""
-"An internal error occurred. If this error occurs repeatedly, it will be "
-"recorded and handled by a human."
+msgid "An internal error occurred. If this error occurs repeatedly, it will be recorded and handled by a human."
 msgstr ""
 
 #: common/templates/500.html:24
-msgid ""
-"If you have an urgent situation or any questions, please contact us through "
-"the link at the bottom of the page."
+msgid "If you have an urgent situation or any questions, please contact us through the link at the bottom of the page."
 msgstr ""
 
 #: common/templates/_footer.html:6
@@ -3866,207 +3887,184 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: common/templates/_footer.html:12 users/templates/users/login.html:265
+#: common/templates/_footer.html:12 users/templates/users/login.html:259
 #, python-format
-msgid ""
-"You are visiting an alternative domain for %(site_name)s, please always use "
-"<a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if "
-"possible."
+msgid "You are visiting an alternative domain for %(site_name)s, please always use <a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if possible."
 msgstr ""
 
-#: common/templates/_header.html:19 common/templates/_header.html:164
+#: common/templates/_header.html:19 common/templates/_header.html:177
 msgid "title, creator, ISBN, item url, @user, @user@instance"
 msgstr ""
 
-#: common/templates/_header.html:24
+#: common/templates/_header.html:34
 msgid "All Items"
 msgstr ""
 
-#: common/templates/_header.html:31
+#: common/templates/_header.html:41
 msgid "Movie & TV"
 msgstr ""
 
-#: common/templates/_header.html:50
+#: common/templates/_header.html:60
 msgid "People & Organizations"
 msgstr ""
 
-#: common/templates/_header.html:52
+#: common/templates/_header.html:62
 msgid "Journal"
 msgstr ""
 
-#: common/templates/_header.html:54 journal/templates/user_post_list.html:10
+#: common/templates/_header.html:64 journal/templates/user_post_list.html:10
 #: journal/templates/user_post_list.html:23
 msgid "Posts"
 msgstr ""
 
-#: common/templates/_header.html:89
+#: common/templates/_header.html:102
 msgid "Explore"
 msgstr ""
 
-#: common/templates/_header.html:93
+#: common/templates/_header.html:106 common/views_manage.py:36
 msgid "Feed"
 msgstr ""
 
-#: common/templates/_header.html:98 journal/templates/profile.html:13
+#: common/templates/_header.html:111 journal/templates/profile.html:13
 #: users/templates/users/preferences.html:46
 msgid "Home"
 msgstr ""
 
-#: common/templates/_header.html:114 common/templates/common/scan.html:9
+#: common/templates/_header.html:127 common/templates/common/scan.html:9
 #: common/templates/common/scan.html:42
 msgid "Scan Barcode"
 msgstr ""
 
-#: common/templates/_header.html:118 social/templates/notification.html:12
+#: common/templates/_header.html:131 social/templates/notification.html:12
 #: social/templates/notification.html:53
 msgid "Notification"
 msgstr ""
 
-#: common/templates/_header.html:122 users/models/task.py:21
+#: common/templates/_header.html:135 users/models/task.py:23
 #: users/templates/users/account.html:219
 #: users/templates/users/crossposts.html:9
 msgid "Pending"
 msgstr ""
 
-#: common/templates/_header.html:125
+#: common/templates/_header.html:138
 msgid "Data"
 msgstr ""
 
-#: common/templates/_header.html:128 common/templates/_header.html:146
+#: common/templates/_header.html:141 common/templates/_header.html:159
 #: users/templates/users/preferences.html:12
 #: users/templates/users/preferences.html:23
 #: users/templates/users/preferences_anonymous.html:13
 msgid "Preferences"
 msgstr ""
 
-#: common/templates/_header.html:131
+#: common/templates/_header.html:144
 msgid "Account"
 msgstr ""
 
-#: common/templates/_header.html:135
+#: common/templates/_header.html:148
 msgid "Manage"
 msgstr ""
 
-#: common/templates/_header.html:139
+#: common/templates/_header.html:152
 msgid "Logout"
 msgstr ""
 
-#: common/templates/_header.html:143
+#: common/templates/_header.html:156
 msgid "Sign up or Login"
 msgstr ""
 
-#: common/templates/_header.html:160
-msgid ""
-"title or content  category:tv  status:complete  rating:8..10  "
-"date:2021-09-11..2022-02"
+#: common/templates/_header.html:173
+msgid "title or content  category:tv  status:complete  rating:8..10  date:2021-09-11..2022-02"
 msgstr ""
 
-#: common/templates/_header.html:162
+#: common/templates/_header.html:175
 msgid "name of a person or company"
 msgstr ""
 
-#: common/templates/_header.html:179
+#: common/templates/_header.html:192
 msgid "Open"
 msgstr ""
 
-#: common/templates/_sidebar.html:62
+#: common/templates/_sidebar.html:61
 #: users/templates/users/profile_actions.html:36
 msgid "approving followers manually"
 msgstr ""
 
-#: common/templates/_sidebar.html:81 common/templates/_sidebar.html:86
+#: common/templates/_sidebar.html:80 common/templates/_sidebar.html:85
 msgid "followers"
 msgstr ""
 
-#: common/templates/_sidebar.html:112
+#: common/templates/_sidebar.html:111
 msgid "Current Targets"
 msgstr ""
 
-#: common/templates/_sidebar.html:125
+#: common/templates/_sidebar.html:124
 msgid "Set a collection as target, its progress will show up here."
 msgstr ""
 
-#: common/templates/_sidebar.html:138
+#: common/templates/_sidebar.html:137
 msgid "Recent podcast episodes"
 msgstr "قسمت‌های اخیر پادپخش"
 
-#: common/templates/_sidebar.html:173
+#: common/templates/_sidebar.html:172
 msgid "Currently reading"
 msgstr ""
 
-#: common/templates/_sidebar.html:215
+#: common/templates/_sidebar.html:214
 msgid "Currently watching"
 msgstr ""
 
-#: common/templates/_sidebar.html:238 journal/forms.py:217
+#: common/templates/_sidebar.html:237 journal/forms.py:217
 #: journal/templates/user_tag_list.html:13
 #: journal/templates/user_tagmember_list.html:4
 msgid "Tags"
 msgstr ""
 
-#: common/templates/_sidebar.html:244 journal/templates/user_tag_list.html:28
+#: common/templates/_sidebar.html:243 journal/templates/user_tag_list.html:28
 #: journal/templates/user_tagmember_list.html:10
 msgid "featured tag"
 msgstr ""
 
-#: common/templates/_sidebar.html:247 journal/templates/user_tag_list.html:31
+#: common/templates/_sidebar.html:246 journal/templates/user_tag_list.html:31
 #: journal/templates/user_tagmember_list.html:15
 msgid "personal tag"
 msgstr ""
 
-#: common/templates/_sidebar.html:254 journal/templates/user_tag_list.html:39
+#: common/templates/_sidebar.html:253 journal/templates/user_tag_list.html:39
 msgid "no tags so far."
 msgstr ""
 
-#: common/templates/_sidebar.html:258 common/templates/_sidebar.html:271
+#: common/templates/_sidebar.html:257 common/templates/_sidebar.html:270
 msgid "show all"
 msgstr ""
 
-#: common/templates/_sidebar_anonymous.html:16
+#: common/templates/_sidebar_anonymous.html:15
 #, python-format
 msgid ""
 "\n"
 "        <h3>Welcome 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is "
-"committed to creating a free, open, and interconnected space for collecting "
-"and reviewing books, movies, music, games, and podcasts. Here, you can "
-"manage your collections, share your thoughts, discover new content, and "
-"connect with others.\n"
+"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is committed to creating a free, open, and interconnected space for collecting and reviewing books, movies, music, games, and podcasts. Here, you can manage your collections, share your thoughts, discover new content, and connect with others.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in "
-"to %(site_name)s is through a Fediverse (a distributed social network, "
-"including Mastodon/Pleroma/etc) instance account. If you haven’t registered "
-"yet, you can <a href=\"https://joinmastodon.org/en/servers\" "
-"target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
+"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in to %(site_name)s is through a Fediverse (a distributed social network, including Mastodon/Pleroma/etc) instance account. If you haven’t registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log "
-"in is through a Bluesky (another distributed social network, also called "
-"ATProto) account. If you haven’t registered yet, you may <a href=\"https://"
-"bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
+"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log in is through a Bluesky (another distributed social network, also called ATProto) account. If you haven’t registered yet, you may <a href=\"https://bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready "
-"to join either Fediverse or Bluesky, that’s perfectly fine. You can create "
-"an account here using your email address, and link it to the Fediverse and "
-"Bluesky in settings whenever you’re ready.\n"
+"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready to join either Fediverse or Bluesky, that’s perfectly fine. You can create an account here using your email address, and link it to the Fediverse and Bluesky in settings whenever you’re ready.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have "
-"any questions or suggestions, please feel free to contact us via <a "
-"href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://"
-"discord.gg/uprvcH8gqD\">Discord</a>.\n"
+"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have any questions or suggestions, please feel free to contact us via <a href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-"href=\"%(login_url)s\">Click here</a> to register or log in.\n"
+"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Click here</a> to register or log in.\n"
 "        </p>\n"
 "        "
 msgstr ""
 
-#: common/templates/_sidebar_anonymous.html:43
+#: common/templates/_sidebar_anonymous.html:42
 #: users/templates/users/announcements.html:12
 #: users/templates/users/announcements.html:39
 msgid "Announcements"
@@ -4088,7 +4086,7 @@ msgstr ""
 msgid "Registration"
 msgstr ""
 
-#: common/templates/common/about.html:35 common/views_manage.py:493
+#: common/templates/common/about.html:35 common/views_manage.py:594
 msgid "Invite Only"
 msgstr ""
 
@@ -4096,7 +4094,7 @@ msgstr ""
 msgid "Open Registration"
 msgstr ""
 
-#: common/templates/common/about.html:40 common/views_manage.py:556
+#: common/templates/common/about.html:40 common/views_manage.py:657
 msgid "Preferred Languages"
 msgstr ""
 
@@ -4141,9 +4139,7 @@ msgid "Error"
 msgstr ""
 
 #: common/templates/common/scan.html:45
-msgid ""
-"Point the camera at a book ISBN or product barcode (EAN / UPC). You will be "
-"redirected to the search once a code is detected."
+msgid "Point the camera at a book ISBN or product barcode (EAN / UPC). You will be redirected to the search once a code is detected."
 msgstr ""
 
 #: common/templates/common/scan.html:50
@@ -4154,7 +4150,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:628
+#: common/templates/common/scan.html:60 common/views_manage.py:738
 msgid "Search"
 msgstr ""
 
@@ -4186,16 +4182,28 @@ msgstr ""
 msgid "Camera unavailable. Use manual entry below."
 msgstr ""
 
-#: common/templates/manage/settings.html:9
+#: common/templates/manage/base.html:9
 msgid "Site Settings"
 msgstr ""
 
-#: common/templates/manage/settings.html:109
+#: common/templates/manage/base.html:127
 msgid "Takahe Admin"
 msgstr ""
 
-#: common/templates/manage/settings.html:112
+#: common/templates/manage/base.html:130
 msgid "Database Admin"
+msgstr ""
+
+#: common/templates/manage/environment.html:6
+msgid "These settings come from environment variables and cannot be changed here. Edit .env and restart the server to change them. Passwords and keys are hidden."
+msgstr ""
+
+#: common/templates/manage/environment.html:23
+msgid "(empty)"
+msgstr ""
+
+#: common/templates/manage/environment.html:26
+msgid "default"
 msgstr ""
 
 #: common/templatetags/duration.py:59
@@ -4214,7 +4222,7 @@ msgstr ""
 msgid "following you"
 msgstr ""
 
-#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:95
+#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:90
 msgid "you"
 msgstr ""
 
@@ -4222,826 +4230,833 @@ msgstr ""
 msgid "unavailable"
 msgstr ""
 
-#: common/utils.py:126 common/utils.py:167 users/views/actions.py:134
+#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr ""
 
-#: common/utils.py:133 common/utils.py:135 common/utils.py:138
-#: common/utils.py:174 common/utils.py:178 journal/views/profile.py:499
+#: common/utils.py:135 common/utils.py:137 common/utils.py:140
+#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
 msgid "Access denied"
 msgstr ""
 
-#: common/utils.py:141 common/utils.py:143 journal/views/article.py:204
+#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr ""
 
-#: common/views_manage.py:144 common/views_manage.py:295
+#: common/views_manage.py:34 common/views_manage.py:373
 #, fuzzy
 #| msgid "binding"
 msgid "Branding"
 msgstr "صحافی"
 
-#: common/views_manage.py:146
+#: common/views_manage.py:37
 msgid "Recommendations"
 msgstr ""
 
-#: common/views_manage.py:147
+#: common/views_manage.py:38
 msgid "Access"
 msgstr ""
 
-#: common/views_manage.py:148 common/views_manage.py:623
+#: common/views_manage.py:39 common/views_manage.py:733
 #, fuzzy
 #| msgid "description"
 msgid "Federation"
 msgstr "توضیحات"
 
-#: common/views_manage.py:149
+#: common/views_manage.py:40
 msgid "Catalog"
 msgstr ""
 
-#: common/views_manage.py:150
+#: common/views_manage.py:41
 msgid "API Keys"
 msgstr ""
 
-#: common/views_manage.py:151
+#: common/views_manage.py:42
 #, fuzzy
 #| msgid "Downloadable Content"
 msgid "Downloader"
 msgstr "محتوای قابل بارگیری"
 
-#: common/views_manage.py:152 common/views_manage.py:303
+#: common/views_manage.py:43 common/views_manage.py:381
 #: users/templates/users/steam_import.html:113
 msgid "Advanced"
 msgstr ""
 
-#: common/views_manage.py:202
+#: common/views_manage.py:44
+msgid "Environment"
+msgstr ""
+
+#: common/views_manage.py:280
 msgid "Invalid value."
 msgstr ""
 
-#: common/views_manage.py:206
+#: common/views_manage.py:284
 msgid "Invalid configuration. Please check your input."
 msgstr ""
 
-#: common/views_manage.py:211
+#: common/views_manage.py:289
 msgid "Settings have been saved."
 msgstr ""
 
-#: common/views_manage.py:231
+#: common/views_manage.py:309
 msgid "Site Name"
 msgstr ""
 
-#: common/views_manage.py:234
+#: common/views_manage.py:312
 #, fuzzy
 #| msgid "description"
 msgid "Site Description"
 msgstr "توضیحات"
 
-#: common/views_manage.py:235
+#: common/views_manage.py:313
 msgid "Short description shown in metadata and about page."
 msgstr ""
 
-#: common/views_manage.py:238
+#: common/views_manage.py:316
 msgid "Site Logo URL"
 msgstr ""
 
-#: common/views_manage.py:239
+#: common/views_manage.py:317
 msgid "URL path to the site logo image."
 msgstr ""
 
-#: common/views_manage.py:242
+#: common/views_manage.py:320
 msgid "Site Icon URL"
 msgstr ""
 
-#: common/views_manage.py:243
+#: common/views_manage.py:321
 msgid "URL path to the site icon/favicon."
 msgstr ""
 
-#: common/views_manage.py:246
+#: common/views_manage.py:324
 msgid "Default User Avatar URL"
 msgstr ""
 
-#: common/views_manage.py:247
+#: common/views_manage.py:325
 msgid "URL path to the default user avatar."
 msgstr ""
 
-#: common/views_manage.py:250
+#: common/views_manage.py:328
 msgid "Site Color Theme"
 msgstr ""
 
-#: common/views_manage.py:251
+#: common/views_manage.py:329
 msgid "PicoCSS color theme."
 msgstr ""
 
-#: common/views_manage.py:276
+#: common/views_manage.py:354
 #, fuzzy
 msgid "Site Introduction"
 msgstr "تولید"
 
-#: common/views_manage.py:277
+#: common/views_manage.py:355
 msgid "URL path for the intro/welcome sidebar page."
 msgstr ""
 
-#: common/views_manage.py:280
+#: common/views_manage.py:358
 msgid "Custom HTML Head"
 msgstr ""
 
-#: common/views_manage.py:281
+#: common/views_manage.py:359
 msgid "Extra HTML injected into the <head> of all pages."
 msgstr ""
 
-#: common/views_manage.py:285
+#: common/views_manage.py:363
 msgid "Footer Links"
 msgstr ""
 
-#: common/views_manage.py:286
+#: common/views_manage.py:364
 msgid "Link title mapped to URL."
 msgstr ""
 
-#: common/views_manage.py:315
+#: common/views_manage.py:393
 msgid "Minimum Marks for Discover"
 msgstr ""
 
-#: common/views_manage.py:317
+#: common/views_manage.py:395
 msgid "Number of marks required for an item to appear in discover."
 msgstr ""
 
-#: common/views_manage.py:322
+#: common/views_manage.py:400
 msgid "Update Interval (minutes)"
 msgstr ""
 
-#: common/views_manage.py:323
+#: common/views_manage.py:401
 msgid "How often to refresh the popular items list."
 msgstr ""
 
-#: common/views_manage.py:327
+#: common/views_manage.py:405
 msgid "Filter by Preferred Languages"
 msgstr ""
 
-#: common/views_manage.py:328
+#: common/views_manage.py:406
 msgid "Only show items with titles in the preferred languages."
 msgstr ""
 
-#: common/views_manage.py:331
+#: common/views_manage.py:409
 msgid "Show Local Only"
 msgstr ""
 
-#: common/views_manage.py:333
+#: common/views_manage.py:411
 msgid "Only show items marked by local users, not the entire network."
 msgstr ""
 
-#: common/views_manage.py:337
+#: common/views_manage.py:415
 msgid "Show Popular Posts"
 msgstr ""
 
-#: common/views_manage.py:338
+#: common/views_manage.py:416
 msgid "Show popular public posts instead of recent ones."
 msgstr ""
 
-#: common/views_manage.py:341
+#: common/views_manage.py:419
 msgid "Show Popular Tags"
 msgstr ""
 
-#: common/views_manage.py:342
+#: common/views_manage.py:420
 msgid "Show popular public tags on the discover page."
 msgstr ""
 
-#: common/views_manage.py:345
+#: common/views_manage.py:423
 #, fuzzy
 msgid "Show Verified Podcasts"
 msgstr "پادکست اسپاتیفای"
 
-#: common/views_manage.py:347
-msgid ""
-"Show a shelf of recent episodes from podcasts with a verified creator on the "
-"discover page."
+#: common/views_manage.py:425
+msgid "Show a shelf of recent episodes from podcasts with a verified creator on the discover page."
 msgstr ""
 
-#: common/views_manage.py:386
+#: common/views_manage.py:447
+msgid "Show World Timeline"
+msgstr ""
+
+#: common/views_manage.py:449
+msgid "Offer a tab with public posts from this site and every server it federates with."
+msgstr ""
+
+#: common/views_manage.py:454
+msgid "Show Local Timeline"
+msgstr ""
+
+#: common/views_manage.py:455
+msgid "Offer a tab with public posts from this site only."
+msgstr ""
+
+#: common/views_manage.py:459
+msgid "Timelines"
+msgstr ""
+
+#: common/views_manage.py:487
 msgid "Enable Recommendations"
 msgstr ""
 
-#: common/views_manage.py:388
-msgid ""
-"Master switch. When off, all recommendation surfaces are hidden and the cron "
-"jobs are not scheduled."
+#: common/views_manage.py:489
+msgid "Master switch. When off, all recommendation surfaces are hidden and the cron jobs are not scheduled."
 msgstr ""
 
-#: common/views_manage.py:393
+#: common/views_manage.py:494
 msgid "Source Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:395
-msgid ""
-"Minimum public marks an item needs before similarity rows are built for it."
+#: common/views_manage.py:496
+msgid "Minimum public marks an item needs before similarity rows are built for it."
 msgstr ""
 
-#: common/views_manage.py:401
+#: common/views_manage.py:502
 msgid "Target Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:403
-msgid ""
-"Minimum public marks an item needs to be eligible as a recommendation target."
+#: common/views_manage.py:504
+msgid "Minimum public marks an item needs to be eligible as a recommendation target."
 msgstr ""
 
-#: common/views_manage.py:409
+#: common/views_manage.py:510
 msgid "Top-K Similar Items per Source"
 msgstr ""
 
-#: common/views_manage.py:410
+#: common/views_manage.py:511
 msgid "Number of similar items stored per source item."
 msgstr ""
 
-#: common/views_manage.py:414
+#: common/views_manage.py:515
 msgid "Top-N Recommendations per User"
 msgstr ""
 
-#: common/views_manage.py:415
+#: common/views_manage.py:516
 msgid "Number of personalised rows stored per user."
 msgstr ""
 
-#: common/views_manage.py:419
+#: common/views_manage.py:520
 msgid "Dampen Heavy Shelvers"
 msgstr ""
 
-#: common/views_manage.py:421
-msgid ""
-"Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-"
-"shelvers in similarity scoring."
+#: common/views_manage.py:522
+msgid "Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-shelvers in similarity scoring."
 msgstr ""
 
-#: common/views_manage.py:426
+#: common/views_manage.py:527
 msgid "Per-User Mark Cap (training)"
 msgstr ""
 
-#: common/views_manage.py:428
-msgid ""
-"Truncate each user's contribution to their N most recent marks when building "
-"the similarity matrix."
-msgstr ""
-
-#: common/views_manage.py:434
-msgid "Active-User Window (days)"
-msgstr ""
-
-#: common/views_manage.py:436
-msgid ""
-"Refresh personalised recommendations for users with at least one public mark "
-"in the last N days."
-msgstr ""
-
-#: common/views_manage.py:442
-msgid "Per-User Seed Cap (serving)"
-msgstr ""
-
-#: common/views_manage.py:444
-msgid ""
-"Number of recent marks used as seeds when scoring personalised "
-"recommendations for one user."
-msgstr ""
-
-#: common/views_manage.py:450
-msgid "Lazy Refresh TTL (days)"
-msgstr ""
-
-#: common/views_manage.py:452
-msgid ""
-"How long cached on-demand recommendations are valid before the next request "
-"triggers a refresh."
-msgstr ""
-
-#: common/views_manage.py:458
-msgid "Circles Window (days)"
-msgstr ""
-
-#: common/views_manage.py:460
-msgid ""
-"Look back N days when finding items recently marked by people the viewer "
-"follows."
-msgstr ""
-
-#: common/views_manage.py:467
-msgid "Master Switch"
-msgstr ""
-
-#: common/views_manage.py:470
-msgid "Similarity Builder"
-msgstr ""
-
-#: common/views_manage.py:477
-msgid "Personalisation"
-msgstr ""
-
-#: common/views_manage.py:495
-msgid ""
-"Require an invite token to register. Invite tokens can be generated with "
-"neodb-manage invite --create."
-msgstr ""
-
-#: common/views_manage.py:500
-msgid "Enable Local-Only Posting"
-msgstr ""
-
-#: common/views_manage.py:501
-msgid "Allow users to create posts visible only to local users."
-msgstr ""
-
-#: common/views_manage.py:504
-msgid "Mastodon Login Whitelist"
-msgstr ""
-
-#: common/views_manage.py:505
-msgid "One domain per line. Leave empty to allow any instance."
-msgstr ""
-
-#: common/views_manage.py:508
-msgid "Registration Captcha Items"
-msgstr ""
-
-#: common/views_manage.py:512
-msgid ""
-"Number of item covers a new user must sort into two category rows before "
-"choosing a username. 0 disables the captcha; 5-6 is recommended. The covers "
-"carry no title text, so this cannot be solved with a screen reader: if you "
-"enable it, keep another way in, such as an invite link."
-msgstr ""
-
-#: common/views_manage.py:520
-msgid "Registration Captcha Minimum Marks"
-msgstr ""
-
-#: common/views_manage.py:523
-msgid ""
-"Marks an item needs before the captcha treats it as well known enough to be "
-"recognizable. Categories with too few such items fall back to any item."
-msgstr ""
-
 #: common/views_manage.py:529
-msgid "Enable Mastodon Login"
-msgstr ""
-
-#: common/views_manage.py:532
-msgid "Enable Bluesky Login"
+msgid "Truncate each user's contribution to their N most recent marks when building the similarity matrix."
 msgstr ""
 
 #: common/views_manage.py:535
-msgid "Enable Threads Login"
+msgid "Active-User Window (days)"
 msgstr ""
 
-#: common/views_manage.py:538
-msgid "Email URL"
+#: common/views_manage.py:537
+msgid "Refresh personalised recommendations for users with at least one public mark in the last N days."
 msgstr ""
 
-#: common/views_manage.py:540
-msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
-msgstr ""
-
-#: common/views_manage.py:544
-msgid "Email From"
+#: common/views_manage.py:543
+msgid "Per-User Seed Cap (serving)"
 msgstr ""
 
 #: common/views_manage.py:545
+msgid "Number of recent marks used as seeds when scoring personalised recommendations for one user."
+msgstr ""
+
+#: common/views_manage.py:551
+msgid "Lazy Refresh TTL (days)"
+msgstr ""
+
+#: common/views_manage.py:553
+msgid "How long cached on-demand recommendations are valid before the next request triggers a refresh."
+msgstr ""
+
+#: common/views_manage.py:559
+msgid "Circles Window (days)"
+msgstr ""
+
+#: common/views_manage.py:561
+msgid "Look back N days when finding items recently marked by people the viewer follows."
+msgstr ""
+
+#: common/views_manage.py:568
+msgid "Master Switch"
+msgstr ""
+
+#: common/views_manage.py:571
+msgid "Similarity Builder"
+msgstr ""
+
+#: common/views_manage.py:578
+msgid "Personalisation"
+msgstr ""
+
+#: common/views_manage.py:596
+msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
+msgstr ""
+
+#: common/views_manage.py:601
+msgid "Enable Local-Only Posting"
+msgstr ""
+
+#: common/views_manage.py:602
+msgid "Allow users to create posts visible only to local users."
+msgstr ""
+
+#: common/views_manage.py:605
+msgid "Mastodon Login Whitelist"
+msgstr ""
+
+#: common/views_manage.py:606
+msgid "One domain per line. Leave empty to allow any instance."
+msgstr ""
+
+#: common/views_manage.py:609
+msgid "Registration Captcha Items"
+msgstr ""
+
+#: common/views_manage.py:613
+msgid "Number of item covers a new user must sort into two category rows before choosing a username. 0 disables the captcha; 5-6 is recommended. The covers carry no title text, so this cannot be solved with a screen reader: if you enable it, keep another way in, such as an invite link."
+msgstr ""
+
+#: common/views_manage.py:621
+msgid "Registration Captcha Minimum Marks"
+msgstr ""
+
+#: common/views_manage.py:624
+msgid "Marks an item needs before the captcha treats it as well known enough to be recognizable. Categories with too few such items fall back to any item."
+msgstr ""
+
+#: common/views_manage.py:630
+msgid "Enable Mastodon Login"
+msgstr ""
+
+#: common/views_manage.py:633
+msgid "Enable Bluesky Login"
+msgstr ""
+
+#: common/views_manage.py:636
+msgid "Enable Threads Login"
+msgstr ""
+
+#: common/views_manage.py:639
+msgid "Email URL"
+msgstr ""
+
+#: common/views_manage.py:641
+msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
+msgstr ""
+
+#: common/views_manage.py:645
+msgid "Email From"
+msgstr ""
+
+#: common/views_manage.py:646
 msgid "Sender name and address for outgoing email."
 msgstr ""
 
-#: common/views_manage.py:548
+#: common/views_manage.py:649
 #, fuzzy
 #| msgid "language"
 msgid "Default Language"
 msgstr "زبان"
 
-#: common/views_manage.py:551
-msgid ""
-"Interface language for visitors and for users who have not chosen one "
-"themselves."
+#: common/views_manage.py:652
+msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:558
-msgid ""
-"Language codes, one per line (e.g. en, zh, ja). First language is the "
-"default."
+#: common/views_manage.py:659
+msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:564
+#: common/views_manage.py:665
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:571
+#: common/views_manage.py:672
 msgid "Login Methods"
 msgstr ""
 
-#: common/views_manage.py:576 mastodon/models/common.py:28
+#: common/views_manage.py:677 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr ""
 
-#: common/views_manage.py:580
+#: common/views_manage.py:681
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:591
+#: common/views_manage.py:692
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:593
-msgid ""
-"Disable relay.neodb.net federation for sharing public ratings across "
-"instances."
+#: common/views_manage.py:694
+msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:598
+#: common/views_manage.py:699
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:599
+#: common/views_manage.py:700
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:603
+#: common/views_manage.py:704
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:605
+#: common/views_manage.py:706
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:610
+#: common/views_manage.py:711
 msgid "Search Sites"
 msgstr ""
 
-#: common/views_manage.py:611
+#: common/views_manage.py:712
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:614
+#: common/views_manage.py:715
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:615
+#: common/views_manage.py:716
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:618
+#: common/views_manage.py:719
 msgid "Hidden Categories"
 msgstr ""
 
-#: common/views_manage.py:619
+#: common/views_manage.py:720
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:640
+#: common/views_manage.py:723
+msgid "Guest Search Page Limit"
+msgstr ""
+
+#: common/views_manage.py:725
+msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
+msgstr ""
+
+#: common/views_manage.py:751
 #, fuzzy
 msgid "Spotify API Key"
 msgstr "آلبوم اسپاتیفای"
 
-#: common/views_manage.py:641
+#: common/views_manage.py:752
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:644
+#: common/views_manage.py:755
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:645
+#: common/views_manage.py:756
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:648
+#: common/views_manage.py:759
 #, fuzzy
 #| msgid "Google Books"
 msgid "Google Books API Key"
 msgstr "کتاب‌های گوگل"
 
-#: common/views_manage.py:649
+#: common/views_manage.py:760
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:652
+#: common/views_manage.py:763
 #, fuzzy
 #| msgid "Discogs Master"
 msgid "Discogs API Key"
 msgstr "استاد دیسکاگ ها"
 
-#: common/views_manage.py:654
+#: common/views_manage.py:765
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:658
+#: common/views_manage.py:769
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:770
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:662
+#: common/views_manage.py:773
 msgid "IGDB Client Secret"
 msgstr ""
 
-#: common/views_manage.py:665
+#: common/views_manage.py:776
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:667
-msgid ""
-"Bearer token from https://boardgamegeek.com/applications (see https://"
-"boardgamegeek.com/using_the_xml_api#toc9)."
+#: common/views_manage.py:778
+msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:672 users/templates/users/steam_import.html:26
+#: common/views_manage.py:783
+msgid "MyAnimeList Client ID"
+msgstr ""
+
+#: common/views_manage.py:785
+msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
+msgstr ""
+
+#: common/views_manage.py:790 users/templates/users/steam_import.html:26
 #, fuzzy
 #| msgid "Steam Game"
 msgid "Steam API Key"
 msgstr "بازی استیم"
 
-#: common/views_manage.py:674
-msgid ""
-"https://steamcommunity.com/dev - fallback key for Steam importer. Users can "
-"provide their own key when importing."
+#: common/views_manage.py:792
+msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:679
+#: common/views_manage.py:797
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:680
+#: common/views_manage.py:798
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:683
+#: common/views_manage.py:801
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:686
+#: common/views_manage.py:804
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:689
+#: common/views_manage.py:807
 msgid "Threads App ID"
 msgstr ""
 
-#: common/views_manage.py:690
+#: common/views_manage.py:808
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:693
+#: common/views_manage.py:811
 msgid "Threads App Secret"
 msgstr ""
 
-#: common/views_manage.py:696
+#: common/views_manage.py:814
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:698
-msgid ""
-"Webhook URLs keyed by channel (default, report, audit, suggest, system). All "
-"channels must be Discord forum or media channels (thread mode) because "
-"notifications are posted as threads."
+#: common/views_manage.py:816
+msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:715
+#: common/views_manage.py:833
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:844
 #, fuzzy
 #| msgid "translator"
 msgid "Translation"
 msgstr "ترجمه‌کننده"
 
-#: common/views_manage.py:730
+#: common/views_manage.py:849
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:734 social/templates/feed.html:27
+#: common/views_manage.py:853 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr ""
 
-#: common/views_manage.py:744
+#: common/views_manage.py:863
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:745
+#: common/views_manage.py:864
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:748
+#: common/views_manage.py:867
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:749
+#: common/views_manage.py:868
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:752
+#: common/views_manage.py:871
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:874
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:758
+#: common/views_manage.py:877
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:761
+#: common/views_manage.py:880
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:764
+#: common/views_manage.py:883
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:767
+#: common/views_manage.py:886
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:768
+#: common/views_manage.py:887
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:771
+#: common/views_manage.py:890
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:775
+#: common/views_manage.py:894
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:779
+#: common/views_manage.py:898
 #, fuzzy
 #| msgid "series"
 msgid "Retries"
 msgstr "دنباله‌ها"
 
-#: common/views_manage.py:784
+#: common/views_manage.py:903
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:789
+#: common/views_manage.py:908
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:796
+#: common/views_manage.py:915
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:808
+#: common/views_manage.py:927
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:809
+#: common/views_manage.py:928
 msgid "One domain per line."
 msgstr ""
 
-#: common/views_manage.py:812
+#: common/views_manage.py:931
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:813
+#: common/views_manage.py:932
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:935
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:818
-msgid ""
-"Timeout for requests to Mastodon instances and remote fediverse servers."
+#: common/views_manage.py:937
+msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:824
+#: common/views_manage.py:943
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:825
+#: common/views_manage.py:944
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:828
+#: common/views_manage.py:947
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:829
+#: common/views_manage.py:948
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:839
+#: common/views_manage.py:958
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:841
-msgid ""
-"Delete import/export tasks and their files after this many days. Set to 0 to "
-"disable cleanup."
+#: common/views_manage.py:960
+msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:847
+#: common/views_manage.py:966
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:849
-msgid ""
-"Post-migration job keys to skip, one per line (e.g. normalize_genre). "
-"Checked by the worker at dequeue time; skipped jobs log a warning and notify "
-"the Discord system channel."
+#: common/views_manage.py:968
+msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:855
+#: common/views_manage.py:974
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:857
-msgid ""
-"Private key (JWK) identifying this site to ATProto authorization servers. "
-"Auto-generated on first Bluesky login; clear to regenerate."
+#: common/views_manage.py:976
+msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:983
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:986
 msgid "Operational"
 msgstr ""
 
-#: common/views_manage.py:883
+#: common/views_manage.py:1002
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:885
-msgid ""
-"Genre codes offered in the Movie edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1004
+msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:1009
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:892
-msgid ""
-"Genre codes offered in the TV edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1011
+msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:897
+#: common/views_manage.py:1016
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:899
-msgid ""
-"Genre codes offered in the Music edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1018
+msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:904
+#: common/views_manage.py:1023
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:906
-msgid ""
-"Genre codes offered in the Game edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1025
+msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:911
+#: common/views_manage.py:1030
 #, fuzzy
 #| msgid "Podcast"
 msgid "Podcast Genres"
 msgstr "پادپخش"
 
-#: common/views_manage.py:913
-msgid ""
-"Genre codes offered in the Podcast edit dropdown, one per line. Leave empty "
-"to use the built-in default."
+#: common/views_manage.py:1032
+msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:918
+#: common/views_manage.py:1037
 #, fuzzy
 #| msgid "Performance"
 msgid "Performance Genres"
 msgstr "عملکرد"
 
-#: common/views_manage.py:920
-msgid ""
-"Genre codes offered in the Performance edit dropdown, one per line. Leave "
-"empty to use the built-in default."
+#: common/views_manage.py:1039
+msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:926
+#: common/views_manage.py:1045
 msgid "Genres by Category"
 msgstr ""
 
+#: common/views_manage.py:1069
+msgid "Site"
+msgstr ""
+
+#: common/views_manage.py:1079
+msgid "Database and Services"
+msgstr ""
+
+#: common/views_manage.py:1089
+msgid "Media and Files"
+msgstr ""
+
+#: common/views_manage.py:1098
+msgid "Monitoring"
+msgstr ""
+
+#: common/views_manage.py:1102
+msgid "Security"
+msgstr ""
+
+#: common/views_manage.py:1111
+msgid "Other Environment Variables"
+msgstr ""
+
+#: common/views_manage.py:1113
+msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
+msgstr ""
+
 #: journal/forms.py:12
-msgid ""
-"Tips: use >!text!< for spoilers; some instances may not be able to show "
-"posts longer than 360 charactors."
+msgid "Tips: use >!text!< for spoilers; some instances may not be able to show posts longer than 360 charactors."
 msgstr ""
 
 #: journal/forms.py:29 journal/forms.py:31 journal/forms.py:80
@@ -5056,12 +5071,12 @@ msgid "Content (Markdown)"
 msgstr ""
 
 #: journal/forms.py:46 journal/forms.py:124 journal/forms.py:226
-#: journal/forms.py:288 journal/views/note.py:38
+#: journal/forms.py:288 journal/views/note.py:37
 msgid "Crosspost"
 msgstr ""
 
 #: journal/forms.py:47 journal/forms.py:125 journal/forms.py:227
-#: journal/forms.py:289 journal/views/note.py:39
+#: journal/forms.py:289 journal/views/note.py:38
 msgid "Crosspost to your connected social networks"
 msgstr ""
 
@@ -5076,10 +5091,10 @@ msgstr ""
 #: journal/forms.py:59 journal/forms.py:137 journal/forms.py:162
 #: journal/forms.py:219 journal/forms.py:281
 #: journal/templates/collection_share.html:24
-#: journal/templates/wrapped_share.html:36 journal/views/note.py:31
-#: users/templates/users/data.html:45 users/templates/users/data.html:98
-#: users/templates/users/data.html:155 users/templates/users/data.html:206
-#: users/templates/users/data.html:269 users/templates/users/data.html:328
+#: journal/templates/wrapped_share.html:36 journal/views/note.py:30
+#: users/templates/users/data.html:60 users/templates/users/data.html:113
+#: users/templates/users/data.html:170 users/templates/users/data.html:221
+#: users/templates/users/data.html:284 users/templates/users/data.html:346
 #: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
@@ -5116,7 +5131,6 @@ msgid "Collaborative editing"
 msgstr ""
 
 #: journal/forms.py:204 users/templates/users/crossposts.html:51
-#: users/templates/users/data.html:483
 msgid "Status"
 msgstr ""
 
@@ -5128,48 +5142,46 @@ msgstr ""
 msgid "Rating"
 msgstr ""
 
-#: journal/importers/goodreads.py:196 journal/importers/letterboxd.py:144
-#: journal/importers/rym.py:442 journal/importers/storygraph.py:500
+#: journal/importers/goodreads.py:198 journal/importers/letterboxd.py:147
+#: journal/importers/rym.py:444 journal/importers/storygraph.py:504
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr ""
 
-#: journal/importers/opml.py:45
+#: journal/importers/opml.py:49
 #, python-brace-format
 msgid "{username}'s podcast subscriptions"
 msgstr ""
 
-#: journal/importers/rym.py:168 journal/importers/storygraph.py:128
+#: journal/importers/rym.py:170 journal/importers/storygraph.py:132
 #, python-brace-format
-msgid ""
-"Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
+msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:178 journal/importers/storygraph.py:138
+#: journal/importers/rym.py:180 journal/importers/storygraph.py:142
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/importers/rym.py:233 journal/importers/storygraph.py:184
+#: journal/importers/rym.py:235 journal/importers/storygraph.py:188
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:348 journal/importers/storygraph.py:389
+#: journal/importers/rym.py:350 journal/importers/storygraph.py:393
 msgid "Matched file missing; cannot import."
 msgstr ""
 
-#: journal/importers/rym.py:376 journal/importers/storygraph.py:412
+#: journal/importers/rym.py:378 journal/importers/storygraph.py:416
 #, python-brace-format
-msgid ""
-"Import complete: {imported} imported, {skipped} skipped, {failed} failed"
+msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:212 journal/views/article.py:218
+#: journal/models/article.py:215 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
-#: journal/models/collection.py:44 journal/templates/add_to_collection.html:39
+#: journal/models/collection.py:48 journal/templates/add_to_collection.html:39
 #: journal/templates/collection_edit.html:64
 #: journal/templates/collection_share.html:63
 #: journal/templates/collection_update_item_note.html:3
@@ -5177,73 +5189,73 @@ msgstr ""
 msgid "note"
 msgstr ""
 
-#: journal/models/collection.py:111
+#: journal/models/collection.py:115
 msgid "search query for dynamic collection"
 msgstr ""
 
-#: journal/models/collection.py:524 journal/templatetags/collection.py:35
+#: journal/models/collection.py:566 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:529 journal/templatetags/collection.py:43
+#: journal/models/collection.py:571 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:534 journal/templatetags/collection.py:51
+#: journal/models/collection.py:576 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:539 journal/templatetags/collection.py:59
+#: journal/models/collection.py:581 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:544 journal/templatetags/collection.py:67
+#: journal/models/collection.py:586 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:549 journal/templatetags/collection.py:75
+#: journal/models/collection.py:591 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:555 journal/templatetags/collection.py:83
+#: journal/models/collection.py:597 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:563 journal/templatetags/collection.py:91
+#: journal/models/collection.py:605 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/common.py:50 journal/templates/action_open_post.html:15
-#: journal/templates/collection_share.html:35 journal/templates/mark.html:84
+#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
-#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:54
-#: users/templates/users/data.html:107 users/templates/users/data.html:164
-#: users/templates/users/data.html:215 users/templates/users/data.html:277
-#: users/templates/users/data.html:337 users/templates/users/data.html:534
+#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
+#: users/templates/users/data.html:122 users/templates/users/data.html:179
+#: users/templates/users/data.html:230 users/templates/users/data.html:292
+#: users/templates/users/data.html:355 users/templates/users/data.html:534
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5251,13 +5263,13 @@ msgstr[1] ""
 msgid "Public"
 msgstr ""
 
-#: journal/models/common.py:51 journal/templates/action_open_post.html:9
-#: journal/templates/collection_share.html:46 journal/templates/mark.html:91
+#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
-#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
-#: users/templates/users/data.html:115 users/templates/users/data.html:172
-#: users/templates/users/data.html:223 users/templates/users/data.html:285
-#: users/templates/users/data.html:345 users/templates/users/data.html:542
+#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
+#: users/templates/users/data.html:130 users/templates/users/data.html:187
+#: users/templates/users/data.html:238 users/templates/users/data.html:300
+#: users/templates/users/data.html:363 users/templates/users/data.html:542
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5265,12 +5277,12 @@ msgstr ""
 msgid "Followers Only"
 msgstr ""
 
-#: journal/models/common.py:52 journal/templates/collection_share.html:57
-#: journal/templates/mark.html:98 journal/templates/post_compose.html:72
-#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
-#: users/templates/users/data.html:123 users/templates/users/data.html:180
-#: users/templates/users/data.html:231 users/templates/users/data.html:293
-#: users/templates/users/data.html:353 users/templates/users/data.html:550
+#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/templates/mark.html:102 journal/templates/post_compose.html:72
+#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
+#: users/templates/users/data.html:138 users/templates/users/data.html:195
+#: users/templates/users/data.html:246 users/templates/users/data.html:308
+#: users/templates/users/data.html:371 users/templates/users/data.html:550
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5278,29 +5290,27 @@ msgstr ""
 msgid "Mentioned Only"
 msgstr ""
 
-#: journal/models/common.py:790
-msgid ""
-"A recent post was not posted to Bluesky, please login NeoDB using ATProto "
-"again to re-authorize."
+#: journal/models/common.py:806
+msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr ""
 
-#: journal/models/common.py:987
+#: journal/models/common.py:1003
 msgid "A recent post was not posted to Threads."
 msgstr ""
 
-#: journal/models/common.py:1020
+#: journal/models/common.py:1036
 msgid "A recent post was not boosted on Mastodon."
 msgstr ""
 
-#: journal/models/common.py:1030
+#: journal/models/common.py:1046
 msgid "Original post no longer exists."
 msgstr ""
 
-#: journal/models/common.py:1044
+#: journal/models/common.py:1060
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr ""
 
-#: journal/models/common.py:1053
+#: journal/models/common.py:1069
 msgid "A recent post was not posted to Mastodon."
 msgstr ""
 
@@ -5308,7 +5318,7 @@ msgstr ""
 msgid "Authorization expired"
 msgstr ""
 
-#: journal/models/crosspost.py:17 users/models/task.py:24
+#: journal/models/crosspost.py:17 users/models/task.py:26
 msgid "Failed"
 msgstr ""
 
@@ -5316,81 +5326,81 @@ msgstr ""
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:469
+#: journal/models/mark.py:475
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:473
+#: journal/models/mark.py:479
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:480
+#: journal/models/mark.py:486
 msgid "Invalid progress type."
 msgstr ""
 
-#: journal/models/mark.py:482
+#: journal/models/mark.py:488
 msgid "Invalid progress type for this item."
 msgstr ""
 
-#: journal/models/note.py:34 users/templates/users/rym_import.html:73
+#: journal/models/note.py:47 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr ""
 
-#: journal/models/note.py:35
+#: journal/models/note.py:48
 msgid "Chapter"
 msgstr ""
 
-#: journal/models/note.py:38
+#: journal/models/note.py:51
 msgid "Part"
 msgstr ""
 
-#: journal/models/note.py:39
+#: journal/models/note.py:52
 msgid "Episode"
 msgstr ""
 
-#: journal/models/note.py:40
+#: journal/models/note.py:53
 msgid "Track"
 msgstr ""
 
-#: journal/models/note.py:41
+#: journal/models/note.py:54
 msgid "Cycle"
 msgstr ""
 
-#: journal/models/note.py:42
+#: journal/models/note.py:55
 msgid "Timestamp"
 msgstr ""
 
-#: journal/models/note.py:43
+#: journal/models/note.py:56
 msgid "Percentage"
 msgstr ""
 
-#: journal/models/note.py:60
+#: journal/models/note.py:77
 #, python-brace-format
 msgid "Page {value}"
 msgstr ""
 
-#: journal/models/note.py:61
+#: journal/models/note.py:78
 #, python-brace-format
 msgid "Chapter {value}"
 msgstr ""
 
-#: journal/models/note.py:64
+#: journal/models/note.py:81
 #, python-brace-format
 msgid "Part {value}"
 msgstr ""
 
-#: journal/models/note.py:65
+#: journal/models/note.py:82
 #, python-brace-format
 msgid "Episode {value}"
 msgstr ""
 
-#: journal/models/note.py:66
+#: journal/models/note.py:83
 #, python-brace-format
 msgid "Track {value}"
 msgstr ""
 
-#: journal/models/note.py:67
+#: journal/models/note.py:84
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr ""
@@ -5400,439 +5410,439 @@ msgstr ""
 msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr ""
 
-#: journal/models/review.py:78
+#: journal/models/review.py:79
 #, python-brace-format
 msgid "a review of {title}"
 msgstr ""
 
-#: journal/models/review.py:80
+#: journal/models/review.py:81
 msgid "(may contain spoilers)"
 msgstr ""
 
-#: journal/models/shelf.py:37
+#: journal/models/shelf.py:39
 msgid "WISHLIST"
 msgstr ""
 
-#: journal/models/shelf.py:38
+#: journal/models/shelf.py:40
 msgid "PROGRESS"
 msgstr ""
 
-#: journal/models/shelf.py:39
+#: journal/models/shelf.py:41
 msgid "COMPLETE"
 msgstr ""
 
-#: journal/models/shelf.py:40
+#: journal/models/shelf.py:42
 msgid "DROPPED"
 msgstr ""
 
-#: journal/models/shelf.py:49
+#: journal/models/shelf.py:51
 msgid "books to read"
 msgstr ""
 
-#: journal/models/shelf.py:50
+#: journal/models/shelf.py:52
 msgid "want to read"
 msgstr ""
 
-#: journal/models/shelf.py:51
+#: journal/models/shelf.py:53
 #, python-brace-format
 msgid "wants to read {item}"
 msgstr ""
 
-#: journal/models/shelf.py:52
+#: journal/models/shelf.py:54
 msgid "to read"
 msgstr ""
 
-#: journal/models/shelf.py:57
+#: journal/models/shelf.py:59
 msgid "books reading"
 msgstr ""
 
-#: journal/models/shelf.py:58
+#: journal/models/shelf.py:60
 msgid "start reading"
 msgstr ""
 
-#: journal/models/shelf.py:59
+#: journal/models/shelf.py:61
 #, python-brace-format
 msgid "started reading {item}"
 msgstr ""
 
-#: journal/models/shelf.py:60
+#: journal/models/shelf.py:62
 msgid "reading"
 msgstr ""
 
-#: journal/models/shelf.py:65
+#: journal/models/shelf.py:67
 msgid "books completed"
 msgstr ""
 
-#: journal/models/shelf.py:66
+#: journal/models/shelf.py:68
 msgid "finish reading"
 msgstr ""
 
-#: journal/models/shelf.py:67
+#: journal/models/shelf.py:69
 #, python-brace-format
 msgid "finished reading {item}"
 msgstr ""
 
-#: journal/models/shelf.py:68
+#: journal/models/shelf.py:70
 msgid "read"
 msgstr ""
 
-#: journal/models/shelf.py:73
+#: journal/models/shelf.py:75
 msgid "books dropped"
 msgstr ""
 
-#: journal/models/shelf.py:74
+#: journal/models/shelf.py:76
 msgid "stop reading"
 msgstr ""
 
-#: journal/models/shelf.py:75
+#: journal/models/shelf.py:77
 #, python-brace-format
 msgid "stopped reading {item}"
 msgstr ""
 
-#: journal/models/shelf.py:76
+#: journal/models/shelf.py:78
 msgid "stopped reading"
 msgstr ""
 
-#: journal/models/shelf.py:81
+#: journal/models/shelf.py:83
 msgid "books reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:82 journal/models/shelf.py:122
-#: journal/models/shelf.py:162 journal/models/shelf.py:202
-#: journal/models/shelf.py:242 journal/models/shelf.py:282
-#: journal/models/shelf.py:316
+#: journal/models/shelf.py:84 journal/models/shelf.py:124
+#: journal/models/shelf.py:164 journal/models/shelf.py:204
+#: journal/models/shelf.py:244 journal/models/shelf.py:284
+#: journal/models/shelf.py:318
 msgid "review"
 msgstr ""
 
-#: journal/models/shelf.py:83 journal/models/shelf.py:123
-#: journal/models/shelf.py:163 journal/models/shelf.py:203
-#: journal/models/shelf.py:243 journal/models/shelf.py:283
-#: journal/models/shelf.py:317
+#: journal/models/shelf.py:85 journal/models/shelf.py:125
+#: journal/models/shelf.py:165 journal/models/shelf.py:205
+#: journal/models/shelf.py:245 journal/models/shelf.py:285
+#: journal/models/shelf.py:319
 #, python-brace-format
 msgid "wrote a review of {item}"
 msgstr ""
 
-#: journal/models/shelf.py:89
+#: journal/models/shelf.py:91
 msgid "movies to watch"
 msgstr ""
 
-#: journal/models/shelf.py:90 journal/models/shelf.py:130
+#: journal/models/shelf.py:92 journal/models/shelf.py:132
 msgid "want to watch"
 msgstr ""
 
-#: journal/models/shelf.py:91 journal/models/shelf.py:131
+#: journal/models/shelf.py:93 journal/models/shelf.py:133
 #, python-brace-format
 msgid "wants to watch {item}"
 msgstr ""
 
-#: journal/models/shelf.py:92 journal/models/shelf.py:132
+#: journal/models/shelf.py:94 journal/models/shelf.py:134
 msgid "to watch"
 msgstr ""
 
-#: journal/models/shelf.py:97
+#: journal/models/shelf.py:99
 msgid "movies watching"
 msgstr ""
 
-#: journal/models/shelf.py:98 journal/models/shelf.py:138
+#: journal/models/shelf.py:100 journal/models/shelf.py:140
 msgid "start watching"
 msgstr ""
 
-#: journal/models/shelf.py:99 journal/models/shelf.py:139
+#: journal/models/shelf.py:101 journal/models/shelf.py:141
 #, python-brace-format
 msgid "started watching {item}"
 msgstr ""
 
-#: journal/models/shelf.py:100 journal/models/shelf.py:140
+#: journal/models/shelf.py:102 journal/models/shelf.py:142
 msgid "watching"
 msgstr ""
 
-#: journal/models/shelf.py:105
+#: journal/models/shelf.py:107
 msgid "movies watched"
 msgstr ""
 
-#: journal/models/shelf.py:106 journal/models/shelf.py:146
+#: journal/models/shelf.py:108 journal/models/shelf.py:148
 msgid "finish watching"
 msgstr ""
 
-#: journal/models/shelf.py:107 journal/models/shelf.py:147
+#: journal/models/shelf.py:109 journal/models/shelf.py:149
 #, python-brace-format
 msgid "finished watching {item}"
 msgstr ""
 
-#: journal/models/shelf.py:108 journal/models/shelf.py:148
+#: journal/models/shelf.py:110 journal/models/shelf.py:150
 msgid "watched"
 msgstr ""
 
-#: journal/models/shelf.py:113
+#: journal/models/shelf.py:115
 msgid "movies dropped"
 msgstr ""
 
-#: journal/models/shelf.py:114 journal/models/shelf.py:154
+#: journal/models/shelf.py:116 journal/models/shelf.py:156
 msgid "stop watching"
 msgstr ""
 
-#: journal/models/shelf.py:115 journal/models/shelf.py:155
+#: journal/models/shelf.py:117 journal/models/shelf.py:157
 #, python-brace-format
 msgid "stopped watching {item}"
 msgstr ""
 
-#: journal/models/shelf.py:116 journal/models/shelf.py:156
+#: journal/models/shelf.py:118 journal/models/shelf.py:158
 msgid "stopped watching"
 msgstr ""
 
-#: journal/models/shelf.py:121
+#: journal/models/shelf.py:123
 msgid "movies reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:129
+#: journal/models/shelf.py:131
 msgid "TV shows to watch"
 msgstr ""
 
-#: journal/models/shelf.py:137
+#: journal/models/shelf.py:139
 msgid "TV shows watching"
 msgstr ""
 
-#: journal/models/shelf.py:145
+#: journal/models/shelf.py:147
 msgid "TV shows watched"
 msgstr ""
 
-#: journal/models/shelf.py:153
+#: journal/models/shelf.py:155
 msgid "TV shows dropped"
 msgstr ""
 
-#: journal/models/shelf.py:161
+#: journal/models/shelf.py:163
 msgid "TV shows reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:169
+#: journal/models/shelf.py:171
 msgid "albums to listen"
 msgstr ""
 
-#: journal/models/shelf.py:170 journal/models/shelf.py:250
+#: journal/models/shelf.py:172 journal/models/shelf.py:252
 msgid "want to listen"
 msgstr ""
 
-#: journal/models/shelf.py:171 journal/models/shelf.py:251
+#: journal/models/shelf.py:173 journal/models/shelf.py:253
 #, python-brace-format
 msgid "wants to listen {item}"
 msgstr ""
 
-#: journal/models/shelf.py:172 journal/models/shelf.py:252
+#: journal/models/shelf.py:174 journal/models/shelf.py:254
 msgid "to listen"
 msgstr ""
 
-#: journal/models/shelf.py:177
+#: journal/models/shelf.py:179
 msgid "albums listening"
 msgstr ""
 
-#: journal/models/shelf.py:178 journal/models/shelf.py:258
+#: journal/models/shelf.py:180 journal/models/shelf.py:260
 msgid "start listening"
 msgstr ""
 
-#: journal/models/shelf.py:179 journal/models/shelf.py:259
+#: journal/models/shelf.py:181 journal/models/shelf.py:261
 #, python-brace-format
 msgid "started listening {item}"
 msgstr ""
 
-#: journal/models/shelf.py:180 journal/models/shelf.py:260
+#: journal/models/shelf.py:182 journal/models/shelf.py:262
 msgid "listening"
 msgstr ""
 
-#: journal/models/shelf.py:185
+#: journal/models/shelf.py:187
 msgid "albums listened"
 msgstr ""
 
-#: journal/models/shelf.py:186 journal/models/shelf.py:266
+#: journal/models/shelf.py:188 journal/models/shelf.py:268
 msgid "finish listening"
 msgstr ""
 
-#: journal/models/shelf.py:187 journal/models/shelf.py:267
+#: journal/models/shelf.py:189 journal/models/shelf.py:269
 #, python-brace-format
 msgid "finished listening {item}"
 msgstr ""
 
-#: journal/models/shelf.py:188 journal/models/shelf.py:268
+#: journal/models/shelf.py:190 journal/models/shelf.py:270
 msgid "listened"
 msgstr ""
 
-#: journal/models/shelf.py:193
+#: journal/models/shelf.py:195
 msgid "albums dropped"
 msgstr ""
 
-#: journal/models/shelf.py:194 journal/models/shelf.py:274
+#: journal/models/shelf.py:196 journal/models/shelf.py:276
 msgid "stop listening"
 msgstr ""
 
-#: journal/models/shelf.py:195 journal/models/shelf.py:275
+#: journal/models/shelf.py:197 journal/models/shelf.py:277
 #, python-brace-format
 msgid "stopped listening {item}"
 msgstr ""
 
-#: journal/models/shelf.py:196 journal/models/shelf.py:276
+#: journal/models/shelf.py:198 journal/models/shelf.py:278
 msgid "stopped listening"
 msgstr ""
 
-#: journal/models/shelf.py:201
+#: journal/models/shelf.py:203
 msgid "albums reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:209
+#: journal/models/shelf.py:211
 msgid "games to play"
 msgstr ""
 
-#: journal/models/shelf.py:210
+#: journal/models/shelf.py:212
 msgid "want to play"
 msgstr ""
 
-#: journal/models/shelf.py:211
+#: journal/models/shelf.py:213
 #, python-brace-format
 msgid "wants to play {item}"
 msgstr ""
 
-#: journal/models/shelf.py:212
+#: journal/models/shelf.py:214
 msgid "to play"
 msgstr ""
 
-#: journal/models/shelf.py:217
+#: journal/models/shelf.py:219
 msgid "games playing"
 msgstr ""
 
-#: journal/models/shelf.py:218
+#: journal/models/shelf.py:220
 msgid "start playing"
 msgstr ""
 
-#: journal/models/shelf.py:219
+#: journal/models/shelf.py:221
 #, python-brace-format
 msgid "started playing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:220
+#: journal/models/shelf.py:222
 msgid "playing"
 msgstr ""
 
-#: journal/models/shelf.py:225
+#: journal/models/shelf.py:227
 msgid "games played"
 msgstr ""
 
-#: journal/models/shelf.py:226
+#: journal/models/shelf.py:228
 msgid "finish playing"
 msgstr ""
 
-#: journal/models/shelf.py:227
+#: journal/models/shelf.py:229
 #, python-brace-format
 msgid "finished playing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:228
+#: journal/models/shelf.py:230
 msgid "played"
 msgstr ""
 
-#: journal/models/shelf.py:233
+#: journal/models/shelf.py:235
 msgid "games dropped"
 msgstr ""
 
-#: journal/models/shelf.py:234
+#: journal/models/shelf.py:236
 msgid "stop playing"
 msgstr ""
 
-#: journal/models/shelf.py:235
+#: journal/models/shelf.py:237
 #, python-brace-format
 msgid "stopped playing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:236
+#: journal/models/shelf.py:238
 msgid "stopped playing"
 msgstr ""
 
-#: journal/models/shelf.py:241
+#: journal/models/shelf.py:243
 msgid "games reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:249
+#: journal/models/shelf.py:251
 msgid "podcasts to listen"
 msgstr "پادپخش‌هایی برای گوش دادن"
 
-#: journal/models/shelf.py:257
+#: journal/models/shelf.py:259
 msgid "podcasts listening"
 msgstr "گوش دادن به پادپخش‌ها"
 
-#: journal/models/shelf.py:265
+#: journal/models/shelf.py:267
 msgid "podcasts listened"
 msgstr "پادپخش‌های گوش داده شده"
 
-#: journal/models/shelf.py:273
+#: journal/models/shelf.py:275
 msgid "podcasts dropped"
 msgstr "پادپخش‌ها برداشته شدند"
 
-#: journal/models/shelf.py:281
+#: journal/models/shelf.py:283
 msgid "podcasts reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:289
+#: journal/models/shelf.py:291
 msgid "performances to see"
 msgstr ""
 
-#: journal/models/shelf.py:290
+#: journal/models/shelf.py:292
 msgid "want to see"
 msgstr ""
 
-#: journal/models/shelf.py:291
+#: journal/models/shelf.py:293
 #, python-brace-format
 msgid "wants to see {item}"
 msgstr ""
 
-#: journal/models/shelf.py:292
+#: journal/models/shelf.py:294
 msgid "to see"
 msgstr ""
 
-#: journal/models/shelf.py:299
+#: journal/models/shelf.py:301
 msgid "performances saw"
 msgstr ""
 
-#: journal/models/shelf.py:300
+#: journal/models/shelf.py:302
 msgid "finish seeing"
 msgstr ""
 
-#: journal/models/shelf.py:301
+#: journal/models/shelf.py:303
 #, python-brace-format
 msgid "finished seeing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:302
+#: journal/models/shelf.py:304
 msgid "seen"
 msgstr ""
 
-#: journal/models/shelf.py:307
+#: journal/models/shelf.py:309
 msgid "performances dropped"
 msgstr ""
 
-#: journal/models/shelf.py:308
+#: journal/models/shelf.py:310
 msgid "stop seeing"
 msgstr ""
 
-#: journal/models/shelf.py:309
+#: journal/models/shelf.py:311
 #, python-brace-format
 msgid "stopped seeing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:310
+#: journal/models/shelf.py:312
 msgid "stopped seeing"
 msgstr ""
 
-#: journal/models/shelf.py:315
+#: journal/models/shelf.py:317
 msgid "performances reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:323
+#: journal/models/shelf.py:325
 msgid "people following"
 msgstr ""
 
-#: journal/models/shelf.py:325
+#: journal/models/shelf.py:327
 #, python-brace-format
 msgid "started following {item}"
 msgstr ""
 
-#: journal/models/shelf.py:921
+#: journal/models/shelf.py:923
 msgid "removed mark"
 msgstr ""
 
@@ -5860,30 +5870,20 @@ msgstr ""
 msgid "Remove from collection"
 msgstr ""
 
-#: journal/templates/_list_item.html:34
-msgid "add mark"
-msgstr ""
-
-#: journal/templates/_list_item.html:42
-msgid "update mark"
-msgstr ""
-
-#: journal/templates/_list_item.html:60
+#: journal/templates/_list_item.html:43
 #: journal/templates/collection_update_item_note_ok.html:3
 msgid "Update note"
 msgstr ""
 
-#: journal/templates/_list_item.html:100 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:123
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
 msgstr ""
 
-#: journal/templates/_list_item.html:133
+#: journal/templates/_list_item.html:91
 #, python-format
-msgid ""
-"%(dups)s item(s) are from the same work or have the same identifier, click "
-"here to display:"
+msgid "%(dups)s item(s) are from the same work or have the same identifier, click here to display:"
 msgstr ""
 
 #: journal/templates/_sidebar_collection_filter.html:32
@@ -5993,6 +5993,14 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
+#: journal/templates/action_mark_item.html:10
+msgid "add mark"
+msgstr ""
+
+#: journal/templates/action_mark_item.html:18
+msgid "update mark"
+msgstr ""
+
 #: journal/templates/action_open_post.html:7
 msgid "Quiet Public"
 msgstr ""
@@ -6047,11 +6055,11 @@ msgstr ""
 msgid "Create a new collection"
 msgstr ""
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:81
+#: journal/templates/article.html:104 social/templates/_event_post.html:76
 msgid "wrote a review"
 msgstr ""
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:83
+#: journal/templates/article.html:106 social/templates/_event_post.html:78
 msgid "wrote an article"
 msgstr ""
 
@@ -6165,19 +6173,19 @@ msgstr ""
 msgid "Mark"
 msgstr ""
 
-#: journal/templates/mark.html:50
+#: journal/templates/mark.html:54
 msgid "not rated"
 msgstr ""
 
-#: journal/templates/mark.html:70
+#: journal/templates/mark.html:74
 msgid "add a tag and press Enter"
 msgstr ""
 
-#: journal/templates/mark.html:122
+#: journal/templates/mark.html:126
 msgid "change mark date"
 msgstr ""
 
-#: journal/templates/mark.html:148
+#: journal/templates/mark.html:156
 msgid "Sure to delete mark, comment and tags for this item?"
 msgstr ""
 
@@ -6220,12 +6228,11 @@ msgid ""
 "Content Cell  | Content Cell\n"
 "Content Cell  | Content Cell\n"
 "\n"
-"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/"
-"Wikipedia-logo-v2.svg)\n"
+"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 "\n"
 msgstr ""
 
-#: journal/templates/note.html:19 journal/views/note.py:23
+#: journal/templates/note.html:19 journal/views/note.py:22
 msgid "Note"
 msgstr ""
 
@@ -6250,9 +6257,7 @@ msgid "Are you sure to delete this entire content?"
 msgstr ""
 
 #: journal/templates/piece_delete.html:24
-msgid ""
-"By deleting it, you will also lose track of others' comments and feedbacks "
-"to your content."
+msgid "By deleting it, you will also lose track of others' comments and feedbacks to your content."
 msgstr ""
 
 #: journal/templates/piece_delete.html:25
@@ -6332,7 +6337,7 @@ msgstr ""
 msgid "Articles"
 msgstr ""
 
-#: journal/templates/profile.html:166 journal/views/collection.py:427
+#: journal/templates/profile.html:166 journal/views/collection.py:409
 #: journal/views/profile.py:401
 msgid "collection"
 msgstr ""
@@ -6366,9 +6371,7 @@ msgid "Personal"
 msgstr ""
 
 #: journal/templates/tag_edit.html:52
-msgid ""
-"Personal tags are not included in public index. However, if you use this tag "
-"when marking an item publicly, it might still be visible to others."
+msgid "Personal tags are not included in public index. However, if you use this tag when marking an item publicly, it might still be visible to others."
 msgstr ""
 
 #: journal/templates/tag_edit.html:55
@@ -6437,113 +6440,114 @@ msgstr ""
 msgid "Link invalid"
 msgstr ""
 
-#: journal/views/collection.py:58 journal/views/collection.py:96
+#: journal/views/collection.py:62 journal/views/collection.py:94
 #, python-brace-format
 msgid "Collection by {0}"
 msgstr ""
 
-#: journal/views/collection.py:432
+#: journal/views/collection.py:414
 msgid "shared my collection"
 msgstr ""
 
-#: journal/views/collection.py:435
+#: journal/views/collection.py:417
 #, python-brace-format
 msgid "shared {username}'s collection"
 msgstr ""
 
-#: journal/views/collection.py:502 journal/views/collection.py:541
-#: journal/views/collection.py:553 journal/views/collection.py:579
+#: journal/views/collection.py:484 journal/views/collection.py:523
+#: journal/views/collection.py:535 journal/views/collection.py:561
 msgid "Dynamic collection is not editable"
 msgstr ""
 
-#: journal/views/collection.py:518
+#: journal/views/collection.py:500
 msgid "The item is already in the collection."
 msgstr ""
 
-#: journal/views/collection.py:520
+#: journal/views/collection.py:502
 msgid "Unable to find the item, please use item url from this site."
 msgstr ""
 
-#: journal/views/collection.py:566
+#: journal/views/collection.py:548
 msgid "Saved."
 msgstr ""
 
-#: journal/views/common.py:119 journal/views/mark.py:225
-#: journal/views/mark.py:279 journal/views/note.py:175
+#: journal/views/common.py:126 journal/views/mark.py:273
+#: journal/views/mark.py:315 journal/views/note.py:167
 #: journal/views/profile.py:42 journal/views/review.py:59
 #: journal/views/review.py:79
 msgid "Content not found"
 msgstr ""
 
-#: journal/views/common.py:174 journal/views/mark.py:159
+#: journal/views/common.py:184 journal/views/mark.py:210
 msgid "Data saved but unable to crosspost to Fediverse instance."
 msgstr ""
 
-#: journal/views/common.py:176
+#: journal/views/common.py:186
 msgid "Redirecting to your Fediverse instance now to re-authenticate."
 msgstr ""
 
-#: journal/views/common.py:183
+#: journal/views/common.py:193
 msgid "List not found."
 msgstr ""
 
-#: journal/views/mark.py:150
+#: journal/views/mark.py:206
 msgid "Content too long for your Fediverse instance."
 msgstr ""
 
-#: journal/views/mark.py:178 journal/views/mark.py:238
+#: journal/views/mark.py:224 journal/views/mark.py:226
+#: journal/views/mark.py:280
 msgid "Invalid input"
 msgstr ""
 
-#: journal/views/note.py:23
+#: journal/views/note.py:22
 msgid "Progress"
 msgstr ""
 
-#: journal/views/note.py:28
+#: journal/views/note.py:27
 msgid "Update progress"
 msgstr ""
 
-#: journal/views/note.py:59
+#: journal/views/note.py:58
 msgid "Progress (optional)"
 msgstr ""
 
-#: journal/views/note.py:61
+#: journal/views/note.py:60
 msgid "Note Content"
 msgstr ""
 
-#: journal/views/note.py:63
+#: journal/views/note.py:62
 msgid "Content Warning (optional)"
 msgstr ""
 
-#: journal/views/note.py:85
+#: journal/views/note.py:84
 msgid "Progress Type (optional)"
 msgstr ""
 
-#: journal/views/note.py:123 journal/views/note.py:183
+#: journal/views/note.py:115 journal/views/note.py:175
 msgid "Only in-progress items can have progress."
 msgstr ""
 
-#: journal/views/post.py:98 journal/views/post.py:392
+#: journal/views/post.py:100 journal/views/post.py:388
 msgid "Post not found"
 msgstr ""
 
-#: journal/views/post.py:189
+#: journal/views/post.py:191
 msgid "Visibility too high for quoting this post"
 msgstr ""
 
-#: journal/views/post.py:337 journal/views/post.py:418
+#: journal/views/post.py:339 journal/views/post.py:414
 msgid "Content cannot be empty."
 msgstr ""
 
-#: journal/views/post.py:396
+#: journal/views/post.py:392
 msgid "This post cannot be edited here"
 msgstr ""
 
-#: journal/views/post.py:541
+#: journal/views/post.py:531
 msgid "Invalid choices"
 msgstr ""
 
-#: journal/views/post.py:544
+#: journal/views/post.py:534
 msgid "Invalid post"
 msgstr ""
 
@@ -6561,56 +6565,54 @@ msgstr ""
 msgid "may contain spoiler or triggering content"
 msgstr ""
 
-#: journal/views/tag.py:47 journal/views/tag.py:61
+#: journal/views/tag.py:46 journal/views/tag.py:60
 msgid "Invalid tag"
 msgstr ""
 
-#: journal/views/tag.py:50
+#: journal/views/tag.py:49
 msgid "Tag not found"
 msgstr ""
 
-#: journal/views/tag.py:72
+#: journal/views/tag.py:65
 msgid "Tag deleted."
 msgstr ""
 
-#: journal/views/tag.py:82
+#: journal/views/tag.py:75
 msgid "Duplicated tag."
 msgstr ""
 
-#: journal/views/tag.py:96
+#: journal/views/tag.py:83
 msgid "Tag updated."
 msgstr ""
 
-#: journal/views/wrapped.py:160
+#: journal/views/wrapped.py:161
 msgid "Summary posted to timeline."
 msgstr ""
 
-#: mastodon/models/common.py:29
+#: mastodon/models/common.py:31
 msgid "Mastodon"
 msgstr ""
 
-#: mastodon/models/common.py:30 users/templates/users/login.html:120
+#: mastodon/models/common.py:32 users/templates/users/login.html:114
 msgid "Threads"
 msgstr ""
 
-#: mastodon/models/common.py:31
+#: mastodon/models/common.py:33
 msgid "Bluesky"
 msgstr ""
 
-#: mastodon/models/email.py:59
+#: mastodon/models/email.py:63
 msgid ""
 "\n"
 "\n"
-"If you did not mean to register or login, please ignore this email. If you "
-"are concerned with your account security, please change the email linked "
-"with your account, or contact us."
+"If you did not mean to register or login, please ignore this email. If you are concerned with your account security, please change the email linked with your account, or contact us."
 msgstr ""
 
-#: mastodon/models/email.py:64 mastodon/models/email.py:69
+#: mastodon/models/email.py:68 mastodon/models/email.py:73
 msgid "Verification Code"
 msgstr ""
 
-#: mastodon/models/email.py:66
+#: mastodon/models/email.py:70
 #, python-brace-format
 msgid ""
 "Use this code to verify your email address {email}\n"
@@ -6618,7 +6620,7 @@ msgid ""
 "{code}"
 msgstr ""
 
-#: mastodon/models/email.py:70
+#: mastodon/models/email.py:74
 #, python-brace-format
 msgid ""
 "Use this code to login as {email}\n"
@@ -6626,23 +6628,21 @@ msgid ""
 "{code}"
 msgstr ""
 
-#: mastodon/models/email.py:74 users/templates/users/captcha.html:13
+#: mastodon/models/email.py:78 users/templates/users/captcha.html:13
 #: users/templates/users/captcha_solved.html:9
 #: users/templates/users/login.html:20 users/templates/users/register.html:9
 #: users/templates/users/welcome.html:10
 msgid "Register"
 msgstr ""
 
-#: mastodon/models/email.py:76
+#: mastodon/models/email.py:80
 #, python-brace-format
 msgid ""
 "There is no account registered with this email address yet: {email}\n"
 "\n"
-"If you already have an account with us, just login and add this email to you "
-"account.\n"
+"If you already have an account with us, just login and add this email to you account.\n"
 "\n"
-"If you prefer to register a new account with this email, please use this "
-"verification code: {code}"
+"If you prefer to register a new account with this email, please use this verification code: {code}"
 msgstr ""
 
 #: mastodon/models/mastodon.py:570
@@ -6685,44 +6685,49 @@ msgstr ""
 msgid "New Post"
 msgstr ""
 
-#: mastodon/views/bluesky.py:26 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:32 mastodon/views/bluesky.py:93
 msgid "Bluesky login is disabled."
 msgstr ""
 
-#: mastodon/views/bluesky.py:28 mastodon/views/email.py:35
-#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:29
-#: users/templates/users/login.html:6 users/views/webauthn.py:133
-msgid "Security check failed. Please try again."
-msgstr ""
-
-#: mastodon/views/bluesky.py:34 mastodon/views/bluesky.py:40
-#: mastodon/views/bluesky.py:64 mastodon/views/bluesky.py:72
-#: mastodon/views/bluesky.py:78 mastodon/views/common.py:36
-#: mastodon/views/mastodon.py:62 mastodon/views/mastodon.py:70
-#: mastodon/views/mastodon.py:77 mastodon/views/mastodon.py:87
-#: mastodon/views/mastodon.py:94 mastodon/views/threads.py:55
-#: mastodon/views/threads.py:63 mastodon/views/threads.py:69
-#: users/views/account.py:254 users/views/account.py:373
+#: mastodon/views/bluesky.py:47 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:65 mastodon/views/bluesky.py:98
+#: mastodon/views/bluesky.py:106 mastodon/views/bluesky.py:112
+#: mastodon/views/common.py:36 mastodon/views/mastodon.py:62
+#: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
+#: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
+#: mastodon/views/threads.py:57 mastodon/views/threads.py:65
+#: mastodon/views/threads.py:71 users/views/account.py:256
+#: users/views/account.py:375
 msgid "Authentication failed"
 msgstr ""
 
-#: mastodon/views/bluesky.py:35 mastodon/views/email.py:66
+#: mastodon/views/bluesky.py:47 mastodon/views/common.py:103
+msgid "Identity not found."
+msgstr ""
+
+#: mastodon/views/bluesky.py:53 mastodon/views/email.py:35
+#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:31
+#: users/templates/users/login.html:6 users/views/webauthn.py:136
+msgid "Security check failed. Please try again."
+msgstr ""
+
+#: mastodon/views/bluesky.py:60 mastodon/views/email.py:66
 msgid "Too many attempts, please try again later."
 msgstr ""
 
-#: mastodon/views/bluesky.py:40
+#: mastodon/views/bluesky.py:65
 msgid "ATProto handle is required."
 msgstr ""
 
-#: mastodon/views/bluesky.py:50
+#: mastodon/views/bluesky.py:84
 msgid "Error connecting to your ATProto server"
 msgstr ""
 
-#: mastodon/views/bluesky.py:73
+#: mastodon/views/bluesky.py:107
 msgid "Invalid response from ATProto authorization server."
 msgstr ""
 
-#: mastodon/views/bluesky.py:78
+#: mastodon/views/bluesky.py:112
 msgid "Invalid account data from Bluesky."
 msgstr ""
 
@@ -6730,7 +6735,7 @@ msgstr ""
 msgid "Invalid user."
 msgstr ""
 
-#: mastodon/views/common.py:52 users/views/account.py:414
+#: mastodon/views/common.py:52 users/views/account.py:416
 msgid "Registration failed"
 msgstr ""
 
@@ -6760,10 +6765,6 @@ msgstr ""
 #: mastodon/views/common.py:103 mastodon/views/common.py:107
 #: mastodon/views/common.py:116
 msgid "Disconnect identity failed"
-msgstr ""
-
-#: mastodon/views/common.py:103
-msgid "Identity not found."
 msgstr ""
 
 #: mastodon/views/common.py:117
@@ -6807,7 +6808,7 @@ msgstr ""
 msgid "Invalid response from Fediverse instance."
 msgstr ""
 
-#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:64
+#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:66
 msgid "Invalid OAuth state. Please try again."
 msgstr ""
 
@@ -6827,19 +6828,17 @@ msgstr ""
 msgid "Invalid account data from Fediverse instance."
 msgstr ""
 
-#: mastodon/views/threads.py:69
+#: mastodon/views/threads.py:71
 msgid "Invalid account data from Threads."
 msgstr ""
 
-#: mastodon/views/threads.py:147
+#: mastodon/views/threads.py:149
 msgid "Data deletion completed"
 msgstr ""
 
-#: mastodon/views/threads.py:149
+#: mastodon/views/threads.py:151
 #, python-brace-format
-msgid ""
-"Data linked to your Threads account has been deleted. Confirmation code: "
-"{code}"
+msgid "Data linked to your Threads account has been deleted. Confirmation code: {code}"
 msgstr ""
 
 #: social/templates/_article_teaser.html:10
@@ -6872,15 +6871,11 @@ msgstr ""
 msgid "play"
 msgstr ""
 
-#: social/templates/_event_post.html:50
-msgid "mark"
-msgstr ""
-
-#: social/templates/_event_post.html:79
+#: social/templates/_event_post.html:74
 msgid "wrote a note"
 msgstr ""
 
-#: social/templates/_event_post.html:88
+#: social/templates/_event_post.html:83
 msgid "replying to"
 msgstr ""
 
@@ -6893,7 +6888,7 @@ msgstr ""
 msgid "Untitled article"
 msgstr ""
 
-#: social/templates/event/boosted.html:3
+#: social/templates/event/boosted.html:2
 msgid "boosted your post"
 msgstr ""
 
@@ -6936,8 +6931,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
 #: social/templates/event/boosted_shelfmember.html:3
@@ -6955,7 +6949,7 @@ msgstr ""
 msgid "followed you"
 msgstr ""
 
-#: social/templates/event/liked.html:3
+#: social/templates/event/liked.html:2
 msgid "liked your post"
 msgstr ""
 
@@ -6998,8 +6992,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
 #: social/templates/event/liked_shelfmember.html:3
@@ -7009,7 +7002,7 @@ msgid ""
 "liked your mark on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
-#: social/templates/event/mentioned.html:3
+#: social/templates/event/mentioned.html:2
 msgid "mentioned you"
 msgstr ""
 
@@ -7052,8 +7045,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
 #: social/templates/event/mentioned_shelfmember.html:3
@@ -7063,26 +7055,39 @@ msgid ""
 "replied to your mark on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
-#: social/templates/feed.html:12 social/templates/feed.html:39
-#: social/templates/search_feed.html:12
-msgid "Activities from those you follow"
+#: social/templates/feed.html:39 users/templates/users/preferences.html:40
+msgid "Activities"
 msgstr ""
 
-#: social/templates/feed.html:42 social/templates/feed.html:44
+#: social/templates/feed.html:43 social/templates/feed.html:45
+msgid "world"
+msgstr ""
+
+#: social/templates/feed.html:51 social/templates/feed.html:53
+#, fuzzy
+#| msgid "locale"
+msgid "local"
+msgstr "محلی"
+
+#: social/templates/feed.html:58 social/templates/feed.html:60
+msgid "those you follow"
+msgstr ""
+
+#: social/templates/feed.html:64 social/templates/feed.html:66
 msgid "what they read/watch/..."
 msgstr ""
 
-#: social/templates/feed_events.html:30
+#: social/templates/feed_events.html:29
 msgid "no matching activities."
 msgstr ""
 
-#: social/templates/feed_events.html:33
+#: social/templates/feed_events.html:31
+msgid "no public activities yet."
+msgstr ""
+
+#: social/templates/feed_events.html:34
 #, python-format
-msgid ""
-"Find and mark some books/movies/podcasts/games, <a "
-"href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/"
-"Douban, follow some fellow %(site_name)s users on the fediverse, so their "
-"recent activities and yours will show up here."
+msgid "Find and mark some books/movies/podcasts/games, <a href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/Douban, follow some fellow %(site_name)s users on the fediverse, so their recent activities and yours will show up here."
 msgstr ""
 
 #: social/templates/notification.html:58
@@ -7117,6 +7122,10 @@ msgstr ""
 msgid "Poll ending at %(end_time)s"
 msgstr ""
 
+#: social/templates/search_feed.html:12 social/views.py:57 social/views.py:58
+msgid "Activities from those you follow"
+msgstr ""
+
 #: social/templates/single_post.html:13 social/templates/single_post.html:32
 msgid "Post"
 msgstr ""
@@ -7129,57 +7138,63 @@ msgstr ""
 msgid "Poll"
 msgstr ""
 
-#: takahe/models.py:453
+#: social/views.py:59
+msgid "Activities on this site"
+msgstr ""
+
+#: social/views.py:60
+msgid "Activities from the fediverse"
+msgstr ""
+
+#: takahe/models.py:445
 msgid "Display Name"
 msgstr ""
 
-#: takahe/models.py:455
+#: takahe/models.py:447
 msgid "Bio"
 msgstr ""
 
-#: takahe/models.py:457
+#: takahe/models.py:449
 msgid "Manually approve new followers"
 msgstr ""
 
-#: takahe/models.py:461
+#: takahe/models.py:453
 msgid "Include profile, marks and posts in discovery"
 msgstr ""
 
-#: takahe/models.py:464
+#: takahe/models.py:456
 msgid "Include posts in search results"
 msgstr ""
 
-#: takahe/models.py:482
+#: takahe/models.py:474
 msgid "Profile picture"
 msgstr ""
 
-#: takahe/models.py:489
+#: takahe/models.py:481
 msgid "Header picture"
 msgstr ""
 
-#: users/models/task.py:22
+#: users/models/task.py:24
 msgid "Started"
 msgstr ""
 
-#: users/models/task.py:23
+#: users/models/task.py:25
 msgid "Complete"
 msgstr ""
 
-#: users/models/user.py:69
-msgid ""
-"Enter a valid username. This value may contain only unaccented lowercase a-z "
-"and uppercase A-Z letters, numbers, and _ characters."
+#: users/models/user.py:71
+msgid "Enter a valid username. This value may contain only unaccented lowercase a-z and uppercase A-Z letters, numbers, and _ characters."
 msgstr ""
 
-#: users/models/user.py:130
+#: users/models/user.py:132
 msgid "username"
 msgstr ""
 
-#: users/models/user.py:135
+#: users/models/user.py:137
 msgid "Required. 50 characters or fewer. Letters, digits and _ only."
 msgstr ""
 
-#: users/models/user.py:138
+#: users/models/user.py:140
 msgid "A user with that username already exists."
 msgstr ""
 
@@ -7316,9 +7331,7 @@ msgid "Cancel import"
 msgstr ""
 
 #: users/templates/users/_rym_section.html:29
-msgid ""
-"On RateYourMusic, go to your profile and use the <b>Export your music "
-"catalog</b> option to download your library as a CSV file."
+msgid "On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:31
@@ -7327,18 +7340,12 @@ msgid "Upload the downloaded CSV file below."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:33
-msgid ""
-"Albums are matched by title + artist (and year if present) — first against "
-"the local catalog, then MusicBrainz, then Spotify. After auto-matching, "
-"you'll preview the matches in a table, edit any link or shelf status, and "
-"confirm the import."
+msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:36
 #: users/templates/users/_storygraph_section.html:38
-msgid ""
-"You can also re-upload a previously-downloaded matched CSV — the existing "
-"<code>link</code> column will be honoured as the default match."
+msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:40
@@ -7365,18 +7372,11 @@ msgid "Cancel the StoryGraph import? Progress will be discarded."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:31
-msgid ""
-"On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to "
-"download your library as a CSV file."
+msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:35
-msgid ""
-"Books are matched by ISBN — first against the local catalog, then Google "
-"Books and OpenLibrary — with a title + author search as fallback. After auto-"
-"matching, you'll preview the matches in a table, edit any link or shelf "
-"status, and confirm the import."
+msgid "Books are matched by ISBN — first against the local catalog, then Google Books and OpenLibrary — with a title + author search as fallback. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/account.html:11
@@ -7388,9 +7388,7 @@ msgid "Display name, avatar and other information"
 msgstr ""
 
 #: users/templates/users/account.html:23
-msgid ""
-"Updating profile information here will turn off automatic sync of display "
-"name, bio and avatar from your Mastodon instance. Sure to continue?"
+msgid "Updating profile information here will turn off automatic sync of display name, bio and avatar from your Mastodon instance. Sure to continue?"
 msgstr ""
 
 #: users/templates/users/account.html:26
@@ -7403,16 +7401,11 @@ msgstr ""
 
 #: users/templates/users/account.html:59 users/templates/users/register.html:47
 #, python-format
-msgid ""
-"Please click the confirmation link in the email sent to %(pending_email)s; "
-"if you haven't received it for more than a few minutes, please input and "
-"save again."
+msgid "Please click the confirmation link in the email sent to %(pending_email)s; if you haven't received it for more than a few minutes, please input and save again."
 msgstr ""
 
 #: users/templates/users/account.html:61 users/templates/users/register.html:50
-msgid ""
-"Email is recommended as a backup login method, if you log in via a Fediverse "
-"instance"
+msgid "Email is recommended as a backup login method, if you log in via a Fediverse instance"
 msgstr ""
 
 #: users/templates/users/account.html:73 users/templates/users/login.html:84
@@ -7430,22 +7423,15 @@ msgid "Last updated"
 msgstr ""
 
 #: users/templates/users/account.html:92
-msgid ""
-"If you have not yet registered with any Federated instance, you may <a "
-"href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an "
-"instance</a> and register."
+msgid "If you have not yet registered with any Federated instance, you may <a href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an instance</a> and register."
 msgstr ""
 
 #: users/templates/users/account.html:97
-msgid ""
-"To associate with another federated identity, please enter the domain name "
-"of the instance where the new identity is located."
+msgid "To associate with another federated identity, please enter the domain name of the instance where the new identity is located."
 msgstr ""
 
 #: users/templates/users/account.html:99
-msgid ""
-"If you have registered with a Federated instance, please enter the instance "
-"domain name."
+msgid "If you have registered with a Federated instance, please enter the instance domain name."
 msgstr ""
 
 #: users/templates/users/account.html:104
@@ -7457,24 +7443,17 @@ msgid "Go to target instance and authorize with the identity"
 msgstr ""
 
 #: users/templates/users/account.html:113
-msgid ""
-"After replacing the association, you may use the new Fediverse identity to "
-"log in and control data visibility. Existing data such as tags, comments, "
-"and collections will not be affected."
+msgid "After replacing the association, you may use the new Fediverse identity to log in and control data visibility. Existing data such as tags, comments, and collections will not be affected."
 msgstr ""
 
 #: users/templates/users/account.html:115
-msgid ""
-"Once associated with Fediverse identity, you can discover more users and use "
-"the full features of this site."
+msgid "Once associated with Fediverse identity, you can discover more users and use the full features of this site."
 msgstr ""
 
 #: users/templates/users/account.html:123
 #: users/templates/users/account.html:160
 #: users/templates/users/account.html:206
-msgid ""
-"Once disconnected, you will no longer be able login with this identity. Are "
-"you sure to continue?"
+msgid "Once disconnected, you will no longer be able login with this identity. Are you sure to continue?"
 msgstr ""
 
 #: users/templates/users/account.html:126
@@ -7501,7 +7480,7 @@ msgstr ""
 msgid "Disconnect with Threads"
 msgstr ""
 
-#: users/templates/users/account.html:173 users/templates/users/login.html:112
+#: users/templates/users/account.html:173 users/templates/users/login.html:106
 msgid "Bluesky (ATProto)"
 msgstr ""
 
@@ -7509,7 +7488,7 @@ msgstr ""
 msgid "Verified ATProto identity"
 msgstr ""
 
-#: users/templates/users/account.html:194 users/templates/users/login.html:216
+#: users/templates/users/account.html:194 users/templates/users/login.html:210
 msgid "ATProto handle"
 msgstr ""
 
@@ -7534,7 +7513,7 @@ msgid "Name this passkey:"
 msgstr ""
 
 #: users/templates/users/account.html:227 users/templates/users/login.html:69
-#: users/templates/users/welcome.html:33 users/views/webauthn.py:106
+#: users/templates/users/welcome.html:33 users/views/webauthn.py:109
 msgid "Passkey"
 msgstr ""
 
@@ -7579,9 +7558,7 @@ msgid "Save sync settings"
 msgstr ""
 
 #: users/templates/users/account.html:297
-msgid ""
-"New follow, mute and blocks in the associated identity may be automatically "
-"imported; removal has to be done manually."
+msgid "New follow, mute and blocks in the associated identity may be automatically imported; removal has to be done manually."
 msgstr ""
 
 #: users/templates/users/account.html:304
@@ -7618,15 +7595,11 @@ msgid "Log out everywhere"
 msgstr ""
 
 #: users/templates/users/account.html:365
-msgid ""
-"This will log you out of all browsers and devices (including the current "
-"one), and revoke all API tokens. Continue?"
+msgid "This will log you out of all browsers and devices (including the current one), and revoke all API tokens. Continue?"
 msgstr ""
 
 #: users/templates/users/account.html:368
-msgid ""
-"If you notice any suspicious activity or have logged in on a shared "
-"computer, you can log out of all sessions and revoke all API tokens."
+msgid "If you notice any suspicious activity or have logged in on a shared computer, you can log out of all sessions and revoke all API tokens."
 msgstr ""
 
 #: users/templates/users/account.html:378
@@ -7689,10 +7662,10 @@ msgstr ""
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:74
-#: users/templates/users/data.html:126 users/templates/users/data.html:183
-#: users/templates/users/data.html:234 users/templates/users/data.html:298
-#: users/templates/users/data.html:358 users/templates/users/data.html:553
+#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/data.html:141 users/templates/users/data.html:198
+#: users/templates/users/data.html:249 users/templates/users/data.html:313
+#: users/templates/users/data.html:376 users/templates/users/data.html:553
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr ""
@@ -7719,9 +7692,7 @@ msgid "Migrate Account"
 msgstr ""
 
 #: users/templates/users/account.html:488
-msgid ""
-"Linking an email to your account is highly recommended before migrating from "
-"another Fediverse instance."
+msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
 msgstr ""
 
 #: users/templates/users/account.html:491
@@ -7741,9 +7712,7 @@ msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
 msgstr ""
 
 #: users/templates/users/account.html:507
-msgid ""
-"Enter full <code>username@instance.social</code> or <code>email@domain.com</"
-"code> to confirm deletion."
+msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
 msgstr ""
 
 #: users/templates/users/account.html:517
@@ -7795,9 +7764,7 @@ msgid "Token Created"
 msgstr ""
 
 #: users/templates/users/authorized_app_created.html:22
-msgid ""
-"Your new personal access token has been created. Copy it now -- you will not "
-"be able to see it again."
+msgid "Your new personal access token has been created. Copy it now -- you will not be able to see it again."
 msgstr ""
 
 #: users/templates/users/authorized_app_created.html:25
@@ -7825,9 +7792,7 @@ msgid "One quick check"
 msgstr ""
 
 #: users/templates/users/captcha.html:28
-msgid ""
-"Put every cover into the row it belongs to. Drag it, or select a cover and "
-"then select a row."
+msgid "Put every cover into the row it belongs to. Drag it, or select a cover and then select a row."
 msgstr ""
 
 #: users/templates/users/captcha.html:41 users/templates/users/captcha.html:43
@@ -7860,7 +7825,7 @@ msgstr ""
 msgid "That is all we needed. Let's get you a username."
 msgstr ""
 
-#: users/templates/users/captcha_solved.html:34
+#: users/templates/users/captcha_solved.html:32
 #: users/templates/users/login.html:63
 #: users/templates/users/verify_email.html:25
 #: users/templates/users/welcome.html:51
@@ -7880,10 +7845,7 @@ msgid "Failed Crossposts"
 msgstr ""
 
 #: users/templates/users/crossposts.html:42
-msgid ""
-"These posts could not be crossposted to your linked social accounts. Re-"
-"authorize the account if needed, then retry. In rare cases retrying may "
-"create a duplicate post."
+msgid "These posts could not be crossposted to your linked social accounts. Re-authorize the account if needed, then retry. In rare cases retrying may create a duplicate post."
 msgstr ""
 
 #: users/templates/users/crossposts.html:48
@@ -7904,210 +7866,163 @@ msgstr ""
 msgid "Data Management"
 msgstr ""
 
-#: users/templates/users/data.html:27
+#: users/templates/users/data.html:39
 msgid "Import Marks and Reviews from Douban"
 msgstr ""
 
-#: users/templates/users/data.html:31
-msgid ""
-"Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
-"target=\"_blank\" rel=\"noopener\">Doufen</a>"
+#: users/templates/users/data.html:43
+msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr ""
 
 #: users/templates/users/data.html:45
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
-"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
-"NeoDB Archive</a> below."
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON format instead; upload it under <a href=\"#import-neodb-archive\">Import NeoDB Archive</a> below."
 msgstr ""
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:256
+#: users/templates/users/data.html:49 users/templates/users/data.html:271
 msgid "Import Method"
 msgstr ""
 
-#: users/templates/users/data.html:37
-msgid ""
-"Merge: only update when status changes from wishlist to in-progress, or from "
-"in-progress to complete."
+#: users/templates/users/data.html:52
+msgid "Merge: only update when status changes from wishlist to in-progress, or from in-progress to complete."
 msgstr ""
 
-#: users/templates/users/data.html:41
+#: users/templates/users/data.html:56
 msgid "Overwrite: update all imported status."
 msgstr ""
 
-#: users/templates/users/data.html:74
-msgid ""
-"Another import is in progress, starting a new import may cause issues, sure "
-"to import?"
+#: users/templates/users/data.html:89
+msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
 msgstr ""
 
-#: users/templates/users/data.html:74
+#: users/templates/users/data.html:89 users/views/data.py:1130
 msgid "Import in progress, please wait"
 msgstr ""
 
-#: users/templates/users/data.html:81
+#: users/templates/users/data.html:96
 #, fuzzy
 #| msgid "Goodreads"
 msgid "Import from Goodreads"
 msgstr "گودریدز"
 
-#: users/templates/users/data.html:87
-msgid ""
-"On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download "
-"your library as a CSV file."
+#: users/templates/users/data.html:102
+msgid "On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download your library as a CSV file."
 msgstr ""
 
-#: users/templates/users/data.html:90
-msgid ""
-"Upload the downloaded <code>goodreads_library_export.csv</code> file below."
+#: users/templates/users/data.html:105
+msgid "Upload the downloaded <code>goodreads_library_export.csv</code> file below."
 msgstr ""
 
-#: users/templates/users/data.html:93
-msgid ""
-"want-to-read / currently-reading / read / did-not-finish books and their "
-"reviews will be imported."
-msgstr ""
-
-#: users/templates/users/data.html:134
-msgid "Import from Letterboxd"
-msgstr ""
-
-#: users/templates/users/data.html:140
-msgid ""
-"on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" "
-"target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap "
-"Advanced Settings in Settings, tap EXPORT YOUR DATA"
-msgstr ""
-
-#: users/templates/users/data.html:143
-msgid ""
-"download file with name like <code>letterboxd-username-2018-03-11-07-52-"
-"utc.zip</code>, do not unzip"
-msgstr ""
-
-#: users/templates/users/data.html:146
-msgid ""
-"the following files in the zip file will be processed: <code>reviews.csv</"
-"code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</"
-"code> <code>lists/*.csv</code>"
+#: users/templates/users/data.html:108
+msgid "want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported."
 msgstr ""
 
 #: users/templates/users/data.html:149
-msgid ""
-"exported file does not indicate whether a list is private, unlisted or "
-"public, so all imported marks, reviews and collections will be created with "
-"the visibility selected below"
+msgid "Import from Letterboxd"
 msgstr ""
 
-#: users/templates/users/data.html:184 users/templates/users/data.html:235
+#: users/templates/users/data.html:155
+msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
+msgstr ""
+
+#: users/templates/users/data.html:158
+msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
+msgstr ""
+
+#: users/templates/users/data.html:161
+msgid "the following files in the zip file will be processed: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
+msgstr ""
+
+#: users/templates/users/data.html:164
+msgid "exported file does not indicate whether a list is private, unlisted or public, so all imported marks, reviews and collections will be created with the visibility selected below"
+msgstr ""
+
+#: users/templates/users/data.html:199 users/templates/users/data.html:250
 msgid "Only forward changes(none->to-watch->watched) will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:191
+#: users/templates/users/data.html:206
 msgid "Import from Trakt"
 msgstr ""
 
-#: users/templates/users/data.html:197
-msgid ""
-"On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" "
-"rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait "
-"for the download link to appear."
+#: users/templates/users/data.html:212
+msgid "On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait for the download link to appear."
 msgstr ""
 
-#: users/templates/users/data.html:200
+#: users/templates/users/data.html:215
 msgid "Upload the downloaded <code>.zip</code> file below, do not unzip."
 msgstr ""
 
-#: users/templates/users/data.html:202
+#: users/templates/users/data.html:217
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:243
+#: users/templates/users/data.html:258
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr ""
 
-#: users/templates/users/data.html:246
+#: users/templates/users/data.html:261
 msgid "Login with Steam"
 msgstr ""
 
-#: users/templates/users/data.html:252
+#: users/templates/users/data.html:267
 msgid "Import Podcast Subscriptions"
 msgstr "وارد کردن اشتراک‌های پادپخش"
 
-#: users/templates/users/data.html:263
+#: users/templates/users/data.html:278
 msgid "Mark as listening"
 msgstr ""
 
-#: users/templates/users/data.html:267
+#: users/templates/users/data.html:282
 msgid "Import as a new collection"
 msgstr ""
 
-#: users/templates/users/data.html:296
+#: users/templates/users/data.html:311
 msgid "Select OPML file"
 msgstr ""
 
-#: users/templates/users/data.html:306
+#: users/templates/users/data.html:321
 msgid "Import NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:312
-msgid ""
-"Upload a <code>.zip</code> file containing <code>.csv</code> or "
-"<code>.ndjson</code> files exported from NeoDB."
+#: users/templates/users/data.html:327
+msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr ""
 
 #: users/templates/users/data.html:330
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
-"imported here."
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is imported here."
 msgstr ""
 
-#: users/templates/users/data.html:314
+#: users/templates/users/data.html:332
 msgid "Existing data may be overwritten."
 msgstr ""
 
-#: users/templates/users/data.html:324
+#: users/templates/users/data.html:342
 msgid "Detected format"
 msgstr ""
 
-#: users/templates/users/data.html:385
+#: users/templates/users/data.html:403
 msgid "Detecting format..."
 msgstr ""
 
-#: users/templates/users/data.html:411
+#: users/templates/users/data.html:429
 msgid "Unknown format"
 msgstr ""
 
-#: users/templates/users/data.html:436
+#: users/templates/users/data.html:454
 msgid "Error detecting format"
 msgstr ""
 
-#: users/templates/users/data.html:460
+#: users/templates/users/data.html:478
 msgid "Export NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:464
+#: users/templates/users/data.html:482
 msgid "Export marks, reviews and notes in CSV"
 msgstr ""
 
-#: users/templates/users/data.html:471
+#: users/templates/users/data.html:489
 msgid "Export everything in NDJSON"
-msgstr ""
-
-#: users/templates/users/data.html:479
-msgid "Export marks and reviews in XLSX (Doufen format)"
-msgstr ""
-
-#: users/templates/users/data.html:482
-msgid "Last export"
-msgstr ""
-
-#: users/templates/users/data.html:487
-msgid "Download"
 msgstr ""
 
 #: users/templates/users/data.html:496
@@ -8115,22 +8030,15 @@ msgid "Import and Export Articles (WordPress)"
 msgstr ""
 
 #: users/templates/users/data.html:499
-msgid ""
-"Your articles are exchanged as WordPress posts in the WXR format, which "
-"WordPress and most blogging tools can read and write. Marks, reviews and "
-"notes are not included: use the NeoDB archive above for those."
+msgid "Your articles are exchanged as WordPress posts in the WXR format, which WordPress and most blogging tools can read and write. Marks, reviews and notes are not included: use the NeoDB archive above for those."
 msgstr ""
 
 #: users/templates/users/data.html:502
-msgid ""
-"Article title, body, excerpt, tags, dates and featured image are exchanged. "
-"Comments and custom fields are ignored."
+msgid "Article title, body, excerpt, tags, dates and featured image are exchanged. Comments and custom fields are ignored."
 msgstr ""
 
 #: users/templates/users/data.html:505
-msgid ""
-"The body is converted between Markdown and HTML, so formatting is kept but "
-"the text is not character-for-character identical."
+msgid "The body is converted between Markdown and HTML, so formatting is kept but the text is not character-for-character identical."
 msgstr ""
 
 #: users/templates/users/data.html:512
@@ -8138,16 +8046,11 @@ msgid "Export articles in WordPress format"
 msgstr ""
 
 #: users/templates/users/data.html:519
-msgid ""
-"In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download "
-"an <code>.xml</code> file, then upload it below."
+msgid "In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download an <code>.xml</code> file, then upload it below."
 msgstr ""
 
 #: users/templates/users/data.html:522
-msgid ""
-"Only published posts use the visibility below. Drafts, pending, private and "
-"password-protected posts are always imported as mentioned-only, so nothing "
-"unpublished becomes public."
+msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
 #: users/templates/users/data.html:560
@@ -8155,9 +8058,7 @@ msgid "View Annual Summary"
 msgstr ""
 
 #: users/templates/users/fetch_identity_failed.html:4
-msgid ""
-"Unable to find the user, please check your spelling; or the server may be "
-"busy, please try again later."
+msgid "Unable to find the user, please check your spelling; or the server may be busy, please try again later."
 msgstr ""
 
 #: users/templates/users/fetch_identity_pending.html:13
@@ -8177,94 +8078,76 @@ msgstr ""
 msgid "logo"
 msgstr ""
 
-#: users/templates/users/login.html:127
-msgid ""
-"Sign in with a passkey saved on this device or in your password manager."
+#: users/templates/users/login.html:121
+msgid "Sign in with a passkey saved on this device or in your password manager."
 msgstr ""
 
-#: users/templates/users/login.html:132
+#: users/templates/users/login.html:126
 msgid "Sign in with Passkey"
 msgstr ""
 
-#: users/templates/users/login.html:148
+#: users/templates/users/login.html:142
 msgid "Enter your email address"
 msgstr ""
 
-#: users/templates/users/login.html:152
+#: users/templates/users/login.html:146
 msgid "Send verification code"
 msgstr ""
 
-#: users/templates/users/login.html:171
+#: users/templates/users/login.html:165
 msgid "Domain of your instance, e.g. mastodon.social"
 msgstr ""
 
-#: users/templates/users/login.html:177
-msgid ""
-"Please enter domain of your instance; e.g. if your id is "
-"<i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
+#: users/templates/users/login.html:171
+msgid "Please enter domain of your instance; e.g. if your id is <i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
 msgstr ""
 
-#: users/templates/users/login.html:182 users/templates/users/login.html:246
+#: users/templates/users/login.html:176 users/templates/users/login.html:240
 msgid "Authorize via Fediverse instance"
 msgstr ""
 
-#: users/templates/users/login.html:187
-msgid ""
-"If you don't have a <a href=\"https://joinmastodon.org/servers\" "
-"target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or "
-"login with Email first, and link it with Fediverse (Mastodon) later in "
-"account settings."
+#: users/templates/users/login.html:181
+msgid "If you don't have a <a href=\"https://joinmastodon.org/servers\" target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or login with Email first, and link it with Fediverse (Mastodon) later in account settings."
 msgstr ""
 
-#: users/templates/users/login.html:200
+#: users/templates/users/login.html:194
 msgid "Authorize via Threads"
 msgstr ""
 
-#: users/templates/users/login.html:221
-msgid ""
-"Please input your ATProto handle (e.g. neodb.bsky.social, without the "
-"leading @), do not use email. If you changed handle recently, just use the "
-"latest one."
+#: users/templates/users/login.html:215
+msgid "Please input your ATProto handle (e.g. neodb.bsky.social, without the leading @), do not use email. If you changed handle recently, just use the latest one."
 msgstr ""
 
-#: users/templates/users/login.html:224
+#: users/templates/users/login.html:218
 msgid "Authorize via ATProto server"
 msgstr ""
 
-#: users/templates/users/login.html:231
+#: users/templates/users/login.html:225
 #, python-format
-msgid ""
-"Please choose one to register or login %(site_name)s. Have more than one of "
-"these identities? Don't worry, you may link them in account settings once "
-"logged in."
+msgid "Please choose one to register or login %(site_name)s. Have more than one of these identities? Don't worry, you may link them in account settings once logged in."
 msgstr ""
 
-#: users/templates/users/login.html:255
+#: users/templates/users/login.html:249
 msgid "Valid invitation code, please login or register."
 msgstr ""
 
-#: users/templates/users/login.html:257
-msgid ""
-"Please use invitation link to register a new account; existing user may "
-"login."
+#: users/templates/users/login.html:251
+msgid "Please use invitation link to register a new account; existing user may login."
 msgstr ""
 
-#: users/templates/users/login.html:259
+#: users/templates/users/login.html:253
 msgid "Invitation code invalid or expired."
 msgstr ""
 
-#: users/templates/users/login.html:267
+#: users/templates/users/login.html:261
 msgid "Loading timed out, please check your network (VPN) settings."
 msgstr ""
 
-#: users/templates/users/login.html:273
-msgid ""
-"Continue using this site implies consent to our <a href=\"/pages/rules/"
-"\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using "
-"cookies to provide necessary functionality."
+#: users/templates/users/login.html:267
+msgid "Continue using this site implies consent to our <a href=\"/pages/rules/\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using cookies to provide necessary functionality."
 msgstr ""
 
-#: users/templates/users/login.html:287
+#: users/templates/users/login.html:281
 msgid "Domain of your instance (excl. @)"
 msgstr ""
 
@@ -8274,9 +8157,7 @@ msgid "Migrate Here"
 msgstr ""
 
 #: users/templates/users/migrate_in.html:22
-msgid ""
-"To move another account to this one, first add it as an alias here, and then "
-"go to the server where it is hosted and initiate the move."
+msgid "To move another account to this one, first add it as an alias here, and then go to the server where it is hosted and initiate the move."
 msgstr ""
 
 #: users/templates/users/migrate_in.html:27
@@ -8318,16 +8199,11 @@ msgstr ""
 
 #: users/templates/users/migrate_out.html:46
 #, python-format
-msgid ""
-"To migrate to another account, first add <code>@%(handle)s</code> as an "
-"alias on the target server, and then type the target account below to start "
-"the migration."
+msgid "To migrate to another account, first add <code>@%(handle)s</code> as an alias on the target server, and then type the target account below to start the migration."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:50
-msgid ""
-"Are you sure you want to migrate your account? Your followers will be moved "
-"to the target account."
+msgid "Are you sure you want to migrate your account? Your followers will be moved to the target account."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:53
@@ -8340,10 +8216,6 @@ msgstr ""
 
 #: users/templates/users/preferences.html:28
 msgid "Default view once logged in"
-msgstr ""
-
-#: users/templates/users/preferences.html:40
-msgid "Activities"
 msgstr ""
 
 #: users/templates/users/preferences.html:49
@@ -8373,9 +8245,7 @@ msgstr ""
 
 #: users/templates/users/preferences.html:111
 #: users/templates/users/register.html:88
-msgid ""
-"If a Mastodon account is linked with this identity, boosting a post will "
-"also make the same post boosted with that Mastodon account."
+msgid "If a Mastodon account is linked with this identity, boosting a post will also make the same post boosted with that Mastodon account."
 msgstr ""
 
 #: users/templates/users/preferences.html:115
@@ -8391,16 +8261,12 @@ msgid "Create a new post"
 msgstr ""
 
 #: users/templates/users/preferences.html:130
-msgid ""
-"this method is less optimal, may generate duplicated posts and miss "
-"reactions."
+msgid "this method is less optimal, may generate duplicated posts and miss reactions."
 msgstr ""
 
 #: users/templates/users/preferences.html:140
 #: users/templates/users/register.html:97
-msgid ""
-"Always publish my public marks, reviews and articles as data records to my "
-"PDS."
+msgid "Always publish my public marks, reviews and articles as data records to my PDS."
 msgstr ""
 
 #: users/templates/users/preferences.html:145
@@ -8420,12 +8286,7 @@ msgid "Automatic bookmark for these categories"
 msgstr ""
 
 #: users/templates/users/preferences.html:175
-msgid ""
-"When start to read/watch/play/... an item in these categories, a bookmark "
-"will be created automatically. Bookmarks can be viewed and managed in most "
-"<a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon "
-"compatible apps</a>; your replies to these posts will automatically become "
-"notes for the item."
+msgid "When start to read/watch/play/... an item in these categories, a bookmark will be created automatically. Bookmarks can be viewed and managed in most <a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon compatible apps</a>; your replies to these posts will automatically become notes for the item."
 msgstr ""
 
 #: users/templates/users/preferences.html:183
@@ -8445,9 +8306,7 @@ msgid "Profile visible to anonymous web visitors and search engines"
 msgstr ""
 
 #: users/templates/users/preferences.html:217
-msgid ""
-"this option limits web visits only; to limit fediverse visibility, choose "
-"followers only or mentioned only when posting"
+msgid "this option limits web visits only; to limit fediverse visibility, choose followers only or mentioned only when posting"
 msgstr ""
 
 #: users/templates/users/preferences.html:225
@@ -8459,17 +8318,7 @@ msgid "Do not show me item recommendations"
 msgstr ""
 
 #: users/templates/users/preferences.html:237
-msgid ""
-"Recommendations are generated only from public marks, processed in batch on "
-"this server. Your private and follower-only marks are never used as a signal "
-"for anyone, and we never share your data with third parties for this "
-"feature. When you share marks publicly and keep your profile discoverable, "
-"your marks help others here and across the Fediverse find things they might "
-"enjoy -- that voluntary contribution is what makes the feature work for "
-"everyone. If you'd rather not contribute, uncheck \"Include profile, marks "
-"and posts in discovery\" on your account page; this setting is published "
-"over ActivityPub, so other servers will also stop including you in their "
-"discovery features."
+msgid "Recommendations are generated only from public marks, processed in batch on this server. Your private and follower-only marks are never used as a signal for anyone, and we never share your data with third parties for this feature. When you share marks publicly and keep your profile discoverable, your marks help others here and across the Fediverse find things they might enjoy -- that voluntary contribution is what makes the feature work for everyone. If you'd rather not contribute, uncheck \"Include profile, marks and posts in discovery\" on your account page; this setting is published over ActivityPub, so other servers will also stop including you in their discovery features."
 msgstr ""
 
 #: users/templates/users/profile_actions.html:12
@@ -8570,19 +8419,11 @@ msgid "2-30 alphabets, numbers or underscore, can't be changed once saved"
 msgstr ""
 
 #: users/templates/users/register.html:72
-msgid ""
-"Use display name, bio and avatar from the social network you authenticated "
-"with"
+msgid "Use display name, bio and avatar from the social network you authenticated with"
 msgstr ""
 
 #: users/templates/users/register.html:80
-msgid ""
-"Add follow, mute and block list from the social network you authenticated "
-"with"
-msgstr ""
-
-#: users/templates/users/register.html:104
-msgid "Confirm and save"
+msgid "Add follow, mute and block list from the social network you authenticated with"
 msgstr ""
 
 #: users/templates/users/register.html:106
@@ -8611,8 +8452,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"              Matched %(local)s locally, %(external)s externally, "
-"%(unmatched)s unmatched out of %(total)s rows.\n"
+"              Matched %(local)s locally, %(external)s externally, %(unmatched)s unmatched out of %(total)s rows.\n"
 "            "
 msgstr ""
 
@@ -8733,9 +8573,7 @@ msgid "Played"
 msgstr ""
 
 #: users/templates/users/steam_import.html:90
-msgid ""
-"Games in wishlist; or purchased in library but never played, mark date will "
-"be set as today"
+msgid "Games in wishlist; or purchased in library but never played, mark date will be set as today"
 msgstr ""
 
 #: users/templates/users/steam_import.html:91
@@ -8775,15 +8613,11 @@ msgid "Comma-separated Steam AppIDs"
 msgstr ""
 
 #: users/templates/users/steam_import.html:121
-msgid ""
-"Allow reverse override of status (e.g. playing -> want to, or played -> "
-"playing)"
+msgid "Allow reverse override of status (e.g. playing -> want to, or played -> playing)"
 msgstr ""
 
 #: users/templates/users/steam_import.html:139
-msgid ""
-"To import from Steam, your game details must be visible to public in Steam "
-"privacy settings."
+msgid "To import from Steam, your game details must be visible to public in Steam privacy settings."
 msgstr ""
 
 #: users/templates/users/storygraph_import.html:9
@@ -8828,23 +8662,16 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"              %(site_name)s is flourishing because of collaborations and "
-"contributions from users like you. Please read our <a href=\"/pages/"
-"rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</"
-"a> if you have any question or feedback.\n"
+"              %(site_name)s is flourishing because of collaborations and contributions from users like you. Please read our <a href=\"/pages/rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</a> if you have any question or feedback.\n"
 "        "
 msgstr ""
 
 #: users/templates/users/welcome.html:37
-msgid ""
-"Set up a passkey to sign in quickly next time using your fingerprint, face, "
-"or screen lock."
+msgid "Set up a passkey to sign in quickly next time using your fingerprint, face, or screen lock."
 msgstr ""
 
 #: users/templates/users/welcome.html:39
-msgid ""
-"Creating a passkey is highly recommended, as the website or email you use to "
-"create this account may not be always available."
+msgid "Creating a passkey is highly recommended, as the website or email you use to create this account may not be always available."
 msgstr ""
 
 #: users/templates/users/welcome.html:43
@@ -8859,220 +8686,219 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:124
+#: users/views/account.py:126
 msgid "This username is already in use."
 msgstr ""
 
-#: users/views/account.py:135
+#: users/views/account.py:137
 msgid "This email address is already in use."
 msgstr ""
 
-#: users/views/account.py:255 users/views/account.py:374
+#: users/views/account.py:257 users/views/account.py:376
 msgid "Registration is for invitation only"
 msgstr ""
 
-#: users/views/account.py:266 users/views/account.py:338
+#: users/views/account.py:268 users/views/account.py:340
 msgid "Time is up"
 msgstr ""
 
-#: users/views/account.py:267 users/views/account.py:310
-#: users/views/account.py:339
+#: users/views/account.py:269 users/views/account.py:312
+#: users/views/account.py:341
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:313
+#: users/views/account.py:315
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:325
+#: users/views/account.py:327
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:326
+#: users/views/account.py:328
 msgid "Please try again later."
 msgstr ""
 
-#: users/views/account.py:415
+#: users/views/account.py:417
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:445
+#: users/views/account.py:447
 msgid "Valid username required"
 msgstr ""
 
-#: users/views/account.py:526
+#: users/views/account.py:518
 msgid "Account is being deleted."
 msgstr ""
 
-#: users/views/account.py:529
+#: users/views/account.py:521
 msgid "Account mismatch."
 msgstr ""
 
-#: users/views/data.py:262 users/views/data.py:294
+#: users/views/data.py:264 users/views/data.py:296
 msgid "Export file not available."
 msgstr ""
 
-#: users/views/data.py:288
+#: users/views/data.py:290
 msgid "Generating exports."
 msgstr ""
 
-#: users/views/data.py:306
+#: users/views/data.py:308
 msgid "Export file expired. Please export again."
 msgstr ""
 
-#: users/views/data.py:321 users/views/data.py:342 users/views/data.py:363
+#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
 msgid "Recent export still in progress."
 msgstr ""
 
-#: users/views/data.py:379 users/views/data.py:513 users/views/data.py:547
-#: users/views/data.py:772 users/views/data.py:989 users/views/data.py:1015
-#: users/views/data.py:1040 users/views/data.py:1065
+#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
+#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
+#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
 msgid "Invalid file."
 msgstr ""
 
-#: users/views/data.py:403
+#: users/views/data.py:405
 msgid "Sync in progress."
 msgstr ""
 
-#: users/views/data.py:417
+#: users/views/data.py:419
 msgid "Settings saved."
 msgstr ""
 
-#: users/views/data.py:472
+#: users/views/data.py:474
 msgid "Account no longer linked."
 msgstr ""
 
-#: users/views/data.py:475
+#: users/views/data.py:477
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:503
+#: users/views/data.py:505
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:583 users/views/data.py:808
+#: users/views/data.py:585 users/views/data.py:810
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:608 users/views/data.py:837
+#: users/views/data.py:610 users/views/data.py:839
 msgid "Cancelled."
 msgstr ""
 
-#: users/views/data.py:628
+#: users/views/data.py:630
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:636 users/views/data.py:746 users/views/data.py:867
-#: users/views/data.py:972
+#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
+#: users/views/data.py:974
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:732 users/views/data.py:958
+#: users/views/data.py:734 users/views/data.py:960
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:742 users/views/data.py:968
+#: users/views/data.py:744 users/views/data.py:970
 msgid "No matched file available."
 msgstr ""
 
-#: users/views/data.py:859
+#: users/views/data.py:861
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1188
+#: users/views/data.py:1226
 msgid "Name is required."
 msgstr ""
 
-#: users/views/data.py:1210
+#: users/views/data.py:1248
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1264
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1231
+#: users/views/data.py:1269
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1241 users/views/data.py:1292
+#: users/views/data.py:1279 users/views/data.py:1330
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:1248
+#: users/views/data.py:1286
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:1253
+#: users/views/data.py:1291
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:1279
+#: users/views/data.py:1317
 msgid "Migration cancelled."
 msgstr ""
 
-#: users/views/data.py:1284
+#: users/views/data.py:1322
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:1297
+#: users/views/data.py:1335
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:1308
+#: users/views/data.py:1346
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:1314
+#: users/views/data.py:1352
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr ""
 
-#: users/views/data.py:1372
+#: users/views/data.py:1410
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1388
+#: users/views/data.py:1426
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1392
+#: users/views/data.py:1430
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1402
+#: users/views/data.py:1440
 #, python-brace-format
-msgid ""
-"Import of {count} entries received. They will be processed in the background."
+msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""
 
-#: users/views/webauthn.py:103
+#: users/views/webauthn.py:106
 msgid "Passkey registration failed"
 msgstr ""
 
-#: users/views/webauthn.py:123
+#: users/views/webauthn.py:126
 msgid "Credential already registered"
 msgstr ""
 
-#: users/views/webauthn.py:165 users/views/webauthn.py:172
-#: users/views/webauthn.py:181
+#: users/views/webauthn.py:168 users/views/webauthn.py:175
+#: users/views/webauthn.py:184
 msgid "Passkey not recognized"
 msgstr ""
 
-#: users/views/webauthn.py:186
+#: users/views/webauthn.py:189
 msgid "Account is inactive"
 msgstr ""
 
-#: users/views/webauthn.py:202
+#: users/views/webauthn.py:205
 msgid "Passkey verification failed"
 msgstr ""
 
-#: users/views/webauthn.py:228 users/views/webauthn.py:250
+#: users/views/webauthn.py:231 users/views/webauthn.py:253
 msgid "Passkey not found"
 msgstr ""
 
-#: users/views/webauthn.py:244
+#: users/views/webauthn.py:247
 msgid "Name is required"
 msgstr ""

--- a/neodb/locale/fr/LC_MESSAGES/django.po
+++ b/neodb/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-23 15:40-0400\n"
+"POT-Creation-Date: 2026-09-06 20:04-0400\n"
 "PO-Revision-Date: 2026-08-09 06:32+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/neodb/neodb/fr/>\n"
@@ -18,161 +18,161 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: boofilsic/settings.py:472 common/models/lang.py:230
+#: boofilsic/settings.py:501 common/models/lang.py:232
 msgid "English"
 msgstr "Anglais"
 
-#: boofilsic/settings.py:473 common/models/lang.py:77
+#: boofilsic/settings.py:502 common/models/lang.py:79
 msgid "Danish"
 msgstr "Danois"
 
-#: boofilsic/settings.py:474 common/models/lang.py:78
+#: boofilsic/settings.py:503 common/models/lang.py:80
 msgid "German"
 msgstr "Allemand"
 
-#: boofilsic/settings.py:475 common/models/lang.py:183
+#: boofilsic/settings.py:504 common/models/lang.py:185
 msgid "Spanish"
 msgstr "Espagnol"
 
-#: boofilsic/settings.py:476 common/models/lang.py:87
+#: boofilsic/settings.py:505 common/models/lang.py:89
 msgid "French"
 msgstr "Français"
 
-#: boofilsic/settings.py:477 common/models/lang.py:112
+#: boofilsic/settings.py:506 common/models/lang.py:114
 msgid "Italian"
 msgstr "Italien"
 
-#: boofilsic/settings.py:478 common/models/lang.py:166
-#: common/models/lang.py:305
+#: boofilsic/settings.py:507 common/models/lang.py:168
+#: common/models/lang.py:307
 msgid "Portuguese"
 msgstr "Portugais"
 
-#: boofilsic/settings.py:479
+#: boofilsic/settings.py:508
 #, fuzzy
 #| msgid "Portuguese"
 msgid "Brazilian Portuguese"
 msgstr "Portugais"
 
-#: boofilsic/settings.py:480 common/models/lang.py:316
+#: boofilsic/settings.py:509 common/models/lang.py:318
 msgid "Simplified Chinese"
 msgstr "Chinois Simplifié"
 
-#: boofilsic/settings.py:481 common/models/lang.py:317
+#: boofilsic/settings.py:510 common/models/lang.py:319
 msgid "Traditional Chinese"
 msgstr "Chinois Traditionnel"
 
-#: catalog/forms.py:35 catalog/models/item.py:291
+#: catalog/forms.py:35 catalog/models/item.py:307
 msgid "Primary ID Type"
 msgstr "Type de l'identifiant primaire"
 
-#: catalog/forms.py:40 catalog/models/item.py:294
+#: catalog/forms.py:40 catalog/models/item.py:310
 msgid "Primary ID Value"
 msgstr "Valeur de l'identifiant primaire"
 
-#: catalog/forms.py:181
+#: catalog/forms.py:176
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
-#: catalog/models/book.py:139 catalog/models/book.py:158
-#: catalog/models/common.py:280 catalog/models/common.py:298
+#: catalog/models/book.py:141 catalog/models/book.py:160
+#: catalog/models/common.py:279 catalog/models/common.py:297
 msgid "locale"
 msgstr "paramètres linguistiques"
 
-#: catalog/models/book.py:142 catalog/models/book.py:161
-#: catalog/models/common.py:283 catalog/models/common.py:303
+#: catalog/models/book.py:144 catalog/models/book.py:163
+#: catalog/models/common.py:282 catalog/models/common.py:302
 msgid "text content"
 msgstr "contenu textuel"
 
-#: catalog/models/book.py:177
+#: catalog/models/book.py:179
 msgid "Paperback"
 msgstr "Poche"
 
-#: catalog/models/book.py:178
+#: catalog/models/book.py:180
 msgid "Hardcover"
 msgstr "Relié"
 
-#: catalog/models/book.py:179
+#: catalog/models/book.py:181
 msgid "eBook"
 msgstr "Livre numérique"
 
-#: catalog/models/book.py:180
+#: catalog/models/book.py:182
 msgid "Audiobook"
 msgstr "Livre audio"
 
-#: catalog/models/book.py:182
+#: catalog/models/book.py:184
 msgid "Web Fiction"
 msgstr "Fiction Web"
 
-#: catalog/models/book.py:183 catalog/models/game.py:38
+#: catalog/models/book.py:185 catalog/models/game.py:38
 msgid "Other"
 msgstr "Autre"
 
-#: catalog/models/book.py:260
+#: catalog/models/book.py:262
 msgid "subtitle"
 msgstr "sous-titre"
 
-#: catalog/models/book.py:270 catalog/models/movie.py:120
-#: catalog/models/performance.py:385 catalog/models/tv.py:211
-#: catalog/models/tv.py:437
+#: catalog/models/book.py:272 catalog/models/movie.py:120
+#: catalog/models/performance.py:385 catalog/models/tv.py:213
+#: catalog/models/tv.py:439
 msgid "original title"
 msgstr "titre original"
 
-#: catalog/models/book.py:274
+#: catalog/models/book.py:276
 msgid "other title"
 msgstr "titre alternatif"
 
-#: catalog/models/book.py:280 catalog/models/book.py:564
-#: catalog/models/item.py:123
+#: catalog/models/book.py:282 catalog/models/book.py:566
+#: catalog/models/item.py:119
 msgid "author"
 msgstr "écrit par"
 
-#: catalog/models/book.py:287 catalog/models/item.py:124
+#: catalog/models/book.py:289 catalog/models/item.py:120
 msgid "translator"
 msgstr "traduit par"
 
-#: catalog/models/book.py:294 catalog/templates/edition.html:26
+#: catalog/models/book.py:296 catalog/templates/edition.html:26
 msgid "book format"
 msgstr "format"
 
-#: catalog/models/book.py:301 catalog/models/game.py:135
-#: catalog/models/item.py:138 catalog/models/music.py:142
+#: catalog/models/book.py:303 catalog/models/game.py:135
+#: catalog/models/item.py:134 catalog/models/music.py:142
 msgid "publisher"
 msgstr "studio d'édition"
 
-#: catalog/models/book.py:308
+#: catalog/models/book.py:310
 msgid "publication year"
 msgstr "année de publication"
 
-#: catalog/models/book.py:314
+#: catalog/models/book.py:316
 msgid "publication month"
 msgstr "mois de publication"
 
-#: catalog/models/book.py:319
+#: catalog/models/book.py:321
 msgid "binding"
 msgstr "reliure"
 
-#: catalog/models/book.py:320
+#: catalog/models/book.py:322
 msgid "pages"
 msgstr "pages"
 
-#: catalog/models/book.py:321 catalog/templates/edition.html:45
+#: catalog/models/book.py:323 catalog/templates/edition.html:45
 msgid "series"
 msgstr "série"
 
-#: catalog/models/book.py:322 catalog/templates/edition.html:65
+#: catalog/models/book.py:324 catalog/templates/edition.html:65
 msgid "contents"
 msgstr "contenus"
 
-#: catalog/models/book.py:323 catalog/templates/edition.html:51
+#: catalog/models/book.py:325 catalog/templates/edition.html:51
 msgid "price"
 msgstr "prix"
 
-#: catalog/models/book.py:324 catalog/models/item.py:149
+#: catalog/models/book.py:326 catalog/models/item.py:145
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr "colophon"
 
-#: catalog/models/common.py:26 common/models/lang.py:256
+#: catalog/models/common.py:26 common/models/lang.py:258
 msgid "Unknown"
 msgstr "Inconnu"
 
@@ -180,11 +180,11 @@ msgstr "Inconnu"
 msgid "Douban"
 msgstr "Douban"
 
-#: catalog/models/common.py:28 catalog/models/common.py:79
+#: catalog/models/common.py:28 catalog/models/common.py:81
 msgid "Goodreads"
 msgstr "Goodreads"
 
-#: catalog/models/common.py:29 catalog/models/common.py:81
+#: catalog/models/common.py:29 catalog/models/common.py:83
 msgid "Google Books"
 msgstr "Google Livres"
 
@@ -192,16 +192,16 @@ msgstr "Google Livres"
 msgid "BooksTW"
 msgstr "BooksTW"
 
-#: catalog/models/common.py:31 catalog/models/common.py:91
-#: catalog/models/common.py:93
+#: catalog/models/common.py:31 catalog/models/common.py:93
+#: catalog/models/common.py:95
 msgid "Bibliotek.dk"
 msgstr ""
 
-#: catalog/models/common.py:32 catalog/models/common.py:92
+#: catalog/models/common.py:32 catalog/models/common.py:94
 msgid "eReolen.dk"
 msgstr ""
 
-#: catalog/models/common.py:33 catalog/models/common.py:74
+#: catalog/models/common.py:33 catalog/models/common.py:76
 #: catalog/templates/movie.html:41 catalog/templates/people.html:37
 #: catalog/templates/tvseason.html:58 catalog/templates/tvshow.html:53
 msgid "IMDb"
@@ -211,7 +211,7 @@ msgstr "IMDb"
 msgid "TMDB"
 msgstr "TMDB"
 
-#: catalog/models/common.py:35 catalog/models/common.py:94
+#: catalog/models/common.py:35 catalog/models/common.py:96
 msgid "Bandcamp"
 msgstr "Bandcamp"
 
@@ -227,11 +227,11 @@ msgstr "IGDB"
 msgid "Steam"
 msgstr "Steam"
 
-#: catalog/models/common.py:39 catalog/models/common.py:114
+#: catalog/models/common.py:39 catalog/models/common.py:116
 msgid "itch.io"
 msgstr ""
 
-#: catalog/models/common.py:40 catalog/models/common.py:115
+#: catalog/models/common.py:40 catalog/models/common.py:117
 msgid "Bangumi"
 msgstr "Bangumi"
 
@@ -239,7 +239,7 @@ msgstr "Bangumi"
 msgid "BGG"
 msgstr "BGG"
 
-#: catalog/models/common.py:42 catalog/models/common.py:116
+#: catalog/models/common.py:42 catalog/models/common.py:118
 msgid "Apple Podcast"
 msgstr "Podcast Apple"
 
@@ -251,35 +251,35 @@ msgstr "RSS"
 msgid "Discogs"
 msgstr "Discogs"
 
-#: catalog/models/common.py:45 catalog/models/common.py:117
+#: catalog/models/common.py:45 catalog/models/common.py:119
 msgid "Apple Music"
 msgstr "Apple Music"
 
-#: catalog/models/common.py:46 catalog/models/common.py:119
+#: catalog/models/common.py:46 catalog/models/common.py:121
 msgid "Fediverse"
 msgstr "Fédivers"
 
-#: catalog/models/common.py:47 catalog/models/common.py:120
+#: catalog/models/common.py:47 catalog/models/common.py:122
 msgid "Qidian"
 msgstr "Qidian"
 
-#: catalog/models/common.py:48 catalog/models/common.py:121
+#: catalog/models/common.py:48 catalog/models/common.py:123
 msgid "Ypshuo"
 msgstr "Ypshuo"
 
-#: catalog/models/common.py:49 catalog/models/common.py:122
+#: catalog/models/common.py:49 catalog/models/common.py:124
 msgid "Archive of Our Own"
 msgstr "Archive of Our Own"
 
-#: catalog/models/common.py:50 catalog/models/common.py:123
+#: catalog/models/common.py:50 catalog/models/common.py:125
 msgid "JinJiang"
 msgstr "JinJiang"
 
-#: catalog/models/common.py:51 catalog/models/common.py:64
+#: catalog/models/common.py:51 catalog/models/common.py:66
 msgid "WikiData"
 msgstr "WikiData"
 
-#: catalog/models/common.py:52 catalog/models/common.py:124
+#: catalog/models/common.py:52 catalog/models/common.py:126
 msgid "Open Library"
 msgstr ""
 
@@ -293,17 +293,17 @@ msgstr "Identifiant MusicBrainz"
 msgid "WorldCat"
 msgstr ""
 
-#: catalog/models/common.py:55 catalog/models/common.py:126
+#: catalog/models/common.py:55 catalog/models/common.py:128
 #, fuzzy
 #| msgid "Game"
 msgid "MobyGames"
 msgstr "Jeu"
 
-#: catalog/models/common.py:56 catalog/models/common.py:127
+#: catalog/models/common.py:56 catalog/models/common.py:129
 msgid "StoryGraph"
 msgstr ""
 
-#: catalog/models/common.py:57 catalog/models/common.py:118
+#: catalog/models/common.py:57 catalog/models/common.py:120
 #, fuzzy
 #| msgid "Douban Music"
 msgid "YouTube Music"
@@ -321,363 +321,374 @@ msgstr ""
 msgid "Readmoo"
 msgstr ""
 
-#: catalog/models/common.py:65
+#: catalog/models/common.py:61
+msgid "MyAnimeList"
+msgstr ""
+
+#: catalog/models/common.py:62 catalog/models/common.py:140
+#, fuzzy
+#| msgid "Update"
+msgid "MangaUpdates"
+msgstr "Mettre à jour"
+
+#: catalog/models/common.py:67
 msgid "ISBN10"
 msgstr "ISBN-10"
 
-#: catalog/models/common.py:66 catalog/templates/edition.html:19
+#: catalog/models/common.py:68 catalog/templates/edition.html:19
 msgid "ISBN"
 msgstr "ISBN"
 
-#: catalog/models/common.py:67
+#: catalog/models/common.py:69
 msgid "ASIN"
 msgstr "ASIN"
 
-#: catalog/models/common.py:68
+#: catalog/models/common.py:70
 msgid "ISSN"
 msgstr "ISSN"
 
-#: catalog/models/common.py:69
+#: catalog/models/common.py:71
 msgid "CUBN"
 msgstr "CUBN"
 
-#: catalog/models/common.py:70
+#: catalog/models/common.py:72
 msgid "ISRC"
 msgstr "ISRC"
 
-#: catalog/models/common.py:71
+#: catalog/models/common.py:73
 msgid "GTIN UPC EAN"
 msgstr "GTIN UPC EAN"
 
-#: catalog/models/common.py:72
+#: catalog/models/common.py:74
 msgid "OCLC Number"
 msgstr ""
 
-#: catalog/models/common.py:73
+#: catalog/models/common.py:75
 msgid "RSS Feed URL"
 msgstr "URL du flux RSS"
 
-#: catalog/models/common.py:75
+#: catalog/models/common.py:77
 #, fuzzy
 #| msgid "TMDB TV Serie"
 msgid "TMDB TV Series"
 msgstr "Série TV TMDB"
 
-#: catalog/models/common.py:76
+#: catalog/models/common.py:78
 msgid "TMDB TV Season"
 msgstr "Saison TMDB"
 
-#: catalog/models/common.py:77
+#: catalog/models/common.py:79
 msgid "TMDB TV Episode"
 msgstr "Épisode TMDB"
 
-#: catalog/models/common.py:78
+#: catalog/models/common.py:80
 msgid "TMDB Movie"
 msgstr "Film TMDB"
 
-#: catalog/models/common.py:80
+#: catalog/models/common.py:82
 msgid "Goodreads Work"
 msgstr "Œuvre Goodreads"
 
-#: catalog/models/common.py:82
+#: catalog/models/common.py:84
 msgid "Douban Book"
 msgstr "Livre Douban"
 
-#: catalog/models/common.py:83
+#: catalog/models/common.py:85
 msgid "Douban Book Work"
 msgstr "Œuvre Douban"
 
-#: catalog/models/common.py:84
+#: catalog/models/common.py:86
 msgid "Douban Movie"
 msgstr "Film Douban"
 
-#: catalog/models/common.py:85
+#: catalog/models/common.py:87
 msgid "Douban Music"
 msgstr "Musique Douban"
 
-#: catalog/models/common.py:86
+#: catalog/models/common.py:88
 msgid "Douban Game"
 msgstr "Jeu Douban"
 
-#: catalog/models/common.py:87
+#: catalog/models/common.py:89
 msgid "Douban Drama"
 msgstr "Drame Douban"
 
-#: catalog/models/common.py:88
+#: catalog/models/common.py:90
 msgid "Douban Drama Version"
 msgstr "Version du drame sur Douban"
 
-#: catalog/models/common.py:89
+#: catalog/models/common.py:91
 msgid "BooksTW Book"
 msgstr "Livre BooksTW"
 
-#: catalog/models/common.py:90
+#: catalog/models/common.py:92
 msgid "Readmoo Book"
 msgstr ""
 
-#: catalog/models/common.py:95
+#: catalog/models/common.py:97
 msgid "Spotify Album"
 msgstr "Album Spotify"
 
-#: catalog/models/common.py:96
+#: catalog/models/common.py:98
 msgid "Spotify Podcast"
 msgstr "Podcast Spotify"
 
-#: catalog/models/common.py:97
+#: catalog/models/common.py:99
 msgid "Discogs Release"
 msgstr "Sortie Discogs"
 
-#: catalog/models/common.py:98
+#: catalog/models/common.py:100
 msgid "Discogs Master"
 msgstr "Master Discogs"
 
-#: catalog/models/common.py:101
+#: catalog/models/common.py:103
 #, fuzzy
 #| msgid "MusicBrainz ID"
 msgid "MusicBrainz Release Group"
 msgstr "Identifiant MusicBrainz"
 
-#: catalog/models/common.py:103
+#: catalog/models/common.py:105
 #, fuzzy
 #| msgid "MusicBrainz ID"
 msgid "MusicBrainz Release"
 msgstr "Identifiant MusicBrainz"
 
-#: catalog/models/common.py:104
+#: catalog/models/common.py:106
 #, fuzzy
 #| msgid "MusicBrainz ID"
 msgid "MusicBrainz Artist"
 msgstr "Identifiant MusicBrainz"
 
-#: catalog/models/common.py:105
+#: catalog/models/common.py:107
 #, fuzzy
 #| msgid "Douban Game"
 msgid "Douban Personage"
 msgstr "Jeu Douban"
 
-#: catalog/models/common.py:106
+#: catalog/models/common.py:108
 #, fuzzy
 #| msgid "Goodreads Work"
 msgid "Goodreads Author"
 msgstr "Œuvre Goodreads"
 
-#: catalog/models/common.py:107
+#: catalog/models/common.py:109
 #, fuzzy
 #| msgid "Spotify Podcast"
 msgid "Spotify Artist"
 msgstr "Podcast Spotify"
 
-#: catalog/models/common.py:108
+#: catalog/models/common.py:110
 #, fuzzy
 #| msgid "TMDB TV Season"
 msgid "TMDB Person"
 msgstr "Saison TMDB"
 
-#: catalog/models/common.py:109
+#: catalog/models/common.py:111
 msgid "Open Library Author"
 msgstr ""
 
-#: catalog/models/common.py:110
+#: catalog/models/common.py:112
 msgid "IGDB Company"
 msgstr ""
 
-#: catalog/models/common.py:111
+#: catalog/models/common.py:113
 msgid "IGDB Game"
 msgstr "Jeu IGDB"
 
-#: catalog/models/common.py:112
+#: catalog/models/common.py:114
 msgid "BGG Boardgame"
 msgstr "Jeu de plateau BGG"
 
-#: catalog/models/common.py:113
+#: catalog/models/common.py:115
 msgid "Steam Game"
 msgstr "Jeu Steam"
 
-#: catalog/models/common.py:125
+#: catalog/models/common.py:127
 msgid "Open Library Work"
 msgstr ""
 
-#: catalog/models/common.py:128
+#: catalog/models/common.py:130
 msgid "RateYourMusic Release"
 msgstr ""
 
-#: catalog/models/common.py:132
+#: catalog/models/common.py:134
 msgid "AniList Anime"
 msgstr ""
 
-#: catalog/models/common.py:133
+#: catalog/models/common.py:135
 msgid "AniList Manga"
 msgstr ""
 
-#: catalog/models/common.py:134
+#: catalog/models/common.py:136
 msgid "MyAnimeList Anime"
 msgstr ""
 
-#: catalog/models/common.py:135
+#: catalog/models/common.py:137
 msgid "MyAnimeList Manga"
 msgstr ""
 
-#: catalog/models/common.py:156
+#: catalog/models/common.py:161
 #, fuzzy
 #| msgid "Editions"
 msgid "Edition"
 msgstr "Éditions"
 
-#: catalog/models/common.py:157 catalog/templates/_sidebar_edit.html:286
+#: catalog/models/common.py:162 catalog/templates/_sidebar_edit.html:289
 msgid "Work"
 msgstr "Œuvre"
 
-#: catalog/models/common.py:158
+#: catalog/models/common.py:163
 #, fuzzy
 #| msgid "TV Serie"
 msgid "TV Series"
 msgstr "Série TV"
 
-#: catalog/models/common.py:159 catalog/templates/_sidebar_edit.html:207
+#: catalog/models/common.py:164 catalog/templates/_sidebar_edit.html:202
+#: catalog/views/edit.py:385
 msgid "TV Season"
 msgstr "Saison"
 
-#: catalog/models/common.py:160
+#: catalog/models/common.py:165
 msgid "TV Episode"
 msgstr "Épisode"
 
-#: catalog/models/common.py:161 catalog/models/common.py:177
-#: catalog/models/common.py:191 catalog/templates/_sidebar_edit.html:200
-#: journal/templates/_sidebar_user_mark_list.html:35
+#: catalog/models/common.py:166 catalog/models/common.py:182
+#: catalog/models/common.py:196 catalog/templates/_sidebar_edit.html:196
+#: catalog/views/edit.py:384 journal/templates/_sidebar_user_mark_list.html:35
 #: journal/templates/_sidebar_user_tag_filter.html:27
 msgid "Movie"
 msgstr "Film"
 
-#: catalog/models/common.py:162
+#: catalog/models/common.py:167
 msgid "Album"
 msgstr "Album"
 
-#: catalog/models/common.py:163 catalog/models/common.py:180
-#: catalog/models/common.py:194 common/templates/_header.html:43
+#: catalog/models/common.py:168 catalog/models/common.py:185
+#: catalog/models/common.py:199 common/templates/_header.html:53
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
 msgstr "Jeu"
 
-#: catalog/models/common.py:164
+#: catalog/models/common.py:169
 msgid "Podcast Program"
 msgstr "Podcast"
 
-#: catalog/models/common.py:165
+#: catalog/models/common.py:170
 msgid "Podcast Episode"
 msgstr "Épisode de Podcast"
 
-#: catalog/models/common.py:166 catalog/models/common.py:182
-#: catalog/models/common.py:196 common/templates/_header.html:47
+#: catalog/models/common.py:171 catalog/models/common.py:187
+#: catalog/models/common.py:201 common/templates/_header.html:57
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
 msgstr "Spectacle"
 
-#: catalog/models/common.py:167
+#: catalog/models/common.py:172
 msgid "Production"
 msgstr "Production"
 
-#: catalog/models/common.py:168
+#: catalog/models/common.py:173
 msgid "Exhibition"
 msgstr "Exposition"
 
-#: catalog/models/common.py:169 catalog/models/common.py:186
+#: catalog/models/common.py:174 catalog/models/common.py:191
 #: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr "Collection"
 
-#: catalog/models/common.py:172 catalog/models/common.py:185
+#: catalog/models/common.py:177 catalog/models/common.py:190
 msgid "Person / Organization"
 msgstr ""
 
-#: catalog/models/common.py:176 catalog/models/common.py:190
-#: common/templates/_header.html:27
+#: catalog/models/common.py:181 catalog/models/common.py:195
+#: common/templates/_header.html:37
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
 msgstr "Livre"
 
-#: catalog/models/common.py:178 catalog/models/common.py:192
+#: catalog/models/common.py:183 catalog/models/common.py:197
 #: journal/templates/_sidebar_user_mark_list.html:38
 #: journal/templates/_sidebar_user_tag_filter.html:30
 msgid "TV"
 msgstr "TV"
 
-#: catalog/models/common.py:179 catalog/models/common.py:193
-#: common/templates/_header.html:39
+#: catalog/models/common.py:184 catalog/models/common.py:198
+#: common/templates/_header.html:49
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr "Musique"
 
-#: catalog/models/common.py:181 catalog/models/common.py:195
-#: catalog/templates/_sidebar_edit.html:219 common/templates/_header.html:35
+#: catalog/models/common.py:186 catalog/models/common.py:200
+#: catalog/templates/_sidebar_edit.html:213 common/templates/_header.html:45
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
 msgstr "Podcast"
 
-#: catalog/models/common.py:346 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:345 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr "genre"
 
-#: catalog/models/common.py:384
+#: catalog/models/common.py:383
 #, fuzzy
 #| msgid "original creator"
 msgid "origin country"
 msgstr "une création originale de"
 
-#: catalog/models/common.py:413 catalog/templates/album.html:33
+#: catalog/models/common.py:412 catalog/templates/album.html:33
 msgid "album type"
 msgstr "type d'album"
 
-#: catalog/models/common.py:417 catalog/templates/_platform_list.html:5
+#: catalog/models/common.py:416 catalog/templates/_platform_list.html:5
 msgid "platform"
 msgstr "plateforme"
 
-#: catalog/models/common.py:421
+#: catalog/models/common.py:420
 #, fuzzy
 #| msgid "media type"
 msgid "media format"
 msgstr "type de média"
 
-#: catalog/models/common.py:426 catalog/templates/_language_list.html:5
-#: users/models/user.py:142
+#: catalog/models/common.py:425 catalog/templates/_language_list.html:5
+#: users/models/user.py:144
 msgid "language"
 msgstr "langue"
 
-#: catalog/models/creator.py:24
+#: catalog/models/creator.py:26
 #, fuzzy
 #| msgid "Pending"
 msgid "pending"
 msgstr "En attente"
 
-#: catalog/models/creator.py:25
+#: catalog/models/creator.py:27
 msgid "verified"
 msgstr ""
 
-#: catalog/models/creator.py:26
+#: catalog/models/creator.py:28
 #, fuzzy
 #| msgid "Failed"
 msgid "failed"
 msgstr "Échec"
 
-#: catalog/models/creator.py:29
+#: catalog/models/creator.py:31
 msgid "no feed url available for this item"
 msgstr ""
 
-#: catalog/models/creator.py:30
+#: catalog/models/creator.py:32
 msgid "unable to fetch or parse the feed"
 msgstr ""
 
-#: catalog/models/creator.py:31
+#: catalog/models/creator.py:33
 msgid "no audio episode found in the feed"
 msgstr ""
 
-#: catalog/models/creator.py:34
+#: catalog/models/creator.py:36
 msgid "no matching identity found in the feed or its linked website"
 msgstr ""
 
@@ -713,16 +724,16 @@ msgstr "Remake"
 msgid "Special Edition"
 msgstr "Édition Spéciale"
 
-#: catalog/models/game.py:111 catalog/models/item.py:130
+#: catalog/models/game.py:111 catalog/models/item.py:126
 msgid "designer"
 msgstr "conception"
 
-#: catalog/models/game.py:119 catalog/models/item.py:129
+#: catalog/models/game.py:119 catalog/models/item.py:125
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr "artiste"
 
-#: catalog/models/game.py:127 catalog/models/item.py:139
+#: catalog/models/game.py:127 catalog/models/item.py:135
 msgid "developer"
 msgstr "studio de développement"
 
@@ -731,8 +742,8 @@ msgid "date of publication"
 msgstr "date de publication"
 
 #: catalog/models/game.py:147 catalog/models/movie.py:156
-#: catalog/models/music.py:128 catalog/models/tv.py:247
-#: catalog/models/tv.py:473
+#: catalog/models/music.py:128 catalog/models/tv.py:249
+#: catalog/models/tv.py:475
 msgid "YYYY, YYYY-MM or YYYY-MM-DD"
 msgstr ""
 
@@ -743,7 +754,7 @@ msgstr "type de sortie"
 #: catalog/models/game.py:180 catalog/models/movie.py:158
 #: catalog/models/people.py:178 catalog/models/performance.py:258
 #: catalog/models/performance.py:465 catalog/models/podcast.py:89
-#: catalog/models/tv.py:249 catalog/models/tv.py:476
+#: catalog/models/tv.py:251 catalog/models/tv.py:478
 #: catalog/templates/game.html:33 catalog/templates/movie.html:48
 #: catalog/templates/people.html:44 catalog/templates/performance.html:35
 #: catalog/templates/performanceproduction.html:35
@@ -752,152 +763,152 @@ msgstr "type de sortie"
 msgid "website"
 msgstr "site internet"
 
-#: catalog/models/item.py:125 catalog/models/movie.py:123
+#: catalog/models/item.py:121 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
-#: catalog/models/tv.py:214 catalog/models/tv.py:440
+#: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr "réalisation"
 
-#: catalog/models/item.py:126 catalog/models/movie.py:130
+#: catalog/models/item.py:122 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
-#: catalog/models/tv.py:221 catalog/models/tv.py:447
+#: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr "scénario"
 
-#: catalog/models/item.py:127 catalog/models/movie.py:137
+#: catalog/models/item.py:123 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
-#: catalog/models/tv.py:228 catalog/models/tv.py:454
+#: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr "casting"
 
-#: catalog/models/item.py:128 catalog/models/movie.py:144
-#: catalog/models/tv.py:235 catalog/models/tv.py:461
+#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/tv.py:237 catalog/models/tv.py:463
 #, fuzzy
 #| msgid "production"
 msgid "producer"
 msgstr "production"
 
-#: catalog/models/item.py:131 catalog/models/performance.py:203
+#: catalog/models/item.py:127 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr "composition musicale"
 
-#: catalog/models/item.py:132 catalog/models/performance.py:210
+#: catalog/models/item.py:128 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr "chorégraphe"
 
-#: catalog/models/item.py:133 catalog/models/performance.py:224
+#: catalog/models/item.py:129 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr "artiste"
 
-#: catalog/models/item.py:134 catalog/models/podcast.py:80
+#: catalog/models/item.py:130 catalog/models/podcast.py:80
 msgid "host"
 msgstr "présenté par"
 
-#: catalog/models/item.py:135 catalog/models/performance.py:196
+#: catalog/models/item.py:131 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr "une création originale de"
 
-#: catalog/models/item.py:136 catalog/models/performance.py:238
+#: catalog/models/item.py:132 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr "équipe"
 
-#: catalog/models/item.py:140
+#: catalog/models/item.py:136
 #, fuzzy
 #| msgid "production"
 msgid "production company"
 msgstr "production"
 
-#: catalog/models/item.py:141
+#: catalog/models/item.py:137
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:142
+#: catalog/models/item.py:138
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:139
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:144 catalog/models/performance.py:231
+#: catalog/models/item.py:140 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr "troupe"
 
-#: catalog/models/item.py:147
+#: catalog/models/item.py:143
 #, fuzzy
 #| msgid "director"
 msgid "voice actor"
 msgstr "réalisation"
 
-#: catalog/models/item.py:148 catalog/templates/edition.html:30
+#: catalog/models/item.py:144 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr "édition"
 
-#: catalog/models/item.py:173 catalog/models/people.py:476
+#: catalog/models/item.py:169 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr "rôle"
 
-#: catalog/models/item.py:174 catalog/models/people.py:155
+#: catalog/models/item.py:170 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr "nom"
 
-#: catalog/models/item.py:176 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:288 catalog/models/item.py:320
-#: journal/models/collection.py:96
+#: catalog/models/item.py:304 catalog/models/item.py:336
+#: journal/models/collection.py:100
 msgid "title"
 msgstr "titre"
 
-#: catalog/models/item.py:289 catalog/models/item.py:328
-#: journal/models/collection.py:97
+#: catalog/models/item.py:305 catalog/models/item.py:344
+#: journal/models/collection.py:101
 msgid "description"
 msgstr "description"
 
-#: catalog/models/item.py:300 catalog/models/people.py:484
+#: catalog/models/item.py:316 catalog/models/people.py:484
 msgid "metadata"
 msgstr "métadonnées"
 
-#: catalog/models/item.py:302 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
 msgid "cover"
 msgstr "couverture"
 
-#: catalog/models/item.py:1485
+#: catalog/models/item.py:1526
 msgid "source site"
 msgstr "site d'origine"
 
-#: catalog/models/item.py:1487
+#: catalog/models/item.py:1528
 msgid "ID on source site"
 msgstr "Identifiant sur le site d'origine"
 
-#: catalog/models/item.py:1489
+#: catalog/models/item.py:1530
 msgid "source url"
 msgstr "URL de la source"
 
-#: catalog/models/item.py:1505
+#: catalog/models/item.py:1546
 msgid "IdType of the source site"
 msgstr "IdType du site d'origine"
 
-#: catalog/models/item.py:1511
+#: catalog/models/item.py:1552
 msgid "Primary Id on the source site"
 msgstr "Identifiant primaire sur le site d'origine"
 
-#: catalog/models/item.py:1514
+#: catalog/models/item.py:1555
 msgid "url to the resource"
 msgstr "URL vers la ressource"
 
 #: catalog/models/movie.py:152 catalog/models/music.py:124
-#: catalog/models/tv.py:243 catalog/models/tv.py:469
+#: catalog/models/tv.py:245 catalog/models/tv.py:471
 #: catalog/templates/_item_card_metadata_album.html:16
 #: catalog/templates/album.html:17 catalog/templates/game.html:22
 #: catalog/templates/movie.html:36 catalog/templates/tvseason.html:53
@@ -912,7 +923,7 @@ msgid "length"
 msgstr "durée"
 
 #: catalog/models/movie.py:162 catalog/models/music.py:131
-#: catalog/models/tv.py:259 catalog/models/tv.py:486
+#: catalog/models/tv.py:261 catalog/models/tv.py:488
 #, fuzzy
 #| msgid "milliseconds"
 msgid "seconds"
@@ -1120,46 +1131,98 @@ msgstr "date de la Première"
 msgid "closing date"
 msgstr "date de la Dernière"
 
-#: catalog/models/tv.py:186 catalog/templates/tvseason.html:38
+#: catalog/models/tv.py:188 catalog/templates/tvseason.html:38
 #: catalog/templates/tvshow.html:33
 msgid "number of seasons"
 msgstr "nombre de saisons"
 
-#: catalog/models/tv.py:189 catalog/models/tv.py:415
+#: catalog/models/tv.py:191 catalog/models/tv.py:417
 #: catalog/templates/tvseason.html:43 catalog/templates/tvshow.html:38
 msgid "number of episodes"
 msgstr "nombre d'épisodes"
 
-#: catalog/models/tv.py:256 catalog/models/tv.py:483
+#: catalog/models/tv.py:258 catalog/models/tv.py:485
 msgid "episode length"
 msgstr "durée de l'épisode"
 
-#: catalog/models/tv.py:412 catalog/templates/tvseason.html:33
+#: catalog/models/tv.py:414 catalog/templates/tvseason.html:33
 msgid "season number"
 msgstr "numéro de saison"
 
-#: catalog/models/tv.py:530
+#: catalog/models/tv.py:532
 #, python-brace-format
 msgid "{show_title} Season {season_number}"
 msgstr "{show_title} — Saison {season_number}"
 
-#: catalog/models/tv.py:684
+#: catalog/models/tv.py:686
 #, python-brace-format
 msgid "{season_title} E{episode_number}"
 msgstr "{season_title} Épisode {episode_number}"
+
+#: catalog/templates/_catalog_confirm_item.html:7
+#: catalog/templates/catalog_edit.html:62
+msgid "Item has been deleted."
+msgstr "L'œuvre a été supprimée."
+
+#: catalog/templates/_catalog_confirm_item.html:12
+#: catalog/templates/catalog_edit.html:65
+msgid "Item contains sub-items."
+msgstr "L'œuvre contient des sous-éléments."
+
+#: catalog/templates/_catalog_confirm_item.html:17
+msgid "Item has been merged to another item."
+msgstr "L'œuvre a été fusionnée avec un autre."
+
+#: catalog/templates/_catalog_confirm_item.html:22
+msgid "Item has been marked by users."
+msgstr "Des membres ont interagi avec l'œuvre."
+
+#: catalog/templates/_catalog_edit_preview.html:11
+#, fuzzy
+#| msgid "Confirm and save"
+msgid "Confirm changes"
+msgstr "Confirmer & enregistrer"
+
+#: catalog/templates/_catalog_edit_preview.html:16
+msgid "Please correct the errors below."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:24
+msgid "Field"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:25
+msgid "From"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:26
+msgid "To"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:45
+#, fuzzy
+#| msgid "Tag deleted."
+msgid "No changes detected."
+msgstr "Étiquette supprimée."
+
+#: catalog/templates/_catalog_edit_preview.html:54
+#: users/templates/users/register.html:104
+msgid "Confirm and save"
+msgstr "Confirmer & enregistrer"
+
+#: catalog/templates/_catalog_edit_preview.html:57
+#, fuzzy
+#| msgid "back to item"
+msgid "Back to editing"
+msgstr "retour à l'œuvre"
 
 #: catalog/templates/_country_list.html:5
 msgid "region"
 msgstr "pays"
 
 #: catalog/templates/_fetch_failed.html:4
-msgid ""
-"Unable to fetch from the link, please check again. Some sites may require "
-"login for certain links, please manually create them here."
-msgstr ""
-"Récupération impossible à partir du lien, veuillez revérifier votre saisie. "
-"Certains sites web peuvent exiger une connexion pour certains liens. Si "
-"nécessaire créez l'œuvre ici manuellement."
+msgid "Unable to fetch from the link, please check again. Some sites may require login for certain links, please manually create them here."
+msgstr "Récupération impossible à partir du lien, veuillez revérifier votre saisie. Certains sites web peuvent exiger une connexion pour certains liens. Si nécessaire créez l'œuvre ici manuellement."
 
 #: catalog/templates/_item_card_metadata_album.html:7
 #: catalog/templates/_item_card_metadata_edition.html:7
@@ -1218,7 +1281,7 @@ msgstr "voir plus"
 #: journal/templates/profile_posts.html:21
 #: journal/templates/user_follow_list_items.html:63
 #: journal/templates/user_post_list_items.html:24
-#: social/templates/events.html:43 social/templates/feed_events.html:28
+#: social/templates/events.html:43 social/templates/feed_events.html:27
 msgid "nothing more."
 msgstr "rien d'autre."
 
@@ -1317,7 +1380,7 @@ msgid "Add note"
 msgstr "Ajouter des films"
 
 #: catalog/templates/_item_user_pieces.html:83
-#: common/templates/_sidebar.html:196 journal/templates/profile_items.html:46
+#: common/templates/_sidebar.html:195 journal/templates/profile_items.html:46
 #, fuzzy
 #| msgid "Sync in progress."
 msgid "Set progress"
@@ -1346,6 +1409,12 @@ msgstr "ma collection"
 #: catalog/templates/_item_user_pieces.html:214
 msgid "mark history"
 msgstr "historique d'interaction"
+
+#: catalog/templates/_search_suggest.html:2
+#, fuzzy
+#| msgid "Suggest Edits"
+msgid "Suggestions"
+msgstr "Proposer une modification"
 
 #: catalog/templates/_sidebar_edit.html:8
 msgid "edit"
@@ -1376,15 +1445,15 @@ msgid "Edit Options"
 msgstr "Option d'édition"
 
 #: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
-#: catalog/views/edit.py:82 catalog/views/edit.py:143 catalog/views/edit.py:197
-#: catalog/views/edit.py:218 catalog/views/edit.py:259
-#: catalog/views/edit.py:328 catalog/views/edit.py:332
-#: catalog/views/edit.py:351 catalog/views/edit.py:400
-#: catalog/views/edit.py:425 catalog/views/edit.py:440
-#: catalog/views/edit.py:480 catalog/views/edit.py:490
-#: catalog/views/edit.py:517 catalog/views/edit.py:582
-#: catalog/views/edit.py:637 catalog/views/edit.py:659
-#: catalog/views/search.py:367
+#: catalog/views/edit.py:160 catalog/views/edit.py:221
+#: catalog/views/edit.py:288 catalog/views/edit.py:309
+#: catalog/views/edit.py:364 catalog/views/edit.py:471
+#: catalog/views/edit.py:475 catalog/views/edit.py:509
+#: catalog/views/edit.py:576 catalog/views/edit.py:601
+#: catalog/views/edit.py:624 catalog/views/edit.py:664
+#: catalog/views/edit.py:674 catalog/views/edit.py:703
+#: catalog/views/edit.py:782 catalog/views/edit.py:837
+#: catalog/views/edit.py:859 catalog/views/search.py:418
 #, fuzzy
 #| msgid "Edit this item"
 msgid "Editing this item is restricted."
@@ -1422,7 +1491,7 @@ msgstr "Des membres ont interagi avec l'œuvre."
 msgid "The following items are merged into this item"
 msgstr "Les œuvres suivantes ont été fusionnées"
 
-#: catalog/templates/_sidebar_edit.html:70
+#: catalog/templates/_sidebar_edit.html:70 catalog/views/edit.py:456
 msgid "External website"
 msgstr "Site externe"
 
@@ -1436,48 +1505,41 @@ msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:88
 msgid "Existing metadata might get overwritten, sure to proceed?"
-msgstr ""
-"Les métadonnées existantes risquent d'être écrasées, voulez-vous continuer ?"
+msgstr "Les métadonnées existantes risquent d'être écrasées, voulez-vous continuer ?"
 
 #: catalog/templates/_sidebar_edit.html:92
 msgid "Fetch again"
 msgstr "Re-télécharger"
 
-#: catalog/templates/_sidebar_edit.html:97
-msgid "You may not be able to undo this operation, sure to remove?"
-msgstr ""
-"Vous ne pourrez peut-être pas annuler cette opération. Confirmer la "
-"suppression ?"
-
-#: catalog/templates/_sidebar_edit.html:102
+#: catalog/templates/_sidebar_edit.html:100
 msgid "Remove link to site"
 msgstr "Retirer le lien vers le site"
 
-#: catalog/templates/_sidebar_edit.html:110
+#: catalog/templates/_sidebar_edit.html:108
 #, fuzzy
 #| msgid "Discover"
 msgid "Choose cover"
 msgstr "Découvrir"
 
-#: catalog/templates/_sidebar_edit.html:119
+#: catalog/templates/_sidebar_edit.html:117
+#: catalog/templates/_sidebar_edit.html:118
 #: catalog/templates/_sidebar_edit.html:120
-#: catalog/templates/_sidebar_edit.html:122
 #, fuzzy
 #| msgid "Current Targets"
 msgid "Current cover"
 msgstr "Objectifs actuels"
 
-#: catalog/templates/_sidebar_edit.html:139
+#: catalog/templates/_sidebar_edit.html:137
 msgid "Select an image to use as the cover of this item."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:140
-#: catalog/templates/catalog_edit.html:65
-#: common/templates/manage/settings.html:136
+#: catalog/templates/_sidebar_edit.html:138
+#: catalog/templates/catalog_edit.html:78
+#: common/templates/manage/settings.html:19
 #: journal/templates/add_to_collection.html:43
 #: journal/templates/article_edit.html:60
 #: journal/templates/collection_edit.html:39 journal/templates/comment.html:41
-#: journal/templates/mark.html:134 journal/templates/note.html:65
+#: journal/templates/mark.html:138 journal/templates/note.html:65
 #: journal/templates/post_compose.html:103
 #: journal/templates/review_edit.html:46 journal/templates/tag_edit.html:51
 #: users/templates/users/_pref_device.html:37
@@ -1486,203 +1548,162 @@ msgstr ""
 msgid "Save"
 msgstr "Enregistrer"
 
-#: catalog/templates/_sidebar_edit.html:147
+#: catalog/templates/_sidebar_edit.html:145
 msgid "Edit sub-items"
 msgstr "Modifier les sous-éléments"
 
-#: catalog/templates/_sidebar_edit.html:160
+#: catalog/templates/_sidebar_edit.html:158
 msgid "create"
 msgstr "créer"
 
-#: catalog/templates/_sidebar_edit.html:166
+#: catalog/templates/_sidebar_edit.html:164
 msgid "Fetch all episodes"
 msgstr "Récupérer tous les épisodes"
 
-#: catalog/templates/_sidebar_edit.html:171
+#: catalog/templates/_sidebar_edit.html:169
 msgid "Fetch all"
 msgstr "Tout récupérer"
 
-#: catalog/templates/_sidebar_edit.html:172
-msgid ""
-"Due to differences in how Douban, IMDB, and TMDB handle season data, a small "
-"number of TV shows and animations may not return correct results. Please "
-"manually verify and clean up after updating."
-msgstr ""
-"En raison de différences dans la manière dont Douban, IMDb & TMDB gèrent les "
-"données liées aux saisons, un petit nombre de séries TV et d'animations "
-"peuvent renvoyer des résultats incorrects. Veillez à les vérifier & nettoyer "
-"manuellement après la mise à jour."
+#: catalog/templates/_sidebar_edit.html:170
+msgid "Due to differences in how Douban, IMDB, and TMDB handle season data, a small number of TV shows and animations may not return correct results. Please manually verify and clean up after updating."
+msgstr "En raison de différences dans la manière dont Douban, IMDb & TMDB gèrent les données liées aux saisons, un petit nombre de séries TV et d'animations peuvent renvoyer des résultats incorrects. Veillez à les vérifier & nettoyer manuellement après la mise à jour."
 
-#: catalog/templates/_sidebar_edit.html:173
+#: catalog/templates/_sidebar_edit.html:171
 msgid "Up to 250 episodes will be fetched for a season."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:176
-msgid ""
-"To fetch all episodes, season numbers and IMDB information are required. If "
-"filling this out is inconvenient, you can also manually create sub-entries."
-msgstr ""
-"Afin de récupérer tous les épisodes, les informations IMDb et le nombre de "
-"saisons sont requises. Si compléter ces informations n'est pas pratique, "
-"vous pouvez aussi créer les sous-entrées manuellement."
+#: catalog/templates/_sidebar_edit.html:174
+msgid "To fetch all episodes, season numbers and IMDB information are required. If filling this out is inconvenient, you can also manually create sub-entries."
+msgstr "Afin de récupérer tous les épisodes, les informations IMDb et le nombre de saisons sont requises. Si compléter ces informations n'est pas pratique, vous pouvez aussi créer les sous-entrées manuellement."
 
-#: catalog/templates/_sidebar_edit.html:182
-#: catalog/templates/_sidebar_edit.html:194
-#: catalog/templates/_sidebar_edit.html:213
+#: catalog/templates/_sidebar_edit.html:180
+#: catalog/templates/_sidebar_edit.html:191
+#: catalog/templates/_sidebar_edit.html:208
 msgid "switch category"
 msgstr "changer de catégorie"
 
-#: catalog/templates/_sidebar_edit.html:185
-msgid "Switching may remove some metadata. Sure to proceed?"
-msgstr ""
-"Le changement peut retirer certaines métadonnées. Voulez-vous continuer ?"
-
-#: catalog/templates/_sidebar_edit.html:188
+#: catalog/templates/_sidebar_edit.html:185 catalog/views/edit.py:383
 msgid "TV Show"
 msgstr "Émission TV"
 
-#: catalog/templates/_sidebar_edit.html:227
+#: catalog/templates/_sidebar_edit.html:221
 msgid "Link to parent item"
 msgstr "Lien vers l'œuvre parente"
 
 #: catalog/templates/_sidebar_edit.html:230
-msgid "Sure to link?"
-msgstr "Confirmer l'association ?"
-
-#: catalog/templates/_sidebar_edit.html:237
 msgid "Update link"
 msgstr "Mettre à jour le lien"
 
-#: catalog/templates/_sidebar_edit.html:243
+#: catalog/templates/_sidebar_edit.html:236
 msgid "Cleanup seasons"
 msgstr "Nettoyer les saisons"
 
-#: catalog/templates/_sidebar_edit.html:246
-#: catalog/templates/catalog_delete.html:45
-msgid "This operation cannot be undone. Sure to delete?"
-msgstr "Cette opération ne peut être annulée. Confirmer la suppression ?"
-
-#: catalog/templates/_sidebar_edit.html:250
+#: catalog/templates/_sidebar_edit.html:242
 msgid "remove seasons not marked"
 msgstr "retirer les saisons sans interaction"
 
-#: catalog/templates/_sidebar_edit.html:256
-#: catalog/templates/catalog_merge.html:12
+#: catalog/templates/_sidebar_edit.html:248
 msgid "Merge"
 msgstr "Fusionner"
 
-#: catalog/templates/_sidebar_edit.html:262
+#: catalog/templates/_sidebar_edit.html:254
 msgid "URL of target item, or empty if undo merge"
 msgstr "URL de l'œuvre cible (vide si annulation de fusion)"
 
-#: catalog/templates/_sidebar_edit.html:268
-#: catalog/templates/_sidebar_edit.html:348
+#: catalog/templates/_sidebar_edit.html:260
+#: catalog/templates/_sidebar_edit.html:350
 msgid "merge to another item"
 msgstr "fusionner avec une autre œuvre"
 
-#: catalog/templates/_sidebar_edit.html:273
-#: catalog/templates/_sidebar_edit.html:277
-#: catalog/templates/catalog_delete.html:12
+#: catalog/templates/_sidebar_edit.html:265
+#: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
 #: journal/templates/article.html:199 journal/templates/collection.html:188
-#: journal/templates/mark.html:149 journal/templates/note.html:82
+#: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
 #: users/templates/users/account.html:254
 msgid "Delete"
 msgstr "Supprimer"
 
-#: catalog/templates/_sidebar_edit.html:287
+#: catalog/templates/_sidebar_edit.html:275
+#: catalog/templates/_sidebar_edit.html:279
+#, fuzzy
+#| msgid "Tag deleted."
+msgid "Undo delete"
+msgstr "Étiquette supprimée."
+
+#: catalog/templates/_sidebar_edit.html:280
+msgid "Links to external sites and parent item were removed on delete and will not be restored."
+msgstr ""
+
+#: catalog/templates/_sidebar_edit.html:290
 msgid "This edition belongs to the following work"
 msgstr "Cette édition est associée à l'œuvre suivante"
 
-#: catalog/templates/_sidebar_edit.html:292
-msgid "Sure to unlink?"
-msgstr "Voulez-vous vraiment rompre le lien ?"
-
-#: catalog/templates/_sidebar_edit.html:298
+#: catalog/templates/_sidebar_edit.html:300
 msgid "Unlink from work"
 msgstr "Rompre le lien avec l'œuvre"
 
-#: catalog/templates/_sidebar_edit.html:304
+#: catalog/templates/_sidebar_edit.html:306
 msgid "Link"
 msgstr "Lier"
 
-#: catalog/templates/_sidebar_edit.html:315
+#: catalog/templates/_sidebar_edit.html:317
 msgid "Link to another edition from same work"
 msgstr "Lier à une autre édition de la même œuvre"
 
-#: catalog/templates/_sidebar_edit.html:324
+#: catalog/templates/_sidebar_edit.html:326
 #, fuzzy
 #| msgid "description"
 msgid "Restriction"
 msgstr "description"
 
-#: catalog/templates/_sidebar_edit.html:337
+#: catalog/templates/_sidebar_edit.html:339
 #: journal/templates/collection_update_item_note.html:4
 msgid "Update"
 msgstr "Mettre à jour"
 
-#: catalog/templates/_sidebar_edit.html:342
+#: catalog/templates/_sidebar_edit.html:344
 msgid "Suggest Edits"
 msgstr "Proposer une modification"
 
-#: catalog/templates/_sidebar_edit.html:347
+#: catalog/templates/_sidebar_edit.html:349
 msgid "proposed action"
 msgstr "action proposée"
 
-#: catalog/templates/_sidebar_edit.html:349
+#: catalog/templates/_sidebar_edit.html:351
 msgid "link to another item"
 msgstr "lien vers une autre œuvre"
 
-#: catalog/templates/_sidebar_edit.html:350
+#: catalog/templates/_sidebar_edit.html:352
 msgid "change item category"
 msgstr "changer la catégorie de l'œuvre"
 
-#: catalog/templates/_sidebar_edit.html:351
+#: catalog/templates/_sidebar_edit.html:353
 msgid "change item metadata"
 msgstr "changer les métadonnées de l'œuvre"
 
-#: catalog/templates/_sidebar_edit.html:352
+#: catalog/templates/_sidebar_edit.html:354
 msgid "remove item"
 msgstr "retirer l'œuvre"
 
-#: catalog/templates/_sidebar_edit.html:353
+#: catalog/templates/_sidebar_edit.html:355
 msgid "other"
 msgstr "autre"
 
-#: catalog/templates/_sidebar_edit.html:357
-msgid ""
-"To suggest merging or association, please include the URL of the target item"
-msgstr ""
-"Pour proposer des fusions ou associations, veuillez inclure l'URL de l'œuvre-"
-"cible"
+#: catalog/templates/_sidebar_edit.html:359
+msgid "To suggest merging or association, please include the URL of the target item"
+msgstr "Pour proposer des fusions ou associations, veuillez inclure l'URL de l'œuvre-cible"
 
-#: catalog/templates/_sidebar_edit.html:358
+#: catalog/templates/_sidebar_edit.html:360
 #: catalog/templates/catalog_verify.html:116
 msgid "submit"
 msgstr "valider"
 
-#: catalog/templates/_sidebar_edit.html:359
-msgid ""
-"As a user of this community, you may edit some metadata of items on this "
-"site. If you are unsure whether your edits are appropriate or are unable to "
-"make a certain change, you can make suggestions here. Moderators will "
-"consider each suggestion, although there is no guarantee that they will "
-"always be fully adopted; suggestions may also be viewed or discussed by "
-"other community users. If you have suggestions that are not related to a "
-"specific item, please contact us. Thank you for your support and "
-"contribution."
-msgstr ""
-"En tant que membre de cette communauté, vous pouvez éditer certaines "
-"métadonnées des œuvres de ce site. Si vous n'avez pas l'assurance que ces "
-"modifications sont adéquates, ou si vous ne parvenez pas à effectuer "
-"certains changements, vous pouvez les suggérer ici. La modération tiendra "
-"compte de toute proposition. Cependant, leur adoption n'est ni automatique, "
-"ni garantie. Les suggestions peuvent également être vues, et discutées, par "
-"d'autres membres de la communauté. Si vous avez des remarques qui ne sont "
-"pas liées à une œuvre en particulier, veuillez nous contacter. Merci de "
-"votre soutien et contribution."
+#: catalog/templates/_sidebar_edit.html:361
+msgid "As a user of this community, you may edit some metadata of items on this site. If you are unsure whether your edits are appropriate or are unable to make a certain change, you can make suggestions here. Moderators will consider each suggestion, although there is no guarantee that they will always be fully adopted; suggestions may also be viewed or discussed by other community users. If you have suggestions that are not related to a specific item, please contact us. Thank you for your support and contribution."
+msgstr "En tant que membre de cette communauté, vous pouvez éditer certaines métadonnées des œuvres de ce site. Si vous n'avez pas l'assurance que ces modifications sont adéquates, ou si vous ne parvenez pas à effectuer certains changements, vous pouvez les suggérer ici. La modération tiendra compte de toute proposition. Cependant, leur adoption n'est ni automatique, ni garantie. Les suggestions peuvent également être vues, et discutées, par d'autres membres de la communauté. Si vous avez des remarques qui ne sont pas liées à une œuvre en particulier, veuillez nous contacter. Merci de votre soutien et contribution."
 
 #: catalog/templates/_sidebar_search.html:5
 #: journal/templates/_sidebar_search_journal.html:4
@@ -1785,9 +1806,7 @@ msgid "matched"
 msgstr "vu"
 
 #: catalog/templates/_verify_status.html:21
-msgid ""
-"Sure to remove your creator verification? Anyone will be able to edit this "
-"item again."
+msgid "Sure to remove your creator verification? Anyone will be able to edit this item again."
 msgstr ""
 
 #: catalog/templates/_verify_status.html:26
@@ -1796,7 +1815,7 @@ msgstr ""
 msgid "Remove my verification"
 msgstr "Retirer de la collection"
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:309
+#: catalog/templates/_verify_status.html:31 users/views/account.py:311
 #, fuzzy
 #| msgid "Verification Code"
 msgid "Verification failed"
@@ -1839,43 +1858,11 @@ msgstr "code-barres"
 msgid "album media"
 msgstr "visuels de l'album"
 
-#: catalog/templates/catalog_delete.html:19
-msgid "Are you sure to delete?"
-msgstr "Confirmer la suppression ?"
-
-#: catalog/templates/catalog_delete.html:24
-#: catalog/templates/catalog_edit.html:52
-#: catalog/templates/catalog_merge.html:36
-#: catalog/templates/catalog_merge.html:64
-msgid "Item has been deleted."
-msgstr "L'œuvre a été supprimée."
-
-#: catalog/templates/catalog_delete.html:29
-#: catalog/templates/catalog_edit.html:55
-#: catalog/templates/catalog_merge.html:41
-#: catalog/templates/catalog_merge.html:69
-msgid "Item contains sub-items."
-msgstr "L'œuvre contient des sous-éléments."
-
-#: catalog/templates/catalog_delete.html:34
-#: catalog/templates/catalog_merge.html:46
-#: catalog/templates/catalog_merge.html:74
-msgid "Item has been merged to another item."
-msgstr "L'œuvre a été fusionnée avec un autre."
-
-#: catalog/templates/catalog_delete.html:39
-#: catalog/templates/catalog_merge.html:51
-#: catalog/templates/catalog_merge.html:79
-msgid "Item has been marked by users."
-msgstr "Des membres ont interagi avec l'œuvre."
-
-#: catalog/templates/catalog_delete.html:48
-#: catalog/templates/catalog_merge.html:92 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:55 common/views_manage.py:139
 msgid "Yes"
 msgstr "Oui"
 
-#: catalog/templates/catalog_delete.html:49
-#: catalog/templates/catalog_merge.html:93 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:56 common/views_manage.py:139
 msgid "No"
 msgstr "Non"
 
@@ -1884,36 +1871,18 @@ msgstr "Non"
 msgid "Create"
 msgstr "Créer"
 
-#: catalog/templates/catalog_edit.html:68
+#: catalog/templates/catalog_edit.html:81
 #: journal/templates/collection_update_item_note.html:8
 #: journal/templates/piece_delete.html:38
 msgid "Cancel"
 msgstr "Annuler"
 
-#: catalog/templates/catalog_edit.html:104
+#: catalog/templates/catalog_edit.html:118
 msgid "open linked people page"
 msgstr ""
 
-#: catalog/templates/catalog_merge.html:22
-msgid "Are you sure to merge?"
-msgstr "Confirmer la fusion ?"
-
-#: catalog/templates/catalog_merge.html:24
-msgid "Are you sure to cancel merge?"
-msgstr "Voulez-vous vraiment annuler la fusion ?"
-
-#: catalog/templates/catalog_merge.html:27
-msgid "Are you sure to link?"
-msgstr "Confirmer le lien ?"
-
-#: catalog/templates/catalog_merge.html:86
-msgid "This operation cannot be undone. Sure to merge?"
-msgstr "Cette opération ne peut être annulée. Confirmer la fusion ?"
-
 #: catalog/templates/catalog_verify.html:21
-msgid ""
-"If you are a creator of this podcast, you may verify the ownership, so that "
-"only you (and other verified creators) can edit its metadata on this site."
+msgid "If you are a creator of this podcast, you may verify the ownership, so that only you (and other verified creators) can edit its metadata on this site."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:22
@@ -1921,9 +1890,7 @@ msgid "Your recent episodes may also occasionally be featured in discovery."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:24
-msgid ""
-"To verify, prove you control one of the following identifiers of your "
-"account (click to copy):"
+msgid "To verify, prove you control one of the following identifiers of your account (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:30
@@ -1934,18 +1901,11 @@ msgid "copied"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:35
-msgid ""
-"You can prove this in a few ways, then start verification: add one of the "
-"identifiers above to the podcast feed's description; add a <code>rel=\"me\"</"
-"code> link back to one of them on the web page your feed links to (the link "
-"verification Mastodon uses); or point your feed's website at your Bluesky "
-"handle's own domain."
+msgid "You can prove this in a few ways, then start verification: add one of the identifiers above to the podcast feed's description; add a <code>rel=\"me\"</code> link back to one of them on the web page your feed links to (the link verification Mastodon uses); or point your feed's website at your Bluesky handle's own domain."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:44
-msgid ""
-"For example, add this rel=me link to the web page your feed links to (click "
-"to copy):"
+msgid "For example, add this rel=me link to the web page your feed links to (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:50
@@ -1953,9 +1913,7 @@ msgid "or, in the page's head:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:57
-msgid ""
-"Can't edit the website? Just add a line like this to your feed's description "
-"instead (click to copy):"
+msgid "Can't edit the website? Just add a line like this to your feed's description instead (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:62
@@ -1963,10 +1921,7 @@ msgid "Welcome to follow me on the Fediverse:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:66
-msgid ""
-"NeoDB does not re-check this periodically at the moment, but we recommend "
-"you keep it so that your audience can discover and connect with you in "
-"distributed social media."
+msgid "NeoDB does not re-check this periodically at the moment, but we recommend you keep it so that your audience can discover and connect with you in distributed social media."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:72
@@ -1996,12 +1951,11 @@ msgid "Send feedback"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:115
-msgid ""
-"Questions or issues with creator verification? Let the site moderators know."
+msgid "Questions or issues with creator verification? Let the site moderators know."
 msgstr ""
 
-#: catalog/templates/discover.html:28 common/views_manage.py:145
-#: common/views_manage.py:353 users/templates/users/preferences.html:34
+#: catalog/templates/discover.html:28 common/views_manage.py:35
+#: common/views_manage.py:431 users/templates/users/preferences.html:34
 msgid "Discover"
 msgstr "Découvrir"
 
@@ -2039,17 +1993,17 @@ msgstr "voir"
 msgid "hide"
 msgstr "masquer"
 
-#: catalog/templates/discover.html:206 common/templates/_sidebar.html:14
+#: catalog/templates/discover.html:206 common/templates/_sidebar.html:13
 msgid "Unread Announcements"
 msgstr "Annonces non-lues"
 
-#: catalog/templates/discover.html:212 common/templates/_sidebar.html:20
+#: catalog/templates/discover.html:212 common/templates/_sidebar.html:19
 #: social/templates/notification.html:67
 msgid "mark all as read"
 msgstr "tout marquer comme lu"
 
 #: catalog/templates/discover.html:222
-#: common/templates/_sidebar_anonymous.html:55
+#: common/templates/_sidebar_anonymous.html:54
 msgid "Popular Tags"
 msgstr "Étiquettes tendances"
 
@@ -2060,9 +2014,9 @@ msgstr "Étiquettes tendances"
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
 #: catalog/templates/user_verified_works.html:23
-#: common/templates/_sidebar.html:127
-#: common/templates/_sidebar_anonymous.html:46
-#: common/templates/_sidebar_anonymous.html:62 journal/templates/posts.html:8
+#: common/templates/_sidebar.html:126
+#: common/templates/_sidebar_anonymous.html:45
+#: common/templates/_sidebar_anonymous.html:61 journal/templates/posts.html:7
 #: journal/templates/profile_articles.html:24
 #: journal/templates/profile_articles.html:26
 #: journal/templates/profile_items.html:65
@@ -2078,7 +2032,7 @@ msgstr "Étiquettes tendances"
 msgid "nothing so far."
 msgstr "rien pour le moment."
 
-#: catalog/templates/discover.html:239 common/templates/_sidebar.html:269
+#: catalog/templates/discover.html:239 common/templates/_sidebar.html:268
 msgid "Recent Posts"
 msgstr "Publications récentes"
 
@@ -2107,15 +2061,9 @@ msgstr "Acheter ou emprunter"
 
 #: catalog/templates/external_search_results.html:10
 #, fuzzy
-#| msgid ""
-#| "System will search other websites and instances, click title of the item "
-#| "to save them locally. "
-msgid ""
-"Some items were found from other websites and instances, click their title "
-"to save them locally."
-msgstr ""
-"Le système va chercher l'œuvre sur d'autres sites et serveurs. Cliquez sur "
-"son titre pour l'importer. "
+#| msgid "System will search other websites and instances, click title of the item to save them locally. "
+msgid "Some items were found from other websites and instances, click their title to save them locally."
+msgstr "Le système va chercher l'œuvre sur d'autres sites et serveurs. Cliquez sur son titre pour l'importer. "
 
 #: catalog/templates/fetch_pending.html:13
 msgid "Search results"
@@ -2141,9 +2089,7 @@ msgstr "interagir, commenter & collectionner"
 
 #: catalog/templates/item_base.html:142
 msgid "Login or register to review or add this item to your collection."
-msgstr ""
-"Inscrivez ou connectez-vous pour évaluer cette œuvre ou l'ajouter à votre "
-"collection."
+msgstr "Inscrivez ou connectez-vous pour évaluer cette œuvre ou l'ajouter à votre collection."
 
 #: catalog/templates/item_base.html:151
 msgid "Related Collections"
@@ -2218,14 +2164,14 @@ msgstr "nombre de Saisons"
 msgid "number of Episodes"
 msgstr "nombre d'Épisodes"
 
-#: catalog/templates/people.html:13 common/templates/_sidebar.html:77
-#: common/templates/_sidebar.html:84 journal/models/shelf.py:326
+#: catalog/templates/people.html:13 common/templates/_sidebar.html:76
+#: common/templates/_sidebar.html:83 journal/models/shelf.py:328
 #, fuzzy
 #| msgid "following you"
 msgid "following"
 msgstr "vous suit"
 
-#: catalog/templates/people.html:15 journal/models/shelf.py:324
+#: catalog/templates/people.html:15 journal/models/shelf.py:326
 #: social/templates/notification.html:60
 msgid "follow"
 msgstr "suivre"
@@ -2244,7 +2190,6 @@ msgstr ""
 #: journal/templates/_sidebar_collection_filter.html:14
 #: journal/templates/_sidebar_collection_filter.html:28
 #: journal/templates/_sidebar_user_mark_list.html:56
-#: social/templates/feed.html:42 social/templates/feed.html:44
 #: social/templates/notification.html:56
 msgid "all"
 msgstr "tout"
@@ -2272,7 +2217,7 @@ msgstr "Terminé"
 msgid "production"
 msgstr "production"
 
-#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:54
+#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:53
 #, fuzzy
 #| msgid "original creator"
 msgid "verified creator"
@@ -2357,14 +2302,8 @@ msgid "No items matching your search query."
 msgstr "Aucune œuvre ne correspond à votre requête."
 
 #: catalog/templates/search_results.html:34
-msgid ""
-"If you have URL from one of these sites, please put the full URL (e.g. "
-"<code>https://www.imdb.com/title/tt2513074/</code>) to the search box and "
-"press Enter."
-msgstr ""
-"Si vous avez l'adresse d'une œuvre sur l'un de ces sites, veuillez saisir "
-"l'URL complète (ex : <code>https://www.imdb.com/fr/title/tt0411008/</code>) "
-"dans la barre de recherche avant d'appuyer sur Entrée."
+msgid "If you have URL from one of these sites, please put the full URL (e.g. <code>https://www.imdb.com/title/tt2513074/</code>) to the search box and press Enter."
+msgstr "Si vous avez l'adresse d'une œuvre sur l'un de ces sites, veuillez saisir l'URL complète (ex : <code>https://www.imdb.com/fr/title/tt0411008/</code>) dans la barre de recherche avant d'appuyer sur Entrée."
 
 #: catalog/templates/search_results.html:48
 msgid "Searching from other sites"
@@ -2402,99 +2341,192 @@ msgstr ""
 msgid "Editions"
 msgstr "Éditions"
 
-#: catalog/views/edit.py:202 catalog/views/edit.py:205
-#: catalog/views/edit.py:306 catalog/views/edit.py:309
-#: catalog/views/verify.py:197 journal/views/collection.py:77
-#: journal/views/collection.py:102 journal/views/collection.py:556
-#: journal/views/collection.py:651 journal/views/common.py:221
-#: journal/views/mark.py:196 journal/views/post.py:117
-#: journal/views/post.py:119 journal/views/post.py:166
-#: journal/views/post.py:185 journal/views/post.py:187
-#: journal/views/post.py:228 journal/views/post.py:241
+#: catalog/views/edit.py:293 catalog/views/edit.py:296
+#: catalog/views/edit.py:440 catalog/views/edit.py:443
+#: catalog/views/verify.py:197 journal/views/collection.py:75
+#: journal/views/collection.py:100 journal/views/collection.py:538
+#: journal/views/collection.py:634 journal/views/common.py:231
+#: journal/views/mark.py:244 journal/views/post.py:119
+#: journal/views/post.py:121 journal/views/post.py:168
+#: journal/views/post.py:187 journal/views/post.py:189
+#: journal/views/post.py:230 journal/views/post.py:243
 #: journal/views/review.py:154 journal/views/review.py:158
-#: users/views/actions.py:179
+#: users/views/actions.py:178
 msgid "Invalid parameter"
 msgstr "Paramètre invalide"
 
-#: catalog/views/edit.py:220
+#: catalog/views/edit.py:313
 msgid "Item in use."
 msgstr "Élément en cours d'utilisation."
 
-#: catalog/views/edit.py:222
+#: catalog/views/edit.py:315
 msgid "Item cannot be deleted."
 msgstr "L'élément ne peut être supprimé."
 
-#: catalog/views/edit.py:247 catalog/views/edit.py:303
-#: catalog/views/edit.py:427 catalog/views/edit.py:519
-#: catalog/views/edit.py:552 catalog/views/verify.py:158
+#: catalog/views/edit.py:319 catalog/views/edit.py:515
+msgid "Are you sure to delete?"
+msgstr "Confirmer la suppression ?"
+
+#: catalog/views/edit.py:323 catalog/views/edit.py:518
+#: catalog/views/edit.py:617
+#, fuzzy
+#| msgid "This operation cannot be undone. Sure to merge?"
+msgid "This operation cannot be undone."
+msgstr "Cette opération ne peut être annulée. Confirmer la fusion ?"
+
+#: catalog/views/edit.py:344 catalog/views/edit.py:437
+#: catalog/views/edit.py:603 catalog/views/edit.py:705
+#: catalog/views/edit.py:752 catalog/views/verify.py:158
 #: catalog/views/verify.py:206 journal/views/article.py:44
 #: journal/views/article.py:133 journal/views/article.py:153
 #: journal/views/collection.py:248 journal/views/collection.py:341
-#: journal/views/collection.py:360 journal/views/collection.py:384
-#: journal/views/collection.py:457 journal/views/collection.py:500
-#: journal/views/collection.py:539 journal/views/collection.py:551
-#: journal/views/collection.py:576 journal/views/collection.py:613
-#: journal/views/common.py:300 journal/views/mark.py:281
-#: journal/views/post.py:58 journal/views/post.py:78 journal/views/post.py:100
-#: journal/views/post.py:170 journal/views/post.py:199
-#: journal/views/post.py:272 journal/views/post.py:287
-#: journal/views/post.py:394 journal/views/post.py:549
+#: journal/views/collection.py:354 journal/views/collection.py:372
+#: journal/views/collection.py:439 journal/views/collection.py:482
+#: journal/views/collection.py:521 journal/views/collection.py:533
+#: journal/views/collection.py:558 journal/views/collection.py:595
+#: journal/views/common.py:304 journal/views/mark.py:317
+#: journal/views/post.py:60 journal/views/post.py:80 journal/views/post.py:102
+#: journal/views/post.py:172 journal/views/post.py:201
+#: journal/views/post.py:274 journal/views/post.py:289
+#: journal/views/post.py:390 journal/views/post.py:539
 #: journal/views/review.py:64 journal/views/review.py:81
 #: journal/views/review.py:106
 msgid "Insufficient permission"
 msgstr "Permissions insuffisantes"
 
-#: catalog/views/edit.py:374
+#: catalog/views/edit.py:346
+#, fuzzy
+#| msgid "Item has been deleted."
+msgid "Item is not deleted"
+msgstr "L'œuvre a été supprimée."
+
+#: catalog/views/edit.py:389
+#, fuzzy
+#| msgid "Switching may remove some metadata. Sure to proceed?"
+msgid "Switching may remove some metadata."
+msgstr "Le changement peut retirer certaines métadonnées. Voulez-vous continuer ?"
+
+#: catalog/views/edit.py:395
+#, fuzzy
+#| msgid "The following items are merged into this item"
+msgid "The following seasons will be detached from this show"
+msgstr "Les œuvres suivantes ont été fusionnées"
+
+#: catalog/views/edit.py:400
+msgid "Links to IMDB and TMDB will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:403
+#, fuzzy
+#| msgid "Are you sure to merge?"
+msgid "Are you sure to switch category?"
+msgstr "Confirmer la fusion ?"
+
+#: catalog/views/edit.py:451
+#, fuzzy
+#| msgid "Are you sure to delete this post?"
+msgid "Are you sure to remove the link to this site?"
+msgstr "Voulez-vous vraiment supprimer cette publication ?"
+
+#: catalog/views/edit.py:457
+#, fuzzy
+#| msgid "You may not be able to undo this operation, sure to remove?"
+msgid "You may not be able to undo this operation."
+msgstr "Vous ne pourrez peut-être pas annuler cette opération. Confirmer la suppression ?"
+
+#: catalog/views/edit.py:483
+#, fuzzy
+#| msgid "Link to parent item"
+msgid "Current parent item"
+msgstr "Lien vers l'œuvre parente"
+
+#: catalog/views/edit.py:487
+msgid "The link to the parent item will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:490 catalog/views/edit.py:680
+msgid "Are you sure to link?"
+msgstr "Confirmer le lien ?"
+
+#: catalog/views/edit.py:521
+msgid "The following seasons will be deleted"
+msgstr ""
+
+#: catalog/views/edit.py:525
+msgid "The following seasons will be kept"
+msgstr ""
+
+#: catalog/views/edit.py:550
 msgid "TV Season with IMDB id and season number required."
 msgstr "Saison avec identifiant IMDb & numéro de saison nécessaire."
 
-#: catalog/views/edit.py:380
+#: catalog/views/edit.py:556
 msgid "Updating episodes"
 msgstr "Mise à jour des épisodes"
 
-#: catalog/views/edit.py:405
+#: catalog/views/edit.py:581
 msgid "This person has no supported source to fetch works from."
 msgstr ""
 
-#: catalog/views/edit.py:412
+#: catalog/views/edit.py:588
 msgid "Already pulling works for this person, try again later."
 msgstr ""
 
-#: catalog/views/edit.py:416
+#: catalog/views/edit.py:592
 msgid "Pulling works in background."
 msgstr ""
 
-#: catalog/views/edit.py:438
+#: catalog/views/edit.py:609
+msgid "Are you sure to merge?"
+msgstr "Confirmer la fusion ?"
+
+#: catalog/views/edit.py:611
+msgid "Are you sure to cancel merge?"
+msgstr "Voulez-vous vraiment annuler la fusion ?"
+
+#: catalog/views/edit.py:622
 msgid "Cannot be merged to an item already deleted or merged"
 msgstr "Impossible de fusionner avec une œuvre supprimée ou déjà fusionnée"
 
-#: catalog/views/edit.py:443
+#: catalog/views/edit.py:627
 msgid "Cannot merge items in different categories"
 msgstr "Impossible de fusionner des œuvres issues de catégories différentes"
 
-#: catalog/views/edit.py:447
+#: catalog/views/edit.py:631
 #, fuzzy
 #| msgid "Cannot merge items in different categories"
 msgid "Cannot merge an item to itself"
 msgstr "Impossible de fusionner des œuvres issues de catégories différentes"
 
-#: catalog/views/edit.py:488
+#: catalog/views/edit.py:672
 msgid "Cannot be linked to an item already deleted or merged"
 msgstr "Impossible d'associer à une œuvre supprimée ou fusionnée"
 
-#: catalog/views/edit.py:492
+#: catalog/views/edit.py:676
 msgid "Cannot link items other than editions"
 msgstr "Impossible de lier des éléments autre que les éditions"
 
-#: catalog/views/search.py:96
+#: catalog/views/edit.py:710
+#, fuzzy
+#| msgid "Are you sure to link?"
+msgid "Are you sure to unlink?"
+msgstr "Confirmer le lien ?"
+
+#: catalog/views/edit.py:715
+#, fuzzy
+#| msgid "This edition belongs to the following work"
+msgid "This edition will be unlinked from the following work"
+msgstr "Cette édition est associée à l'œuvre suivante"
+
+#: catalog/views/search.py:113
 msgid "the internet"
 msgstr ""
 
-#: catalog/views/search.py:359
+#: catalog/views/search.py:410
 msgid "Invalid URL"
 msgstr "URL incorrecte"
 
-#: catalog/views/search.py:362
+#: catalog/views/search.py:413
 #, fuzzy
 #| msgid "Unsupported item type."
 msgid "Unsupported URL"
@@ -2520,9 +2552,9 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:122 common/utils.py:163
+#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
 #: journal/views/article.py:186 journal/views/review.py:182
-#: users/views/actions.py:45 users/views/actions.py:131
+#: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
 msgstr "Membre introuvable"
 
@@ -2536,15 +2568,15 @@ msgstr ""
 msgid "Creator verification removed."
 msgstr "Envoyer le code de vérification"
 
-#: catalog/views/view.py:74 catalog/views/view.py:99
+#: catalog/views/view.py:77 catalog/views/view.py:102
 msgid "Item not found"
 msgstr "Élément introuvable"
 
-#: catalog/views/view.py:78 catalog/views/view.py:107 catalog/views/view.py:190
+#: catalog/views/view.py:81 catalog/views/view.py:110 catalog/views/view.py:193
 msgid "Item no longer exists"
 msgstr "Élément disparu"
 
-#: catalog/views/view.py:187
+#: catalog/views/view.py:190
 #, fuzzy
 #| msgid "Invalid file."
 msgid "Invalid role"
@@ -3092,759 +3124,759 @@ msgctxt "genre"
 msgid "Health"
 msgstr ""
 
-#: common/models/lang.py:54
+#: common/models/lang.py:56
 msgid "Afar"
 msgstr "Afar"
 
-#: common/models/lang.py:55
+#: common/models/lang.py:57
 msgid "Afrikaans"
 msgstr "Afrikaans"
 
-#: common/models/lang.py:56
+#: common/models/lang.py:58
 msgid "Akan"
 msgstr "Akan"
 
-#: common/models/lang.py:57
+#: common/models/lang.py:59
 msgid "Aragonese"
 msgstr "Aragonais"
 
-#: common/models/lang.py:58
+#: common/models/lang.py:60
 msgid "Assamese"
 msgstr "Assamais"
 
-#: common/models/lang.py:59
+#: common/models/lang.py:61
 msgid "Avaric"
 msgstr "Avar"
 
-#: common/models/lang.py:60
+#: common/models/lang.py:62
 msgid "Avestan"
 msgstr "Avestique"
 
-#: common/models/lang.py:61
+#: common/models/lang.py:63
 msgid "Aymara"
 msgstr "Aymara"
 
-#: common/models/lang.py:62
+#: common/models/lang.py:64
 msgid "Azerbaijani"
 msgstr "Azéri"
 
-#: common/models/lang.py:63
+#: common/models/lang.py:65
 msgid "Bashkir"
 msgstr "Bachkir"
 
-#: common/models/lang.py:64
+#: common/models/lang.py:66
 msgid "Bambara"
 msgstr "Bambara"
 
-#: common/models/lang.py:65
+#: common/models/lang.py:67
 msgid "Bislama"
 msgstr "Bichelamar"
 
-#: common/models/lang.py:66
+#: common/models/lang.py:68
 msgid "Tibetan"
 msgstr "Tibétain"
 
-#: common/models/lang.py:67
+#: common/models/lang.py:69
 msgid "Breton"
 msgstr "Breton"
 
-#: common/models/lang.py:68
+#: common/models/lang.py:70
 msgid "Catalan"
 msgstr "Catalan"
 
-#: common/models/lang.py:69
+#: common/models/lang.py:71
 msgid "Czech"
 msgstr "Tchèque"
 
-#: common/models/lang.py:70
+#: common/models/lang.py:72
 msgid "Chechen"
 msgstr "Tchétchène"
 
-#: common/models/lang.py:71
+#: common/models/lang.py:73
 msgid "Slavic"
 msgstr "Slave"
 
-#: common/models/lang.py:72
+#: common/models/lang.py:74
 msgid "Chuvash"
 msgstr "Tchouvache"
 
-#: common/models/lang.py:73
+#: common/models/lang.py:75
 msgid "Cornish"
 msgstr "Cornique"
 
-#: common/models/lang.py:74
+#: common/models/lang.py:76
 msgid "Corsican"
 msgstr "Corse"
 
-#: common/models/lang.py:75
+#: common/models/lang.py:77
 msgid "Cree"
 msgstr "Cri"
 
-#: common/models/lang.py:76
+#: common/models/lang.py:78
 msgid "Welsh"
 msgstr "Gallois"
 
-#: common/models/lang.py:79
+#: common/models/lang.py:81
 msgid "Divehi"
 msgstr "Maldivien"
 
-#: common/models/lang.py:80
+#: common/models/lang.py:82
 msgid "Dzongkha"
 msgstr "Dzongkha"
 
-#: common/models/lang.py:81
+#: common/models/lang.py:83
 msgid "Esperanto"
 msgstr "Esperanto"
 
-#: common/models/lang.py:82
+#: common/models/lang.py:84
 msgid "Estonian"
 msgstr "Estonien"
 
-#: common/models/lang.py:83
+#: common/models/lang.py:85
 msgid "Basque"
 msgstr "Basque"
 
-#: common/models/lang.py:84
+#: common/models/lang.py:86
 msgid "Faroese"
 msgstr "Féroïen"
 
-#: common/models/lang.py:85
+#: common/models/lang.py:87
 msgid "Fijian"
 msgstr "Fidjien"
 
-#: common/models/lang.py:86
+#: common/models/lang.py:88
 msgid "Finnish"
 msgstr "Finlandais"
 
-#: common/models/lang.py:88
+#: common/models/lang.py:90
 msgid "Frisian"
 msgstr "Frison"
 
-#: common/models/lang.py:89
+#: common/models/lang.py:91
 msgid "Fulah"
 msgstr "Peul"
 
-#: common/models/lang.py:90
+#: common/models/lang.py:92
 msgid "Gaelic"
 msgstr "Gaélique"
 
-#: common/models/lang.py:91
+#: common/models/lang.py:93
 msgid "Irish"
 msgstr "Irlandais"
 
-#: common/models/lang.py:92
+#: common/models/lang.py:94
 msgid "Galician"
 msgstr "Galicien"
 
-#: common/models/lang.py:93
+#: common/models/lang.py:95
 msgid "Manx"
 msgstr "Mannois"
 
-#: common/models/lang.py:94
+#: common/models/lang.py:96
 msgid "Guarani"
 msgstr "Guarani"
 
-#: common/models/lang.py:95
+#: common/models/lang.py:97
 msgid "Gujarati"
 msgstr "Gujarati"
 
-#: common/models/lang.py:96
+#: common/models/lang.py:98
 msgid "Haitian; Haitian Creole"
 msgstr "Haïtien ; Créole Haïtien"
 
-#: common/models/lang.py:97
+#: common/models/lang.py:99
 msgid "Hausa"
 msgstr "Haoussa"
 
-#: common/models/lang.py:98
+#: common/models/lang.py:100
 msgid "Serbo-Croatian"
 msgstr "Serbo-Croate"
 
-#: common/models/lang.py:99
+#: common/models/lang.py:101
 msgid "Herero"
 msgstr "Héréro"
 
-#: common/models/lang.py:100
+#: common/models/lang.py:102
 msgid "Hiri Motu"
 msgstr "Hiri Motou"
 
-#: common/models/lang.py:101
+#: common/models/lang.py:103
 msgid "Croatian"
 msgstr "Croate"
 
-#: common/models/lang.py:102
+#: common/models/lang.py:104
 msgid "Hungarian"
 msgstr "Hongrois"
 
-#: common/models/lang.py:103
+#: common/models/lang.py:105
 msgid "Igbo"
 msgstr "Igbo"
 
-#: common/models/lang.py:104
+#: common/models/lang.py:106
 msgid "Ido"
 msgstr "Ido"
 
-#: common/models/lang.py:105
+#: common/models/lang.py:107
 msgid "Yi"
 msgstr "Yi"
 
-#: common/models/lang.py:106
+#: common/models/lang.py:108
 msgid "Inuktitut"
 msgstr "Inuktitut"
 
-#: common/models/lang.py:107
+#: common/models/lang.py:109
 msgid "Interlingue"
 msgstr "Interlingue"
 
-#: common/models/lang.py:108
+#: common/models/lang.py:110
 msgid "Interlingua"
 msgstr "Interlingua"
 
-#: common/models/lang.py:109
+#: common/models/lang.py:111
 msgid "Indonesian"
 msgstr "Indonésien"
 
-#: common/models/lang.py:110
+#: common/models/lang.py:112
 msgid "Inupiaq"
 msgstr "Inupiaq"
 
-#: common/models/lang.py:111
+#: common/models/lang.py:113
 msgid "Icelandic"
 msgstr "Islandais"
 
-#: common/models/lang.py:113
+#: common/models/lang.py:115
 msgid "Javanese"
 msgstr "Javanais"
 
-#: common/models/lang.py:114
+#: common/models/lang.py:116
 msgid "Japanese"
 msgstr "Japonais"
 
-#: common/models/lang.py:115
+#: common/models/lang.py:117
 msgid "Kalaallisut"
 msgstr "Groenlandais"
 
-#: common/models/lang.py:116
+#: common/models/lang.py:118
 msgid "Kannada"
 msgstr "Kannada"
 
-#: common/models/lang.py:117
+#: common/models/lang.py:119
 msgid "Kashmiri"
 msgstr "Cachemiri"
 
-#: common/models/lang.py:118
+#: common/models/lang.py:120
 msgid "Kanuri"
 msgstr "Kanouri"
 
-#: common/models/lang.py:119
+#: common/models/lang.py:121
 msgid "Kazakh"
 msgstr "Kazakh"
 
-#: common/models/lang.py:120
+#: common/models/lang.py:122
 msgid "Khmer"
 msgstr "Khmer ; Cambodgien"
 
-#: common/models/lang.py:121
+#: common/models/lang.py:123
 msgid "Kikuyu"
 msgstr "Kikuyu"
 
-#: common/models/lang.py:122
+#: common/models/lang.py:124
 msgid "Kinyarwanda"
 msgstr "Kinyarwanda"
 
-#: common/models/lang.py:123
+#: common/models/lang.py:125
 msgid "Kirghiz"
 msgstr "Kirghize"
 
-#: common/models/lang.py:124
+#: common/models/lang.py:126
 msgid "Komi"
 msgstr "Komi"
 
-#: common/models/lang.py:125
+#: common/models/lang.py:127
 msgid "Kongo"
 msgstr "Kikongo"
 
-#: common/models/lang.py:126
+#: common/models/lang.py:128
 msgid "Korean"
 msgstr "Coréen"
 
-#: common/models/lang.py:127
+#: common/models/lang.py:129
 msgid "Kuanyama"
 msgstr "Kuanyama"
 
-#: common/models/lang.py:128
+#: common/models/lang.py:130
 msgid "Kurdish"
 msgstr "Kurde"
 
-#: common/models/lang.py:129
+#: common/models/lang.py:131
 msgid "Lao"
 msgstr "Lao ; Laotien"
 
-#: common/models/lang.py:130
+#: common/models/lang.py:132
 msgid "Latin"
 msgstr "Latin"
 
-#: common/models/lang.py:131
+#: common/models/lang.py:133
 msgid "Latvian"
 msgstr "Letton"
 
-#: common/models/lang.py:132
+#: common/models/lang.py:134
 msgid "Limburgish"
 msgstr "Limbourgeois"
 
-#: common/models/lang.py:133
+#: common/models/lang.py:135
 msgid "Lingala"
 msgstr "Lingala"
 
-#: common/models/lang.py:134
+#: common/models/lang.py:136
 msgid "Lithuanian"
 msgstr "Lituanien"
 
-#: common/models/lang.py:135
+#: common/models/lang.py:137
 msgid "Letzeburgesch"
 msgstr "Luxembourgeois ; Lëtzebuergesch"
 
-#: common/models/lang.py:136
+#: common/models/lang.py:138
 msgid "Luba-Katanga"
 msgstr "Luba-Katanga ; Kiluba"
 
-#: common/models/lang.py:137
+#: common/models/lang.py:139
 msgid "Ganda"
 msgstr "Luganda ; Ganda"
 
-#: common/models/lang.py:138
+#: common/models/lang.py:140
 msgid "Marshall"
 msgstr "Marshallais"
 
-#: common/models/lang.py:139
+#: common/models/lang.py:141
 msgid "Malayalam"
 msgstr "Malayalam"
 
-#: common/models/lang.py:140
+#: common/models/lang.py:142
 msgid "Marathi"
 msgstr "Marathi"
 
-#: common/models/lang.py:141
+#: common/models/lang.py:143
 msgid "Malagasy"
 msgstr "Malgache"
 
-#: common/models/lang.py:142
+#: common/models/lang.py:144
 msgid "Maltese"
 msgstr "Maltais"
 
-#: common/models/lang.py:143
+#: common/models/lang.py:145
 msgid "Moldavian"
 msgstr "Moldave"
 
-#: common/models/lang.py:144
+#: common/models/lang.py:146
 msgid "Mongolian"
 msgstr "Mongol"
 
-#: common/models/lang.py:145
+#: common/models/lang.py:147
 msgid "Maori"
 msgstr "Maori"
 
-#: common/models/lang.py:146
+#: common/models/lang.py:148
 msgid "Malay"
 msgstr "Malais"
 
-#: common/models/lang.py:147
+#: common/models/lang.py:149
 msgid "Burmese"
 msgstr "Birman"
 
-#: common/models/lang.py:148
+#: common/models/lang.py:150
 msgid "Nauru"
 msgstr "Nauru"
 
-#: common/models/lang.py:149
+#: common/models/lang.py:151
 msgid "Navajo"
 msgstr "Navajo"
 
-#: common/models/lang.py:150 common/models/lang.py:151
+#: common/models/lang.py:152 common/models/lang.py:153
 msgid "Ndebele"
 msgstr "Ndébélé"
 
-#: common/models/lang.py:152
+#: common/models/lang.py:154
 msgid "Ndonga"
 msgstr "Ndonga"
 
-#: common/models/lang.py:153
+#: common/models/lang.py:155
 msgid "Nepali"
 msgstr "Népalais"
 
-#: common/models/lang.py:154
+#: common/models/lang.py:156
 msgid "Dutch"
 msgstr "Néerlandais"
 
-#: common/models/lang.py:155
+#: common/models/lang.py:157
 msgid "Norwegian Nynorsk"
 msgstr "Norvégien (Nynorsk)"
 
-#: common/models/lang.py:156
+#: common/models/lang.py:158
 msgid "Norwegian Bokmål"
 msgstr "Norvégien (Bokmål)"
 
-#: common/models/lang.py:157
+#: common/models/lang.py:159
 msgid "Norwegian"
 msgstr "Norvégien"
 
-#: common/models/lang.py:158
+#: common/models/lang.py:160
 msgid "Chichewa; Nyanja"
 msgstr "Chewa ; Nyanja"
 
-#: common/models/lang.py:159
+#: common/models/lang.py:161
 msgid "Occitan"
 msgstr "Occitan"
 
-#: common/models/lang.py:160
+#: common/models/lang.py:162
 msgid "Ojibwa"
 msgstr "Ojibwé"
 
-#: common/models/lang.py:161
+#: common/models/lang.py:163
 msgid "Oriya"
 msgstr "Odia"
 
-#: common/models/lang.py:162
+#: common/models/lang.py:164
 msgid "Oromo"
 msgstr "Oromo"
 
-#: common/models/lang.py:163
+#: common/models/lang.py:165
 msgid "Ossetian; Ossetic"
 msgstr "Ossète"
 
-#: common/models/lang.py:164
+#: common/models/lang.py:166
 msgid "Pali"
 msgstr "Pali"
 
-#: common/models/lang.py:165
+#: common/models/lang.py:167
 msgid "Polish"
 msgstr "Polonais"
 
-#: common/models/lang.py:167
+#: common/models/lang.py:169
 msgid "Quechua"
 msgstr "Quechua"
 
-#: common/models/lang.py:168
+#: common/models/lang.py:170
 msgid "Raeto-Romance"
 msgstr "Langues rhéto-romanes"
 
-#: common/models/lang.py:169
+#: common/models/lang.py:171
 msgid "Romanian"
 msgstr "Roumain"
 
-#: common/models/lang.py:170
+#: common/models/lang.py:172
 msgid "Rundi"
 msgstr "Kirundi"
 
-#: common/models/lang.py:171
+#: common/models/lang.py:173
 msgid "Russian"
 msgstr "Russe"
 
-#: common/models/lang.py:172
+#: common/models/lang.py:174
 msgid "Sango"
 msgstr "Sango"
 
-#: common/models/lang.py:173
+#: common/models/lang.py:175
 msgid "Sanskrit"
 msgstr "Sanskrit"
 
-#: common/models/lang.py:174
+#: common/models/lang.py:176
 msgid "Sinhalese"
 msgstr "Singhalais"
 
-#: common/models/lang.py:175
+#: common/models/lang.py:177
 msgid "Slovak"
 msgstr "Slovaque"
 
-#: common/models/lang.py:176
+#: common/models/lang.py:178
 msgid "Slovenian"
 msgstr "Slovène"
 
-#: common/models/lang.py:177
+#: common/models/lang.py:179
 msgid "Northern Sami"
 msgstr "Same du Nord"
 
-#: common/models/lang.py:178
+#: common/models/lang.py:180
 msgid "Samoan"
 msgstr "Samoan"
 
-#: common/models/lang.py:179
+#: common/models/lang.py:181
 msgid "Shona"
 msgstr "Shona"
 
-#: common/models/lang.py:180
+#: common/models/lang.py:182
 msgid "Sindhi"
 msgstr "Sindhi"
 
-#: common/models/lang.py:181
+#: common/models/lang.py:183
 msgid "Somali"
 msgstr "Somali"
 
-#: common/models/lang.py:182
+#: common/models/lang.py:184
 msgid "Sotho"
 msgstr "Sotho"
 
-#: common/models/lang.py:184
+#: common/models/lang.py:186
 msgid "Albanian"
 msgstr "Albanais"
 
-#: common/models/lang.py:185
+#: common/models/lang.py:187
 msgid "Sardinian"
 msgstr "Sarde"
 
-#: common/models/lang.py:186
+#: common/models/lang.py:188
 msgid "Serbian"
 msgstr "Serbe"
 
-#: common/models/lang.py:187
+#: common/models/lang.py:189
 msgid "Swati"
 msgstr "Swati"
 
-#: common/models/lang.py:188
+#: common/models/lang.py:190
 msgid "Sundanese"
 msgstr "Soundanais"
 
-#: common/models/lang.py:189
+#: common/models/lang.py:191
 msgid "Swahili"
 msgstr "Swahili"
 
-#: common/models/lang.py:190
+#: common/models/lang.py:192
 msgid "Swedish"
 msgstr "Suédois"
 
-#: common/models/lang.py:191
+#: common/models/lang.py:193
 msgid "Tahitian"
 msgstr "Tahitien"
 
-#: common/models/lang.py:192
+#: common/models/lang.py:194
 msgid "Tamil"
 msgstr "Tamoul"
 
-#: common/models/lang.py:193
+#: common/models/lang.py:195
 msgid "Tatar"
 msgstr "Tatar"
 
-#: common/models/lang.py:194
+#: common/models/lang.py:196
 msgid "Telugu"
 msgstr "Télougou"
 
-#: common/models/lang.py:195
+#: common/models/lang.py:197
 msgid "Tajik"
 msgstr "Tadjik"
 
-#: common/models/lang.py:196
+#: common/models/lang.py:198
 msgid "Tagalog"
 msgstr "Tagalog"
 
-#: common/models/lang.py:197
+#: common/models/lang.py:199
 msgid "Thai"
 msgstr "Thaï"
 
-#: common/models/lang.py:198
+#: common/models/lang.py:200
 msgid "Tigrinya"
 msgstr "Tigrigna"
 
-#: common/models/lang.py:199
+#: common/models/lang.py:201
 msgid "Tonga"
 msgstr "Tongien"
 
-#: common/models/lang.py:200
+#: common/models/lang.py:202
 msgid "Tswana"
 msgstr "Tswana"
 
-#: common/models/lang.py:201
+#: common/models/lang.py:203
 msgid "Tsonga"
 msgstr "Tsonga"
 
-#: common/models/lang.py:202
+#: common/models/lang.py:204
 msgid "Turkmen"
 msgstr "Turkmène"
 
-#: common/models/lang.py:203
+#: common/models/lang.py:205
 msgid "Turkish"
 msgstr "Turc"
 
-#: common/models/lang.py:204
+#: common/models/lang.py:206
 msgid "Twi"
 msgstr "Twi ; Tchi ; Asante"
 
-#: common/models/lang.py:205
+#: common/models/lang.py:207
 msgid "Uighur"
 msgstr "Ouïghour"
 
-#: common/models/lang.py:206
+#: common/models/lang.py:208
 msgid "Ukrainian"
 msgstr "Ukrainien"
 
-#: common/models/lang.py:207
+#: common/models/lang.py:209
 msgid "Urdu"
 msgstr "Ourdou"
 
-#: common/models/lang.py:208
+#: common/models/lang.py:210
 msgid "Uzbek"
 msgstr "Ouzbek"
 
-#: common/models/lang.py:209
+#: common/models/lang.py:211
 msgid "Venda"
 msgstr "Venda"
 
-#: common/models/lang.py:210
+#: common/models/lang.py:212
 msgid "Vietnamese"
 msgstr "Vietnamien"
 
-#: common/models/lang.py:211
+#: common/models/lang.py:213
 msgid "Volapük"
 msgstr "Volapük"
 
-#: common/models/lang.py:212
+#: common/models/lang.py:214
 msgid "Walloon"
 msgstr "Wallon"
 
-#: common/models/lang.py:213
+#: common/models/lang.py:215
 msgid "Wolof"
 msgstr "Wolof"
 
-#: common/models/lang.py:214
+#: common/models/lang.py:216
 msgid "Xhosa"
 msgstr "Xhosa"
 
-#: common/models/lang.py:215
+#: common/models/lang.py:217
 msgid "Yiddish"
 msgstr "Yiddish"
 
-#: common/models/lang.py:216
+#: common/models/lang.py:218
 msgid "Zhuang"
 msgstr "Zhuang"
 
-#: common/models/lang.py:217
+#: common/models/lang.py:219
 msgid "Zulu"
 msgstr "Zoulou"
 
-#: common/models/lang.py:218
+#: common/models/lang.py:220
 msgid "Abkhazian"
 msgstr "Abkhaze"
 
-#: common/models/lang.py:219
+#: common/models/lang.py:221
 msgid "Chinese"
 msgstr "Chinois"
 
-#: common/models/lang.py:220
+#: common/models/lang.py:222
 msgid "Pushto"
 msgstr "Pachto"
 
-#: common/models/lang.py:221
+#: common/models/lang.py:223
 msgid "Amharic"
 msgstr "Amharique"
 
-#: common/models/lang.py:222
+#: common/models/lang.py:224
 msgid "Arabic"
 msgstr "Arabe"
 
-#: common/models/lang.py:223
+#: common/models/lang.py:225
 msgid "Bulgarian"
 msgstr "Bulgare"
 
-#: common/models/lang.py:224
+#: common/models/lang.py:226
 msgid "Macedonian"
 msgstr "Macédonien"
 
-#: common/models/lang.py:225
+#: common/models/lang.py:227
 msgid "Greek"
 msgstr "Grec"
 
-#: common/models/lang.py:226
+#: common/models/lang.py:228
 msgid "Persian"
 msgstr "Perse"
 
-#: common/models/lang.py:227
+#: common/models/lang.py:229
 msgid "Hebrew"
 msgstr "Hébreu"
 
-#: common/models/lang.py:228
+#: common/models/lang.py:230
 msgid "Hindi"
 msgstr "Hindi"
 
-#: common/models/lang.py:229
+#: common/models/lang.py:231
 msgid "Armenian"
 msgstr "Arménien"
 
-#: common/models/lang.py:231
+#: common/models/lang.py:233
 msgid "Ewe"
 msgstr "Éwé"
 
-#: common/models/lang.py:232
+#: common/models/lang.py:234
 msgid "Georgian"
 msgstr "Géorgien"
 
-#: common/models/lang.py:233
+#: common/models/lang.py:235
 msgid "Punjabi"
 msgstr "Pendjabi"
 
-#: common/models/lang.py:234
+#: common/models/lang.py:236
 msgid "Bengali"
 msgstr "Bengali"
 
-#: common/models/lang.py:235
+#: common/models/lang.py:237
 msgid "Bosnian"
 msgstr "Bosnien"
 
-#: common/models/lang.py:236
+#: common/models/lang.py:238
 msgid "Chamorro"
 msgstr "Chamorro"
 
-#: common/models/lang.py:237
+#: common/models/lang.py:239
 msgid "Belarusian"
 msgstr "Biolérusse"
 
-#: common/models/lang.py:238
+#: common/models/lang.py:240
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: common/models/lang.py:300
+#: common/models/lang.py:302
 msgid "Simplified Chinese (Mainland)"
 msgstr "Chinois simplifié (Chine continentale)"
 
-#: common/models/lang.py:301
+#: common/models/lang.py:303
 msgid "Traditional Chinese (Taiwan)"
 msgstr "Chinois Traditionnel (Taïwan)"
 
-#: common/models/lang.py:302
+#: common/models/lang.py:304
 msgid "Traditional Chinese (Hongkong)"
 msgstr "Chinois Traditionnel (Hong Kong)"
 
-#: common/models/lang.py:310
+#: common/models/lang.py:312
 msgid "Portuguese (Brazil)"
 msgstr "Portugais (Brésil)"
 
-#: common/models/lang.py:313
+#: common/models/lang.py:315
 msgid "Simplified Chinese (Singapore)"
 msgstr "Chinois Simplifié (Singapour)"
 
-#: common/models/lang.py:314
+#: common/models/lang.py:316
 msgid "Simplified Chinese (Malaysia)"
 msgstr "Chinois Simplifié (Malaisie)"
 
-#: common/models/lang.py:315
+#: common/models/lang.py:317
 msgid "Traditional Chinese (Macau)"
 msgstr "Chinois Traditionnel (Macao)"
 
-#: common/models/lang.py:323
+#: common/models/lang.py:325
 msgid "Mandarin Chinese"
 msgstr "Chinois Mandarin"
 
-#: common/models/lang.py:324
+#: common/models/lang.py:326
 msgid "Yue Chinese"
 msgstr "Chinois Cantonais"
 
-#: common/models/lang.py:328
+#: common/models/lang.py:330
 msgid "Min Nan Chinese"
 msgstr "Chinois Min"
 
-#: common/models/lang.py:329
+#: common/models/lang.py:331
 msgid "Wu Chinese"
 msgstr "Chinois Wu"
 
-#: common/models/lang.py:330
+#: common/models/lang.py:332
 msgid "Hakka Chinese"
 msgstr "Chinois Hakka"
 
@@ -3990,61 +4022,37 @@ msgid "VCD"
 msgstr ""
 
 #: common/templates/400.html:23
-msgid ""
-"You may have submitted invalid data, or the content may have been deleted by "
-"the author."
-msgstr ""
-"Vous semblez avoir soumis une donnée incorrecte. Il se peut également que ce "
-"contenu ait été supprimé par son auteurice."
+msgid "You may have submitted invalid data, or the content may have been deleted by the author."
+msgstr "Vous semblez avoir soumis une donnée incorrecte. Il se peut également que ce contenu ait été supprimé par son auteurice."
 
 #: common/templates/400.html:25 common/templates/403.html:24
 #: common/templates/404.html:24
-msgid ""
-"If you believe this is our mistake, please contact us through the link at "
-"the bottom of the page."
-msgstr ""
-"Si vous pensez qu'il s'agit d'une erreur de notre part, n'hésitez pas à nous "
-"contacter via le lien en bas de page."
+msgid "If you believe this is our mistake, please contact us through the link at the bottom of the page."
+msgstr "Si vous pensez qu'il s'agit d'une erreur de notre part, n'hésitez pas à nous contacter via le lien en bas de page."
 
 #: common/templates/403.html:22
-msgid ""
-"Author may require you to log in before accessing this content, or you do "
-"not have permission to view it."
-msgstr ""
-"Il vous sera peut-être demandé de vous identifier avant d'accéder à ce "
-"contenu. Il se peut également que vous n'ayez pas les autorisations "
-"nécessaire pour le consulter."
+msgid "Author may require you to log in before accessing this content, or you do not have permission to view it."
+msgstr "Il vous sera peut-être demandé de vous identifier avant d'accéder à ce contenu. Il se peut également que vous n'ayez pas les autorisations nécessaire pour le consulter."
 
 #: common/templates/404.html:20
 msgid "Something is missing"
 msgstr "Il manque quelque chose"
 
 #: common/templates/404.html:22
-msgid ""
-"You may have visited an incorrect URL, or the content you are looking for "
-"has been deleted by the author."
-msgstr ""
-"L'URL demandée est incorrecte, ou alors le contenu recherché a été supprimé."
+msgid "You may have visited an incorrect URL, or the content you are looking for has been deleted by the author."
+msgstr "L'URL demandée est incorrecte, ou alors le contenu recherché a été supprimé."
 
 #: common/templates/404.html:26
 msgid "Go to Home"
 msgstr ""
 
 #: common/templates/500.html:22
-msgid ""
-"An internal error occurred. If this error occurs repeatedly, it will be "
-"recorded and handled by a human."
-msgstr ""
-"Une erreur interne s'est produite. Si cette erreur apparait de manière "
-"réccurente, elle sera enregistrée et traitée par une vraie personne."
+msgid "An internal error occurred. If this error occurs repeatedly, it will be recorded and handled by a human."
+msgstr "Une erreur interne s'est produite. Si cette erreur apparait de manière réccurente, elle sera enregistrée et traitée par une vraie personne."
 
 #: common/templates/500.html:24
-msgid ""
-"If you have an urgent situation or any questions, please contact us through "
-"the link at the bottom of the page."
-msgstr ""
-"Si votre situation est urgente, ou si vous avez une question, veuillez nous "
-"contacter via le lien en bas de page."
+msgid "If you have an urgent situation or any questions, please contact us through the link at the bottom of the page."
+msgstr "Si votre situation est urgente, ou si vous avez une question, veuillez nous contacter via le lien en bas de page."
 
 #: common/templates/_footer.html:6
 msgid "Rules"
@@ -4058,287 +4066,225 @@ msgstr "Termes & Conditions"
 msgid "About"
 msgstr ""
 
-#: common/templates/_footer.html:12 users/templates/users/login.html:265
+#: common/templates/_footer.html:12 users/templates/users/login.html:259
 #, python-format
-msgid ""
-"You are visiting an alternative domain for %(site_name)s, please always use "
-"<a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if "
-"possible."
-msgstr ""
-"Vous consultez un serveur alternatif à %(site_name)s, veuillez autant que "
-"possible utiliser votre <a "
-"href=\"%(site_url)s%(request.get_full_path)s\">serveur d'origine</a>."
+msgid "You are visiting an alternative domain for %(site_name)s, please always use <a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if possible."
+msgstr "Vous consultez un serveur alternatif à %(site_name)s, veuillez autant que possible utiliser votre <a href=\"%(site_url)s%(request.get_full_path)s\">serveur d'origine</a>."
 
-#: common/templates/_header.html:19 common/templates/_header.html:164
+#: common/templates/_header.html:19 common/templates/_header.html:177
 msgid "title, creator, ISBN, item url, @user, @user@instance"
-msgstr ""
-"Recherche par titre, créateur, autrice, ISBN, URL de l'œuvre, @user, "
-"@user@instance"
+msgstr "Recherche par titre, créateur, autrice, ISBN, URL de l'œuvre, @user, @user@instance"
 
-#: common/templates/_header.html:24
+#: common/templates/_header.html:34
 msgid "All Items"
 msgstr "Tout"
 
-#: common/templates/_header.html:31
+#: common/templates/_header.html:41
 msgid "Movie & TV"
 msgstr "Cinéma & TV"
 
-#: common/templates/_header.html:50
+#: common/templates/_header.html:60
 msgid "People & Organizations"
 msgstr ""
 
-#: common/templates/_header.html:52
+#: common/templates/_header.html:62
 msgid "Journal"
 msgstr "Journal"
 
-#: common/templates/_header.html:54 journal/templates/user_post_list.html:10
+#: common/templates/_header.html:64 journal/templates/user_post_list.html:10
 #: journal/templates/user_post_list.html:23
 msgid "Posts"
 msgstr "Publications"
 
-#: common/templates/_header.html:89
+#: common/templates/_header.html:102
 msgid "Explore"
 msgstr "Explorer"
 
-#: common/templates/_header.html:93
+#: common/templates/_header.html:106 common/views_manage.py:36
 msgid "Feed"
 msgstr "Activités"
 
-#: common/templates/_header.html:98 journal/templates/profile.html:13
+#: common/templates/_header.html:111 journal/templates/profile.html:13
 #: users/templates/users/preferences.html:46
 msgid "Home"
 msgstr "Accueil"
 
-#: common/templates/_header.html:114 common/templates/common/scan.html:9
+#: common/templates/_header.html:127 common/templates/common/scan.html:9
 #: common/templates/common/scan.html:42
 #, fuzzy
 #| msgid "barcode"
 msgid "Scan Barcode"
 msgstr "code-barres"
 
-#: common/templates/_header.html:118 social/templates/notification.html:12
+#: common/templates/_header.html:131 social/templates/notification.html:12
 #: social/templates/notification.html:53
 msgid "Notification"
 msgstr "Notifications"
 
-#: common/templates/_header.html:122 users/models/task.py:21
+#: common/templates/_header.html:135 users/models/task.py:23
 #: users/templates/users/account.html:219
 #: users/templates/users/crossposts.html:9
 msgid "Pending"
 msgstr "En attente"
 
-#: common/templates/_header.html:125
+#: common/templates/_header.html:138
 msgid "Data"
 msgstr "Données"
 
-#: common/templates/_header.html:128 common/templates/_header.html:146
+#: common/templates/_header.html:141 common/templates/_header.html:159
 #: users/templates/users/preferences.html:12
 #: users/templates/users/preferences.html:23
 #: users/templates/users/preferences_anonymous.html:13
 msgid "Preferences"
 msgstr "Préférences"
 
-#: common/templates/_header.html:131
+#: common/templates/_header.html:144
 msgid "Account"
 msgstr "Compte"
 
-#: common/templates/_header.html:135
+#: common/templates/_header.html:148
 msgid "Manage"
 msgstr "Gérer"
 
-#: common/templates/_header.html:139
+#: common/templates/_header.html:152
 msgid "Logout"
 msgstr "Déconnexion"
 
-#: common/templates/_header.html:143
+#: common/templates/_header.html:156
 msgid "Sign up or Login"
 msgstr "S'inscrire ou Se connecter"
 
-#: common/templates/_header.html:160
-msgid ""
-"title or content  category:tv  status:complete  rating:8..10  "
-"date:2021-09-11..2022-02"
-msgstr ""
-"titre ou contenu. Vous pouvez également utiliser des filtres, par ex : "
-"category:tv, status:complete, rating:8..10, date:2021-09-11..2022-02"
+#: common/templates/_header.html:173
+msgid "title or content  category:tv  status:complete  rating:8..10  date:2021-09-11..2022-02"
+msgstr "titre ou contenu. Vous pouvez également utiliser des filtres, par ex : category:tv, status:complete, rating:8..10, date:2021-09-11..2022-02"
 
-#: common/templates/_header.html:162
+#: common/templates/_header.html:175
 msgid "name of a person or company"
 msgstr ""
 
-#: common/templates/_header.html:179
+#: common/templates/_header.html:192
 msgid "Open"
 msgstr "Ouvert"
 
-#: common/templates/_sidebar.html:62
+#: common/templates/_sidebar.html:61
 #: users/templates/users/profile_actions.html:36
 msgid "approving followers manually"
 msgstr "valider manuellement les demandes de suivi"
 
-#: common/templates/_sidebar.html:81 common/templates/_sidebar.html:86
+#: common/templates/_sidebar.html:80 common/templates/_sidebar.html:85
 #, fuzzy
 #| msgid "followed"
 msgid "followers"
 msgstr "suivi⋅e"
 
-#: common/templates/_sidebar.html:112
+#: common/templates/_sidebar.html:111
 msgid "Current Targets"
 msgstr "Objectifs actuels"
 
-#: common/templates/_sidebar.html:125
+#: common/templates/_sidebar.html:124
 msgid "Set a collection as target, its progress will show up here."
-msgstr ""
-"Définissez une collection comme objectif et sa progression s'affichera ici."
+msgstr "Définissez une collection comme objectif et sa progression s'affichera ici."
 
-#: common/templates/_sidebar.html:138
+#: common/templates/_sidebar.html:137
 msgid "Recent podcast episodes"
 msgstr "Épisodes récents de podcasts"
 
-#: common/templates/_sidebar.html:173
+#: common/templates/_sidebar.html:172
 msgid "Currently reading"
 msgstr "Lectures en cours"
 
-#: common/templates/_sidebar.html:215
+#: common/templates/_sidebar.html:214
 msgid "Currently watching"
 msgstr "Visionnage en cours"
 
-#: common/templates/_sidebar.html:238 journal/forms.py:217
+#: common/templates/_sidebar.html:237 journal/forms.py:217
 #: journal/templates/user_tag_list.html:13
 #: journal/templates/user_tagmember_list.html:4
 msgid "Tags"
 msgstr "Étiquettes"
 
-#: common/templates/_sidebar.html:244 journal/templates/user_tag_list.html:28
+#: common/templates/_sidebar.html:243 journal/templates/user_tag_list.html:28
 #: journal/templates/user_tagmember_list.html:10
 msgid "featured tag"
 msgstr "Étiquette en vedette"
 
-#: common/templates/_sidebar.html:247 journal/templates/user_tag_list.html:31
+#: common/templates/_sidebar.html:246 journal/templates/user_tag_list.html:31
 #: journal/templates/user_tagmember_list.html:15
 msgid "personal tag"
 msgstr "étiquette personnelle"
 
-#: common/templates/_sidebar.html:254 journal/templates/user_tag_list.html:39
+#: common/templates/_sidebar.html:253 journal/templates/user_tag_list.html:39
 msgid "no tags so far."
 msgstr "aucune étiquette pour le moment."
 
-#: common/templates/_sidebar.html:258 common/templates/_sidebar.html:271
+#: common/templates/_sidebar.html:257 common/templates/_sidebar.html:270
 msgid "show all"
 msgstr "tout voir"
 
-#: common/templates/_sidebar_anonymous.html:16
+#: common/templates/_sidebar_anonymous.html:15
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
 #| "        <h3>Welcome 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s "
-#| "is committed to creating a free, open, and interconnected space for "
-#| "collecting and reviewing books, movies, music, games, and podcasts. Here, "
-#| "you can document your collections and thoughts, discover new content, and "
-#| "connect with others.\n"
+#| "          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is committed to creating a free, open, and interconnected space for collecting and reviewing books, movies, music, games, and podcasts. Here, you can document your collections and thoughts, discover new content, and connect with others.\n"
 #| "        </p>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log "
-#| "in to %(site_name)s is through a Fediverse (a distributed social network, "
-#| "including Mastodon/Pleroma/etc) instance account. If you haven’t "
-#| "registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" "
-#| "target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
+#| "          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in to %(site_name)s is through a Fediverse (a distributed social network, including Mastodon/Pleroma/etc) instance account. If you haven’t registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
 #| "        </p>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not "
-#| "ready to join the Fediverse, that’s perfectly fine. You can create an "
-#| "account here using your email address, and link it to the Fediverse "
-#| "whenever you’re ready.\n"
+#| "          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready to join the Fediverse, that’s perfectly fine. You can create an account here using your email address, and link it to the Fediverse whenever you’re ready.\n"
 #| "        </p>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you "
-#| "have any questions or suggestions, feel free to contact us via <a "
-#| "href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a "
-#| "href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
+#| "          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have any questions or suggestions, feel free to contact us via <a href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 #| "        </p>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-#| "href=\"%(login_url)s\">Click here</a> to register or log in.\n"
+#| "          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Click here</a> to register or log in.\n"
 #| "        </p>\n"
 #| "        "
 msgid ""
 "\n"
 "        <h3>Welcome 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is "
-"committed to creating a free, open, and interconnected space for collecting "
-"and reviewing books, movies, music, games, and podcasts. Here, you can "
-"manage your collections, share your thoughts, discover new content, and "
-"connect with others.\n"
+"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is committed to creating a free, open, and interconnected space for collecting and reviewing books, movies, music, games, and podcasts. Here, you can manage your collections, share your thoughts, discover new content, and connect with others.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in "
-"to %(site_name)s is through a Fediverse (a distributed social network, "
-"including Mastodon/Pleroma/etc) instance account. If you haven’t registered "
-"yet, you can <a href=\"https://joinmastodon.org/en/servers\" "
-"target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
+"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in to %(site_name)s is through a Fediverse (a distributed social network, including Mastodon/Pleroma/etc) instance account. If you haven’t registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log "
-"in is through a Bluesky (another distributed social network, also called "
-"ATProto) account. If you haven’t registered yet, you may <a href=\"https://"
-"bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
+"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log in is through a Bluesky (another distributed social network, also called ATProto) account. If you haven’t registered yet, you may <a href=\"https://bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready "
-"to join either Fediverse or Bluesky, that’s perfectly fine. You can create "
-"an account here using your email address, and link it to the Fediverse and "
-"Bluesky in settings whenever you’re ready.\n"
+"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready to join either Fediverse or Bluesky, that’s perfectly fine. You can create an account here using your email address, and link it to the Fediverse and Bluesky in settings whenever you’re ready.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have "
-"any questions or suggestions, please feel free to contact us via <a "
-"href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://"
-"discord.gg/uprvcH8gqD\">Discord</a>.\n"
+"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have any questions or suggestions, please feel free to contact us via <a href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-"href=\"%(login_url)s\">Click here</a> to register or log in.\n"
+"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Click here</a> to register or log in.\n"
 "        </p>\n"
 "        "
 msgstr ""
 "\n"
 "        <h3>Bienvenue !🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s a "
-"pour objectif de créer un espace communautaire, libre, ouvert &#38; "
-"décentralisé pour collectionner et commenter des œuvres (livres, films, "
-"séries TV, musique, podcasts &#38; jeux. Ici, vous pouvez consigner vos "
-"œuvres et leur laisser une note ou un avis, en découvrir de nouvelles et "
-"interagir avec d'autres membres.\n"
+"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s a pour objectif de créer un espace communautaire, libre, ouvert &#38; décentralisé pour collectionner et commenter des œuvres (livres, films, séries TV, musique, podcasts &#38; jeux. Ici, vous pouvez consigner vos œuvres et leur laisser une note ou un avis, en découvrir de nouvelles et interagir avec d'autres membres.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-globe\"></i> &nbsp; La manière la plus "
-"simple de se connecter à %(site_name)s est via le Fédivers (le réseau social "
-"décentralisé qui inclue Mastodon / Akkoma / etc). Si vous n'y avez pas "
-"encore de compte, vous pouvez <a href=\"https://joinmastodon.org/en/"
-"servers\" target=\"_blank\">choisir un serveur et vous en créer un.</a>.\n"
+"          <i class=\"fa-solid fa-globe\"></i> &nbsp; La manière la plus simple de se connecter à %(site_name)s est via le Fédivers (le réseau social décentralisé qui inclue Mastodon / Akkoma / etc). Si vous n'y avez pas encore de compte, vous pouvez <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">choisir un serveur et vous en créer un.</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; Si vous ne souhaitez "
-"pas rejoindre le Fédivers, pas de souci ! Vous pouvez vous créer un compte "
-"ici avec votre adresse email. Vous pourrez même l'associer à un compte du "
-"Fédivers ultérieurement si vous changez d'avis.\n"
+"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; Si vous ne souhaitez pas rejoindre le Fédivers, pas de souci ! Vous pouvez vous créer un compte ici avec votre adresse email. Vous pourrez même l'associer à un compte du Fédivers ultérieurement si vous changez d'avis.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp;Si vous avez "
-"des questions ou suggestions, n'hésitez pas à nous contacter sur <a "
-"href=\"https://mastodon.social/@neodb\">le Fédivers</a> ou <a href=\"https://"
-"discord.gg/uprvcH8gqD\">Discord</a>.\n"
+"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp;Si vous avez des questions ou suggestions, n'hésitez pas à nous contacter sur <a href=\"https://mastodon.social/@neodb\">le Fédivers</a> ou <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-"href=\"%(login_url)s\">S'inscrire ou se connecter</a>.\n"
+"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">S'inscrire ou se connecter</a>.\n"
 "        </p>\n"
 "        "
 
-#: common/templates/_sidebar_anonymous.html:43
+#: common/templates/_sidebar_anonymous.html:42
 #: users/templates/users/announcements.html:12
 #: users/templates/users/announcements.html:39
 msgid "Announcements"
@@ -4366,7 +4312,7 @@ msgstr "Code Source"
 msgid "Registration"
 msgstr "Échec de l'inscription"
 
-#: common/templates/common/about.html:35 common/views_manage.py:493
+#: common/templates/common/about.html:35 common/views_manage.py:594
 #, fuzzy
 #| msgid "Mentioned Only"
 msgid "Invite Only"
@@ -4378,7 +4324,7 @@ msgstr "Mentionné⋅es seulement"
 msgid "Open Registration"
 msgstr "Échec de l'inscription"
 
-#: common/templates/common/about.html:40 common/views_manage.py:556
+#: common/templates/common/about.html:40 common/views_manage.py:657
 #, fuzzy
 #| msgid "Preferences"
 msgid "Preferred Languages"
@@ -4433,9 +4379,7 @@ msgid "Error"
 msgstr "Erreur"
 
 #: common/templates/common/scan.html:45
-msgid ""
-"Point the camera at a book ISBN or product barcode (EAN / UPC). You will be "
-"redirected to the search once a code is detected."
+msgid "Point the camera at a book ISBN or product barcode (EAN / UPC). You will be redirected to the search once a code is detected."
 msgstr ""
 
 #: common/templates/common/scan.html:50
@@ -4446,7 +4390,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:628
+#: common/templates/common/scan.html:60 common/views_manage.py:738
 #, fuzzy
 #| msgid "Search results"
 msgid "Search"
@@ -4480,21 +4424,33 @@ msgstr ""
 msgid "Camera unavailable. Use manual entry below."
 msgstr ""
 
-#: common/templates/manage/settings.html:9
+#: common/templates/manage/base.html:9
 #, fuzzy
 #| msgid "Additional Settings"
 msgid "Site Settings"
 msgstr "Réglages additionnels"
 
-#: common/templates/manage/settings.html:109
+#: common/templates/manage/base.html:127
 msgid "Takahe Admin"
 msgstr ""
 
-#: common/templates/manage/settings.html:112
+#: common/templates/manage/base.html:130
 #, fuzzy
 #| msgid "Database"
 msgid "Database Admin"
 msgstr "Base de données"
+
+#: common/templates/manage/environment.html:6
+msgid "These settings come from environment variables and cannot be changed here. Edit .env and restart the server to change them. Passwords and keys are hidden."
+msgstr ""
+
+#: common/templates/manage/environment.html:23
+msgid "(empty)"
+msgstr ""
+
+#: common/templates/manage/environment.html:26
+msgid "default"
+msgstr ""
 
 #: common/templatetags/duration.py:59
 msgid "just now"
@@ -4512,7 +4468,7 @@ msgstr "suivi⋅e"
 msgid "following you"
 msgstr "vous suit"
 
-#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:95
+#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:90
 msgid "you"
 msgstr "vous"
 
@@ -4520,874 +4476,887 @@ msgstr "vous"
 msgid "unavailable"
 msgstr "indisponible"
 
-#: common/utils.py:126 common/utils.py:167 users/views/actions.py:134
+#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr "Membre disparu"
 
-#: common/utils.py:133 common/utils.py:135 common/utils.py:138
-#: common/utils.py:174 common/utils.py:178 journal/views/profile.py:499
+#: common/utils.py:135 common/utils.py:137 common/utils.py:140
+#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
 msgid "Access denied"
 msgstr "Accès refusé"
 
-#: common/utils.py:141 common/utils.py:143 journal/views/article.py:204
+#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr "Connexion requise"
 
-#: common/views_manage.py:144 common/views_manage.py:295
+#: common/views_manage.py:34 common/views_manage.py:373
 #, fuzzy
 #| msgid "reading"
 msgid "Branding"
 msgstr "lecture en cours"
 
-#: common/views_manage.py:146
+#: common/views_manage.py:37
 #, fuzzy
 #| msgid "comments"
 msgid "Recommendations"
 msgstr "commentaires"
 
-#: common/views_manage.py:147
+#: common/views_manage.py:38
 #, fuzzy
 #| msgid "Access denied"
 msgid "Access"
 msgstr "Accès refusé"
 
-#: common/views_manage.py:148 common/views_manage.py:623
+#: common/views_manage.py:39 common/views_manage.py:733
 #, fuzzy
 #| msgid "duration"
 msgid "Federation"
 msgstr "durée"
 
-#: common/views_manage.py:149
+#: common/views_manage.py:40
 #, fuzzy
 #| msgid "Catalan"
 msgid "Catalog"
 msgstr "Catalan"
 
-#: common/views_manage.py:150
+#: common/views_manage.py:41
 msgid "API Keys"
 msgstr ""
 
-#: common/views_manage.py:151
+#: common/views_manage.py:42
 #, fuzzy
 #| msgid "Download"
 msgid "Downloader"
 msgstr "Télécharger"
 
-#: common/views_manage.py:152 common/views_manage.py:303
+#: common/views_manage.py:43 common/views_manage.py:381
 #: users/templates/users/steam_import.html:113
 msgid "Advanced"
 msgstr ""
 
-#: common/views_manage.py:202
+#: common/views_manage.py:44
+msgid "Environment"
+msgstr ""
+
+#: common/views_manage.py:280
 #, fuzzy
 #| msgid "Invalid user."
 msgid "Invalid value."
 msgstr "Membre non-reconnu."
 
-#: common/views_manage.py:206
+#: common/views_manage.py:284
 msgid "Invalid configuration. Please check your input."
 msgstr ""
 
-#: common/views_manage.py:211
+#: common/views_manage.py:289
 #, fuzzy
 #| msgid "Settings saved."
 msgid "Settings have been saved."
 msgstr "Réglages sauvegardés."
 
-#: common/views_manage.py:231
+#: common/views_manage.py:309
 msgid "Site Name"
 msgstr ""
 
-#: common/views_manage.py:234
+#: common/views_manage.py:312
 #, fuzzy
 #| msgid "Title and Description"
 msgid "Site Description"
 msgstr "Titre & description"
 
-#: common/views_manage.py:235
+#: common/views_manage.py:313
 msgid "Short description shown in metadata and about page."
 msgstr ""
 
-#: common/views_manage.py:238
+#: common/views_manage.py:316
 msgid "Site Logo URL"
 msgstr ""
 
-#: common/views_manage.py:239
+#: common/views_manage.py:317
 msgid "URL path to the site logo image."
 msgstr ""
 
-#: common/views_manage.py:242
+#: common/views_manage.py:320
 msgid "Site Icon URL"
 msgstr ""
 
-#: common/views_manage.py:243
+#: common/views_manage.py:321
 msgid "URL path to the site icon/favicon."
 msgstr ""
 
-#: common/views_manage.py:246
+#: common/views_manage.py:324
 msgid "Default User Avatar URL"
 msgstr ""
 
-#: common/views_manage.py:247
+#: common/views_manage.py:325
 msgid "URL path to the default user avatar."
 msgstr ""
 
-#: common/views_manage.py:250
+#: common/views_manage.py:328
 msgid "Site Color Theme"
 msgstr ""
 
-#: common/views_manage.py:251
+#: common/views_manage.py:329
 msgid "PicoCSS color theme."
 msgstr ""
 
-#: common/views_manage.py:276
+#: common/views_manage.py:354
 #, fuzzy
 #| msgid "Production"
 msgid "Site Introduction"
 msgstr "Production"
 
-#: common/views_manage.py:277
+#: common/views_manage.py:355
 msgid "URL path for the intro/welcome sidebar page."
 msgstr ""
 
-#: common/views_manage.py:280
+#: common/views_manage.py:358
 msgid "Custom HTML Head"
 msgstr ""
 
-#: common/views_manage.py:281
+#: common/views_manage.py:359
 msgid "Extra HTML injected into the <head> of all pages."
 msgstr ""
 
-#: common/views_manage.py:285
+#: common/views_manage.py:363
 msgid "Footer Links"
 msgstr ""
 
-#: common/views_manage.py:286
+#: common/views_manage.py:364
 msgid "Link title mapped to URL."
 msgstr ""
 
-#: common/views_manage.py:315
+#: common/views_manage.py:393
 msgid "Minimum Marks for Discover"
 msgstr ""
 
-#: common/views_manage.py:317
+#: common/views_manage.py:395
 msgid "Number of marks required for an item to appear in discover."
 msgstr ""
 
-#: common/views_manage.py:322
+#: common/views_manage.py:400
 msgid "Update Interval (minutes)"
 msgstr ""
 
-#: common/views_manage.py:323
+#: common/views_manage.py:401
 msgid "How often to refresh the popular items list."
 msgstr ""
 
-#: common/views_manage.py:327
+#: common/views_manage.py:405
 msgid "Filter by Preferred Languages"
 msgstr ""
 
-#: common/views_manage.py:328
+#: common/views_manage.py:406
 msgid "Only show items with titles in the preferred languages."
 msgstr ""
 
-#: common/views_manage.py:331
+#: common/views_manage.py:409
 #, fuzzy
 #| msgid "show all"
 msgid "Show Local Only"
 msgstr "tout voir"
 
-#: common/views_manage.py:333
+#: common/views_manage.py:411
 msgid "Only show items marked by local users, not the entire network."
 msgstr ""
 
-#: common/views_manage.py:337
+#: common/views_manage.py:415
 #, fuzzy
 #| msgid "Popular Tags"
 msgid "Show Popular Posts"
 msgstr "Étiquettes tendances"
 
-#: common/views_manage.py:338
+#: common/views_manage.py:416
 msgid "Show popular public posts instead of recent ones."
 msgstr ""
 
-#: common/views_manage.py:341
+#: common/views_manage.py:419
 #, fuzzy
 #| msgid "Popular Tags"
 msgid "Show Popular Tags"
 msgstr "Étiquettes tendances"
 
-#: common/views_manage.py:342
+#: common/views_manage.py:420
 msgid "Show popular public tags on the discover page."
 msgstr ""
 
-#: common/views_manage.py:345
+#: common/views_manage.py:423
 #, fuzzy
 #| msgid "Spotify Podcast"
 msgid "Show Verified Podcasts"
 msgstr "Podcast Spotify"
 
-#: common/views_manage.py:347
-msgid ""
-"Show a shelf of recent episodes from podcasts with a verified creator on the "
-"discover page."
+#: common/views_manage.py:425
+msgid "Show a shelf of recent episodes from podcasts with a verified creator on the discover page."
 msgstr ""
 
-#: common/views_manage.py:386
+#: common/views_manage.py:447
+#, fuzzy
+#| msgid "your timeline"
+msgid "Show World Timeline"
+msgstr "votre timeline"
+
+#: common/views_manage.py:449
+msgid "Offer a tab with public posts from this site and every server it federates with."
+msgstr ""
+
+#: common/views_manage.py:454
+#, fuzzy
+#| msgid "show all"
+msgid "Show Local Timeline"
+msgstr "tout voir"
+
+#: common/views_manage.py:455
+msgid "Offer a tab with public posts from this site only."
+msgstr ""
+
+#: common/views_manage.py:459
+#, fuzzy
+#| msgid "your timeline"
+msgid "Timelines"
+msgstr "votre timeline"
+
+#: common/views_manage.py:487
 msgid "Enable Recommendations"
 msgstr ""
 
-#: common/views_manage.py:388
-msgid ""
-"Master switch. When off, all recommendation surfaces are hidden and the cron "
-"jobs are not scheduled."
+#: common/views_manage.py:489
+msgid "Master switch. When off, all recommendation surfaces are hidden and the cron jobs are not scheduled."
 msgstr ""
 
-#: common/views_manage.py:393
+#: common/views_manage.py:494
 msgid "Source Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:395
-msgid ""
-"Minimum public marks an item needs before similarity rows are built for it."
+#: common/views_manage.py:496
+msgid "Minimum public marks an item needs before similarity rows are built for it."
 msgstr ""
 
-#: common/views_manage.py:401
+#: common/views_manage.py:502
 msgid "Target Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:403
-msgid ""
-"Minimum public marks an item needs to be eligible as a recommendation target."
+#: common/views_manage.py:504
+msgid "Minimum public marks an item needs to be eligible as a recommendation target."
 msgstr ""
 
-#: common/views_manage.py:409
+#: common/views_manage.py:510
 msgid "Top-K Similar Items per Source"
 msgstr ""
 
-#: common/views_manage.py:410
+#: common/views_manage.py:511
 msgid "Number of similar items stored per source item."
 msgstr ""
 
-#: common/views_manage.py:414
+#: common/views_manage.py:515
 msgid "Top-N Recommendations per User"
 msgstr ""
 
-#: common/views_manage.py:415
+#: common/views_manage.py:516
 msgid "Number of personalised rows stored per user."
 msgstr ""
 
-#: common/views_manage.py:419
+#: common/views_manage.py:520
 msgid "Dampen Heavy Shelvers"
 msgstr ""
 
-#: common/views_manage.py:421
-msgid ""
-"Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-"
-"shelvers in similarity scoring."
+#: common/views_manage.py:522
+msgid "Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-shelvers in similarity scoring."
 msgstr ""
 
-#: common/views_manage.py:426
+#: common/views_manage.py:527
 msgid "Per-User Mark Cap (training)"
 msgstr ""
 
-#: common/views_manage.py:428
-msgid ""
-"Truncate each user's contribution to their N most recent marks when building "
-"the similarity matrix."
+#: common/views_manage.py:529
+msgid "Truncate each user's contribution to their N most recent marks when building the similarity matrix."
 msgstr ""
 
-#: common/views_manage.py:434
+#: common/views_manage.py:535
 msgid "Active-User Window (days)"
 msgstr ""
 
-#: common/views_manage.py:436
-msgid ""
-"Refresh personalised recommendations for users with at least one public mark "
-"in the last N days."
+#: common/views_manage.py:537
+msgid "Refresh personalised recommendations for users with at least one public mark in the last N days."
 msgstr ""
 
-#: common/views_manage.py:442
+#: common/views_manage.py:543
 msgid "Per-User Seed Cap (serving)"
 msgstr ""
 
-#: common/views_manage.py:444
-msgid ""
-"Number of recent marks used as seeds when scoring personalised "
-"recommendations for one user."
+#: common/views_manage.py:545
+msgid "Number of recent marks used as seeds when scoring personalised recommendations for one user."
 msgstr ""
 
-#: common/views_manage.py:450
+#: common/views_manage.py:551
 msgid "Lazy Refresh TTL (days)"
 msgstr ""
 
-#: common/views_manage.py:452
-msgid ""
-"How long cached on-demand recommendations are valid before the next request "
-"triggers a refresh."
+#: common/views_manage.py:553
+msgid "How long cached on-demand recommendations are valid before the next request triggers a refresh."
 msgstr ""
 
-#: common/views_manage.py:458
+#: common/views_manage.py:559
 msgid "Circles Window (days)"
 msgstr ""
 
-#: common/views_manage.py:460
-msgid ""
-"Look back N days when finding items recently marked by people the viewer "
-"follows."
+#: common/views_manage.py:561
+msgid "Look back N days when finding items recently marked by people the viewer follows."
 msgstr ""
 
-#: common/views_manage.py:467
+#: common/views_manage.py:568
 msgid "Master Switch"
 msgstr ""
 
-#: common/views_manage.py:470
+#: common/views_manage.py:571
 msgid "Similarity Builder"
 msgstr ""
 
-#: common/views_manage.py:477
+#: common/views_manage.py:578
 #, fuzzy
 #| msgid "Personal"
 msgid "Personalisation"
 msgstr "Personnel"
 
-#: common/views_manage.py:495
-msgid ""
-"Require an invite token to register. Invite tokens can be generated with "
-"neodb-manage invite --create."
+#: common/views_manage.py:596
+msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
 msgstr ""
 
-#: common/views_manage.py:500
+#: common/views_manage.py:601
 msgid "Enable Local-Only Posting"
 msgstr ""
 
-#: common/views_manage.py:501
+#: common/views_manage.py:602
 msgid "Allow users to create posts visible only to local users."
 msgstr ""
 
-#: common/views_manage.py:504
+#: common/views_manage.py:605
 msgid "Mastodon Login Whitelist"
 msgstr ""
 
-#: common/views_manage.py:505
+#: common/views_manage.py:606
 msgid "One domain per line. Leave empty to allow any instance."
 msgstr ""
 
-#: common/views_manage.py:508
+#: common/views_manage.py:609
 #, fuzzy
 #| msgid "Registration failed"
 msgid "Registration Captcha Items"
 msgstr "Échec de l'inscription"
 
-#: common/views_manage.py:512
-msgid ""
-"Number of item covers a new user must sort into two category rows before "
-"choosing a username. 0 disables the captcha; 5-6 is recommended. The covers "
-"carry no title text, so this cannot be solved with a screen reader: if you "
-"enable it, keep another way in, such as an invite link."
+#: common/views_manage.py:613
+msgid "Number of item covers a new user must sort into two category rows before choosing a username. 0 disables the captcha; 5-6 is recommended. The covers carry no title text, so this cannot be solved with a screen reader: if you enable it, keep another way in, such as an invite link."
 msgstr ""
 
-#: common/views_manage.py:520
+#: common/views_manage.py:621
 msgid "Registration Captcha Minimum Marks"
 msgstr ""
 
-#: common/views_manage.py:523
-msgid ""
-"Marks an item needs before the captcha treats it as well known enough to be "
-"recognizable. Categories with too few such items fall back to any item."
+#: common/views_manage.py:624
+msgid "Marks an item needs before the captcha treats it as well known enough to be recognizable. Categories with too few such items fall back to any item."
 msgstr ""
 
-#: common/views_manage.py:529
+#: common/views_manage.py:630
 msgid "Enable Mastodon Login"
 msgstr ""
 
-#: common/views_manage.py:532
+#: common/views_manage.py:633
 #, fuzzy
 #| msgid "Bluesky Login ID"
 msgid "Enable Bluesky Login"
 msgstr "Identifiant de connexion Bluesky"
 
-#: common/views_manage.py:535
+#: common/views_manage.py:636
 msgid "Enable Threads Login"
 msgstr ""
 
-#: common/views_manage.py:538
+#: common/views_manage.py:639
 #, fuzzy
 #| msgid "Email"
 msgid "Email URL"
 msgstr "Mail"
 
-#: common/views_manage.py:540
+#: common/views_manage.py:641
 msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
 msgstr ""
 
-#: common/views_manage.py:544
+#: common/views_manage.py:645
 #, fuzzy
 #| msgid "Email"
 msgid "Email From"
 msgstr "Mail"
 
-#: common/views_manage.py:545
+#: common/views_manage.py:646
 msgid "Sender name and address for outgoing email."
 msgstr ""
 
-#: common/views_manage.py:548
+#: common/views_manage.py:649
 #, fuzzy
 #| msgid "Language"
 msgid "Default Language"
 msgstr "Langue"
 
-#: common/views_manage.py:551
-msgid ""
-"Interface language for visitors and for users who have not chosen one "
-"themselves."
+#: common/views_manage.py:652
+msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:558
-msgid ""
-"Language codes, one per line (e.g. en, zh, ja). First language is the "
-"default."
+#: common/views_manage.py:659
+msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:564
+#: common/views_manage.py:665
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:571
+#: common/views_manage.py:672
 #, fuzzy
 #| msgid "Import Method"
 msgid "Login Methods"
 msgstr "Méthode d'import"
 
-#: common/views_manage.py:576 mastodon/models/common.py:28
+#: common/views_manage.py:677 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr "Mail"
 
-#: common/views_manage.py:580
+#: common/views_manage.py:681
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:591
+#: common/views_manage.py:692
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:593
-msgid ""
-"Disable relay.neodb.net federation for sharing public ratings across "
-"instances."
+#: common/views_manage.py:694
+msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:598
+#: common/views_manage.py:699
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:599
+#: common/views_manage.py:700
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:603
+#: common/views_manage.py:704
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:605
+#: common/views_manage.py:706
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:610
+#: common/views_manage.py:711
 #, fuzzy
 #| msgid "Search results"
 msgid "Search Sites"
 msgstr "Résultats de la recherche"
 
-#: common/views_manage.py:611
+#: common/views_manage.py:712
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:614
+#: common/views_manage.py:715
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:615
+#: common/views_manage.py:716
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:618
+#: common/views_manage.py:719
 #, fuzzy
 #| msgid "Add tv series"
 msgid "Hidden Categories"
 msgstr "Ajouter des séries TV"
 
-#: common/views_manage.py:619
+#: common/views_manage.py:720
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:640
+#: common/views_manage.py:723
+msgid "Guest Search Page Limit"
+msgstr ""
+
+#: common/views_manage.py:725
+msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
+msgstr ""
+
+#: common/views_manage.py:751
 #, fuzzy
 #| msgid "Spotify Album"
 msgid "Spotify API Key"
 msgstr "Album Spotify"
 
-#: common/views_manage.py:641
+#: common/views_manage.py:752
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:644
+#: common/views_manage.py:755
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:645
+#: common/views_manage.py:756
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:648
+#: common/views_manage.py:759
 #, fuzzy
 #| msgid "Google Books"
 msgid "Google Books API Key"
 msgstr "Google Livres"
 
-#: common/views_manage.py:649
+#: common/views_manage.py:760
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:652
+#: common/views_manage.py:763
 #, fuzzy
 #| msgid "Discogs"
 msgid "Discogs API Key"
 msgstr "Discogs"
 
-#: common/views_manage.py:654
+#: common/views_manage.py:765
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:658
+#: common/views_manage.py:769
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:770
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:662
+#: common/views_manage.py:773
 #, fuzzy
 #| msgid "client secret"
 msgid "IGDB Client Secret"
 msgstr "secret du client"
 
-#: common/views_manage.py:665
+#: common/views_manage.py:776
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:667
-msgid ""
-"Bearer token from https://boardgamegeek.com/applications (see https://"
-"boardgamegeek.com/using_the_xml_api#toc9)."
+#: common/views_manage.py:778
+msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:672 users/templates/users/steam_import.html:26
+#: common/views_manage.py:783
+msgid "MyAnimeList Client ID"
+msgstr ""
+
+#: common/views_manage.py:785
+msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
+msgstr ""
+
+#: common/views_manage.py:790 users/templates/users/steam_import.html:26
 #, fuzzy
 #| msgid "Steam Game"
 msgid "Steam API Key"
 msgstr "Jeu Steam"
 
-#: common/views_manage.py:674
-msgid ""
-"https://steamcommunity.com/dev - fallback key for Steam importer. Users can "
-"provide their own key when importing."
+#: common/views_manage.py:792
+msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:679
+#: common/views_manage.py:797
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:680
+#: common/views_manage.py:798
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:683
+#: common/views_manage.py:801
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:686
+#: common/views_manage.py:804
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:689
+#: common/views_manage.py:807
 #, fuzzy
 #| msgid "Threads"
 msgid "Threads App ID"
 msgstr "Threads"
 
-#: common/views_manage.py:690
+#: common/views_manage.py:808
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:693
+#: common/views_manage.py:811
 #, fuzzy
 #| msgid "Threads.net"
 msgid "Threads App Secret"
 msgstr "Threads"
 
-#: common/views_manage.py:696
+#: common/views_manage.py:814
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:698
-msgid ""
-"Webhook URLs keyed by channel (default, report, audit, suggest, system). All "
-"channels must be Discord forum or media channels (thread mode) because "
-"notifications are posted as threads."
+#: common/views_manage.py:816
+msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:715
+#: common/views_manage.py:833
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:844
 #, fuzzy
 #| msgid "translator"
 msgid "Translation"
 msgstr "traduit par"
 
-#: common/views_manage.py:730
+#: common/views_manage.py:849
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:734 social/templates/feed.html:27
+#: common/views_manage.py:853 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr "Notifications"
 
-#: common/views_manage.py:744
+#: common/views_manage.py:863
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:745
+#: common/views_manage.py:864
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:748
+#: common/views_manage.py:867
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:749
+#: common/views_manage.py:868
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:752
+#: common/views_manage.py:871
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:874
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:758
+#: common/views_manage.py:877
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:761
+#: common/views_manage.py:880
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:764
+#: common/views_manage.py:883
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:767
+#: common/views_manage.py:886
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:768
+#: common/views_manage.py:887
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:771
+#: common/views_manage.py:890
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:775
+#: common/views_manage.py:894
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:779
+#: common/views_manage.py:898
 #, fuzzy
 #| msgid "series"
 msgid "Retries"
 msgstr "série"
 
-#: common/views_manage.py:784
+#: common/views_manage.py:903
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:789
+#: common/views_manage.py:908
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:796
+#: common/views_manage.py:915
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:808
+#: common/views_manage.py:927
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:809
+#: common/views_manage.py:928
 #, fuzzy
 #| msgid "site domain name"
 msgid "One domain per line."
 msgstr "nom de domaine du site"
 
-#: common/views_manage.py:812
+#: common/views_manage.py:931
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:813
+#: common/views_manage.py:932
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:935
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:818
-msgid ""
-"Timeout for requests to Mastodon instances and remote fediverse servers."
+#: common/views_manage.py:937
+msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:824
+#: common/views_manage.py:943
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:825
+#: common/views_manage.py:944
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:828
+#: common/views_manage.py:947
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:829
+#: common/views_manage.py:948
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:839
+#: common/views_manage.py:958
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:841
-msgid ""
-"Delete import/export tasks and their files after this many days. Set to 0 to "
-"disable cleanup."
+#: common/views_manage.py:960
+msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:847
+#: common/views_manage.py:966
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:849
-msgid ""
-"Post-migration job keys to skip, one per line (e.g. normalize_genre). "
-"Checked by the worker at dequeue time; skipped jobs log a warning and notify "
-"the Discord system channel."
+#: common/views_manage.py:968
+msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:855
+#: common/views_manage.py:974
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:857
-msgid ""
-"Private key (JWK) identifying this site to ATProto authorization servers. "
-"Auto-generated on first Bluesky login; clear to regenerate."
+#: common/views_manage.py:976
+msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:983
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:986
 #, fuzzy
 #| msgid "optional"
 msgid "Operational"
 msgstr "optionnel"
 
-#: common/views_manage.py:883
+#: common/views_manage.py:1002
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:885
-msgid ""
-"Genre codes offered in the Movie edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1004
+msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:1009
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:892
-msgid ""
-"Genre codes offered in the TV edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1011
+msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:897
+#: common/views_manage.py:1016
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:899
-msgid ""
-"Genre codes offered in the Music edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1018
+msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:904
+#: common/views_manage.py:1023
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:906
-msgid ""
-"Genre codes offered in the Game edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1025
+msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:911
+#: common/views_manage.py:1030
 #, fuzzy
 #| msgid "Podcast"
 msgid "Podcast Genres"
 msgstr "Podcast"
 
-#: common/views_manage.py:913
-msgid ""
-"Genre codes offered in the Podcast edit dropdown, one per line. Leave empty "
-"to use the built-in default."
+#: common/views_manage.py:1032
+msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:918
+#: common/views_manage.py:1037
 #, fuzzy
 #| msgid "Performance"
 msgid "Performance Genres"
 msgstr "Spectacle"
 
-#: common/views_manage.py:920
-msgid ""
-"Genre codes offered in the Performance edit dropdown, one per line. Leave "
-"empty to use the built-in default."
+#: common/views_manage.py:1039
+msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:926
+#: common/views_manage.py:1045
 msgid "Genres by Category"
 msgstr ""
 
-#: journal/forms.py:12
-msgid ""
-"Tips: use >!text!< for spoilers; some instances may not be able to show "
-"posts longer than 360 charactors."
+#: common/views_manage.py:1069
+msgid "Site"
 msgstr ""
-"Astuce : utilisez <!texte!> pour les spoilers. Certains serveurs peuvent ne "
-"pas afficher des publications dépassant les 360 caractères."
+
+#: common/views_manage.py:1079
+#, fuzzy
+#| msgid "Database"
+msgid "Database and Services"
+msgstr "Base de données"
+
+#: common/views_manage.py:1089
+msgid "Media and Files"
+msgstr ""
+
+#: common/views_manage.py:1098
+msgid "Monitoring"
+msgstr ""
+
+#: common/views_manage.py:1102
+msgid "Security"
+msgstr ""
+
+#: common/views_manage.py:1111
+msgid "Other Environment Variables"
+msgstr ""
+
+#: common/views_manage.py:1113
+msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
+msgstr ""
+
+#: journal/forms.py:12
+msgid "Tips: use >!text!< for spoilers; some instances may not be able to show posts longer than 360 charactors."
+msgstr "Astuce : utilisez <!texte!> pour les spoilers. Certains serveurs peuvent ne pas afficher des publications dépassant les 360 caractères."
 
 #: journal/forms.py:29 journal/forms.py:31 journal/forms.py:80
 #: journal/forms.py:83 journal/forms.py:153
@@ -5401,14 +5370,14 @@ msgid "Content (Markdown)"
 msgstr "Contenu (Markdown)"
 
 #: journal/forms.py:46 journal/forms.py:124 journal/forms.py:226
-#: journal/forms.py:288 journal/views/note.py:38
+#: journal/forms.py:288 journal/views/note.py:37
 #, fuzzy
 #| msgid "Crosspost to timeline"
 msgid "Crosspost"
 msgstr "Repartager sur mon compte associé"
 
 #: journal/forms.py:47 journal/forms.py:125 journal/forms.py:227
-#: journal/forms.py:289 journal/views/note.py:39
+#: journal/forms.py:289 journal/views/note.py:38
 #, fuzzy
 #| msgid "Turn on crosspost to other social networks by default"
 msgid "Crosspost to your connected social networks"
@@ -5420,17 +5389,15 @@ msgstr ""
 
 #: journal/forms.py:53 journal/forms.py:131
 msgid "When saving, replace leading spaces with full-width spaces"
-msgstr ""
-"Au moment de l'enregistrement, remplacer les espaces en début de ligne par "
-"des espaces de pleine largeur"
+msgstr "Au moment de l'enregistrement, remplacer les espaces en début de ligne par des espaces de pleine largeur"
 
 #: journal/forms.py:59 journal/forms.py:137 journal/forms.py:162
 #: journal/forms.py:219 journal/forms.py:281
 #: journal/templates/collection_share.html:24
-#: journal/templates/wrapped_share.html:36 journal/views/note.py:31
-#: users/templates/users/data.html:45 users/templates/users/data.html:98
-#: users/templates/users/data.html:155 users/templates/users/data.html:206
-#: users/templates/users/data.html:269 users/templates/users/data.html:328
+#: journal/templates/wrapped_share.html:36 journal/views/note.py:30
+#: users/templates/users/data.html:60 users/templates/users/data.html:113
+#: users/templates/users/data.html:170 users/templates/users/data.html:221
+#: users/templates/users/data.html:284 users/templates/users/data.html:346
 #: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
@@ -5477,7 +5444,6 @@ msgid "Collaborative editing"
 msgstr "Édition collaborative"
 
 #: journal/forms.py:204 users/templates/users/crossposts.html:51
-#: users/templates/users/data.html:483
 msgid "Status"
 msgstr "Statut"
 
@@ -5491,48 +5457,46 @@ msgstr "Commenter"
 msgid "Rating"
 msgstr "évaluation"
 
-#: journal/importers/goodreads.py:196 journal/importers/letterboxd.py:144
-#: journal/importers/rym.py:442 journal/importers/storygraph.py:500
+#: journal/importers/goodreads.py:198 journal/importers/letterboxd.py:147
+#: journal/importers/rym.py:444 journal/importers/storygraph.py:504
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr "un avis sur {item_title}"
 
-#: journal/importers/opml.py:45
+#: journal/importers/opml.py:49
 #, python-brace-format
 msgid "{username}'s podcast subscriptions"
 msgstr "les podcasts suivis par {username}"
 
-#: journal/importers/rym.py:168 journal/importers/storygraph.py:128
+#: journal/importers/rym.py:170 journal/importers/storygraph.py:132
 #, python-brace-format
-msgid ""
-"Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
+msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:178 journal/importers/storygraph.py:138
+#: journal/importers/rym.py:180 journal/importers/storygraph.py:142
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/importers/rym.py:233 journal/importers/storygraph.py:184
+#: journal/importers/rym.py:235 journal/importers/storygraph.py:188
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:348 journal/importers/storygraph.py:389
+#: journal/importers/rym.py:350 journal/importers/storygraph.py:393
 msgid "Matched file missing; cannot import."
 msgstr ""
 
-#: journal/importers/rym.py:376 journal/importers/storygraph.py:412
+#: journal/importers/rym.py:378 journal/importers/storygraph.py:416
 #, python-brace-format
-msgid ""
-"Import complete: {imported} imported, {skipped} skipped, {failed} failed"
+msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:212 journal/views/article.py:218
+#: journal/models/article.py:215 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
-#: journal/models/collection.py:44 journal/templates/add_to_collection.html:39
+#: journal/models/collection.py:48 journal/templates/add_to_collection.html:39
 #: journal/templates/collection_edit.html:64
 #: journal/templates/collection_share.html:63
 #: journal/templates/collection_update_item_note.html:3
@@ -5540,75 +5504,75 @@ msgstr ""
 msgid "note"
 msgstr "note"
 
-#: journal/models/collection.py:111
+#: journal/models/collection.py:115
 #, fuzzy
 #| msgid "shared {username}'s collection"
 msgid "search query for dynamic collection"
 msgstr "a partagé la collection de {username}"
 
-#: journal/models/collection.py:524 journal/templatetags/collection.py:35
+#: journal/models/collection.py:566 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] "%(count)d livre"
 msgstr[1] "%(count)d livres"
 
-#: journal/models/collection.py:529 journal/templatetags/collection.py:43
+#: journal/models/collection.py:571 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] "%(count)d film"
 msgstr[1] "%(count)d films"
 
-#: journal/models/collection.py:534 journal/templatetags/collection.py:51
+#: journal/models/collection.py:576 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] "%(count)d série TV"
 msgstr[1] "%(count)d séries TV"
 
-#: journal/models/collection.py:539 journal/templatetags/collection.py:59
+#: journal/models/collection.py:581 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] "%(count)d album"
 msgstr[1] "%(count)d albums"
 
-#: journal/models/collection.py:544 journal/templatetags/collection.py:67
+#: journal/models/collection.py:586 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] "%(count)d jeu"
 msgstr[1] "%(count)d jeux"
 
-#: journal/models/collection.py:549 journal/templatetags/collection.py:75
+#: journal/models/collection.py:591 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] "%(count)d podcast"
 msgstr[1] "%(count)d podcasts"
 
-#: journal/models/collection.py:555 journal/templatetags/collection.py:83
+#: journal/models/collection.py:597 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] "%(count)d spectacle"
 msgstr[1] "%(count)d spectacles"
 
-#: journal/models/collection.py:563 journal/templatetags/collection.py:91
+#: journal/models/collection.py:605 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] "%(count)d œuvre"
 msgstr[1] "%(count)d œuvres"
 
-#: journal/models/common.py:50 journal/templates/action_open_post.html:15
-#: journal/templates/collection_share.html:35 journal/templates/mark.html:84
+#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
-#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:54
-#: users/templates/users/data.html:107 users/templates/users/data.html:164
-#: users/templates/users/data.html:215 users/templates/users/data.html:277
-#: users/templates/users/data.html:337 users/templates/users/data.html:534
+#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
+#: users/templates/users/data.html:122 users/templates/users/data.html:179
+#: users/templates/users/data.html:230 users/templates/users/data.html:292
+#: users/templates/users/data.html:355 users/templates/users/data.html:534
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5616,13 +5580,13 @@ msgstr[1] "%(count)d œuvres"
 msgid "Public"
 msgstr "Public"
 
-#: journal/models/common.py:51 journal/templates/action_open_post.html:9
-#: journal/templates/collection_share.html:46 journal/templates/mark.html:91
+#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
-#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
-#: users/templates/users/data.html:115 users/templates/users/data.html:172
-#: users/templates/users/data.html:223 users/templates/users/data.html:285
-#: users/templates/users/data.html:345 users/templates/users/data.html:542
+#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
+#: users/templates/users/data.html:130 users/templates/users/data.html:187
+#: users/templates/users/data.html:238 users/templates/users/data.html:300
+#: users/templates/users/data.html:363 users/templates/users/data.html:542
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5630,12 +5594,12 @@ msgstr "Public"
 msgid "Followers Only"
 msgstr "Abonné⋅es seulement"
 
-#: journal/models/common.py:52 journal/templates/collection_share.html:57
-#: journal/templates/mark.html:98 journal/templates/post_compose.html:72
-#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
-#: users/templates/users/data.html:123 users/templates/users/data.html:180
-#: users/templates/users/data.html:231 users/templates/users/data.html:293
-#: users/templates/users/data.html:353 users/templates/users/data.html:550
+#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/templates/mark.html:102 journal/templates/post_compose.html:72
+#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
+#: users/templates/users/data.html:138 users/templates/users/data.html:195
+#: users/templates/users/data.html:246 users/templates/users/data.html:308
+#: users/templates/users/data.html:371 users/templates/users/data.html:550
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5643,35 +5607,33 @@ msgstr "Abonné⋅es seulement"
 msgid "Mentioned Only"
 msgstr "Mentionné⋅es seulement"
 
-#: journal/models/common.py:790
+#: journal/models/common.py:806
 #, fuzzy
 #| msgid "A recent post was not posted to Mastodon, please re-authorize."
-msgid ""
-"A recent post was not posted to Bluesky, please login NeoDB using ATProto "
-"again to re-authorize."
+msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr "Échec de publication sur Mastodon. Veuillez réautoriser."
 
-#: journal/models/common.py:987
+#: journal/models/common.py:1003
 msgid "A recent post was not posted to Threads."
 msgstr "Échec de publication sur Threads."
 
-#: journal/models/common.py:1020
+#: journal/models/common.py:1036
 #, fuzzy
 #| msgid "A recent post was not posted to Mastodon."
 msgid "A recent post was not boosted on Mastodon."
 msgstr "Échec de publication sur Mastodon."
 
-#: journal/models/common.py:1030
+#: journal/models/common.py:1046
 #, fuzzy
 #| msgid "Item no longer exists"
 msgid "Original post no longer exists."
 msgstr "Élément disparu"
 
-#: journal/models/common.py:1044
+#: journal/models/common.py:1060
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr "Échec de publication sur Mastodon. Veuillez réautoriser."
 
-#: journal/models/common.py:1053
+#: journal/models/common.py:1069
 msgid "A recent post was not posted to Mastodon."
 msgstr "Échec de publication sur Mastodon."
 
@@ -5681,7 +5643,7 @@ msgstr "Échec de publication sur Mastodon."
 msgid "Authorization expired"
 msgstr "Échec d'authentification"
 
-#: journal/models/crosspost.py:17 users/models/task.py:24
+#: journal/models/crosspost.py:17 users/models/task.py:26
 msgid "Failed"
 msgstr "Échec"
 
@@ -5689,85 +5651,85 @@ msgstr "Échec"
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:469
+#: journal/models/mark.py:475
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:473
+#: journal/models/mark.py:479
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:480
+#: journal/models/mark.py:486
 #, fuzzy
 #| msgid "Invalid parameter"
 msgid "Invalid progress type."
 msgstr "Paramètre invalide"
 
-#: journal/models/mark.py:482
+#: journal/models/mark.py:488
 #, fuzzy
 #| msgid "Invalid response from Fediverse instance."
 msgid "Invalid progress type for this item."
 msgstr "Réponse incorrecte depuis l'instance du Fédivers."
 
-#: journal/models/note.py:34 users/templates/users/rym_import.html:73
+#: journal/models/note.py:47 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr "Page"
 
-#: journal/models/note.py:35
+#: journal/models/note.py:48
 msgid "Chapter"
 msgstr "Chapitre"
 
-#: journal/models/note.py:38
+#: journal/models/note.py:51
 msgid "Part"
 msgstr "Partie"
 
-#: journal/models/note.py:39
+#: journal/models/note.py:52
 msgid "Episode"
 msgstr "Épisode"
 
-#: journal/models/note.py:40
+#: journal/models/note.py:53
 msgid "Track"
 msgstr "Piste"
 
-#: journal/models/note.py:41
+#: journal/models/note.py:54
 msgid "Cycle"
 msgstr "Répétition"
 
-#: journal/models/note.py:42
+#: journal/models/note.py:55
 msgid "Timestamp"
 msgstr "Horodatage"
 
-#: journal/models/note.py:43
+#: journal/models/note.py:56
 msgid "Percentage"
 msgstr "Pourcentage"
 
-#: journal/models/note.py:60
+#: journal/models/note.py:77
 #, python-brace-format
 msgid "Page {value}"
 msgstr "Page {value}"
 
-#: journal/models/note.py:61
+#: journal/models/note.py:78
 #, python-brace-format
 msgid "Chapter {value}"
 msgstr "Chapitre {value}"
 
-#: journal/models/note.py:64
+#: journal/models/note.py:81
 #, python-brace-format
 msgid "Part {value}"
 msgstr "Partie {value}"
 
-#: journal/models/note.py:65
+#: journal/models/note.py:82
 #, python-brace-format
 msgid "Episode {value}"
 msgstr "Épisode {value}"
 
-#: journal/models/note.py:66
+#: journal/models/note.py:83
 #, python-brace-format
 msgid "Track {value}"
 msgstr "Piste {value}"
 
-#: journal/models/note.py:67
+#: journal/models/note.py:84
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr "Répétition {value}"
@@ -5775,449 +5737,447 @@ msgstr "Répétition {value}"
 #: journal/models/renderers.py:208
 #, python-brace-format
 msgid "regarding {item_title}, may contain spoiler or triggering content"
-msgstr ""
-"à propos de {item_title}, peut contenir des spoilers ou du contenu "
-"potentiellement choquant"
+msgstr "à propos de {item_title}, peut contenir des spoilers ou du contenu potentiellement choquant"
 
-#: journal/models/review.py:78
+#: journal/models/review.py:79
 #, fuzzy, python-brace-format
 #| msgid "a review of {item_title}"
 msgid "a review of {title}"
 msgstr "un avis sur {item_title}"
 
-#: journal/models/review.py:80
+#: journal/models/review.py:81
 #, fuzzy
 #| msgid "Item contains sub-items."
 msgid "(may contain spoilers)"
 msgstr "L'œuvre contient des sous-éléments."
 
-#: journal/models/shelf.py:37
+#: journal/models/shelf.py:39
 msgid "WISHLIST"
 msgstr "LISTE D'ENVIES"
 
-#: journal/models/shelf.py:38
+#: journal/models/shelf.py:40
 msgid "PROGRESS"
 msgstr "PROGRESSION"
 
-#: journal/models/shelf.py:39
+#: journal/models/shelf.py:41
 msgid "COMPLETE"
 msgstr "TERMINÉ"
 
-#: journal/models/shelf.py:40
+#: journal/models/shelf.py:42
 msgid "DROPPED"
 msgstr "ABANDONNÉ"
 
-#: journal/models/shelf.py:49
+#: journal/models/shelf.py:51
 msgid "books to read"
 msgstr "livres à lire"
 
-#: journal/models/shelf.py:50
+#: journal/models/shelf.py:52
 msgid "want to read"
 msgstr "envie de le lire"
 
-#: journal/models/shelf.py:51
+#: journal/models/shelf.py:53
 #, python-brace-format
 msgid "wants to read {item}"
 msgstr "a envie de lire {item}"
 
-#: journal/models/shelf.py:52
+#: journal/models/shelf.py:54
 msgid "to read"
 msgstr "à lire"
 
-#: journal/models/shelf.py:57
+#: journal/models/shelf.py:59
 msgid "books reading"
 msgstr "livres en cours"
 
-#: journal/models/shelf.py:58
+#: journal/models/shelf.py:60
 msgid "start reading"
 msgstr "commencer à lire"
 
-#: journal/models/shelf.py:59
+#: journal/models/shelf.py:61
 #, python-brace-format
 msgid "started reading {item}"
 msgstr "a commencé à lire {item}"
 
-#: journal/models/shelf.py:60
+#: journal/models/shelf.py:62
 msgid "reading"
 msgstr "lecture en cours"
 
-#: journal/models/shelf.py:65
+#: journal/models/shelf.py:67
 msgid "books completed"
 msgstr "livres terminés"
 
-#: journal/models/shelf.py:66
+#: journal/models/shelf.py:68
 msgid "finish reading"
 msgstr "terminer la lecture"
 
-#: journal/models/shelf.py:67
+#: journal/models/shelf.py:69
 #, python-brace-format
 msgid "finished reading {item}"
 msgstr "a fini de lire {item}"
 
-#: journal/models/shelf.py:68
+#: journal/models/shelf.py:70
 msgid "read"
 msgstr "lu"
 
-#: journal/models/shelf.py:73
+#: journal/models/shelf.py:75
 msgid "books dropped"
 msgstr "livres abandonnés"
 
-#: journal/models/shelf.py:74
+#: journal/models/shelf.py:76
 msgid "stop reading"
 msgstr "interrompre la lecture"
 
-#: journal/models/shelf.py:75
+#: journal/models/shelf.py:77
 #, python-brace-format
 msgid "stopped reading {item}"
 msgstr "a arrêté de lire {item}"
 
-#: journal/models/shelf.py:76
+#: journal/models/shelf.py:78
 msgid "stopped reading"
 msgstr "lecture interrompue"
 
-#: journal/models/shelf.py:81
+#: journal/models/shelf.py:83
 msgid "books reviewed"
 msgstr "avis sur des livres"
 
-#: journal/models/shelf.py:82 journal/models/shelf.py:122
-#: journal/models/shelf.py:162 journal/models/shelf.py:202
-#: journal/models/shelf.py:242 journal/models/shelf.py:282
-#: journal/models/shelf.py:316
+#: journal/models/shelf.py:84 journal/models/shelf.py:124
+#: journal/models/shelf.py:164 journal/models/shelf.py:204
+#: journal/models/shelf.py:244 journal/models/shelf.py:284
+#: journal/models/shelf.py:318
 msgid "review"
 msgstr "avis"
 
-#: journal/models/shelf.py:83 journal/models/shelf.py:123
-#: journal/models/shelf.py:163 journal/models/shelf.py:203
-#: journal/models/shelf.py:243 journal/models/shelf.py:283
-#: journal/models/shelf.py:317
+#: journal/models/shelf.py:85 journal/models/shelf.py:125
+#: journal/models/shelf.py:165 journal/models/shelf.py:205
+#: journal/models/shelf.py:245 journal/models/shelf.py:285
+#: journal/models/shelf.py:319
 #, python-brace-format
 msgid "wrote a review of {item}"
 msgstr "a laissé un avis sur {item}"
 
-#: journal/models/shelf.py:89
+#: journal/models/shelf.py:91
 msgid "movies to watch"
 msgstr "films à voir"
 
-#: journal/models/shelf.py:90 journal/models/shelf.py:130
+#: journal/models/shelf.py:92 journal/models/shelf.py:132
 msgid "want to watch"
 msgstr "envie de le voir"
 
-#: journal/models/shelf.py:91 journal/models/shelf.py:131
+#: journal/models/shelf.py:93 journal/models/shelf.py:133
 #, python-brace-format
 msgid "wants to watch {item}"
 msgstr "veut voir {item}"
 
-#: journal/models/shelf.py:92 journal/models/shelf.py:132
+#: journal/models/shelf.py:94 journal/models/shelf.py:134
 msgid "to watch"
 msgstr "à voir"
 
-#: journal/models/shelf.py:97
+#: journal/models/shelf.py:99
 msgid "movies watching"
 msgstr "films en cours"
 
-#: journal/models/shelf.py:98 journal/models/shelf.py:138
+#: journal/models/shelf.py:100 journal/models/shelf.py:140
 msgid "start watching"
 msgstr "démarrer le visionnage"
 
-#: journal/models/shelf.py:99 journal/models/shelf.py:139
+#: journal/models/shelf.py:101 journal/models/shelf.py:141
 #, python-brace-format
 msgid "started watching {item}"
 msgstr "a commencé à regarder {item}"
 
-#: journal/models/shelf.py:100 journal/models/shelf.py:140
+#: journal/models/shelf.py:102 journal/models/shelf.py:142
 msgid "watching"
 msgstr "visionnage en cours"
 
-#: journal/models/shelf.py:105
+#: journal/models/shelf.py:107
 msgid "movies watched"
 msgstr "films vus"
 
-#: journal/models/shelf.py:106 journal/models/shelf.py:146
+#: journal/models/shelf.py:108 journal/models/shelf.py:148
 msgid "finish watching"
 msgstr "terminer le visionnage"
 
-#: journal/models/shelf.py:107 journal/models/shelf.py:147
+#: journal/models/shelf.py:109 journal/models/shelf.py:149
 #, python-brace-format
 msgid "finished watching {item}"
 msgstr "a fini de regarder {item}"
 
-#: journal/models/shelf.py:108 journal/models/shelf.py:148
+#: journal/models/shelf.py:110 journal/models/shelf.py:150
 msgid "watched"
 msgstr "vu"
 
-#: journal/models/shelf.py:113
+#: journal/models/shelf.py:115
 msgid "movies dropped"
 msgstr "films abandonnés"
 
-#: journal/models/shelf.py:114 journal/models/shelf.py:154
+#: journal/models/shelf.py:116 journal/models/shelf.py:156
 msgid "stop watching"
 msgstr "arrêter le visionnage"
 
-#: journal/models/shelf.py:115 journal/models/shelf.py:155
+#: journal/models/shelf.py:117 journal/models/shelf.py:157
 #, python-brace-format
 msgid "stopped watching {item}"
 msgstr "a arrêté de regarder {item}"
 
-#: journal/models/shelf.py:116 journal/models/shelf.py:156
+#: journal/models/shelf.py:118 journal/models/shelf.py:158
 msgid "stopped watching"
 msgstr "visionnage interrompu"
 
-#: journal/models/shelf.py:121
+#: journal/models/shelf.py:123
 msgid "movies reviewed"
 msgstr "avis sur des films"
 
-#: journal/models/shelf.py:129
+#: journal/models/shelf.py:131
 msgid "TV shows to watch"
 msgstr "séries TV à voir"
 
-#: journal/models/shelf.py:137
+#: journal/models/shelf.py:139
 msgid "TV shows watching"
 msgstr "séries TV en cours"
 
-#: journal/models/shelf.py:145
+#: journal/models/shelf.py:147
 msgid "TV shows watched"
 msgstr "séries TV vues"
 
-#: journal/models/shelf.py:153
+#: journal/models/shelf.py:155
 msgid "TV shows dropped"
 msgstr "séries TV abandonnées"
 
-#: journal/models/shelf.py:161
+#: journal/models/shelf.py:163
 msgid "TV shows reviewed"
 msgstr "avis sur des séries TV"
 
-#: journal/models/shelf.py:169
+#: journal/models/shelf.py:171
 msgid "albums to listen"
 msgstr "albums à écouter"
 
-#: journal/models/shelf.py:170 journal/models/shelf.py:250
+#: journal/models/shelf.py:172 journal/models/shelf.py:252
 msgid "want to listen"
 msgstr "envie de l'écouter"
 
-#: journal/models/shelf.py:171 journal/models/shelf.py:251
+#: journal/models/shelf.py:173 journal/models/shelf.py:253
 #, python-brace-format
 msgid "wants to listen {item}"
 msgstr "a envie d'écouter {item}"
 
-#: journal/models/shelf.py:172 journal/models/shelf.py:252
+#: journal/models/shelf.py:174 journal/models/shelf.py:254
 msgid "to listen"
 msgstr "à écouter"
 
-#: journal/models/shelf.py:177
+#: journal/models/shelf.py:179
 msgid "albums listening"
 msgstr "albums en cours"
 
-#: journal/models/shelf.py:178 journal/models/shelf.py:258
+#: journal/models/shelf.py:180 journal/models/shelf.py:260
 msgid "start listening"
 msgstr "commencer l'écoute"
 
-#: journal/models/shelf.py:179 journal/models/shelf.py:259
+#: journal/models/shelf.py:181 journal/models/shelf.py:261
 #, python-brace-format
 msgid "started listening {item}"
 msgstr "a commencé à écouter {item}"
 
-#: journal/models/shelf.py:180 journal/models/shelf.py:260
+#: journal/models/shelf.py:182 journal/models/shelf.py:262
 msgid "listening"
 msgstr "écoute en cours"
 
-#: journal/models/shelf.py:185
+#: journal/models/shelf.py:187
 msgid "albums listened"
 msgstr "albums écoutés"
 
-#: journal/models/shelf.py:186 journal/models/shelf.py:266
+#: journal/models/shelf.py:188 journal/models/shelf.py:268
 msgid "finish listening"
 msgstr "terminer l'écoute"
 
-#: journal/models/shelf.py:187 journal/models/shelf.py:267
+#: journal/models/shelf.py:189 journal/models/shelf.py:269
 #, python-brace-format
 msgid "finished listening {item}"
 msgstr "a fini d'écouter {item}"
 
-#: journal/models/shelf.py:188 journal/models/shelf.py:268
+#: journal/models/shelf.py:190 journal/models/shelf.py:270
 msgid "listened"
 msgstr "écouté"
 
-#: journal/models/shelf.py:193
+#: journal/models/shelf.py:195
 msgid "albums dropped"
 msgstr "albums abandonnés"
 
-#: journal/models/shelf.py:194 journal/models/shelf.py:274
+#: journal/models/shelf.py:196 journal/models/shelf.py:276
 msgid "stop listening"
 msgstr "arrêter l'écoute"
 
-#: journal/models/shelf.py:195 journal/models/shelf.py:275
+#: journal/models/shelf.py:197 journal/models/shelf.py:277
 #, python-brace-format
 msgid "stopped listening {item}"
 msgstr "a arrêté d'écouter {item}"
 
-#: journal/models/shelf.py:196 journal/models/shelf.py:276
+#: journal/models/shelf.py:198 journal/models/shelf.py:278
 msgid "stopped listening"
 msgstr "écoute interrompue"
 
-#: journal/models/shelf.py:201
+#: journal/models/shelf.py:203
 msgid "albums reviewed"
 msgstr "avis sur des albums"
 
-#: journal/models/shelf.py:209
+#: journal/models/shelf.py:211
 msgid "games to play"
 msgstr "jeux à tester"
 
-#: journal/models/shelf.py:210
+#: journal/models/shelf.py:212
 msgid "want to play"
 msgstr "envie d'y jouer"
 
-#: journal/models/shelf.py:211
+#: journal/models/shelf.py:213
 #, python-brace-format
 msgid "wants to play {item}"
 msgstr "veut jouer à {item}"
 
-#: journal/models/shelf.py:212
+#: journal/models/shelf.py:214
 msgid "to play"
 msgstr "à tester"
 
-#: journal/models/shelf.py:217
+#: journal/models/shelf.py:219
 msgid "games playing"
 msgstr "jeux en cours"
 
-#: journal/models/shelf.py:218
+#: journal/models/shelf.py:220
 msgid "start playing"
 msgstr "commencer à jouer"
 
-#: journal/models/shelf.py:219
+#: journal/models/shelf.py:221
 #, python-brace-format
 msgid "started playing {item}"
 msgstr "a commencé à jouer à {item}"
 
-#: journal/models/shelf.py:220
+#: journal/models/shelf.py:222
 msgid "playing"
 msgstr "jeu en cours"
 
-#: journal/models/shelf.py:225
+#: journal/models/shelf.py:227
 msgid "games played"
 msgstr "jeux testés"
 
-#: journal/models/shelf.py:226
+#: journal/models/shelf.py:228
 msgid "finish playing"
 msgstr "terminer le jeu"
 
-#: journal/models/shelf.py:227
+#: journal/models/shelf.py:229
 #, python-brace-format
 msgid "finished playing {item}"
 msgstr "a fini de jouer à {item}"
 
-#: journal/models/shelf.py:228
+#: journal/models/shelf.py:230
 msgid "played"
 msgstr "joué"
 
-#: journal/models/shelf.py:233
+#: journal/models/shelf.py:235
 msgid "games dropped"
 msgstr "jeux abandonnés"
 
-#: journal/models/shelf.py:234
+#: journal/models/shelf.py:236
 msgid "stop playing"
 msgstr "arrêter de jouer"
 
-#: journal/models/shelf.py:235
+#: journal/models/shelf.py:237
 #, python-brace-format
 msgid "stopped playing {item}"
 msgstr "a arrêté de jouer à {item}"
 
-#: journal/models/shelf.py:236
+#: journal/models/shelf.py:238
 msgid "stopped playing"
 msgstr "jeu interrompu"
 
-#: journal/models/shelf.py:241
+#: journal/models/shelf.py:243
 msgid "games reviewed"
 msgstr "avis sur des jeux"
 
-#: journal/models/shelf.py:249
+#: journal/models/shelf.py:251
 msgid "podcasts to listen"
 msgstr "podcasts à écouter"
 
-#: journal/models/shelf.py:257
+#: journal/models/shelf.py:259
 msgid "podcasts listening"
 msgstr "podcasts en cours"
 
-#: journal/models/shelf.py:265
+#: journal/models/shelf.py:267
 msgid "podcasts listened"
 msgstr "podcasts écoutés"
 
-#: journal/models/shelf.py:273
+#: journal/models/shelf.py:275
 msgid "podcasts dropped"
 msgstr "podcasts abandonnés"
 
-#: journal/models/shelf.py:281
+#: journal/models/shelf.py:283
 msgid "podcasts reviewed"
 msgstr "avis sur des podcasts"
 
-#: journal/models/shelf.py:289
+#: journal/models/shelf.py:291
 msgid "performances to see"
 msgstr "spectacles à voir"
 
-#: journal/models/shelf.py:290
+#: journal/models/shelf.py:292
 msgid "want to see"
 msgstr "envie de la voir"
 
-#: journal/models/shelf.py:291
+#: journal/models/shelf.py:293
 #, python-brace-format
 msgid "wants to see {item}"
 msgstr "a envie de voir {item}"
 
-#: journal/models/shelf.py:292
+#: journal/models/shelf.py:294
 msgid "to see"
 msgstr "à voir"
 
-#: journal/models/shelf.py:299
+#: journal/models/shelf.py:301
 msgid "performances saw"
 msgstr "spectacles vus"
 
-#: journal/models/shelf.py:300
+#: journal/models/shelf.py:302
 msgid "finish seeing"
 msgstr "finir de voir"
 
-#: journal/models/shelf.py:301
+#: journal/models/shelf.py:303
 #, python-brace-format
 msgid "finished seeing {item}"
 msgstr "a fini de voir {item}"
 
-#: journal/models/shelf.py:302
+#: journal/models/shelf.py:304
 msgid "seen"
 msgstr "vu"
 
-#: journal/models/shelf.py:307
+#: journal/models/shelf.py:309
 msgid "performances dropped"
 msgstr "spectacles abandonnés"
 
-#: journal/models/shelf.py:308
+#: journal/models/shelf.py:310
 msgid "stop seeing"
 msgstr "interrompre le visionnage"
 
-#: journal/models/shelf.py:309
+#: journal/models/shelf.py:311
 #, python-brace-format
 msgid "stopped seeing {item}"
 msgstr "a arrêté de regarder {item}"
 
-#: journal/models/shelf.py:310
+#: journal/models/shelf.py:312
 msgid "stopped seeing"
 msgstr "visionnage interrompu"
 
-#: journal/models/shelf.py:315
+#: journal/models/shelf.py:317
 msgid "performances reviewed"
 msgstr "avis sur des spectacles"
 
-#: journal/models/shelf.py:323
+#: journal/models/shelf.py:325
 #, fuzzy
 #| msgid "Users you are following"
 msgid "people following"
 msgstr "Membres que vous suivez"
 
-#: journal/models/shelf.py:325
+#: journal/models/shelf.py:327
 #, fuzzy, python-brace-format
 #| msgid "started playing {item}"
 msgid "started following {item}"
 msgstr "a commencé à jouer à {item}"
 
-#: journal/models/shelf.py:921
+#: journal/models/shelf.py:923
 msgid "removed mark"
 msgstr "interaction effacée"
 
@@ -6247,38 +6207,22 @@ msgstr ""
 msgid "Remove from collection"
 msgstr "Retirer de la collection"
 
-#: journal/templates/_list_item.html:34
-msgid "add mark"
-msgstr "interagir"
-
-#: journal/templates/_list_item.html:42
-msgid "update mark"
-msgstr "mettre à jour l'interaction"
-
-#: journal/templates/_list_item.html:60
+#: journal/templates/_list_item.html:43
 #: journal/templates/collection_update_item_note_ok.html:3
 msgid "Update note"
 msgstr "Mettre à jour la note"
 
-#: journal/templates/_list_item.html:100 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:123
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
 msgstr "Avis"
 
-#: journal/templates/_list_item.html:133
+#: journal/templates/_list_item.html:91
 #, fuzzy, python-format
-#| msgid ""
-#| " %(dups)s items are from the same work or have the same identifier, they "
-#| "are hidden from the search results, <a _=\"on click toggle .unfold on "
-#| "#dup\">click here to show them.</a> "
-msgid ""
-"%(dups)s item(s) are from the same work or have the same identifier, click "
-"here to display:"
-msgstr ""
-" les éléments %(dups)s font partie de la même œuvre ou possèdent le même "
-"identifiant et ont donc été retirés des résultats. <a _=\"on click "
-"toggle .unfold on #dup\">Cliquez ici pour les afficher.</a> "
+#| msgid " %(dups)s items are from the same work or have the same identifier, they are hidden from the search results, <a _=\"on click toggle .unfold on #dup\">click here to show them.</a> "
+msgid "%(dups)s item(s) are from the same work or have the same identifier, click here to display:"
+msgstr " les éléments %(dups)s font partie de la même œuvre ou possèdent le même identifiant et ont donc été retirés des résultats. <a _=\"on click toggle .unfold on #dup\">Cliquez ici pour les afficher.</a> "
 
 #: journal/templates/_sidebar_collection_filter.html:32
 #, fuzzy
@@ -6368,9 +6312,7 @@ msgstr "Relayer"
 
 #: journal/templates/action_delete_post.html:7
 msgid "Are you sure to delete this post and the mark or note related with it?"
-msgstr ""
-"Voulez-vous vraiment supprimer cette publication et l'interaction ou la note "
-"associée ?"
+msgstr "Voulez-vous vraiment supprimer cette publication et l'interaction ou la note associée ?"
 
 #: journal/templates/action_delete_post.html:7
 msgid "Are you sure to delete this reply?"
@@ -6398,6 +6340,14 @@ msgstr "aimé"
 #: journal/templates/action_like_post.html:16
 msgid "Like"
 msgstr ""
+
+#: journal/templates/action_mark_item.html:10
+msgid "add mark"
+msgstr "interagir"
+
+#: journal/templates/action_mark_item.html:18
+msgid "update mark"
+msgstr "mettre à jour l'interaction"
 
 #: journal/templates/action_open_post.html:7
 #, fuzzy
@@ -6459,13 +6409,13 @@ msgstr "Ajouter à la collection"
 msgid "Create a new collection"
 msgstr "Créer une nouvelle collection"
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:81
+#: journal/templates/article.html:104 social/templates/_event_post.html:76
 #, fuzzy
 #| msgid "wrote a review of {item}"
 msgid "wrote a review"
 msgstr "a laissé un avis sur {item}"
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:83
+#: journal/templates/article.html:106 social/templates/_event_post.html:78
 #, fuzzy
 #| msgid "wrote a note"
 msgid "wrote an article"
@@ -6477,8 +6427,7 @@ msgstr ""
 
 #: journal/templates/article.html:155
 msgid "The author has set it to be viewable only by logged-in users."
-msgstr ""
-"Læ propriétaire a défini ce contenu comme réservé aux membres connectés."
+msgstr "Læ propriétaire a défini ce contenu comme réservé aux membres connectés."
 
 #: journal/templates/article_edit.html:13
 #, fuzzy
@@ -6572,14 +6521,11 @@ msgstr "Ajouter une œuvre à cette collection"
 
 #: journal/templates/collection_edit.html:89
 msgid "Drag and drop to change the order order and click here to save"
-msgstr ""
-"Glissez-déposez pour changer l'ordre, puis cliquez ici pour enregistrer"
+msgstr "Glissez-déposez pour changer l'ordre, puis cliquez ici pour enregistrer"
 
 #: journal/templates/collection_share.html:24
 msgid "for the sharing post only, not visibility of the collection"
-msgstr ""
-"concerne seulement la visibilité de la publication partagée, non la "
-"collection"
+msgstr "concerne seulement la visibilité de la publication partagée, non la collection"
 
 #: journal/templates/comment.html:47
 msgid "share with playback position"
@@ -6589,23 +6535,21 @@ msgstr "partager avec la position de lecture"
 msgid "Mark"
 msgstr "Interaction"
 
-#: journal/templates/mark.html:50
+#: journal/templates/mark.html:54
 msgid "not rated"
 msgstr "non évalué"
 
-#: journal/templates/mark.html:70
+#: journal/templates/mark.html:74
 msgid "add a tag and press Enter"
 msgstr "ajoutez une étiquette et validez avec Entrée"
 
-#: journal/templates/mark.html:122
+#: journal/templates/mark.html:126
 msgid "change mark date"
 msgstr "changer la date d'interaction"
 
-#: journal/templates/mark.html:148
+#: journal/templates/mark.html:156
 msgid "Sure to delete mark, comment and tags for this item?"
-msgstr ""
-"Voulez-vous supprimer les interactions, commentaires & étiquettes de cette "
-"œuvre ?"
+msgstr "Voulez-vous supprimer les interactions, commentaires & étiquettes de cette œuvre ?"
 
 #: journal/templates/markdown_editor.html:9
 msgid "Markdown format references"
@@ -6623,15 +6567,13 @@ msgstr "Aide-mémoire du format Markdown"
 #| "\n"
 #| "  Paragraphs need to be separated by a blank line\n"
 #| "\n"
-#| "  Indentation at the beginning of the paragraph requires using a Unicode "
-#| "full-width space\n"
+#| "  Indentation at the beginning of the paragraph requires using a Unicode full-width space\n"
 #| "\n"
 #| "[Link](https://zh.wikipedia.org/wiki/Markdown)\n"
 #| "**Bold**  *Italic* ==Highlight== ~~Strikethrough~~\n"
 #| "^Super^script ~Sub~script [拼(pīn)音(yīn)]\n"
 #| "\n"
-#| "Drag and drop an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/"
-#| "Wikipedia-logo-v2.svg)\n"
+#| "Drag and drop an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 #| "\n"
 #| "> Quote\n"
 #| ">> Multi-level quote\n"
@@ -6691,8 +6633,7 @@ msgid ""
 "Content Cell  | Content Cell\n"
 "Content Cell  | Content Cell\n"
 "\n"
-"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/"
-"Wikipedia-logo-v2.svg)\n"
+"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 "\n"
 msgstr ""
 "\n"
@@ -6704,21 +6645,18 @@ msgstr ""
 "\n"
 "  Les paragraphes doivent être séparés par une ligne vide\n"
 "\n"
-"  L'indentation au début des paragraphes nécessite l'utiliation d'un espace "
-"plein en Unicode\n"
+"  L'indentation au début des paragraphes nécessite l'utiliation d'un espace plein en Unicode\n"
 "\n"
 "[Lien](https://zh.wikipedia.org/wiki/Markdown)\n"
 "**Gras**  *Italique* ==Surligné== ~~Barré~~\n"
 "^Super^script ~Sub~script [拼(pīn)音(yīn)]\n"
 "\n"
-"Glissez-déposez une image ![](https://upload.wikimedia.org/wikipedia/en/8/80/"
-"Wikipedia-logo-v2.svg)\n"
+"Glissez-déposez une image ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 "\n"
 "> Citation\n"
 ">> Citation sur plusieurs niveaux\n"
 "\n"
-">! balise spoiler !< en ligne. (Fonctionne également dans des courts "
-"commentaires)\n"
+">! balise spoiler !< en ligne. (Fonctionne également dans des courts commentaires)\n"
 "\n"
 ">! Balise spoiler\n"
 ">! sur plusieurs lignes\n"
@@ -6740,7 +6678,7 @@ msgstr ""
 "Contenu de la cellule  | Contenu de la cellule\n"
 "Contenu de la cellule  | Contenu de la cellule\n"
 
-#: journal/templates/note.html:19 journal/views/note.py:23
+#: journal/templates/note.html:19 journal/views/note.py:22
 msgid "Note"
 msgstr "Note"
 
@@ -6771,12 +6709,8 @@ msgid "Are you sure to delete this entire content?"
 msgstr "Voulez-vous supprimer l'intégralité de ce contenu ?"
 
 #: journal/templates/piece_delete.html:24
-msgid ""
-"By deleting it, you will also lose track of others' comments and feedbacks "
-"to your content."
-msgstr ""
-"En supprimant ceci, vous perdrez également toute trace des commentaires et "
-"réponses d'autres membres sur votre contenu."
+msgid "By deleting it, you will also lose track of others' comments and feedbacks to your content."
+msgstr "En supprimant ceci, vous perdrez également toute trace des commentaires et réponses d'autres membres sur votre contenu."
 
 #: journal/templates/piece_delete.html:25
 #: journal/templates/piece_delete.html:32
@@ -6869,7 +6803,7 @@ msgstr "Récap' annuel"
 msgid "Articles"
 msgstr ""
 
-#: journal/templates/profile.html:166 journal/views/collection.py:427
+#: journal/templates/profile.html:166 journal/views/collection.py:409
 #: journal/views/profile.py:401
 msgid "collection"
 msgstr "collection"
@@ -6905,13 +6839,8 @@ msgid "Personal"
 msgstr "Personnel"
 
 #: journal/templates/tag_edit.html:52
-msgid ""
-"Personal tags are not included in public index. However, if you use this tag "
-"when marking an item publicly, it might still be visible to others."
-msgstr ""
-"Les étiquettes personnelles ne sont pas incluses dans le flux public. "
-"Cependant, si vous utilisez cette étiquette pour interagir publiquement avec "
-"une œuvre, elle est susceptible d'être visible par d'autres membres."
+msgid "Personal tags are not included in public index. However, if you use this tag when marking an item publicly, it might still be visible to others."
+msgstr "Les étiquettes personnelles ne sont pas incluses dans le flux public. Cependant, si vous utilisez cette étiquette pour interagir publiquement avec une œuvre, elle est susceptible d'être visible par d'autres membres."
 
 #: journal/templates/tag_edit.html:55
 msgid "Delete this tag"
@@ -6986,130 +6915,128 @@ msgstr "Avis de {0}"
 msgid "Link invalid"
 msgstr "Lien invalide"
 
-#: journal/views/collection.py:58 journal/views/collection.py:96
+#: journal/views/collection.py:62 journal/views/collection.py:94
 #, python-brace-format
 msgid "Collection by {0}"
 msgstr "Collection de {0}"
 
-#: journal/views/collection.py:432
+#: journal/views/collection.py:414
 msgid "shared my collection"
 msgstr "a partagé ma collection"
 
-#: journal/views/collection.py:435
+#: journal/views/collection.py:417
 #, python-brace-format
 msgid "shared {username}'s collection"
 msgstr "a partagé la collection de {username}"
 
-#: journal/views/collection.py:502 journal/views/collection.py:541
-#: journal/views/collection.py:553 journal/views/collection.py:579
+#: journal/views/collection.py:484 journal/views/collection.py:523
+#: journal/views/collection.py:535 journal/views/collection.py:561
 msgid "Dynamic collection is not editable"
 msgstr ""
 
-#: journal/views/collection.py:518
+#: journal/views/collection.py:500
 #, fuzzy
 #| msgid "This username is already in use."
 msgid "The item is already in the collection."
 msgstr "Cet identifiant est déjà utilisé."
 
-#: journal/views/collection.py:520
+#: journal/views/collection.py:502
 msgid "Unable to find the item, please use item url from this site."
-msgstr ""
-"Impossible de trouver l'œuvre. Veuillez saisir l'URL locale de l'œuvre."
+msgstr "Impossible de trouver l'œuvre. Veuillez saisir l'URL locale de l'œuvre."
 
-#: journal/views/collection.py:566
+#: journal/views/collection.py:548
 #, fuzzy
 #| msgid "Save"
 msgid "Saved."
 msgstr "Enregistrer"
 
-#: journal/views/common.py:119 journal/views/mark.py:225
-#: journal/views/mark.py:279 journal/views/note.py:175
+#: journal/views/common.py:126 journal/views/mark.py:273
+#: journal/views/mark.py:315 journal/views/note.py:167
 #: journal/views/profile.py:42 journal/views/review.py:59
 #: journal/views/review.py:79
 msgid "Content not found"
 msgstr "Contenu introuvable"
 
-#: journal/views/common.py:174 journal/views/mark.py:159
+#: journal/views/common.py:184 journal/views/mark.py:210
 msgid "Data saved but unable to crosspost to Fediverse instance."
-msgstr ""
-"Les données ont été sauvegardées mais elles n'ont pas pu être repartagées "
-"sur votre instance du Fédivers."
+msgstr "Les données ont été sauvegardées mais elles n'ont pas pu être repartagées sur votre instance du Fédivers."
 
-#: journal/views/common.py:176
+#: journal/views/common.py:186
 msgid "Redirecting to your Fediverse instance now to re-authenticate."
 msgstr "Redirection vers votre instance du Fédivers pour réauthentification."
 
-#: journal/views/common.py:183
+#: journal/views/common.py:193
 msgid "List not found."
 msgstr "Liste non trouvée."
 
-#: journal/views/mark.py:150
+#: journal/views/mark.py:206
 msgid "Content too long for your Fediverse instance."
 msgstr "Contenu trop long pour votre instance du Fédivers."
 
-#: journal/views/mark.py:178 journal/views/mark.py:238
+#: journal/views/mark.py:224 journal/views/mark.py:226
+#: journal/views/mark.py:280
 #, fuzzy
 #| msgid "Invalid tag"
 msgid "Invalid input"
 msgstr "Étiquette invalide"
 
-#: journal/views/note.py:23
+#: journal/views/note.py:22
 msgid "Progress"
 msgstr ""
 
-#: journal/views/note.py:28
+#: journal/views/note.py:27
 #, fuzzy
 #| msgid "Update note"
 msgid "Update progress"
 msgstr "Mettre à jour la note"
 
-#: journal/views/note.py:59
+#: journal/views/note.py:58
 msgid "Progress (optional)"
 msgstr "Progression (optionnel)"
 
-#: journal/views/note.py:61
+#: journal/views/note.py:60
 msgid "Note Content"
 msgstr "Contenu de la note"
 
-#: journal/views/note.py:63
+#: journal/views/note.py:62
 msgid "Content Warning (optional)"
 msgstr "Alerte sur le contenu (optionnel)"
 
-#: journal/views/note.py:85
+#: journal/views/note.py:84
 msgid "Progress Type (optional)"
 msgstr "Type de progression (optionnel)"
 
-#: journal/views/note.py:123 journal/views/note.py:183
+#: journal/views/note.py:115 journal/views/note.py:175
 msgid "Only in-progress items can have progress."
 msgstr ""
 
-#: journal/views/post.py:98 journal/views/post.py:392
+#: journal/views/post.py:100 journal/views/post.py:388
 msgid "Post not found"
 msgstr "Publication introuvable"
 
-#: journal/views/post.py:189
+#: journal/views/post.py:191
 msgid "Visibility too high for quoting this post"
 msgstr ""
 
-#: journal/views/post.py:337 journal/views/post.py:418
+#: journal/views/post.py:339 journal/views/post.py:414
 #, fuzzy
 #| msgid "Item cannot be deleted."
 msgid "Content cannot be empty."
 msgstr "L'élément ne peut être supprimé."
 
-#: journal/views/post.py:396
+#: journal/views/post.py:392
 #, fuzzy
 #| msgid "This operation cannot be undone. Sure to merge?"
 msgid "This post cannot be edited here"
 msgstr "Cette opération ne peut être annulée. Confirmer la fusion ?"
 
-#: journal/views/post.py:541
+#: journal/views/post.py:531
 #, fuzzy
 #| msgid "Invalid file."
 msgid "Invalid choices"
 msgstr "Fichier incorrect."
 
-#: journal/views/post.py:544
+#: journal/views/post.py:534
 #, fuzzy
 #| msgid "Invalid tag"
 msgid "Invalid post"
@@ -7129,66 +7056,59 @@ msgstr "{review_title} — Un avis sur {item_title}"
 #, fuzzy
 #| msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgid "may contain spoiler or triggering content"
-msgstr ""
-"à propos de {item_title}, peut contenir des spoilers ou du contenu "
-"potentiellement choquant"
+msgstr "à propos de {item_title}, peut contenir des spoilers ou du contenu potentiellement choquant"
 
-#: journal/views/tag.py:47 journal/views/tag.py:61
+#: journal/views/tag.py:46 journal/views/tag.py:60
 msgid "Invalid tag"
 msgstr "Étiquette invalide"
 
-#: journal/views/tag.py:50
+#: journal/views/tag.py:49
 msgid "Tag not found"
 msgstr "Étiquette introuvable"
 
-#: journal/views/tag.py:72
+#: journal/views/tag.py:65
 msgid "Tag deleted."
 msgstr "Étiquette supprimée."
 
-#: journal/views/tag.py:82
+#: journal/views/tag.py:75
 msgid "Duplicated tag."
 msgstr "Étiquette en double."
 
-#: journal/views/tag.py:96
+#: journal/views/tag.py:83
 msgid "Tag updated."
 msgstr "Étiquette mise à jour."
 
-#: journal/views/wrapped.py:160
+#: journal/views/wrapped.py:161
 msgid "Summary posted to timeline."
 msgstr "Récap' publié sur votre timeline."
 
-#: mastodon/models/common.py:29
+#: mastodon/models/common.py:31
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: mastodon/models/common.py:30 users/templates/users/login.html:120
+#: mastodon/models/common.py:32 users/templates/users/login.html:114
 msgid "Threads"
 msgstr "Threads"
 
-#: mastodon/models/common.py:31
+#: mastodon/models/common.py:33
 msgid "Bluesky"
 msgstr "Bluesky"
 
-#: mastodon/models/email.py:59
+#: mastodon/models/email.py:63
 msgid ""
 "\n"
 "\n"
-"If you did not mean to register or login, please ignore this email. If you "
-"are concerned with your account security, please change the email linked "
-"with your account, or contact us."
+"If you did not mean to register or login, please ignore this email. If you are concerned with your account security, please change the email linked with your account, or contact us."
 msgstr ""
 "\n"
 "\n"
-"Si vous n'aviez pas l'intention de vous connecter ou vous inscrire, veuillez "
-"ne pas tenir compte de ce mail. Si vous avez un doute quant à la sécurité de "
-"votre compte, vous pouvez changer l'adresse associée à celui-ci ou nous "
-"contacter."
+"Si vous n'aviez pas l'intention de vous connecter ou vous inscrire, veuillez ne pas tenir compte de ce mail. Si vous avez un doute quant à la sécurité de votre compte, vous pouvez changer l'adresse associée à celui-ci ou nous contacter."
 
-#: mastodon/models/email.py:64 mastodon/models/email.py:69
+#: mastodon/models/email.py:68 mastodon/models/email.py:73
 msgid "Verification Code"
 msgstr "Code de vérification"
 
-#: mastodon/models/email.py:66
+#: mastodon/models/email.py:70
 #, python-brace-format
 msgid ""
 "Use this code to verify your email address {email}\n"
@@ -7199,7 +7119,7 @@ msgstr ""
 "\n"
 "{code}"
 
-#: mastodon/models/email.py:70
+#: mastodon/models/email.py:74
 #, python-brace-format
 msgid ""
 "Use this code to login as {email}\n"
@@ -7210,31 +7130,27 @@ msgstr ""
 "\n"
 "{code}"
 
-#: mastodon/models/email.py:74 users/templates/users/captcha.html:13
+#: mastodon/models/email.py:78 users/templates/users/captcha.html:13
 #: users/templates/users/captcha_solved.html:9
 #: users/templates/users/login.html:20 users/templates/users/register.html:9
 #: users/templates/users/welcome.html:10
 msgid "Register"
 msgstr "S'inscrire"
 
-#: mastodon/models/email.py:76
+#: mastodon/models/email.py:80
 #, python-brace-format
 msgid ""
 "There is no account registered with this email address yet: {email}\n"
 "\n"
-"If you already have an account with us, just login and add this email to you "
-"account.\n"
+"If you already have an account with us, just login and add this email to you account.\n"
 "\n"
-"If you prefer to register a new account with this email, please use this "
-"verification code: {code}"
+"If you prefer to register a new account with this email, please use this verification code: {code}"
 msgstr ""
 "Aucun compte n'est enregistré avec l'adresse mail suivante : {email}\n"
 "\n"
-"Si vous avez déjà un compte chez nous, connectez-vous et ajoutez cette "
-"adresse mail à votre compte.\n"
+"Si vous avez déjà un compte chez nous, connectez-vous et ajoutez cette adresse mail à votre compte.\n"
 "\n"
-"Si vous préférez créer un nouveau compte avec cette adresse mail, veuillez "
-"utiliser le code de vérirication suivant : {code}"
+"Si vous préférez créer un nouveau compte avec cette adresse mail, veuillez utiliser le code de vérirication suivant : {code}"
 
 #: mastodon/models/mastodon.py:570
 msgid "site domain name"
@@ -7276,56 +7192,61 @@ msgstr "longueur maximale de la publication"
 msgid "New Post"
 msgstr "Nouvelle Publication"
 
-#: mastodon/views/bluesky.py:26 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:32 mastodon/views/bluesky.py:93
 #, fuzzy
 #| msgid "Bluesky Login ID"
 msgid "Bluesky login is disabled."
 msgstr "Identifiant de connexion Bluesky"
 
-#: mastodon/views/bluesky.py:28 mastodon/views/email.py:35
-#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:29
-#: users/templates/users/login.html:6 users/views/webauthn.py:133
+#: mastodon/views/bluesky.py:47 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:65 mastodon/views/bluesky.py:98
+#: mastodon/views/bluesky.py:106 mastodon/views/bluesky.py:112
+#: mastodon/views/common.py:36 mastodon/views/mastodon.py:62
+#: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
+#: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
+#: mastodon/views/threads.py:57 mastodon/views/threads.py:65
+#: mastodon/views/threads.py:71 users/views/account.py:256
+#: users/views/account.py:375
+msgid "Authentication failed"
+msgstr "Échec d'authentification"
+
+#: mastodon/views/bluesky.py:47 mastodon/views/common.py:103
+msgid "Identity not found."
+msgstr "Identifiant introuvable."
+
+#: mastodon/views/bluesky.py:53 mastodon/views/email.py:35
+#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:31
+#: users/templates/users/login.html:6 users/views/webauthn.py:136
 #, fuzzy
 #| msgid "Export file expired. Please export again."
 msgid "Security check failed. Please try again."
 msgstr "Fichier d'export expiré. Veuillez ré-exporter."
 
-#: mastodon/views/bluesky.py:34 mastodon/views/bluesky.py:40
-#: mastodon/views/bluesky.py:64 mastodon/views/bluesky.py:72
-#: mastodon/views/bluesky.py:78 mastodon/views/common.py:36
-#: mastodon/views/mastodon.py:62 mastodon/views/mastodon.py:70
-#: mastodon/views/mastodon.py:77 mastodon/views/mastodon.py:87
-#: mastodon/views/mastodon.py:94 mastodon/views/threads.py:55
-#: mastodon/views/threads.py:63 mastodon/views/threads.py:69
-#: users/views/account.py:254 users/views/account.py:373
-msgid "Authentication failed"
-msgstr "Échec d'authentification"
-
-#: mastodon/views/bluesky.py:35 mastodon/views/email.py:66
+#: mastodon/views/bluesky.py:60 mastodon/views/email.py:66
 #, fuzzy
 #| msgid "System busy, please try again in a minute."
 msgid "Too many attempts, please try again later."
 msgstr "Système occupé, veuillez réessayer dans une minute."
 
-#: mastodon/views/bluesky.py:40
+#: mastodon/views/bluesky.py:65
 #, fuzzy
 #| msgid "ATProto handle"
 msgid "ATProto handle is required."
 msgstr "identifiant ATProto"
 
-#: mastodon/views/bluesky.py:50
+#: mastodon/views/bluesky.py:84
 #, fuzzy
 #| msgid "Error connecting to instance"
 msgid "Error connecting to your ATProto server"
 msgstr "Erreur lors de la connexion à l'instance"
 
-#: mastodon/views/bluesky.py:73
+#: mastodon/views/bluesky.py:107
 #, fuzzy
 #| msgid "Invalid response from Fediverse instance."
 msgid "Invalid response from ATProto authorization server."
 msgstr "Réponse incorrecte depuis l'instance du Fédivers."
 
-#: mastodon/views/bluesky.py:78
+#: mastodon/views/bluesky.py:112
 msgid "Invalid account data from Bluesky."
 msgstr "Informations du compte BlueSky invalides."
 
@@ -7333,7 +7254,7 @@ msgstr "Informations du compte BlueSky invalides."
 msgid "Invalid user."
 msgstr "Membre non-reconnu."
 
-#: mastodon/views/common.py:52 users/views/account.py:414
+#: mastodon/views/common.py:52 users/views/account.py:416
 msgid "Registration failed"
 msgstr "Échec de l'inscription"
 
@@ -7365,10 +7286,6 @@ msgstr "Information de connexion mises à jour en tant que {handle}."
 msgid "Disconnect identity failed"
 msgstr "Échec de dissociation de l'identifiant"
 
-#: mastodon/views/common.py:103
-msgid "Identity not found."
-msgstr "Identifiant introuvable."
-
 #: mastodon/views/common.py:117
 msgid "You cannot disconnect last login identity."
 msgstr "Vous ne pouvez pas détacher le dernier identifiant utilisé."
@@ -7388,9 +7305,7 @@ msgstr "Vérification"
 
 #: mastodon/views/email.py:48 users/templates/users/verify.html:20
 msgid "Verification email is being sent, please check your inbox."
-msgstr ""
-"Un mail de vérification est en cours d'envoi, veuillez surveiller votre "
-"boîte mail."
+msgstr "Un mail de vérification est en cours d'envoi, veuillez surveiller votre boîte mail."
 
 #: mastodon/views/email.py:80
 msgid "Invalid verification code"
@@ -7412,7 +7327,7 @@ msgstr "Erreur lors de la connexion à l'instance"
 msgid "Invalid response from Fediverse instance."
 msgstr "Réponse incorrecte depuis l'instance du Fédivers."
 
-#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:64
+#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:66
 msgid "Invalid OAuth state. Please try again."
 msgstr ""
 
@@ -7432,21 +7347,19 @@ msgstr "Token de l'instance du Fédivers incorrect."
 msgid "Invalid account data from Fediverse instance."
 msgstr "Données du compte Fédivers incorrectes."
 
-#: mastodon/views/threads.py:69
+#: mastodon/views/threads.py:71
 msgid "Invalid account data from Threads."
 msgstr "Données du compte Threads incorrectes."
 
-#: mastodon/views/threads.py:147
+#: mastodon/views/threads.py:149
 #, fuzzy
 #| msgid "Reset completed."
 msgid "Data deletion completed"
 msgstr "Réinitialisation terminée."
 
-#: mastodon/views/threads.py:149
+#: mastodon/views/threads.py:151
 #, python-brace-format
-msgid ""
-"Data linked to your Threads account has been deleted. Confirmation code: "
-"{code}"
+msgid "Data linked to your Threads account has been deleted. Confirmation code: {code}"
 msgstr ""
 
 #: social/templates/_article_teaser.html:10
@@ -7485,15 +7398,11 @@ msgstr "relayé"
 msgid "play"
 msgstr "lancer"
 
-#: social/templates/_event_post.html:50
-msgid "mark"
-msgstr "interaction"
-
-#: social/templates/_event_post.html:79
+#: social/templates/_event_post.html:74
 msgid "wrote a note"
 msgstr "a écrit une note"
 
-#: social/templates/_event_post.html:88
+#: social/templates/_event_post.html:83
 #, fuzzy
 #| msgid "playing"
 msgid "replying to"
@@ -7508,7 +7417,7 @@ msgstr ""
 msgid "Untitled article"
 msgstr ""
 
-#: social/templates/event/boosted.html:3
+#: social/templates/event/boosted.html:2
 msgid "boosted your post"
 msgstr "a relayé votre publication"
 
@@ -7564,12 +7473,10 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"a relayé votre avis sur <a href=\"%(piece_url)s\">%(piece_title)s</a> sur <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"a relayé votre avis sur <a href=\"%(piece_url)s\">%(piece_title)s</a> sur <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/boosted_shelfmember.html:3
 #, python-format
@@ -7588,7 +7495,7 @@ msgstr "a demandé à vous suivre"
 msgid "followed you"
 msgstr "s'est abonné⋅e à vous"
 
-#: social/templates/event/liked.html:3
+#: social/templates/event/liked.html:2
 msgid "liked your post"
 msgstr "a aimé votre publication"
 
@@ -7644,12 +7551,10 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"a aimé votre avis <a href=\"%(piece_url)s\">%(piece_title)s</a> sur <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"a aimé votre avis <a href=\"%(piece_url)s\">%(piece_title)s</a> sur <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/liked_shelfmember.html:3
 #, python-format
@@ -7660,7 +7565,7 @@ msgstr ""
 "\n"
 "a aimé votre interaction avec <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
-#: social/templates/event/mentioned.html:3
+#: social/templates/event/mentioned.html:2
 msgid "mentioned you"
 msgstr "vous a mentionné⋅e"
 
@@ -7692,8 +7597,7 @@ msgid ""
 "replied to your comment on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"a répondu à votre commentaire sur <a href=\"%(item_url)s\">%(item_title)s</"
-"a>\n"
+"a répondu à votre commentaire sur <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/mentioned_note.html:3
 #, python-format
@@ -7717,12 +7621,10 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"a répondu à votre avis <a href=\"%(piece_url)s\">%(piece_title)s</a> sur <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"a répondu à votre avis <a href=\"%(piece_url)s\">%(piece_title)s</a> sur <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/mentioned_shelfmember.html:3
 #, python-format
@@ -7731,36 +7633,48 @@ msgid ""
 "replied to your mark on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"a répondu à votre interaction avec <a href=\"%(item_url)s\">%(item_title)s</"
-"a>\n"
+"a répondu à votre interaction avec <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
-#: social/templates/feed.html:12 social/templates/feed.html:39
-#: social/templates/search_feed.html:12
-msgid "Activities from those you follow"
-msgstr "Activités des membres que vous suivez"
+#: social/templates/feed.html:39 users/templates/users/preferences.html:40
+msgid "Activities"
+msgstr "Activités"
 
-#: social/templates/feed.html:42 social/templates/feed.html:44
+#: social/templates/feed.html:43 social/templates/feed.html:45
+msgid "world"
+msgstr ""
+
+#: social/templates/feed.html:51 social/templates/feed.html:53
+#, fuzzy
+#| msgid "locale"
+msgid "local"
+msgstr "paramètres linguistiques"
+
+#: social/templates/feed.html:58 social/templates/feed.html:60
+#, fuzzy
+#| msgid "sure to follow?"
+msgid "those you follow"
+msgstr "confirmer le suivi ?"
+
+#: social/templates/feed.html:64 social/templates/feed.html:66
 #, fuzzy
 #| msgid "What they read/watch/..."
 msgid "what they read/watch/..."
 msgstr "Ce qu'iels ont lu/vu/..."
 
-#: social/templates/feed_events.html:30
+#: social/templates/feed_events.html:29
 msgid "no matching activities."
 msgstr "aucune activité correspondante."
 
-#: social/templates/feed_events.html:33
+#: social/templates/feed_events.html:31
+#, fuzzy
+#| msgid "no matching activities."
+msgid "no public activities yet."
+msgstr "aucune activité correspondante."
+
+#: social/templates/feed_events.html:34
 #, python-format
-msgid ""
-"Find and mark some books/movies/podcasts/games, <a "
-"href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/"
-"Douban, follow some fellow %(site_name)s users on the fediverse, so their "
-"recent activities and yours will show up here."
-msgstr ""
-"Trouvez et interagissez avec des livres/films/podcats/jeux, <a "
-"href=\"%(import_url)s\">importez vos données</a> depuis Goodreads/"
-"Letterboxd/..., et suivez d'autres membres de %(site_name)s sur le Fédivers "
-"afin que leur activité, et la votre, apparaissent ici."
+msgid "Find and mark some books/movies/podcasts/games, <a href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/Douban, follow some fellow %(site_name)s users on the fediverse, so their recent activities and yours will show up here."
+msgstr "Trouvez et interagissez avec des livres/films/podcats/jeux, <a href=\"%(import_url)s\">importez vos données</a> depuis Goodreads/Letterboxd/..., et suivez d'autres membres de %(site_name)s sur le Fédivers afin que leur activité, et la votre, apparaissent ici."
 
 #: social/templates/notification.html:58
 msgid "mention"
@@ -7796,6 +7710,10 @@ msgstr ""
 msgid "Poll ending at %(end_time)s"
 msgstr ""
 
+#: social/templates/search_feed.html:12 social/views.py:57 social/views.py:58
+msgid "Activities from those you follow"
+msgstr "Activités des membres que vous suivez"
+
 #: social/templates/single_post.html:13 social/templates/single_post.html:32
 #, fuzzy
 #| msgid "Posts"
@@ -7810,62 +7728,69 @@ msgstr ""
 msgid "Poll"
 msgstr ""
 
-#: takahe/models.py:453
+#: social/views.py:59
+#, fuzzy
+#| msgid "Activities from those you follow"
+msgid "Activities on this site"
+msgstr "Activités des membres que vous suivez"
+
+#: social/views.py:60
+#, fuzzy
+#| msgid "Activities from those you follow"
+msgid "Activities from the fediverse"
+msgstr "Activités des membres que vous suivez"
+
+#: takahe/models.py:445
 msgid "Display Name"
 msgstr "Nom d'affichage"
 
-#: takahe/models.py:455
+#: takahe/models.py:447
 msgid "Bio"
 msgstr "Bio"
 
-#: takahe/models.py:457
+#: takahe/models.py:449
 msgid "Manually approve new followers"
 msgstr "Valider manuellement les demandes de suivi"
 
-#: takahe/models.py:461
+#: takahe/models.py:453
 #, fuzzy
 #| msgid "Include profile and posts in discovery"
 msgid "Include profile, marks and posts in discovery"
 msgstr "Autoriser la découverte du profil et des publications"
 
-#: takahe/models.py:464
+#: takahe/models.py:456
 msgid "Include posts in search results"
 msgstr "Inclure les publications dans les résultats de recherche"
 
-#: takahe/models.py:482
+#: takahe/models.py:474
 msgid "Profile picture"
 msgstr "Avatar"
 
-#: takahe/models.py:489
+#: takahe/models.py:481
 msgid "Header picture"
 msgstr "Bannière"
 
-#: users/models/task.py:22
+#: users/models/task.py:24
 msgid "Started"
 msgstr "Démarré"
 
-#: users/models/task.py:23
+#: users/models/task.py:25
 msgid "Complete"
 msgstr "Terminé"
 
-#: users/models/user.py:69
-msgid ""
-"Enter a valid username. This value may contain only unaccented lowercase a-z "
-"and uppercase A-Z letters, numbers, and _ characters."
-msgstr ""
-"Veuillez saisir un identifiant valide. Il ne peut contenir que des "
-"caractères (de A à Z) non accentués, majuscules ou minuscules, des chiffres "
-"et le _ (tiret bas)."
+#: users/models/user.py:71
+msgid "Enter a valid username. This value may contain only unaccented lowercase a-z and uppercase A-Z letters, numbers, and _ characters."
+msgstr "Veuillez saisir un identifiant valide. Il ne peut contenir que des caractères (de A à Z) non accentués, majuscules ou minuscules, des chiffres et le _ (tiret bas)."
 
-#: users/models/user.py:130
+#: users/models/user.py:132
 msgid "username"
 msgstr "identifiant"
 
-#: users/models/user.py:135
+#: users/models/user.py:137
 msgid "Required. 50 characters or fewer. Letters, digits and _ only."
 msgstr "Requis. Max 50 caractères. Lettres, chiffres et _ seulement."
 
-#: users/models/user.py:138
+#: users/models/user.py:140
 msgid "A user with that username already exists."
 msgstr "Il y a déjà un membre avec cet identifiant."
 
@@ -8020,9 +7945,7 @@ msgid "Cancel import"
 msgstr "Annuler"
 
 #: users/templates/users/_rym_section.html:29
-msgid ""
-"On RateYourMusic, go to your profile and use the <b>Export your music "
-"catalog</b> option to download your library as a CSV file."
+msgid "On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:31
@@ -8031,18 +7954,12 @@ msgid "Upload the downloaded CSV file below."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:33
-msgid ""
-"Albums are matched by title + artist (and year if present) — first against "
-"the local catalog, then MusicBrainz, then Spotify. After auto-matching, "
-"you'll preview the matches in a table, edit any link or shelf status, and "
-"confirm the import."
+msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:36
 #: users/templates/users/_storygraph_section.html:38
-msgid ""
-"You can also re-upload a previously-downloaded matched CSV — the existing "
-"<code>link</code> column will be honoured as the default match."
+msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:40
@@ -8073,18 +7990,11 @@ msgid "Cancel the StoryGraph import? Progress will be discarded."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:31
-msgid ""
-"On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to "
-"download your library as a CSV file."
+msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:35
-msgid ""
-"Books are matched by ISBN — first against the local catalog, then Google "
-"Books and OpenLibrary — with a title + author search as fallback. After auto-"
-"matching, you'll preview the matches in a table, edit any link or shelf "
-"status, and confirm the import."
+msgid "Books are matched by ISBN — first against the local catalog, then Google Books and OpenLibrary — with a title + author search as fallback. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/account.html:11
@@ -8096,13 +8006,8 @@ msgid "Display name, avatar and other information"
 msgstr "Nom d'affichage, avatar & autres informations"
 
 #: users/templates/users/account.html:23
-msgid ""
-"Updating profile information here will turn off automatic sync of display "
-"name, bio and avatar from your Mastodon instance. Sure to continue?"
-msgstr ""
-"Mettre à jour les infos du profil ici désactivera la synchro automatique du "
-"nom d'affichage, de la bio et de l'avatar de votre instance du Fédivers. "
-"Voulez-vous poursuivre ?"
+msgid "Updating profile information here will turn off automatic sync of display name, bio and avatar from your Mastodon instance. Sure to continue?"
+msgstr "Mettre à jour les infos du profil ici désactivera la synchro automatique du nom d'affichage, de la bio et de l'avatar de votre instance du Fédivers. Voulez-vous poursuivre ?"
 
 #: users/templates/users/account.html:26
 msgid "Username"
@@ -8114,22 +8019,12 @@ msgstr "Adresse mail"
 
 #: users/templates/users/account.html:59 users/templates/users/register.html:47
 #, python-format
-msgid ""
-"Please click the confirmation link in the email sent to %(pending_email)s; "
-"if you haven't received it for more than a few minutes, please input and "
-"save again."
-msgstr ""
-"Veuillez cliquer sur le lien de confirmation contenu dans l'email envoyé à "
-"%(pending_email)s. Si vous ne l'avez pas reçu au bout de quelques minutes, "
-"veuillez saisir et enregister votre adresse mail à nouveau."
+msgid "Please click the confirmation link in the email sent to %(pending_email)s; if you haven't received it for more than a few minutes, please input and save again."
+msgstr "Veuillez cliquer sur le lien de confirmation contenu dans l'email envoyé à %(pending_email)s. Si vous ne l'avez pas reçu au bout de quelques minutes, veuillez saisir et enregister votre adresse mail à nouveau."
 
 #: users/templates/users/account.html:61 users/templates/users/register.html:50
-msgid ""
-"Email is recommended as a backup login method, if you log in via a Fediverse "
-"instance"
-msgstr ""
-"L'adresse mail est recomandée comme méthode de connexion de secours si vous "
-"vous connectez via le Fédivers"
+msgid "Email is recommended as a backup login method, if you log in via a Fediverse instance"
+msgstr "L'adresse mail est recomandée comme méthode de connexion de secours si vous vous connectez via le Fédivers"
 
 #: users/templates/users/account.html:73 users/templates/users/login.html:84
 msgid "Fediverse (Mastodon)"
@@ -8146,30 +8041,16 @@ msgid "Last updated"
 msgstr "Denière mise à jour"
 
 #: users/templates/users/account.html:92
-msgid ""
-"If you have not yet registered with any Federated instance, you may <a "
-"href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an "
-"instance</a> and register."
-msgstr ""
-"Si vous n'avez pas de compte sur le Fédivers, vous pouvez <a href=\"https://"
-"joinmastodon.org/fr/servers\" target=\"_blank\">choisir un serveur</a> et "
-"vous inscrire."
+msgid "If you have not yet registered with any Federated instance, you may <a href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an instance</a> and register."
+msgstr "Si vous n'avez pas de compte sur le Fédivers, vous pouvez <a href=\"https://joinmastodon.org/fr/servers\" target=\"_blank\">choisir un serveur</a> et vous inscrire."
 
 #: users/templates/users/account.html:97
-msgid ""
-"To associate with another federated identity, please enter the domain name "
-"of the instance where the new identity is located."
-msgstr ""
-"Pour associer ce compte NeoDB à un autre identifiant du Fédivers, veuillez "
-"entrer le nom de domaine de l'instance concernée."
+msgid "To associate with another federated identity, please enter the domain name of the instance where the new identity is located."
+msgstr "Pour associer ce compte NeoDB à un autre identifiant du Fédivers, veuillez entrer le nom de domaine de l'instance concernée."
 
 #: users/templates/users/account.html:99
-msgid ""
-"If you have registered with a Federated instance, please enter the instance "
-"domain name."
-msgstr ""
-"Si vous avez créé ce compte via le Fédivers, veuillez saisir le nom de "
-"domaine de l'instance."
+msgid "If you have registered with a Federated instance, please enter the instance domain name."
+msgstr "Si vous avez créé ce compte via le Fédivers, veuillez saisir le nom de domaine de l'instance."
 
 #: users/templates/users/account.html:104
 #, fuzzy
@@ -8182,34 +8063,18 @@ msgid "Go to target instance and authorize with the identity"
 msgstr "Aller sur l'instance cible pour valider l'autorisation"
 
 #: users/templates/users/account.html:113
-msgid ""
-"After replacing the association, you may use the new Fediverse identity to "
-"log in and control data visibility. Existing data such as tags, comments, "
-"and collections will not be affected."
-msgstr ""
-"Après avoir remplacé l'identifiant Fédivers associée à ce compte, vous "
-"pourrez utiliser cette nouvelle identité pour vous connecter et contrôler la "
-"visibilité de vos données. Les données existantes telles que les étiquettes, "
-"commentaires, et collections ne seront pas affectées."
+msgid "After replacing the association, you may use the new Fediverse identity to log in and control data visibility. Existing data such as tags, comments, and collections will not be affected."
+msgstr "Après avoir remplacé l'identifiant Fédivers associée à ce compte, vous pourrez utiliser cette nouvelle identité pour vous connecter et contrôler la visibilité de vos données. Les données existantes telles que les étiquettes, commentaires, et collections ne seront pas affectées."
 
 #: users/templates/users/account.html:115
-msgid ""
-"Once associated with Fediverse identity, you can discover more users and use "
-"the full features of this site."
-msgstr ""
-"Une fois votre compte associé à un identifiant Fédivers, vous pourrez "
-"découvrir plus de membres et aurez accès à l'ensemble des fonctionnalités de "
-"ce site."
+msgid "Once associated with Fediverse identity, you can discover more users and use the full features of this site."
+msgstr "Une fois votre compte associé à un identifiant Fédivers, vous pourrez découvrir plus de membres et aurez accès à l'ensemble des fonctionnalités de ce site."
 
 #: users/templates/users/account.html:123
 #: users/templates/users/account.html:160
 #: users/templates/users/account.html:206
-msgid ""
-"Once disconnected, you will no longer be able login with this identity. Are "
-"you sure to continue?"
-msgstr ""
-"Une fois votre compte détaché de votre identifiant Fédivers, vous ne serez "
-"plus en mesure de vous connecter avec celle-ci. Voulez-vous continuer ?"
+msgid "Once disconnected, you will no longer be able login with this identity. Are you sure to continue?"
+msgstr "Une fois votre compte détaché de votre identifiant Fédivers, vous ne serez plus en mesure de vous connecter avec celle-ci. Voulez-vous continuer ?"
 
 #: users/templates/users/account.html:126
 msgid "Disconnect with this identity"
@@ -8235,7 +8100,7 @@ msgstr "Associer un compte Threads"
 msgid "Disconnect with Threads"
 msgstr "Détacher le compte Threads"
 
-#: users/templates/users/account.html:173 users/templates/users/login.html:112
+#: users/templates/users/account.html:173 users/templates/users/login.html:106
 msgid "Bluesky (ATProto)"
 msgstr "Bluesky (ATProto)"
 
@@ -8243,7 +8108,7 @@ msgstr "Bluesky (ATProto)"
 msgid "Verified ATProto identity"
 msgstr "Idendifiant ATProto validé"
 
-#: users/templates/users/account.html:194 users/templates/users/login.html:216
+#: users/templates/users/account.html:194 users/templates/users/login.html:210
 msgid "ATProto handle"
 msgstr "identifiant ATProto"
 
@@ -8268,7 +8133,7 @@ msgid "Name this passkey:"
 msgstr ""
 
 #: users/templates/users/account.html:227 users/templates/users/login.html:69
-#: users/templates/users/welcome.html:33 users/views/webauthn.py:106
+#: users/templates/users/welcome.html:33 users/views/webauthn.py:109
 msgid "Passkey"
 msgstr ""
 
@@ -8317,12 +8182,8 @@ msgid "Save sync settings"
 msgstr "Enregistrer les paramètres de synchronisation"
 
 #: users/templates/users/account.html:297
-msgid ""
-"New follow, mute and blocks in the associated identity may be automatically "
-"imported; removal has to be done manually."
-msgstr ""
-"Les abonnements, masquages & blocages du nouvel identifiant associé seront "
-"importés automatiquement. Vous pourrez les retirer manuellement."
+msgid "New follow, mute and blocks in the associated identity may be automatically imported; removal has to be done manually."
+msgstr "Les abonnements, masquages & blocages du nouvel identifiant associé seront importés automatiquement. Vous pourrez les retirer manuellement."
 
 #: users/templates/users/account.html:304
 msgid "Click button below to start sync now."
@@ -8358,15 +8219,11 @@ msgid "Log out everywhere"
 msgstr ""
 
 #: users/templates/users/account.html:365
-msgid ""
-"This will log you out of all browsers and devices (including the current "
-"one), and revoke all API tokens. Continue?"
+msgid "This will log you out of all browsers and devices (including the current one), and revoke all API tokens. Continue?"
 msgstr ""
 
 #: users/templates/users/account.html:368
-msgid ""
-"If you notice any suspicious activity or have logged in on a shared "
-"computer, you can log out of all sessions and revoke all API tokens."
+msgid "If you notice any suspicious activity or have logged in on a shared computer, you can log out of all sessions and revoke all API tokens."
 msgstr ""
 
 #: users/templates/users/account.html:378
@@ -8441,10 +8298,10 @@ msgstr "à écouter"
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:74
-#: users/templates/users/data.html:126 users/templates/users/data.html:183
-#: users/templates/users/data.html:234 users/templates/users/data.html:298
-#: users/templates/users/data.html:358 users/templates/users/data.html:553
+#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/data.html:141 users/templates/users/data.html:198
+#: users/templates/users/data.html:249 users/templates/users/data.html:313
+#: users/templates/users/data.html:376 users/templates/users/data.html:553
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr "Importer"
@@ -8476,15 +8333,9 @@ msgstr "Migrer mon compte"
 
 #: users/templates/users/account.html:488
 #, fuzzy
-#| msgid ""
-#| "Link an email so that you can migrate followers from other Fediverse "
-#| "instances."
-msgid ""
-"Linking an email to your account is highly recommended before migrating from "
-"another Fediverse instance."
-msgstr ""
-"Associez une adresse mail afin de pouvoir migrer vos abonné⋅es depuis une "
-"autre instance du Fédivers."
+#| msgid "Link an email so that you can migrate followers from other Fediverse instances."
+msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
+msgstr "Associez une adresse mail afin de pouvoir migrer vos abonné⋅es depuis une autre instance du Fédivers."
 
 #: users/templates/users/account.html:491
 #, fuzzy
@@ -8504,22 +8355,15 @@ msgstr "Supprimer mon compte"
 
 #: users/templates/users/account.html:504
 msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
-msgstr ""
-"Une fois supprimées, les données d'un compte ne peuvent être récupérées. "
-"Voulez-vous continuer ?"
+msgstr "Une fois supprimées, les données d'un compte ne peuvent être récupérées. Voulez-vous continuer ?"
 
 #: users/templates/users/account.html:507
-msgid ""
-"Enter full <code>username@instance.social</code> or <code>email@domain.com</"
-"code> to confirm deletion."
-msgstr ""
-"Veuillez saisir l'identifiant complet <code>pseudo@instance.social</code> ou "
-"<code>email@domain.com</code> pour confirmer la suppression."
+msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
+msgstr "Veuillez saisir l'identifiant complet <code>pseudo@instance.social</code> ou <code>email@domain.com</code> pour confirmer la suppression."
 
 #: users/templates/users/account.html:517
 msgid "Once deleted, account data cannot be recovered."
-msgstr ""
-"Une fois votre compte supprimé, ses données ne peuvent être restaurées."
+msgstr "Une fois votre compte supprimé, ses données ne peuvent être restaurées."
 
 #: users/templates/users/account.html:520
 #, fuzzy
@@ -8576,9 +8420,7 @@ msgid "Token Created"
 msgstr "non évalué"
 
 #: users/templates/users/authorized_app_created.html:22
-msgid ""
-"Your new personal access token has been created. Copy it now -- you will not "
-"be able to see it again."
+msgid "Your new personal access token has been created. Copy it now -- you will not be able to see it again."
 msgstr ""
 
 #: users/templates/users/authorized_app_created.html:25
@@ -8606,9 +8448,7 @@ msgid "One quick check"
 msgstr ""
 
 #: users/templates/users/captcha.html:28
-msgid ""
-"Put every cover into the row it belongs to. Drag it, or select a cover and "
-"then select a row."
+msgid "Put every cover into the row it belongs to. Drag it, or select a cover and then select a row."
 msgstr ""
 
 #: users/templates/users/captcha.html:41 users/templates/users/captcha.html:43
@@ -8643,7 +8483,7 @@ msgstr ""
 msgid "That is all we needed. Let's get you a username."
 msgstr ""
 
-#: users/templates/users/captcha_solved.html:34
+#: users/templates/users/captcha_solved.html:32
 #: users/templates/users/login.html:63
 #: users/templates/users/verify_email.html:25
 #: users/templates/users/welcome.html:51
@@ -8663,10 +8503,7 @@ msgid "Failed Crossposts"
 msgstr ""
 
 #: users/templates/users/crossposts.html:42
-msgid ""
-"These posts could not be crossposted to your linked social accounts. Re-"
-"authorize the account if needed, then retry. In rare cases retrying may "
-"create a duplicate post."
+msgid "These posts could not be crossposted to your linked social accounts. Re-authorize the account if needed, then retry. In rare cases retrying may create a duplicate post."
 msgstr ""
 
 #: users/templates/users/crossposts.html:48
@@ -8689,265 +8526,193 @@ msgstr ""
 msgid "Data Management"
 msgstr "Gestion des données"
 
-#: users/templates/users/data.html:27
+#: users/templates/users/data.html:39
 msgid "Import Marks and Reviews from Douban"
 msgstr "Importer les interactions & avis depuis Douban"
 
-#: users/templates/users/data.html:31
-msgid ""
-"Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
-"target=\"_blank\" rel=\"noopener\">Doufen</a>"
-msgstr ""
-"Sélectionnez le fichier <code>.xlsx</code> exporté depuis <a href=\"https://"
-"doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
+#: users/templates/users/data.html:43
+msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
+msgstr "Sélectionnez le fichier <code>.xlsx</code> exporté depuis <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 
 #: users/templates/users/data.html:45
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
-"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
-"NeoDB Archive</a> below."
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON format instead; upload it under <a href=\"#import-neodb-archive\">Import NeoDB Archive</a> below."
 msgstr ""
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:256
+#: users/templates/users/data.html:49 users/templates/users/data.html:271
 msgid "Import Method"
 msgstr "Méthode d'import"
 
-#: users/templates/users/data.html:37
-msgid ""
-"Merge: only update when status changes from wishlist to in-progress, or from "
-"in-progress to complete."
-msgstr ""
-"Fusionner : ne mettre à jour que lorsque le statut passe des envies à \"en "
-"cours\", ou de \"en cours\" à \"terminé\"."
+#: users/templates/users/data.html:52
+msgid "Merge: only update when status changes from wishlist to in-progress, or from in-progress to complete."
+msgstr "Fusionner : ne mettre à jour que lorsque le statut passe des envies à \"en cours\", ou de \"en cours\" à \"terminé\"."
 
-#: users/templates/users/data.html:41
+#: users/templates/users/data.html:56
 msgid "Overwrite: update all imported status."
 msgstr "Écraser : mettre à jour tous les statuts importés."
 
-#: users/templates/users/data.html:74
-msgid ""
-"Another import is in progress, starting a new import may cause issues, sure "
-"to import?"
-msgstr ""
-"Un autre import est en cours. Démarrer un nouvel import peut créer des "
-"erreurs. Voulez-vous continuer ?"
+#: users/templates/users/data.html:89
+msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
+msgstr "Un autre import est en cours. Démarrer un nouvel import peut créer des erreurs. Voulez-vous continuer ?"
 
-#: users/templates/users/data.html:74
+#: users/templates/users/data.html:89 users/views/data.py:1130
 msgid "Import in progress, please wait"
 msgstr "Import en cours, veuillez patienter"
 
-#: users/templates/users/data.html:81
+#: users/templates/users/data.html:96
 #, fuzzy
 #| msgid "Import Shelf or List from Goodreads"
 msgid "Import from Goodreads"
 msgstr "Importer une Bibliothèque ou une Liste depuis Goodreads"
 
-#: users/templates/users/data.html:87
-msgid ""
-"On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download "
-"your library as a CSV file."
+#: users/templates/users/data.html:102
+msgid "On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download your library as a CSV file."
 msgstr ""
 
-#: users/templates/users/data.html:90
-msgid ""
-"Upload the downloaded <code>goodreads_library_export.csv</code> file below."
+#: users/templates/users/data.html:105
+msgid "Upload the downloaded <code>goodreads_library_export.csv</code> file below."
 msgstr ""
 
-#: users/templates/users/data.html:93
+#: users/templates/users/data.html:108
 #, fuzzy
-#| msgid ""
-#| "want-to-read / currently-reading / read books and their reviews will be "
-#| "imported."
-msgid ""
-"want-to-read / currently-reading / read / did-not-finish books and their "
-"reviews will be imported."
-msgstr ""
-"les livres dans vos envies / en cours / déjà lus, ainsi que les avis "
-"associés seront importés."
+#| msgid "want-to-read / currently-reading / read books and their reviews will be imported."
+msgid "want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported."
+msgstr "les livres dans vos envies / en cours / déjà lus, ainsi que les avis associés seront importés."
 
-#: users/templates/users/data.html:134
+#: users/templates/users/data.html:149
 msgid "Import from Letterboxd"
 msgstr "Importer depuis Letterboxd"
 
-#: users/templates/users/data.html:140
-msgid ""
-"on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" "
-"target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap "
-"Advanced Settings in Settings, tap EXPORT YOUR DATA"
+#: users/templates/users/data.html:155
+msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
 msgstr ""
 
-#: users/templates/users/data.html:143
-msgid ""
-"download file with name like <code>letterboxd-username-2018-03-11-07-52-"
-"utc.zip</code>, do not unzip"
+#: users/templates/users/data.html:158
+msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
 msgstr ""
 
-#: users/templates/users/data.html:146
-msgid ""
-"the following files in the zip file will be processed: <code>reviews.csv</"
-"code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</"
-"code> <code>lists/*.csv</code>"
+#: users/templates/users/data.html:161
+msgid "the following files in the zip file will be processed: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
 msgstr ""
 
-#: users/templates/users/data.html:149
-msgid ""
-"exported file does not indicate whether a list is private, unlisted or "
-"public, so all imported marks, reviews and collections will be created with "
-"the visibility selected below"
+#: users/templates/users/data.html:164
+msgid "exported file does not indicate whether a list is private, unlisted or public, so all imported marks, reviews and collections will be created with the visibility selected below"
 msgstr ""
 
-#: users/templates/users/data.html:184 users/templates/users/data.html:235
+#: users/templates/users/data.html:199 users/templates/users/data.html:250
 msgid "Only forward changes(none->to-watch->watched) will be imported."
-msgstr ""
-"Seuls les changements chronologiques (aucun → à voir → vu) seront importés."
+msgstr "Seuls les changements chronologiques (aucun → à voir → vu) seront importés."
 
-#: users/templates/users/data.html:191
+#: users/templates/users/data.html:206
 #, fuzzy
 #| msgid "Import from Letterboxd"
 msgid "Import from Trakt"
 msgstr "Importer depuis Letterboxd"
 
-#: users/templates/users/data.html:197
-msgid ""
-"On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" "
-"rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait "
-"for the download link to appear."
+#: users/templates/users/data.html:212
+msgid "On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait for the download link to appear."
 msgstr ""
 
-#: users/templates/users/data.html:200
+#: users/templates/users/data.html:215
 msgid "Upload the downloaded <code>.zip</code> file below, do not unzip."
 msgstr ""
 
-#: users/templates/users/data.html:202
+#: users/templates/users/data.html:217
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:243
+#: users/templates/users/data.html:258
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr ""
 
-#: users/templates/users/data.html:246
+#: users/templates/users/data.html:261
 msgid "Login with Steam"
 msgstr ""
 
-#: users/templates/users/data.html:252
+#: users/templates/users/data.html:267
 msgid "Import Podcast Subscriptions"
 msgstr "Importer vos abonnements podcasts"
 
-#: users/templates/users/data.html:263
+#: users/templates/users/data.html:278
 msgid "Mark as listening"
 msgstr "Écoute en cours"
 
-#: users/templates/users/data.html:267
+#: users/templates/users/data.html:282
 msgid "Import as a new collection"
 msgstr "Importer en tant que nouvelle collection"
 
-#: users/templates/users/data.html:296
+#: users/templates/users/data.html:311
 msgid "Select OPML file"
 msgstr "Sélectionner le fichier OPML"
 
-#: users/templates/users/data.html:306
+#: users/templates/users/data.html:321
 msgid "Import NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:312
-msgid ""
-"Upload a <code>.zip</code> file containing <code>.csv</code> or "
-"<code>.ndjson</code> files exported from NeoDB."
+#: users/templates/users/data.html:327
+msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr ""
 
 #: users/templates/users/data.html:330
 #, fuzzy
-#| msgid ""
-#| "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
-#| "target=\"_blank\" rel=\"noopener\">Doufen</a>"
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
-"imported here."
-msgstr ""
-"Sélectionnez le fichier <code>.xlsx</code> exporté depuis <a href=\"https://"
-"doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
+#| msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is imported here."
+msgstr "Sélectionnez le fichier <code>.xlsx</code> exporté depuis <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 
-#: users/templates/users/data.html:314
+#: users/templates/users/data.html:332
 #, fuzzy
 #| msgid "Existing metadata might get overwritten, sure to proceed?"
 msgid "Existing data may be overwritten."
-msgstr ""
-"Les métadonnées existantes risquent d'être écrasées, voulez-vous continuer ?"
+msgstr "Les métadonnées existantes risquent d'être écrasées, voulez-vous continuer ?"
 
-#: users/templates/users/data.html:324
+#: users/templates/users/data.html:342
 msgid "Detected format"
 msgstr ""
 
-#: users/templates/users/data.html:385
+#: users/templates/users/data.html:403
 msgid "Detecting format..."
 msgstr ""
 
-#: users/templates/users/data.html:411
+#: users/templates/users/data.html:429
 #, fuzzy
 #| msgid "Unknown or Other"
 msgid "Unknown format"
 msgstr "Autre ou Inconnu"
 
-#: users/templates/users/data.html:436
+#: users/templates/users/data.html:454
 #, fuzzy
 #| msgid "Error connecting to instance"
 msgid "Error detecting format"
 msgstr "Erreur lors de la connexion à l'instance"
 
-#: users/templates/users/data.html:460
+#: users/templates/users/data.html:478
 msgid "Export NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:464
+#: users/templates/users/data.html:482
 #, fuzzy
 #| msgid "Export marks and reviews"
 msgid "Export marks, reviews and notes in CSV"
 msgstr "Exporter les interactions & avis"
 
-#: users/templates/users/data.html:471
+#: users/templates/users/data.html:489
 msgid "Export everything in NDJSON"
 msgstr ""
-
-#: users/templates/users/data.html:479
-#, fuzzy
-#| msgid "Export marks and reviews"
-msgid "Export marks and reviews in XLSX (Doufen format)"
-msgstr "Exporter les interactions & avis"
-
-#: users/templates/users/data.html:482
-msgid "Last export"
-msgstr "Dernier export"
-
-#: users/templates/users/data.html:487
-msgid "Download"
-msgstr "Télécharger"
 
 #: users/templates/users/data.html:496
 msgid "Import and Export Articles (WordPress)"
 msgstr ""
 
 #: users/templates/users/data.html:499
-msgid ""
-"Your articles are exchanged as WordPress posts in the WXR format, which "
-"WordPress and most blogging tools can read and write. Marks, reviews and "
-"notes are not included: use the NeoDB archive above for those."
+msgid "Your articles are exchanged as WordPress posts in the WXR format, which WordPress and most blogging tools can read and write. Marks, reviews and notes are not included: use the NeoDB archive above for those."
 msgstr ""
 
 #: users/templates/users/data.html:502
-msgid ""
-"Article title, body, excerpt, tags, dates and featured image are exchanged. "
-"Comments and custom fields are ignored."
+msgid "Article title, body, excerpt, tags, dates and featured image are exchanged. Comments and custom fields are ignored."
 msgstr ""
 
 #: users/templates/users/data.html:505
-msgid ""
-"The body is converted between Markdown and HTML, so formatting is kept but "
-"the text is not character-for-character identical."
+msgid "The body is converted between Markdown and HTML, so formatting is kept but the text is not character-for-character identical."
 msgstr ""
 
 #: users/templates/users/data.html:512
@@ -8957,16 +8722,11 @@ msgid "Export articles in WordPress format"
 msgstr "Exporter les interactions & avis"
 
 #: users/templates/users/data.html:519
-msgid ""
-"In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download "
-"an <code>.xml</code> file, then upload it below."
+msgid "In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download an <code>.xml</code> file, then upload it below."
 msgstr ""
 
 #: users/templates/users/data.html:522
-msgid ""
-"Only published posts use the visibility below. Drafts, pending, private and "
-"password-protected posts are always imported as mentioned-only, so nothing "
-"unpublished becomes public."
+msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
 #: users/templates/users/data.html:560
@@ -8974,12 +8734,8 @@ msgid "View Annual Summary"
 msgstr "Voir le Récap' annuel"
 
 #: users/templates/users/fetch_identity_failed.html:4
-msgid ""
-"Unable to find the user, please check your spelling; or the server may be "
-"busy, please try again later."
-msgstr ""
-"Membre introuvable, pouvez-vous vérifier la saisie ? Il se peut également "
-"que le serveur soit occupé, dans ce cas vous pourrez réessayer plus tard."
+msgid "Unable to find the user, please check your spelling; or the server may be busy, please try again later."
+msgstr "Membre introuvable, pouvez-vous vérifier la saisie ? Il se peut également que le serveur soit occupé, dans ce cas vous pourrez réessayer plus tard."
 
 #: users/templates/users/fetch_identity_pending.html:13
 #: users/templates/users/fetch_identity_pending.html:22
@@ -8998,115 +8754,78 @@ msgstr "Connexion"
 msgid "logo"
 msgstr ""
 
-#: users/templates/users/login.html:127
-msgid ""
-"Sign in with a passkey saved on this device or in your password manager."
+#: users/templates/users/login.html:121
+msgid "Sign in with a passkey saved on this device or in your password manager."
 msgstr ""
 
-#: users/templates/users/login.html:132
+#: users/templates/users/login.html:126
 msgid "Sign in with Passkey"
 msgstr ""
 
-#: users/templates/users/login.html:148
+#: users/templates/users/login.html:142
 msgid "Enter your email address"
 msgstr "Saisissez votre adresse mail"
 
-#: users/templates/users/login.html:152
+#: users/templates/users/login.html:146
 msgid "Send verification code"
 msgstr "Envoyer le code de vérification"
 
-#: users/templates/users/login.html:171
+#: users/templates/users/login.html:165
 msgid "Domain of your instance, e.g. mastodon.social"
 msgstr "Adresse de votre instance, ex : piaille.fr"
 
-#: users/templates/users/login.html:177
-msgid ""
-"Please enter domain of your instance; e.g. if your id is "
-"<i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
-msgstr ""
-"Veuillez saisir l'adresse de votre instance. Par ex : si votre identifiant "
-"est <i>@membre@piaille.fr</i>, ne saisissez que <i>piaille.fr</i>."
+#: users/templates/users/login.html:171
+msgid "Please enter domain of your instance; e.g. if your id is <i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
+msgstr "Veuillez saisir l'adresse de votre instance. Par ex : si votre identifiant est <i>@membre@piaille.fr</i>, ne saisissez que <i>piaille.fr</i>."
 
-#: users/templates/users/login.html:182 users/templates/users/login.html:246
+#: users/templates/users/login.html:176 users/templates/users/login.html:240
 msgid "Authorize via Fediverse instance"
 msgstr "Autoriser via une instance du Fédivers"
 
-#: users/templates/users/login.html:187
-msgid ""
-"If you don't have a <a href=\"https://joinmastodon.org/servers\" "
-"target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or "
-"login with Email first, and link it with Fediverse (Mastodon) later in "
-"account settings."
-msgstr ""
-"Si vous n'avez pas encore de <a href=\"https://joinmastodon.org/servers\" "
-"target=\"_blank\">compte sur le Fédivers (par ex. Mastodon)</a>, vous pouvez "
-"vous inscrire ou vous connecter avec votre adresse de courriel. Vous pourrez "
-"toujours y associer un compte du Fédivers plus tard, dans vos paramètres de "
-"compte."
+#: users/templates/users/login.html:181
+msgid "If you don't have a <a href=\"https://joinmastodon.org/servers\" target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or login with Email first, and link it with Fediverse (Mastodon) later in account settings."
+msgstr "Si vous n'avez pas encore de <a href=\"https://joinmastodon.org/servers\" target=\"_blank\">compte sur le Fédivers (par ex. Mastodon)</a>, vous pouvez vous inscrire ou vous connecter avec votre adresse de courriel. Vous pourrez toujours y associer un compte du Fédivers plus tard, dans vos paramètres de compte."
 
-#: users/templates/users/login.html:200
+#: users/templates/users/login.html:194
 msgid "Authorize via Threads"
 msgstr "Autoriser via Threads"
 
-#: users/templates/users/login.html:221
-msgid ""
-"Please input your ATProto handle (e.g. neodb.bsky.social, without the "
-"leading @), do not use email. If you changed handle recently, just use the "
-"latest one."
-msgstr ""
-"Veuillez saisir votre idenfitiant ATProto (ex : membre@bsky.app, sans le @ "
-"initial). N'utilisez pas d'adresse mail. Si vous avez changé votre "
-"identifiant récemment, utilisez le plus récent."
+#: users/templates/users/login.html:215
+msgid "Please input your ATProto handle (e.g. neodb.bsky.social, without the leading @), do not use email. If you changed handle recently, just use the latest one."
+msgstr "Veuillez saisir votre idenfitiant ATProto (ex : membre@bsky.app, sans le @ initial). N'utilisez pas d'adresse mail. Si vous avez changé votre identifiant récemment, utilisez le plus récent."
 
-#: users/templates/users/login.html:224
+#: users/templates/users/login.html:218
 #, fuzzy
 #| msgid "Authorize via Threads"
 msgid "Authorize via ATProto server"
 msgstr "Autoriser via Threads"
 
-#: users/templates/users/login.html:231
+#: users/templates/users/login.html:225
 #, python-format
-msgid ""
-"Please choose one to register or login %(site_name)s. Have more than one of "
-"these identities? Don't worry, you may link them in account settings once "
-"logged in."
-msgstr ""
-"Sélectionnez un compte pour vous inscrire ou vous connecter à %(site_name)s. "
-"Vous en avez plusieurs ? Pas de souci, vous pourrez en ajouter d'autres "
-"ultérieurement, dans vos réglages de compte."
+msgid "Please choose one to register or login %(site_name)s. Have more than one of these identities? Don't worry, you may link them in account settings once logged in."
+msgstr "Sélectionnez un compte pour vous inscrire ou vous connecter à %(site_name)s. Vous en avez plusieurs ? Pas de souci, vous pourrez en ajouter d'autres ultérieurement, dans vos réglages de compte."
 
-#: users/templates/users/login.html:255
+#: users/templates/users/login.html:249
 msgid "Valid invitation code, please login or register."
 msgstr "Code d'invitation correct ! Vous pouvez vous inscrire."
 
-#: users/templates/users/login.html:257
-msgid ""
-"Please use invitation link to register a new account; existing user may "
-"login."
-msgstr ""
-"Inscriptions fermées, veuillez utiliser un lien d'invitation pour créer un "
-"compte. Si vous avez déjà un compte, vous pouvez vous connecter."
+#: users/templates/users/login.html:251
+msgid "Please use invitation link to register a new account; existing user may login."
+msgstr "Inscriptions fermées, veuillez utiliser un lien d'invitation pour créer un compte. Si vous avez déjà un compte, vous pouvez vous connecter."
 
-#: users/templates/users/login.html:259
+#: users/templates/users/login.html:253
 msgid "Invitation code invalid or expired."
 msgstr "Code d'invitation incorrect ou expiré."
 
-#: users/templates/users/login.html:267
+#: users/templates/users/login.html:261
 msgid "Loading timed out, please check your network (VPN) settings."
-msgstr ""
-"Temps de chargement dépassé. Veuillez vérifier vos paramètres réseau ou VPN."
+msgstr "Temps de chargement dépassé. Veuillez vérifier vos paramètres réseau ou VPN."
 
-#: users/templates/users/login.html:273
-msgid ""
-"Continue using this site implies consent to our <a href=\"/pages/rules/"
-"\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using "
-"cookies to provide necessary functionality."
-msgstr ""
-"L'utilisation de ce site implique l'acceptation du <a href=\"/pages/rules/"
-"\">règlement</a> et des <a href=\"/pages/terms/\">termes &#38; conditions</"
-"a>, ce qui inclut l'usage des cookies nécessaires à son bon fonctionnement."
+#: users/templates/users/login.html:267
+msgid "Continue using this site implies consent to our <a href=\"/pages/rules/\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using cookies to provide necessary functionality."
+msgstr "L'utilisation de ce site implique l'acceptation du <a href=\"/pages/rules/\">règlement</a> et des <a href=\"/pages/terms/\">termes &#38; conditions</a>, ce qui inclut l'usage des cookies nécessaires à son bon fonctionnement."
 
-#: users/templates/users/login.html:287
+#: users/templates/users/login.html:281
 msgid "Domain of your instance (excl. @)"
 msgstr "Adresse de votre instance (ex : piaille.fr)"
 
@@ -9116,9 +8835,7 @@ msgid "Migrate Here"
 msgstr ""
 
 #: users/templates/users/migrate_in.html:22
-msgid ""
-"To move another account to this one, first add it as an alias here, and then "
-"go to the server where it is hosted and initiate the move."
+msgid "To move another account to this one, first add it as an alias here, and then go to the server where it is hosted and initiate the move."
 msgstr ""
 
 #: users/templates/users/migrate_in.html:27
@@ -9174,16 +8891,11 @@ msgstr ""
 
 #: users/templates/users/migrate_out.html:46
 #, python-format
-msgid ""
-"To migrate to another account, first add <code>@%(handle)s</code> as an "
-"alias on the target server, and then type the target account below to start "
-"the migration."
+msgid "To migrate to another account, first add <code>@%(handle)s</code> as an alias on the target server, and then type the target account below to start the migration."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:50
-msgid ""
-"Are you sure you want to migrate your account? Your followers will be moved "
-"to the target account."
+msgid "Are you sure you want to migrate your account? Your followers will be moved to the target account."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:53
@@ -9201,10 +8913,6 @@ msgstr "commencer à lire"
 #: users/templates/users/preferences.html:28
 msgid "Default view once logged in"
 msgstr "Vue par défaut"
-
-#: users/templates/users/preferences.html:40
-msgid "Activities"
-msgstr "Activités"
 
 #: users/templates/users/preferences.html:49
 msgid "Default visibility"
@@ -9233,9 +8941,7 @@ msgstr "Repartager par défaut sur vos autres réseaux sociaux"
 
 #: users/templates/users/preferences.html:111
 #: users/templates/users/register.html:88
-msgid ""
-"If a Mastodon account is linked with this identity, boosting a post will "
-"also make the same post boosted with that Mastodon account."
+msgid "If a Mastodon account is linked with this identity, boosting a post will also make the same post boosted with that Mastodon account."
 msgstr ""
 
 #: users/templates/users/preferences.html:115
@@ -9251,18 +8957,12 @@ msgid "Create a new post"
 msgstr "Créer une nouvelle publication"
 
 #: users/templates/users/preferences.html:130
-msgid ""
-"this method is less optimal, may generate duplicated posts and miss "
-"reactions."
-msgstr ""
-"cette méthode est moins optimisée, elle peut générer des doublons et ne pas "
-"recevoir toutes les réactions."
+msgid "this method is less optimal, may generate duplicated posts and miss reactions."
+msgstr "cette méthode est moins optimisée, elle peut générer des doublons et ne pas recevoir toutes les réactions."
 
 #: users/templates/users/preferences.html:140
 #: users/templates/users/register.html:97
-msgid ""
-"Always publish my public marks, reviews and articles as data records to my "
-"PDS."
+msgid "Always publish my public marks, reviews and articles as data records to my PDS."
 msgstr ""
 
 #: users/templates/users/preferences.html:145
@@ -9282,19 +8982,8 @@ msgid "Automatic bookmark for these categories"
 msgstr "Ajouter automatiquement un marque-page pour ces catégories"
 
 #: users/templates/users/preferences.html:175
-msgid ""
-"When start to read/watch/play/... an item in these categories, a bookmark "
-"will be created automatically. Bookmarks can be viewed and managed in most "
-"<a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon "
-"compatible apps</a>; your replies to these posts will automatically become "
-"notes for the item."
-msgstr ""
-"Quand vous commencez à lire/regarder/écouter/... une œuvre de ces "
-"catégories, un marque-page sera automatiquement créé. Les marque-pages "
-"peuvent être consultés et gérés dans la plupart des <a href=\"https://"
-"joinmastodon.org/apps\" target=\"_blank\">applis compatibles avec Mastodon</"
-"a>. Vos réponses à ces marques-pages seront transformées en notes sur "
-"l'œuvre sur ce site."
+msgid "When start to read/watch/play/... an item in these categories, a bookmark will be created automatically. Bookmarks can be viewed and managed in most <a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon compatible apps</a>; your replies to these posts will automatically become notes for the item."
+msgstr "Quand vous commencez à lire/regarder/écouter/... une œuvre de ces catégories, un marque-page sera automatiquement créé. Les marque-pages peuvent être consultés et gérés dans la plupart des <a href=\"https://joinmastodon.org/apps\" target=\"_blank\">applis compatibles avec Mastodon</a>. Vos réponses à ces marques-pages seront transformées en notes sur l'œuvre sur ce site."
 
 #: users/templates/users/preferences.html:183
 msgid "Turn replies to my own catalog item posts into notes for the item"
@@ -9313,35 +9002,19 @@ msgid "Profile visible to anonymous web visitors and search engines"
 msgstr "Profil visible par les visiteurs anonymes et les moteurs de recherche"
 
 #: users/templates/users/preferences.html:217
-msgid ""
-"this option limits web visits only; to limit fediverse visibility, choose "
-"followers only or mentioned only when posting"
-msgstr ""
-"cette option limite les visites via le site web seulement. Pour limiter la "
-"visibilité sur le Fédivers, veuillez passer en \"Abonné⋅es seulement\" ou "
-"\"Mentionné⋅es seulement\" lorsque vous publiez"
+msgid "this option limits web visits only; to limit fediverse visibility, choose followers only or mentioned only when posting"
+msgstr "cette option limite les visites via le site web seulement. Pour limiter la visibilité sur le Fédivers, veuillez passer en \"Abonné⋅es seulement\" ou \"Mentionné⋅es seulement\" lorsque vous publiez"
 
 #: users/templates/users/preferences.html:225
 msgid "Show your name on item page if you recently edited it"
-msgstr ""
-"Afficher votre nom sur la page de l'œuvre si vous l'avez récemment modifiée"
+msgstr "Afficher votre nom sur la page de l'œuvre si vous l'avez récemment modifiée"
 
 #: users/templates/users/preferences.html:234
 msgid "Do not show me item recommendations"
 msgstr ""
 
 #: users/templates/users/preferences.html:237
-msgid ""
-"Recommendations are generated only from public marks, processed in batch on "
-"this server. Your private and follower-only marks are never used as a signal "
-"for anyone, and we never share your data with third parties for this "
-"feature. When you share marks publicly and keep your profile discoverable, "
-"your marks help others here and across the Fediverse find things they might "
-"enjoy -- that voluntary contribution is what makes the feature work for "
-"everyone. If you'd rather not contribute, uncheck \"Include profile, marks "
-"and posts in discovery\" on your account page; this setting is published "
-"over ActivityPub, so other servers will also stop including you in their "
-"discovery features."
+msgid "Recommendations are generated only from public marks, processed in batch on this server. Your private and follower-only marks are never used as a signal for anyone, and we never share your data with third parties for this feature. When you share marks publicly and keep your profile discoverable, your marks help others here and across the Fediverse find things they might enjoy -- that voluntary contribution is what makes the feature work for everyone. If you'd rather not contribute, uncheck \"Include profile, marks and posts in discovery\" on your account page; this setting is published over ActivityPub, so other servers will also stop including you in their discovery features."
 msgstr ""
 
 #: users/templates/users/profile_actions.html:12
@@ -9439,29 +9112,15 @@ msgstr "Votre identifiant sur %(site_name)s"
 
 #: users/templates/users/register.html:28
 msgid "2-30 alphabets, numbers or underscore, can't be changed once saved"
-msgstr ""
-"de 2 à 30 caractères, uniquement alphanumériques et _ tiret bas. Vous ne "
-"pourrez pas le modifier ultiérieurement"
+msgstr "de 2 à 30 caractères, uniquement alphanumériques et _ tiret bas. Vous ne pourrez pas le modifier ultiérieurement"
 
 #: users/templates/users/register.html:72
-msgid ""
-"Use display name, bio and avatar from the social network you authenticated "
-"with"
-msgstr ""
-"Utiliser le nom d'affichage, la bio & l'avatar du réseau social utilisé pour "
-"votre authentification"
+msgid "Use display name, bio and avatar from the social network you authenticated with"
+msgstr "Utiliser le nom d'affichage, la bio & l'avatar du réseau social utilisé pour votre authentification"
 
 #: users/templates/users/register.html:80
-msgid ""
-"Add follow, mute and block list from the social network you authenticated "
-"with"
-msgstr ""
-"Importer les listes de suivi, masquage & blocage du réseau social utilisé "
-"pour votre authentification"
-
-#: users/templates/users/register.html:104
-msgid "Confirm and save"
-msgstr "Confirmer & enregistrer"
+msgid "Add follow, mute and block list from the social network you authenticated with"
+msgstr "Importer les listes de suivi, masquage & blocage du réseau social utilisé pour votre authentification"
 
 #: users/templates/users/register.html:106
 msgid "Close"
@@ -9489,8 +9148,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"              Matched %(local)s locally, %(external)s externally, "
-"%(unmatched)s unmatched out of %(total)s rows.\n"
+"              Matched %(local)s locally, %(external)s externally, %(unmatched)s unmatched out of %(total)s rows.\n"
 "            "
 msgstr ""
 
@@ -9625,9 +9283,7 @@ msgid "Played"
 msgstr "joué"
 
 #: users/templates/users/steam_import.html:90
-msgid ""
-"Games in wishlist; or purchased in library but never played, mark date will "
-"be set as today"
+msgid "Games in wishlist; or purchased in library but never played, mark date will be set as today"
 msgstr ""
 
 #: users/templates/users/steam_import.html:91
@@ -9671,15 +9327,11 @@ msgid "Comma-separated Steam AppIDs"
 msgstr ""
 
 #: users/templates/users/steam_import.html:121
-msgid ""
-"Allow reverse override of status (e.g. playing -> want to, or played -> "
-"playing)"
+msgid "Allow reverse override of status (e.g. playing -> want to, or played -> playing)"
 msgstr ""
 
 #: users/templates/users/steam_import.html:139
-msgid ""
-"To import from Steam, your game details must be visible to public in Steam "
-"privacy settings."
+msgid "To import from Steam, your game details must be visible to public in Steam privacy settings."
 msgstr ""
 
 #: users/templates/users/storygraph_import.html:9
@@ -9699,9 +9351,7 @@ msgstr "Échec"
 
 #: users/templates/users/user_task_status.html:33
 msgid "Failed links, you may have to mark them manually"
-msgstr ""
-"Échec d'import pour les liens suivant. Veuillez créer ces interactions "
-"manuellement"
+msgstr "Échec d'import pour les liens suivant. Veuillez créer ces interactions manuellement"
 
 #: users/templates/users/verify.html:22
 msgid "Please enter the verification code you received."
@@ -9732,38 +9382,23 @@ msgstr "Bienvenue"
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
-#| "              %(site_name)s is flourishing because of collaborations and "
-#| "contributions from users like you. Please read our <a href=\"/pages/"
-#| "terms\">term of service</a>, and feel free to <a "
-#| "href=\"%(support_link)s\">contact us</a> if you have any question or "
-#| "feedback.\n"
+#| "              %(site_name)s is flourishing because of collaborations and contributions from users like you. Please read our <a href=\"/pages/terms\">term of service</a>, and feel free to <a href=\"%(support_link)s\">contact us</a> if you have any question or feedback.\n"
 #| "        "
 msgid ""
 "\n"
-"              %(site_name)s is flourishing because of collaborations and "
-"contributions from users like you. Please read our <a href=\"/pages/"
-"rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</"
-"a> if you have any question or feedback.\n"
+"              %(site_name)s is flourishing because of collaborations and contributions from users like you. Please read our <a href=\"/pages/rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</a> if you have any question or feedback.\n"
 "        "
 msgstr ""
 "\n"
-"              %(site_name)s grandit grâce à la collaboration et aux "
-"contributions de gens comme vous 🤗. Veuillez lire nos <a href=\"/pages/"
-"terms\">termes &#38; conditions</a>, et n'hésitez pas à <a "
-"href=\"%(support_link)s\">nous contacter</a> si vous avez une question ou un "
-"retour à nous faire.\n"
+"              %(site_name)s grandit grâce à la collaboration et aux contributions de gens comme vous 🤗. Veuillez lire nos <a href=\"/pages/terms\">termes &#38; conditions</a>, et n'hésitez pas à <a href=\"%(support_link)s\">nous contacter</a> si vous avez une question ou un retour à nous faire.\n"
 "        "
 
 #: users/templates/users/welcome.html:37
-msgid ""
-"Set up a passkey to sign in quickly next time using your fingerprint, face, "
-"or screen lock."
+msgid "Set up a passkey to sign in quickly next time using your fingerprint, face, or screen lock."
 msgstr ""
 
 #: users/templates/users/welcome.html:39
-msgid ""
-"Creating a passkey is highly recommended, as the website or email you use to "
-"create this account may not be always available."
+msgid "Creating a passkey is highly recommended, as the website or email you use to create this account may not be always available."
 msgstr ""
 
 #: users/templates/users/welcome.html:43
@@ -9780,346 +9415,246 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:124
+#: users/views/account.py:126
 msgid "This username is already in use."
 msgstr "Cet identifiant est déjà utilisé."
 
-#: users/views/account.py:135
+#: users/views/account.py:137
 msgid "This email address is already in use."
 msgstr "Cette adresse mail est déjà utilisée."
 
-#: users/views/account.py:255 users/views/account.py:374
+#: users/views/account.py:257 users/views/account.py:376
 msgid "Registration is for invitation only"
 msgstr "Inscription sur invitation seulement"
 
-#: users/views/account.py:266 users/views/account.py:338
+#: users/views/account.py:268 users/views/account.py:340
 #, fuzzy
 #| msgid "Timestamp"
 msgid "Time is up"
 msgstr "Horodatage"
 
-#: users/views/account.py:267 users/views/account.py:310
-#: users/views/account.py:339
+#: users/views/account.py:269 users/views/account.py:312
+#: users/views/account.py:341
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:313
+#: users/views/account.py:315
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:325
+#: users/views/account.py:327
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:326
+#: users/views/account.py:328
 #, fuzzy
 #| msgid "System busy, please try again in a minute."
 msgid "Please try again later."
 msgstr "Système occupé, veuillez réessayer dans une minute."
 
-#: users/views/account.py:415
+#: users/views/account.py:417
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:445
+#: users/views/account.py:447
 msgid "Valid username required"
 msgstr "Un identifiant valide est requis"
 
-#: users/views/account.py:526
+#: users/views/account.py:518
 msgid "Account is being deleted."
 msgstr "Votre compte est en cours de suppression."
 
-#: users/views/account.py:529
+#: users/views/account.py:521
 msgid "Account mismatch."
 msgstr "Les infos du compte ne correspondent pas."
 
-#: users/views/data.py:262 users/views/data.py:294
+#: users/views/data.py:264 users/views/data.py:296
 msgid "Export file not available."
 msgstr "FIchier d'export non disponible."
 
-#: users/views/data.py:288
+#: users/views/data.py:290
 msgid "Generating exports."
 msgstr "Ficher d'export en cours de génération."
 
-#: users/views/data.py:306
+#: users/views/data.py:308
 msgid "Export file expired. Please export again."
 msgstr "Fichier d'export expiré. Veuillez ré-exporter."
 
-#: users/views/data.py:321 users/views/data.py:342 users/views/data.py:363
+#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
 #, fuzzy
 #| msgid "Import in progress."
 msgid "Recent export still in progress."
 msgstr "Import en cours."
 
-#: users/views/data.py:379 users/views/data.py:513 users/views/data.py:547
-#: users/views/data.py:772 users/views/data.py:989 users/views/data.py:1015
-#: users/views/data.py:1040 users/views/data.py:1065
+#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
+#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
+#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
 msgid "Invalid file."
 msgstr "Fichier incorrect."
 
-#: users/views/data.py:403
+#: users/views/data.py:405
 msgid "Sync in progress."
 msgstr "Synchro en cours."
 
-#: users/views/data.py:417
+#: users/views/data.py:419
 msgid "Settings saved."
 msgstr "Réglages sauvegardés."
 
-#: users/views/data.py:472
+#: users/views/data.py:474
 #, fuzzy
 #| msgid "Account is being deleted."
 msgid "Account no longer linked."
 msgstr "Votre compte est en cours de suppression."
 
-#: users/views/data.py:475
+#: users/views/data.py:477
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:503
+#: users/views/data.py:505
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:583 users/views/data.py:808
+#: users/views/data.py:585 users/views/data.py:810
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:608 users/views/data.py:837
+#: users/views/data.py:610 users/views/data.py:839
 #, fuzzy
 #| msgid "Cancel"
 msgid "Cancelled."
 msgstr "Annuler"
 
-#: users/views/data.py:628
+#: users/views/data.py:630
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:636 users/views/data.py:746 users/views/data.py:867
-#: users/views/data.py:972
+#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
+#: users/views/data.py:974
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:732 users/views/data.py:958
+#: users/views/data.py:734 users/views/data.py:960
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:742 users/views/data.py:968
+#: users/views/data.py:744 users/views/data.py:970
 #, fuzzy
 #| msgid "Export file not available."
 msgid "No matched file available."
 msgstr "FIchier d'export non disponible."
 
-#: users/views/data.py:859
+#: users/views/data.py:861
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1188
+#: users/views/data.py:1226
 #, fuzzy
 #| msgid "Login required"
 msgid "Name is required."
 msgstr "Connexion requise"
 
-#: users/views/data.py:1210
+#: users/views/data.py:1248
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1264
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1231
+#: users/views/data.py:1269
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1241 users/views/data.py:1292
+#: users/views/data.py:1279 users/views/data.py:1330
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:1248
+#: users/views/data.py:1286
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:1253
+#: users/views/data.py:1291
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:1279
+#: users/views/data.py:1317
 #, fuzzy
 #| msgid "Registration failed"
 msgid "Migration cancelled."
 msgstr "Échec de l'inscription"
 
-#: users/views/data.py:1284
+#: users/views/data.py:1322
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:1297
+#: users/views/data.py:1335
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:1308
+#: users/views/data.py:1346
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:1314
+#: users/views/data.py:1352
 #, fuzzy, python-brace-format
 #| msgid "Continue login as {handle}."
 msgid "Start moving to {handle}."
 msgstr "Poursuivre la connexion en tant que {handle}."
 
-#: users/views/data.py:1372
+#: users/views/data.py:1410
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1388
+#: users/views/data.py:1426
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1392
+#: users/views/data.py:1430
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1402
+#: users/views/data.py:1440
 #, python-brace-format
-msgid ""
-"Import of {count} entries received. They will be processed in the background."
+msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""
 
-#: users/views/webauthn.py:103
+#: users/views/webauthn.py:106
 #, fuzzy
 #| msgid "Registration failed"
 msgid "Passkey registration failed"
 msgstr "Échec de l'inscription"
 
-#: users/views/webauthn.py:123
+#: users/views/webauthn.py:126
 msgid "Credential already registered"
 msgstr ""
 
-#: users/views/webauthn.py:165 users/views/webauthn.py:172
-#: users/views/webauthn.py:181
+#: users/views/webauthn.py:168 users/views/webauthn.py:175
+#: users/views/webauthn.py:184
 msgid "Passkey not recognized"
 msgstr ""
 
-#: users/views/webauthn.py:186
+#: users/views/webauthn.py:189
 #, fuzzy
 #| msgid "Account is being deleted."
 msgid "Account is inactive"
 msgstr "Votre compte est en cours de suppression."
 
-#: users/views/webauthn.py:202
+#: users/views/webauthn.py:205
 #, fuzzy
 #| msgid "Send verification code"
 msgid "Passkey verification failed"
 msgstr "Envoyer le code de vérification"
 
-#: users/views/webauthn.py:228 users/views/webauthn.py:250
+#: users/views/webauthn.py:231 users/views/webauthn.py:253
 #, fuzzy
 #| msgid "User not found"
 msgid "Passkey not found"
 msgstr "Membre introuvable"
 
-#: users/views/webauthn.py:244
+#: users/views/webauthn.py:247
 #, fuzzy
 #| msgid "Login required"
 msgid "Name is required"
 msgstr "Connexion requise"
-
-#~ msgid "Fanfic"
-#~ msgstr "Fanfiction"
-
-#~ msgid "FanFic"
-#~ msgstr "FanFiction"
-
-#~ msgid "year of publication"
-#~ msgstr "année de publication"
-
-#~ msgid "YYYY-MM-DD"
-#~ msgstr "AAAA-MM-JJ"
-
-#~ msgid "region or event"
-#~ msgstr "pays ou évènement"
-
-#~ msgid "Germany or Toronto International Film Festival"
-#~ msgstr "ex : \"Belgique\", ou \"Festival de Cannes\""
-
-#~ msgid "year"
-#~ msgstr "année"
-
-#~ msgctxt "music"
-#~ msgid "genre"
-#~ msgstr "genre"
-
-#~ msgid "my notes"
-#~ msgstr "mes notes"
-
-#~ msgid "release year"
-#~ msgstr "année de sortie"
-
-#~ msgid "episode Length"
-#~ msgstr "Durée de l'épisode"
-
-#~ msgid "show time"
-#~ msgstr "première diffusion"
-
-#~ msgid "Region or Event"
-#~ msgstr "Pays ou Évènement"
-
-#~ msgid "boost"
-#~ msgstr "relayer"
-
-#~ msgid "Invalid form data"
-#~ msgstr "Donnée invalide"
-
-#~ msgid "Username and app password is required."
-#~ msgstr "Identifiant & mot de passe de l'app requis."
-
-#~ msgid "All"
-#~ msgstr "Tout"
-
-#~ msgid "Bluesky app password"
-#~ msgstr "Mot de passe d'application Bluesky"
-
-#~ msgid ""
-#~ "App password can be created on <a href=\"https://bsky.app/settings/app-"
-#~ "passwords\" target=\"_blank\">bsky.app</a>."
-#~ msgstr ""
-#~ "Un mot de passe d'application peut être créé sur <a href=\"https://"
-#~ "bsky.app/settings/app-passwords\" target=\"_blank\">bsky.app</a>."
-
-#~ msgid "Link to Goodreads Profile / Shelf / List"
-#~ msgstr "Lien vers le profil / la bibliothèque / la liste Goodreads"
-
-#~ msgid "Last import started"
-#~ msgstr "Dernier import lancé"
-
-#~ msgid "Shelf will be imported as a new collection."
-#~ msgstr "La bibliothèque sera importée en tant que nouvelle collection."
-
-#~ msgid "List will be imported as a new collection."
-#~ msgstr "La liste sera importée en tant que nouvelle collection."
-
-#~ msgid ""
-#~ "Failed links, likely due to Letterboxd error, you may have to mark them "
-#~ "manually"
-#~ msgstr ""
-#~ "Échec d'import pour les liens suivants, probablement à cause d'une erreur "
-#~ "du côté de Letterboxd. Veuillez créer ces interactions manuellement"
-
-#~ msgid "Export Data"
-#~ msgstr "Exporter les données"
-
-#~ msgid "back to your home page."
-#~ msgstr "Retour à la page d'accueil."
-
-#~ msgid "Turn on crosspost to timeline by default"
-#~ msgstr "Repartager par défaut sur le compte associé"
-
-#~ msgid "Username in use"
-#~ msgstr "Identifiant déjà pris"
-
-#~ msgid "Invalid URL."
-#~ msgstr "URL incorrecte."
-
-#~ msgid "File is uploaded and will be imported soon."
-#~ msgstr "Fichier téléversé. L'import sera bientôt terminé."

--- a/neodb/locale/it/LC_MESSAGES/django.po
+++ b/neodb/locale/it/LC_MESSAGES/django.po
@@ -7,11 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-23 15:40-0400\n"
+"POT-Creation-Date: 2026-09-06 20:04-0400\n"
 "PO-Revision-Date: 2026-08-09 06:32+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Italian <https://hosted.weblate.org/projects/neodb/neodb/it/"
-">\n"
+"Language-Team: Italian <https://hosted.weblate.org/projects/neodb/neodb/it/>\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,161 +18,161 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: boofilsic/settings.py:472 common/models/lang.py:230
+#: boofilsic/settings.py:501 common/models/lang.py:232
 msgid "English"
 msgstr "Inglese"
 
-#: boofilsic/settings.py:473 common/models/lang.py:77
+#: boofilsic/settings.py:502 common/models/lang.py:79
 msgid "Danish"
 msgstr "Danese"
 
-#: boofilsic/settings.py:474 common/models/lang.py:78
+#: boofilsic/settings.py:503 common/models/lang.py:80
 msgid "German"
 msgstr "Tedesco"
 
-#: boofilsic/settings.py:475 common/models/lang.py:183
+#: boofilsic/settings.py:504 common/models/lang.py:185
 msgid "Spanish"
 msgstr "Spagnolo"
 
-#: boofilsic/settings.py:476 common/models/lang.py:87
+#: boofilsic/settings.py:505 common/models/lang.py:89
 msgid "French"
 msgstr "Francese"
 
-#: boofilsic/settings.py:477 common/models/lang.py:112
+#: boofilsic/settings.py:506 common/models/lang.py:114
 msgid "Italian"
 msgstr "Italiano"
 
-#: boofilsic/settings.py:478 common/models/lang.py:166
-#: common/models/lang.py:305
+#: boofilsic/settings.py:507 common/models/lang.py:168
+#: common/models/lang.py:307
 msgid "Portuguese"
 msgstr "Portoghese"
 
-#: boofilsic/settings.py:479
+#: boofilsic/settings.py:508
 #, fuzzy
 #| msgid "Portuguese"
 msgid "Brazilian Portuguese"
 msgstr "Portoghese"
 
-#: boofilsic/settings.py:480 common/models/lang.py:316
+#: boofilsic/settings.py:509 common/models/lang.py:318
 msgid "Simplified Chinese"
 msgstr "Cinese Semplificato"
 
-#: boofilsic/settings.py:481 common/models/lang.py:317
+#: boofilsic/settings.py:510 common/models/lang.py:319
 msgid "Traditional Chinese"
 msgstr "Cinese Tradizionale"
 
-#: catalog/forms.py:35 catalog/models/item.py:291
+#: catalog/forms.py:35 catalog/models/item.py:307
 msgid "Primary ID Type"
 msgstr "Tipo d'identificativo primario"
 
-#: catalog/forms.py:40 catalog/models/item.py:294
+#: catalog/forms.py:40 catalog/models/item.py:310
 msgid "Primary ID Value"
 msgstr "Valore dell'ID primario"
 
-#: catalog/forms.py:181
+#: catalog/forms.py:176
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
-#: catalog/models/book.py:139 catalog/models/book.py:158
-#: catalog/models/common.py:280 catalog/models/common.py:298
+#: catalog/models/book.py:141 catalog/models/book.py:160
+#: catalog/models/common.py:279 catalog/models/common.py:297
 msgid "locale"
 msgstr "locale"
 
-#: catalog/models/book.py:142 catalog/models/book.py:161
-#: catalog/models/common.py:283 catalog/models/common.py:303
+#: catalog/models/book.py:144 catalog/models/book.py:163
+#: catalog/models/common.py:282 catalog/models/common.py:302
 msgid "text content"
 msgstr "contenuto testuale"
 
-#: catalog/models/book.py:177
+#: catalog/models/book.py:179
 msgid "Paperback"
 msgstr "Brossurato"
 
-#: catalog/models/book.py:178
+#: catalog/models/book.py:180
 msgid "Hardcover"
 msgstr "Copertina rigida"
 
-#: catalog/models/book.py:179
+#: catalog/models/book.py:181
 msgid "eBook"
 msgstr "Libro digitale"
 
-#: catalog/models/book.py:180
+#: catalog/models/book.py:182
 msgid "Audiobook"
 msgstr "Audiolibro"
 
-#: catalog/models/book.py:182
+#: catalog/models/book.py:184
 msgid "Web Fiction"
 msgstr "Web Fiction"
 
-#: catalog/models/book.py:183 catalog/models/game.py:38
+#: catalog/models/book.py:185 catalog/models/game.py:38
 msgid "Other"
 msgstr "Altro"
 
-#: catalog/models/book.py:260
+#: catalog/models/book.py:262
 msgid "subtitle"
 msgstr "sottotitolo"
 
-#: catalog/models/book.py:270 catalog/models/movie.py:120
-#: catalog/models/performance.py:385 catalog/models/tv.py:211
-#: catalog/models/tv.py:437
+#: catalog/models/book.py:272 catalog/models/movie.py:120
+#: catalog/models/performance.py:385 catalog/models/tv.py:213
+#: catalog/models/tv.py:439
 msgid "original title"
 msgstr "titolo originale"
 
-#: catalog/models/book.py:274
+#: catalog/models/book.py:276
 msgid "other title"
 msgstr "titolo alternativo"
 
-#: catalog/models/book.py:280 catalog/models/book.py:564
-#: catalog/models/item.py:123
+#: catalog/models/book.py:282 catalog/models/book.py:566
+#: catalog/models/item.py:119
 msgid "author"
 msgstr "Autore"
 
-#: catalog/models/book.py:287 catalog/models/item.py:124
+#: catalog/models/book.py:289 catalog/models/item.py:120
 msgid "translator"
 msgstr "Tradotto da"
 
-#: catalog/models/book.py:294 catalog/templates/edition.html:26
+#: catalog/models/book.py:296 catalog/templates/edition.html:26
 msgid "book format"
 msgstr "formato del libro"
 
-#: catalog/models/book.py:301 catalog/models/game.py:135
-#: catalog/models/item.py:138 catalog/models/music.py:142
+#: catalog/models/book.py:303 catalog/models/game.py:135
+#: catalog/models/item.py:134 catalog/models/music.py:142
 msgid "publisher"
 msgstr "Editore"
 
-#: catalog/models/book.py:308
+#: catalog/models/book.py:310
 msgid "publication year"
 msgstr "anno di pubblicazione"
 
-#: catalog/models/book.py:314
+#: catalog/models/book.py:316
 msgid "publication month"
 msgstr "mese di pubblicazione"
 
-#: catalog/models/book.py:319
+#: catalog/models/book.py:321
 msgid "binding"
 msgstr "Formato"
 
-#: catalog/models/book.py:320
+#: catalog/models/book.py:322
 msgid "pages"
 msgstr "pagine"
 
-#: catalog/models/book.py:321 catalog/templates/edition.html:45
+#: catalog/models/book.py:323 catalog/templates/edition.html:45
 msgid "series"
 msgstr "Serie"
 
-#: catalog/models/book.py:322 catalog/templates/edition.html:65
+#: catalog/models/book.py:324 catalog/templates/edition.html:65
 msgid "contents"
 msgstr "contenuti"
 
-#: catalog/models/book.py:323 catalog/templates/edition.html:51
+#: catalog/models/book.py:325 catalog/templates/edition.html:51
 msgid "price"
 msgstr "Prezzo"
 
-#: catalog/models/book.py:324 catalog/models/item.py:149
+#: catalog/models/book.py:326 catalog/models/item.py:145
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr "Stampa"
 
-#: catalog/models/common.py:26 common/models/lang.py:256
+#: catalog/models/common.py:26 common/models/lang.py:258
 msgid "Unknown"
 msgstr "Sconosciuto"
 
@@ -181,11 +180,11 @@ msgstr "Sconosciuto"
 msgid "Douban"
 msgstr "Douban"
 
-#: catalog/models/common.py:28 catalog/models/common.py:79
+#: catalog/models/common.py:28 catalog/models/common.py:81
 msgid "Goodreads"
 msgstr "Goodreads"
 
-#: catalog/models/common.py:29 catalog/models/common.py:81
+#: catalog/models/common.py:29 catalog/models/common.py:83
 msgid "Google Books"
 msgstr "Google Books"
 
@@ -193,16 +192,16 @@ msgstr "Google Books"
 msgid "BooksTW"
 msgstr "BooksTW"
 
-#: catalog/models/common.py:31 catalog/models/common.py:91
-#: catalog/models/common.py:93
+#: catalog/models/common.py:31 catalog/models/common.py:93
+#: catalog/models/common.py:95
 msgid "Bibliotek.dk"
 msgstr ""
 
-#: catalog/models/common.py:32 catalog/models/common.py:92
+#: catalog/models/common.py:32 catalog/models/common.py:94
 msgid "eReolen.dk"
 msgstr ""
 
-#: catalog/models/common.py:33 catalog/models/common.py:74
+#: catalog/models/common.py:33 catalog/models/common.py:76
 #: catalog/templates/movie.html:41 catalog/templates/people.html:37
 #: catalog/templates/tvseason.html:58 catalog/templates/tvshow.html:53
 msgid "IMDb"
@@ -212,7 +211,7 @@ msgstr "IMDb"
 msgid "TMDB"
 msgstr "TMDB"
 
-#: catalog/models/common.py:35 catalog/models/common.py:94
+#: catalog/models/common.py:35 catalog/models/common.py:96
 msgid "Bandcamp"
 msgstr "Bandcamp"
 
@@ -228,11 +227,11 @@ msgstr "IGDB"
 msgid "Steam"
 msgstr "Steam"
 
-#: catalog/models/common.py:39 catalog/models/common.py:114
+#: catalog/models/common.py:39 catalog/models/common.py:116
 msgid "itch.io"
 msgstr ""
 
-#: catalog/models/common.py:40 catalog/models/common.py:115
+#: catalog/models/common.py:40 catalog/models/common.py:117
 msgid "Bangumi"
 msgstr "Bangumi"
 
@@ -240,7 +239,7 @@ msgstr "Bangumi"
 msgid "BGG"
 msgstr "BGG"
 
-#: catalog/models/common.py:42 catalog/models/common.py:116
+#: catalog/models/common.py:42 catalog/models/common.py:118
 msgid "Apple Podcast"
 msgstr "Podcast Apple"
 
@@ -252,35 +251,35 @@ msgstr "RSS"
 msgid "Discogs"
 msgstr "Discogs"
 
-#: catalog/models/common.py:45 catalog/models/common.py:117
+#: catalog/models/common.py:45 catalog/models/common.py:119
 msgid "Apple Music"
 msgstr "Apple Music"
 
-#: catalog/models/common.py:46 catalog/models/common.py:119
+#: catalog/models/common.py:46 catalog/models/common.py:121
 msgid "Fediverse"
 msgstr "Fediverso"
 
-#: catalog/models/common.py:47 catalog/models/common.py:120
+#: catalog/models/common.py:47 catalog/models/common.py:122
 msgid "Qidian"
 msgstr "Qidian"
 
-#: catalog/models/common.py:48 catalog/models/common.py:121
+#: catalog/models/common.py:48 catalog/models/common.py:123
 msgid "Ypshuo"
 msgstr "Ypshuo"
 
-#: catalog/models/common.py:49 catalog/models/common.py:122
+#: catalog/models/common.py:49 catalog/models/common.py:124
 msgid "Archive of Our Own"
 msgstr "Archive of Our Own"
 
-#: catalog/models/common.py:50 catalog/models/common.py:123
+#: catalog/models/common.py:50 catalog/models/common.py:125
 msgid "JinJiang"
 msgstr "JinJiang"
 
-#: catalog/models/common.py:51 catalog/models/common.py:64
+#: catalog/models/common.py:51 catalog/models/common.py:66
 msgid "WikiData"
 msgstr "WikiData"
 
-#: catalog/models/common.py:52 catalog/models/common.py:124
+#: catalog/models/common.py:52 catalog/models/common.py:126
 msgid "Open Library"
 msgstr ""
 
@@ -294,17 +293,17 @@ msgstr "Identificativo MusicBrainz"
 msgid "WorldCat"
 msgstr ""
 
-#: catalog/models/common.py:55 catalog/models/common.py:126
+#: catalog/models/common.py:55 catalog/models/common.py:128
 #, fuzzy
 #| msgid "Game"
 msgid "MobyGames"
 msgstr "Giochi"
 
-#: catalog/models/common.py:56 catalog/models/common.py:127
+#: catalog/models/common.py:56 catalog/models/common.py:129
 msgid "StoryGraph"
 msgstr ""
 
-#: catalog/models/common.py:57 catalog/models/common.py:118
+#: catalog/models/common.py:57 catalog/models/common.py:120
 #, fuzzy
 #| msgid "Douban Music"
 msgid "YouTube Music"
@@ -322,363 +321,374 @@ msgstr ""
 msgid "Readmoo"
 msgstr ""
 
-#: catalog/models/common.py:65
+#: catalog/models/common.py:61
+msgid "MyAnimeList"
+msgstr ""
+
+#: catalog/models/common.py:62 catalog/models/common.py:140
+#, fuzzy
+#| msgid "Update"
+msgid "MangaUpdates"
+msgstr "Aggiorna"
+
+#: catalog/models/common.py:67
 msgid "ISBN10"
 msgstr "ISBN10"
 
-#: catalog/models/common.py:66 catalog/templates/edition.html:19
+#: catalog/models/common.py:68 catalog/templates/edition.html:19
 msgid "ISBN"
 msgstr "ISBN"
 
-#: catalog/models/common.py:67
+#: catalog/models/common.py:69
 msgid "ASIN"
 msgstr "ASIN"
 
-#: catalog/models/common.py:68
+#: catalog/models/common.py:70
 msgid "ISSN"
 msgstr "ISSN"
 
-#: catalog/models/common.py:69
+#: catalog/models/common.py:71
 msgid "CUBN"
 msgstr "CUBN"
 
-#: catalog/models/common.py:70
+#: catalog/models/common.py:72
 msgid "ISRC"
 msgstr "ISRC"
 
-#: catalog/models/common.py:71
+#: catalog/models/common.py:73
 msgid "GTIN UPC EAN"
 msgstr "GTIN UPC EAN"
 
-#: catalog/models/common.py:72
+#: catalog/models/common.py:74
 msgid "OCLC Number"
 msgstr ""
 
-#: catalog/models/common.py:73
+#: catalog/models/common.py:75
 msgid "RSS Feed URL"
 msgstr "URL del Feed RSS"
 
-#: catalog/models/common.py:75
+#: catalog/models/common.py:77
 #, fuzzy
 #| msgid "TMDB TV Serie"
 msgid "TMDB TV Series"
 msgstr "Serie TV TMDB"
 
-#: catalog/models/common.py:76
+#: catalog/models/common.py:78
 msgid "TMDB TV Season"
 msgstr "Stagione TV TMDB"
 
-#: catalog/models/common.py:77
+#: catalog/models/common.py:79
 msgid "TMDB TV Episode"
 msgstr "Episodio TV TMDB"
 
-#: catalog/models/common.py:78
+#: catalog/models/common.py:80
 msgid "TMDB Movie"
 msgstr "Film TMDB"
 
-#: catalog/models/common.py:80
+#: catalog/models/common.py:82
 msgid "Goodreads Work"
 msgstr "Lavoro Goodreads"
 
-#: catalog/models/common.py:82
+#: catalog/models/common.py:84
 msgid "Douban Book"
 msgstr "Libro Douban"
 
-#: catalog/models/common.py:83
+#: catalog/models/common.py:85
 msgid "Douban Book Work"
 msgstr "Libro Douban Lavoro"
 
-#: catalog/models/common.py:84
+#: catalog/models/common.py:86
 msgid "Douban Movie"
 msgstr "Film Douban"
 
-#: catalog/models/common.py:85
+#: catalog/models/common.py:87
 msgid "Douban Music"
 msgstr "Musica Douban"
 
-#: catalog/models/common.py:86
+#: catalog/models/common.py:88
 msgid "Douban Game"
 msgstr "Gioco Douban"
 
-#: catalog/models/common.py:87
+#: catalog/models/common.py:89
 msgid "Douban Drama"
 msgstr "Dramma Douban"
 
-#: catalog/models/common.py:88
+#: catalog/models/common.py:90
 msgid "Douban Drama Version"
 msgstr "Versione drama su Douban"
 
-#: catalog/models/common.py:89
+#: catalog/models/common.py:91
 msgid "BooksTW Book"
 msgstr "Libro BooksTW"
 
-#: catalog/models/common.py:90
+#: catalog/models/common.py:92
 msgid "Readmoo Book"
 msgstr ""
 
-#: catalog/models/common.py:95
+#: catalog/models/common.py:97
 msgid "Spotify Album"
 msgstr "Album Spotify"
 
-#: catalog/models/common.py:96
+#: catalog/models/common.py:98
 msgid "Spotify Podcast"
 msgstr "Podcast Spotify"
 
-#: catalog/models/common.py:97
+#: catalog/models/common.py:99
 msgid "Discogs Release"
 msgstr "Uscita Discogs"
 
-#: catalog/models/common.py:98
+#: catalog/models/common.py:100
 msgid "Discogs Master"
 msgstr "Master Discogs"
 
-#: catalog/models/common.py:101
+#: catalog/models/common.py:103
 #, fuzzy
 #| msgid "MusicBrainz ID"
 msgid "MusicBrainz Release Group"
 msgstr "Identificativo MusicBrainz"
 
-#: catalog/models/common.py:103
+#: catalog/models/common.py:105
 #, fuzzy
 #| msgid "MusicBrainz ID"
 msgid "MusicBrainz Release"
 msgstr "Identificativo MusicBrainz"
 
-#: catalog/models/common.py:104
+#: catalog/models/common.py:106
 #, fuzzy
 #| msgid "MusicBrainz ID"
 msgid "MusicBrainz Artist"
 msgstr "Identificativo MusicBrainz"
 
-#: catalog/models/common.py:105
+#: catalog/models/common.py:107
 #, fuzzy
 #| msgid "Douban Game"
 msgid "Douban Personage"
 msgstr "Gioco Douban"
 
-#: catalog/models/common.py:106
+#: catalog/models/common.py:108
 #, fuzzy
 #| msgid "Goodreads Work"
 msgid "Goodreads Author"
 msgstr "Lavoro Goodreads"
 
-#: catalog/models/common.py:107
+#: catalog/models/common.py:109
 #, fuzzy
 #| msgid "Spotify Podcast"
 msgid "Spotify Artist"
 msgstr "Podcast Spotify"
 
-#: catalog/models/common.py:108
+#: catalog/models/common.py:110
 #, fuzzy
 #| msgid "TMDB TV Season"
 msgid "TMDB Person"
 msgstr "Stagione TV TMDB"
 
-#: catalog/models/common.py:109
+#: catalog/models/common.py:111
 msgid "Open Library Author"
 msgstr ""
 
-#: catalog/models/common.py:110
+#: catalog/models/common.py:112
 msgid "IGDB Company"
 msgstr ""
 
-#: catalog/models/common.py:111
+#: catalog/models/common.py:113
 msgid "IGDB Game"
 msgstr "Gioco IGDB"
 
-#: catalog/models/common.py:112
+#: catalog/models/common.py:114
 msgid "BGG Boardgame"
 msgstr "Gioco da tavolo BGG"
 
-#: catalog/models/common.py:113
+#: catalog/models/common.py:115
 msgid "Steam Game"
 msgstr "Gioco Steam"
 
-#: catalog/models/common.py:125
+#: catalog/models/common.py:127
 msgid "Open Library Work"
 msgstr ""
 
-#: catalog/models/common.py:128
+#: catalog/models/common.py:130
 msgid "RateYourMusic Release"
 msgstr ""
 
-#: catalog/models/common.py:132
+#: catalog/models/common.py:134
 msgid "AniList Anime"
 msgstr ""
 
-#: catalog/models/common.py:133
+#: catalog/models/common.py:135
 msgid "AniList Manga"
 msgstr ""
 
-#: catalog/models/common.py:134
+#: catalog/models/common.py:136
 msgid "MyAnimeList Anime"
 msgstr ""
 
-#: catalog/models/common.py:135
+#: catalog/models/common.py:137
 msgid "MyAnimeList Manga"
 msgstr ""
 
-#: catalog/models/common.py:156
+#: catalog/models/common.py:161
 #, fuzzy
 #| msgid "Editions"
 msgid "Edition"
 msgstr "Edizioni"
 
-#: catalog/models/common.py:157 catalog/templates/_sidebar_edit.html:286
+#: catalog/models/common.py:162 catalog/templates/_sidebar_edit.html:289
 msgid "Work"
 msgstr "Lavoro"
 
-#: catalog/models/common.py:158
+#: catalog/models/common.py:163
 #, fuzzy
 #| msgid "TV Serie"
 msgid "TV Series"
 msgstr "Serie TV"
 
-#: catalog/models/common.py:159 catalog/templates/_sidebar_edit.html:207
+#: catalog/models/common.py:164 catalog/templates/_sidebar_edit.html:202
+#: catalog/views/edit.py:385
 msgid "TV Season"
 msgstr "Stagione TV"
 
-#: catalog/models/common.py:160
+#: catalog/models/common.py:165
 msgid "TV Episode"
 msgstr "Episodio TV"
 
-#: catalog/models/common.py:161 catalog/models/common.py:177
-#: catalog/models/common.py:191 catalog/templates/_sidebar_edit.html:200
-#: journal/templates/_sidebar_user_mark_list.html:35
+#: catalog/models/common.py:166 catalog/models/common.py:182
+#: catalog/models/common.py:196 catalog/templates/_sidebar_edit.html:196
+#: catalog/views/edit.py:384 journal/templates/_sidebar_user_mark_list.html:35
 #: journal/templates/_sidebar_user_tag_filter.html:27
 msgid "Movie"
 msgstr "Film"
 
-#: catalog/models/common.py:162
+#: catalog/models/common.py:167
 msgid "Album"
 msgstr "Album"
 
-#: catalog/models/common.py:163 catalog/models/common.py:180
-#: catalog/models/common.py:194 common/templates/_header.html:43
+#: catalog/models/common.py:168 catalog/models/common.py:185
+#: catalog/models/common.py:199 common/templates/_header.html:53
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
 msgstr "Giochi"
 
-#: catalog/models/common.py:164
+#: catalog/models/common.py:169
 msgid "Podcast Program"
 msgstr "Programma Podcast"
 
-#: catalog/models/common.py:165
+#: catalog/models/common.py:170
 msgid "Podcast Episode"
 msgstr "Episodio Podcast"
 
-#: catalog/models/common.py:166 catalog/models/common.py:182
-#: catalog/models/common.py:196 common/templates/_header.html:47
+#: catalog/models/common.py:171 catalog/models/common.py:187
+#: catalog/models/common.py:201 common/templates/_header.html:57
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
 msgstr "Esibizione"
 
-#: catalog/models/common.py:167
+#: catalog/models/common.py:172
 msgid "Production"
 msgstr "Produzione"
 
-#: catalog/models/common.py:168
+#: catalog/models/common.py:173
 msgid "Exhibition"
 msgstr "Mostra"
 
-#: catalog/models/common.py:169 catalog/models/common.py:186
+#: catalog/models/common.py:174 catalog/models/common.py:191
 #: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr "Collezione"
 
-#: catalog/models/common.py:172 catalog/models/common.py:185
+#: catalog/models/common.py:177 catalog/models/common.py:190
 msgid "Person / Organization"
 msgstr ""
 
-#: catalog/models/common.py:176 catalog/models/common.py:190
-#: common/templates/_header.html:27
+#: catalog/models/common.py:181 catalog/models/common.py:195
+#: common/templates/_header.html:37
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
 msgstr "Libri"
 
-#: catalog/models/common.py:178 catalog/models/common.py:192
+#: catalog/models/common.py:183 catalog/models/common.py:197
 #: journal/templates/_sidebar_user_mark_list.html:38
 #: journal/templates/_sidebar_user_tag_filter.html:30
 msgid "TV"
 msgstr "TV"
 
-#: catalog/models/common.py:179 catalog/models/common.py:193
-#: common/templates/_header.html:39
+#: catalog/models/common.py:184 catalog/models/common.py:198
+#: common/templates/_header.html:49
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr "Musica"
 
-#: catalog/models/common.py:181 catalog/models/common.py:195
-#: catalog/templates/_sidebar_edit.html:219 common/templates/_header.html:35
+#: catalog/models/common.py:186 catalog/models/common.py:200
+#: catalog/templates/_sidebar_edit.html:213 common/templates/_header.html:45
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
 msgstr "Podcast"
 
-#: catalog/models/common.py:346 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:345 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr "Genere"
 
-#: catalog/models/common.py:384
+#: catalog/models/common.py:383
 #, fuzzy
 #| msgid "original creator"
 msgid "origin country"
 msgstr "creatore originale"
 
-#: catalog/models/common.py:413 catalog/templates/album.html:33
+#: catalog/models/common.py:412 catalog/templates/album.html:33
 msgid "album type"
 msgstr "tipo d'album"
 
-#: catalog/models/common.py:417 catalog/templates/_platform_list.html:5
+#: catalog/models/common.py:416 catalog/templates/_platform_list.html:5
 msgid "platform"
 msgstr "Piattaforma"
 
-#: catalog/models/common.py:421
+#: catalog/models/common.py:420
 #, fuzzy
 #| msgid "media type"
 msgid "media format"
 msgstr "tipo di supporto"
 
-#: catalog/models/common.py:426 catalog/templates/_language_list.html:5
-#: users/models/user.py:142
+#: catalog/models/common.py:425 catalog/templates/_language_list.html:5
+#: users/models/user.py:144
 msgid "language"
 msgstr "Lingua"
 
-#: catalog/models/creator.py:24
+#: catalog/models/creator.py:26
 #, fuzzy
 #| msgid "Pending"
 msgid "pending"
 msgstr "In attesa"
 
-#: catalog/models/creator.py:25
+#: catalog/models/creator.py:27
 msgid "verified"
 msgstr ""
 
-#: catalog/models/creator.py:26
+#: catalog/models/creator.py:28
 #, fuzzy
 #| msgid "Failed"
 msgid "failed"
 msgstr "Fallito"
 
-#: catalog/models/creator.py:29
+#: catalog/models/creator.py:31
 msgid "no feed url available for this item"
 msgstr ""
 
-#: catalog/models/creator.py:30
+#: catalog/models/creator.py:32
 msgid "unable to fetch or parse the feed"
 msgstr ""
 
-#: catalog/models/creator.py:31
+#: catalog/models/creator.py:33
 msgid "no audio episode found in the feed"
 msgstr ""
 
-#: catalog/models/creator.py:34
+#: catalog/models/creator.py:36
 msgid "no matching identity found in the feed or its linked website"
 msgstr ""
 
@@ -714,16 +724,16 @@ msgstr "Remake"
 msgid "Special Edition"
 msgstr "Edizione Speciale"
 
-#: catalog/models/game.py:111 catalog/models/item.py:130
+#: catalog/models/game.py:111 catalog/models/item.py:126
 msgid "designer"
 msgstr "designer"
 
-#: catalog/models/game.py:119 catalog/models/item.py:129
+#: catalog/models/game.py:119 catalog/models/item.py:125
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr "artista"
 
-#: catalog/models/game.py:127 catalog/models/item.py:139
+#: catalog/models/game.py:127 catalog/models/item.py:135
 msgid "developer"
 msgstr "Sviluppatore"
 
@@ -732,8 +742,8 @@ msgid "date of publication"
 msgstr "Data di pubblicazione"
 
 #: catalog/models/game.py:147 catalog/models/movie.py:156
-#: catalog/models/music.py:128 catalog/models/tv.py:247
-#: catalog/models/tv.py:473
+#: catalog/models/music.py:128 catalog/models/tv.py:249
+#: catalog/models/tv.py:475
 msgid "YYYY, YYYY-MM or YYYY-MM-DD"
 msgstr ""
 
@@ -744,7 +754,7 @@ msgstr "tipo di rilascio"
 #: catalog/models/game.py:180 catalog/models/movie.py:158
 #: catalog/models/people.py:178 catalog/models/performance.py:258
 #: catalog/models/performance.py:465 catalog/models/podcast.py:89
-#: catalog/models/tv.py:249 catalog/models/tv.py:476
+#: catalog/models/tv.py:251 catalog/models/tv.py:478
 #: catalog/templates/game.html:33 catalog/templates/movie.html:48
 #: catalog/templates/people.html:44 catalog/templates/performance.html:35
 #: catalog/templates/performanceproduction.html:35
@@ -753,152 +763,152 @@ msgstr "tipo di rilascio"
 msgid "website"
 msgstr "Sito internet"
 
-#: catalog/models/item.py:125 catalog/models/movie.py:123
+#: catalog/models/item.py:121 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
-#: catalog/models/tv.py:214 catalog/models/tv.py:440
+#: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr "Diretto da"
 
-#: catalog/models/item.py:126 catalog/models/movie.py:130
+#: catalog/models/item.py:122 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
-#: catalog/models/tv.py:221 catalog/models/tv.py:447
+#: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr "Scritto da"
 
-#: catalog/models/item.py:127 catalog/models/movie.py:137
+#: catalog/models/item.py:123 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
-#: catalog/models/tv.py:228 catalog/models/tv.py:454
+#: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr "Cast"
 
-#: catalog/models/item.py:128 catalog/models/movie.py:144
-#: catalog/models/tv.py:235 catalog/models/tv.py:461
+#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/tv.py:237 catalog/models/tv.py:463
 #, fuzzy
 #| msgid "production"
 msgid "producer"
 msgstr "produzione"
 
-#: catalog/models/item.py:131 catalog/models/performance.py:203
+#: catalog/models/item.py:127 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr "compositore"
 
-#: catalog/models/item.py:132 catalog/models/performance.py:210
+#: catalog/models/item.py:128 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr "coreografo"
 
-#: catalog/models/item.py:133 catalog/models/performance.py:224
+#: catalog/models/item.py:129 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr "performer"
 
-#: catalog/models/item.py:134 catalog/models/podcast.py:80
+#: catalog/models/item.py:130 catalog/models/podcast.py:80
 msgid "host"
 msgstr "presentatore"
 
-#: catalog/models/item.py:135 catalog/models/performance.py:196
+#: catalog/models/item.py:131 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr "creatore originale"
 
-#: catalog/models/item.py:136 catalog/models/performance.py:238
+#: catalog/models/item.py:132 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr "squadra"
 
-#: catalog/models/item.py:140
+#: catalog/models/item.py:136
 #, fuzzy
 #| msgid "production"
 msgid "production company"
 msgstr "produzione"
 
-#: catalog/models/item.py:141
+#: catalog/models/item.py:137
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:142
+#: catalog/models/item.py:138
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:139
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:144 catalog/models/performance.py:231
+#: catalog/models/item.py:140 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr "troupe"
 
-#: catalog/models/item.py:147
+#: catalog/models/item.py:143
 #, fuzzy
 #| msgid "director"
 msgid "voice actor"
 msgstr "Diretto da"
 
-#: catalog/models/item.py:148 catalog/templates/edition.html:30
+#: catalog/models/item.py:144 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr "Casa editrice"
 
-#: catalog/models/item.py:173 catalog/models/people.py:476
+#: catalog/models/item.py:169 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr "ruolo"
 
-#: catalog/models/item.py:174 catalog/models/people.py:155
+#: catalog/models/item.py:170 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr "nome"
 
-#: catalog/models/item.py:176 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:288 catalog/models/item.py:320
-#: journal/models/collection.py:96
+#: catalog/models/item.py:304 catalog/models/item.py:336
+#: journal/models/collection.py:100
 msgid "title"
 msgstr "titolo"
 
-#: catalog/models/item.py:289 catalog/models/item.py:328
-#: journal/models/collection.py:97
+#: catalog/models/item.py:305 catalog/models/item.py:344
+#: journal/models/collection.py:101
 msgid "description"
 msgstr "descrizione"
 
-#: catalog/models/item.py:300 catalog/models/people.py:484
+#: catalog/models/item.py:316 catalog/models/people.py:484
 msgid "metadata"
 msgstr "metadati"
 
-#: catalog/models/item.py:302 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
 msgid "cover"
 msgstr "copertina"
 
-#: catalog/models/item.py:1485
+#: catalog/models/item.py:1526
 msgid "source site"
 msgstr "sito d'origine"
 
-#: catalog/models/item.py:1487
+#: catalog/models/item.py:1528
 msgid "ID on source site"
 msgstr "ID sul sito sorgente"
 
-#: catalog/models/item.py:1489
+#: catalog/models/item.py:1530
 msgid "source url"
 msgstr "URL della sorgente"
 
-#: catalog/models/item.py:1505
+#: catalog/models/item.py:1546
 msgid "IdType of the source site"
 msgstr "IdType del sito sorgente"
 
-#: catalog/models/item.py:1511
+#: catalog/models/item.py:1552
 msgid "Primary Id on the source site"
 msgstr "Id Primario sul sito sorgente"
 
-#: catalog/models/item.py:1514
+#: catalog/models/item.py:1555
 msgid "url to the resource"
 msgstr "URL alla risorsa"
 
 #: catalog/models/movie.py:152 catalog/models/music.py:124
-#: catalog/models/tv.py:243 catalog/models/tv.py:469
+#: catalog/models/tv.py:245 catalog/models/tv.py:471
 #: catalog/templates/_item_card_metadata_album.html:16
 #: catalog/templates/album.html:17 catalog/templates/game.html:22
 #: catalog/templates/movie.html:36 catalog/templates/tvseason.html:53
@@ -913,7 +923,7 @@ msgid "length"
 msgstr "Durata"
 
 #: catalog/models/movie.py:162 catalog/models/music.py:131
-#: catalog/models/tv.py:259 catalog/models/tv.py:486
+#: catalog/models/tv.py:261 catalog/models/tv.py:488
 #, fuzzy
 #| msgid "milliseconds"
 msgid "seconds"
@@ -1121,46 +1131,98 @@ msgstr "data della première"
 msgid "closing date"
 msgstr "data di chiusura"
 
-#: catalog/models/tv.py:186 catalog/templates/tvseason.html:38
+#: catalog/models/tv.py:188 catalog/templates/tvseason.html:38
 #: catalog/templates/tvshow.html:33
 msgid "number of seasons"
 msgstr "Numero delle stagioni"
 
-#: catalog/models/tv.py:189 catalog/models/tv.py:415
+#: catalog/models/tv.py:191 catalog/models/tv.py:417
 #: catalog/templates/tvseason.html:43 catalog/templates/tvshow.html:38
 msgid "number of episodes"
 msgstr "Numero di episodi"
 
-#: catalog/models/tv.py:256 catalog/models/tv.py:483
+#: catalog/models/tv.py:258 catalog/models/tv.py:485
 msgid "episode length"
 msgstr "durata dell'episodio"
 
-#: catalog/models/tv.py:412 catalog/templates/tvseason.html:33
+#: catalog/models/tv.py:414 catalog/templates/tvseason.html:33
 msgid "season number"
 msgstr "Stagione numero"
 
-#: catalog/models/tv.py:530
+#: catalog/models/tv.py:532
 #, python-brace-format
 msgid "{show_title} Season {season_number}"
 msgstr "{show_title} Stagione {season_number}"
 
-#: catalog/models/tv.py:684
+#: catalog/models/tv.py:686
 #, python-brace-format
 msgid "{season_title} E{episode_number}"
 msgstr "{season_title} Ep{episode_number}"
+
+#: catalog/templates/_catalog_confirm_item.html:7
+#: catalog/templates/catalog_edit.html:62
+msgid "Item has been deleted."
+msgstr "L'elemento è stato cancellato."
+
+#: catalog/templates/_catalog_confirm_item.html:12
+#: catalog/templates/catalog_edit.html:65
+msgid "Item contains sub-items."
+msgstr "L'elemento contiene sotto-elementi."
+
+#: catalog/templates/_catalog_confirm_item.html:17
+msgid "Item has been merged to another item."
+msgstr "L'elemento è stato incorporato in un altro elemento."
+
+#: catalog/templates/_catalog_confirm_item.html:22
+msgid "Item has been marked by users."
+msgstr "L'elemento è stato segnato dagli utenti."
+
+#: catalog/templates/_catalog_edit_preview.html:11
+#, fuzzy
+#| msgid "Confirm and save"
+msgid "Confirm changes"
+msgstr "Conferma e salva"
+
+#: catalog/templates/_catalog_edit_preview.html:16
+msgid "Please correct the errors below."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:24
+msgid "Field"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:25
+msgid "From"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:26
+msgid "To"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:45
+#, fuzzy
+#| msgid "Tag deleted."
+msgid "No changes detected."
+msgstr "Tag eliminato."
+
+#: catalog/templates/_catalog_edit_preview.html:54
+#: users/templates/users/register.html:104
+msgid "Confirm and save"
+msgstr "Conferma e salva"
+
+#: catalog/templates/_catalog_edit_preview.html:57
+#, fuzzy
+#| msgid "back to item"
+msgid "Back to editing"
+msgstr "ritorna all'elemento"
 
 #: catalog/templates/_country_list.html:5
 msgid "region"
 msgstr "Paese"
 
 #: catalog/templates/_fetch_failed.html:4
-msgid ""
-"Unable to fetch from the link, please check again. Some sites may require "
-"login for certain links, please manually create them here."
-msgstr ""
-"Impossibile recuperare dal link, si prega di controllare ancora. Alcuni siti "
-"richiedono l'accesso per alcuni tipi di link. Se necessario è possibile "
-"crearli qui manualmente."
+msgid "Unable to fetch from the link, please check again. Some sites may require login for certain links, please manually create them here."
+msgstr "Impossibile recuperare dal link, si prega di controllare ancora. Alcuni siti richiedono l'accesso per alcuni tipi di link. Se necessario è possibile crearli qui manualmente."
 
 #: catalog/templates/_item_card_metadata_album.html:7
 #: catalog/templates/_item_card_metadata_edition.html:7
@@ -1190,8 +1252,7 @@ msgstr "Tutte le stagioni"
 
 #: catalog/templates/_item_comments.html:25
 msgid "edit this item to fetch or add episode list here"
-msgstr ""
-"modifica questo elemento per recuperare o aggiungere qui una lista di episodi"
+msgstr "modifica questo elemento per recuperare o aggiungere qui una lista di episodi"
 
 #: catalog/templates/_item_comments.html:27
 msgid "hide this tooltip"
@@ -1220,7 +1281,7 @@ msgstr "mostra di più"
 #: journal/templates/profile_posts.html:21
 #: journal/templates/user_follow_list_items.html:63
 #: journal/templates/user_post_list_items.html:24
-#: social/templates/events.html:43 social/templates/feed_events.html:28
+#: social/templates/events.html:43 social/templates/feed_events.html:27
 msgid "nothing more."
 msgstr "nient'altro."
 
@@ -1319,7 +1380,7 @@ msgid "Add note"
 msgstr "Aggiungi film"
 
 #: catalog/templates/_item_user_pieces.html:83
-#: common/templates/_sidebar.html:196 journal/templates/profile_items.html:46
+#: common/templates/_sidebar.html:195 journal/templates/profile_items.html:46
 #, fuzzy
 #| msgid "Sync in progress."
 msgid "Set progress"
@@ -1348,6 +1409,12 @@ msgstr "La mia collezione"
 #: catalog/templates/_item_user_pieces.html:214
 msgid "mark history"
 msgstr "Cronologia delle interazioni"
+
+#: catalog/templates/_search_suggest.html:2
+#, fuzzy
+#| msgid "Suggest Edits"
+msgid "Suggestions"
+msgstr "Suggerisci Modifiche"
 
 #: catalog/templates/_sidebar_edit.html:8
 msgid "edit"
@@ -1378,15 +1445,15 @@ msgid "Edit Options"
 msgstr "Modifica Opzioni"
 
 #: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
-#: catalog/views/edit.py:82 catalog/views/edit.py:143 catalog/views/edit.py:197
-#: catalog/views/edit.py:218 catalog/views/edit.py:259
-#: catalog/views/edit.py:328 catalog/views/edit.py:332
-#: catalog/views/edit.py:351 catalog/views/edit.py:400
-#: catalog/views/edit.py:425 catalog/views/edit.py:440
-#: catalog/views/edit.py:480 catalog/views/edit.py:490
-#: catalog/views/edit.py:517 catalog/views/edit.py:582
-#: catalog/views/edit.py:637 catalog/views/edit.py:659
-#: catalog/views/search.py:367
+#: catalog/views/edit.py:160 catalog/views/edit.py:221
+#: catalog/views/edit.py:288 catalog/views/edit.py:309
+#: catalog/views/edit.py:364 catalog/views/edit.py:471
+#: catalog/views/edit.py:475 catalog/views/edit.py:509
+#: catalog/views/edit.py:576 catalog/views/edit.py:601
+#: catalog/views/edit.py:624 catalog/views/edit.py:664
+#: catalog/views/edit.py:674 catalog/views/edit.py:703
+#: catalog/views/edit.py:782 catalog/views/edit.py:837
+#: catalog/views/edit.py:859 catalog/views/search.py:418
 #, fuzzy
 #| msgid "Edit this item"
 msgid "Editing this item is restricted."
@@ -1424,7 +1491,7 @@ msgstr "L'elemento è stato segnato dagli utenti."
 msgid "The following items are merged into this item"
 msgstr "I seguenti elementi sono stati accorpati in questo elemento"
 
-#: catalog/templates/_sidebar_edit.html:70
+#: catalog/templates/_sidebar_edit.html:70 catalog/views/edit.py:456
 msgid "External website"
 msgstr "Sito internet esterno"
 
@@ -1438,49 +1505,41 @@ msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:88
 msgid "Existing metadata might get overwritten, sure to proceed?"
-msgstr ""
-"I metadati esistenti potrebbero essere sovrascritti, sicuro di voler "
-"procedere?"
+msgstr "I metadati esistenti potrebbero essere sovrascritti, sicuro di voler procedere?"
 
 #: catalog/templates/_sidebar_edit.html:92
 msgid "Fetch again"
 msgstr "Recupera nuovamente"
 
-#: catalog/templates/_sidebar_edit.html:97
-msgid "You may not be able to undo this operation, sure to remove?"
-msgstr ""
-"Potresti non essere in grado di annullare questa operazione, sicuro di voler "
-"rimuovere?"
-
-#: catalog/templates/_sidebar_edit.html:102
+#: catalog/templates/_sidebar_edit.html:100
 msgid "Remove link to site"
 msgstr "Rimuovi il link al sito"
 
-#: catalog/templates/_sidebar_edit.html:110
+#: catalog/templates/_sidebar_edit.html:108
 #, fuzzy
 #| msgid "Discover"
 msgid "Choose cover"
 msgstr "Scopri"
 
-#: catalog/templates/_sidebar_edit.html:119
+#: catalog/templates/_sidebar_edit.html:117
+#: catalog/templates/_sidebar_edit.html:118
 #: catalog/templates/_sidebar_edit.html:120
-#: catalog/templates/_sidebar_edit.html:122
 #, fuzzy
 #| msgid "Current Targets"
 msgid "Current cover"
 msgstr "Obbiettivi in corso"
 
-#: catalog/templates/_sidebar_edit.html:139
+#: catalog/templates/_sidebar_edit.html:137
 msgid "Select an image to use as the cover of this item."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:140
-#: catalog/templates/catalog_edit.html:65
-#: common/templates/manage/settings.html:136
+#: catalog/templates/_sidebar_edit.html:138
+#: catalog/templates/catalog_edit.html:78
+#: common/templates/manage/settings.html:19
 #: journal/templates/add_to_collection.html:43
 #: journal/templates/article_edit.html:60
 #: journal/templates/collection_edit.html:39 journal/templates/comment.html:41
-#: journal/templates/mark.html:134 journal/templates/note.html:65
+#: journal/templates/mark.html:138 journal/templates/note.html:65
 #: journal/templates/post_compose.html:103
 #: journal/templates/review_edit.html:46 journal/templates/tag_edit.html:51
 #: users/templates/users/_pref_device.html:37
@@ -1489,202 +1548,162 @@ msgstr ""
 msgid "Save"
 msgstr "Salva"
 
-#: catalog/templates/_sidebar_edit.html:147
+#: catalog/templates/_sidebar_edit.html:145
 msgid "Edit sub-items"
 msgstr "Modifica sotto-elementi"
 
-#: catalog/templates/_sidebar_edit.html:160
+#: catalog/templates/_sidebar_edit.html:158
 msgid "create"
 msgstr "crea"
 
-#: catalog/templates/_sidebar_edit.html:166
+#: catalog/templates/_sidebar_edit.html:164
 msgid "Fetch all episodes"
 msgstr "Recupera tutti gli episodi"
 
-#: catalog/templates/_sidebar_edit.html:171
+#: catalog/templates/_sidebar_edit.html:169
 msgid "Fetch all"
 msgstr "Recupera tutto"
 
-#: catalog/templates/_sidebar_edit.html:172
-msgid ""
-"Due to differences in how Douban, IMDB, and TMDB handle season data, a small "
-"number of TV shows and animations may not return correct results. Please "
-"manually verify and clean up after updating."
-msgstr ""
-"A causa delle differenze dei modi nei quali Douban, IMDB e TMDB gestiscono i "
-"dati delle stagioni, un piccolo numero di prodotti animati e serie TV "
-"potrebbero contenere dati sbagliati. Si prega di verificare i dati "
-"manualmente e aggiornarli dopo averli corretti."
+#: catalog/templates/_sidebar_edit.html:170
+msgid "Due to differences in how Douban, IMDB, and TMDB handle season data, a small number of TV shows and animations may not return correct results. Please manually verify and clean up after updating."
+msgstr "A causa delle differenze dei modi nei quali Douban, IMDB e TMDB gestiscono i dati delle stagioni, un piccolo numero di prodotti animati e serie TV potrebbero contenere dati sbagliati. Si prega di verificare i dati manualmente e aggiornarli dopo averli corretti."
 
-#: catalog/templates/_sidebar_edit.html:173
+#: catalog/templates/_sidebar_edit.html:171
 msgid "Up to 250 episodes will be fetched for a season."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:176
-msgid ""
-"To fetch all episodes, season numbers and IMDB information are required. If "
-"filling this out is inconvenient, you can also manually create sub-entries."
-msgstr ""
-"Per recuperare tutti gli episodi, sono richiesti i numeri delle stagioni e "
-"le informazioni IMDB. Se non conviene compilare i dati, puoi creare "
-"manualmente delle sotto-voci."
+#: catalog/templates/_sidebar_edit.html:174
+msgid "To fetch all episodes, season numbers and IMDB information are required. If filling this out is inconvenient, you can also manually create sub-entries."
+msgstr "Per recuperare tutti gli episodi, sono richiesti i numeri delle stagioni e le informazioni IMDB. Se non conviene compilare i dati, puoi creare manualmente delle sotto-voci."
 
-#: catalog/templates/_sidebar_edit.html:182
-#: catalog/templates/_sidebar_edit.html:194
-#: catalog/templates/_sidebar_edit.html:213
+#: catalog/templates/_sidebar_edit.html:180
+#: catalog/templates/_sidebar_edit.html:191
+#: catalog/templates/_sidebar_edit.html:208
 msgid "switch category"
 msgstr "cambia categoria"
 
-#: catalog/templates/_sidebar_edit.html:185
-msgid "Switching may remove some metadata. Sure to proceed?"
-msgstr "Cambiare potrebbe rimuovere alcuni metadati. Vuoi procedere?"
-
-#: catalog/templates/_sidebar_edit.html:188
+#: catalog/templates/_sidebar_edit.html:185 catalog/views/edit.py:383
 msgid "TV Show"
 msgstr "Show TV"
 
-#: catalog/templates/_sidebar_edit.html:227
+#: catalog/templates/_sidebar_edit.html:221
 msgid "Link to parent item"
 msgstr "Collega ad elemento genitore"
 
 #: catalog/templates/_sidebar_edit.html:230
-msgid "Sure to link?"
-msgstr "Confermare il collegamento?"
-
-#: catalog/templates/_sidebar_edit.html:237
 msgid "Update link"
 msgstr "Aggiorna collegamento"
 
-#: catalog/templates/_sidebar_edit.html:243
+#: catalog/templates/_sidebar_edit.html:236
 msgid "Cleanup seasons"
 msgstr "Riordina stagioni"
 
-#: catalog/templates/_sidebar_edit.html:246
-#: catalog/templates/catalog_delete.html:45
-msgid "This operation cannot be undone. Sure to delete?"
-msgstr "Questa operazione non può essere annullata. Confermi l'eliminazione?"
-
-#: catalog/templates/_sidebar_edit.html:250
+#: catalog/templates/_sidebar_edit.html:242
 msgid "remove seasons not marked"
 msgstr "rimuovi le stagioni non contrassegnate"
 
-#: catalog/templates/_sidebar_edit.html:256
-#: catalog/templates/catalog_merge.html:12
+#: catalog/templates/_sidebar_edit.html:248
 msgid "Merge"
 msgstr "Unisci"
 
-#: catalog/templates/_sidebar_edit.html:262
+#: catalog/templates/_sidebar_edit.html:254
 msgid "URL of target item, or empty if undo merge"
 msgstr "URL dell'elemento di destinazione, o vuoto se si annulla accorpamento"
 
-#: catalog/templates/_sidebar_edit.html:268
-#: catalog/templates/_sidebar_edit.html:348
+#: catalog/templates/_sidebar_edit.html:260
+#: catalog/templates/_sidebar_edit.html:350
 msgid "merge to another item"
 msgstr "unisci ad un altro elemento"
 
-#: catalog/templates/_sidebar_edit.html:273
-#: catalog/templates/_sidebar_edit.html:277
-#: catalog/templates/catalog_delete.html:12
+#: catalog/templates/_sidebar_edit.html:265
+#: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
 #: journal/templates/article.html:199 journal/templates/collection.html:188
-#: journal/templates/mark.html:149 journal/templates/note.html:82
+#: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
 #: users/templates/users/account.html:254
 msgid "Delete"
 msgstr "Elimina"
 
-#: catalog/templates/_sidebar_edit.html:287
+#: catalog/templates/_sidebar_edit.html:275
+#: catalog/templates/_sidebar_edit.html:279
+#, fuzzy
+#| msgid "Tag deleted."
+msgid "Undo delete"
+msgstr "Tag eliminato."
+
+#: catalog/templates/_sidebar_edit.html:280
+msgid "Links to external sites and parent item were removed on delete and will not be restored."
+msgstr ""
+
+#: catalog/templates/_sidebar_edit.html:290
 msgid "This edition belongs to the following work"
 msgstr "Questa edizione appartiene al seguente lavoro"
 
-#: catalog/templates/_sidebar_edit.html:292
-msgid "Sure to unlink?"
-msgstr "Sicuro di voler scollegare?"
-
-#: catalog/templates/_sidebar_edit.html:298
+#: catalog/templates/_sidebar_edit.html:300
 msgid "Unlink from work"
 msgstr "Scollega dal lavoro"
 
-#: catalog/templates/_sidebar_edit.html:304
+#: catalog/templates/_sidebar_edit.html:306
 msgid "Link"
 msgstr "Collegamento"
 
-#: catalog/templates/_sidebar_edit.html:315
+#: catalog/templates/_sidebar_edit.html:317
 msgid "Link to another edition from same work"
 msgstr "Collega ad un'altra edizione dallo stesso lavoro"
 
-#: catalog/templates/_sidebar_edit.html:324
+#: catalog/templates/_sidebar_edit.html:326
 #, fuzzy
 #| msgid "description"
 msgid "Restriction"
 msgstr "descrizione"
 
-#: catalog/templates/_sidebar_edit.html:337
+#: catalog/templates/_sidebar_edit.html:339
 #: journal/templates/collection_update_item_note.html:4
 msgid "Update"
 msgstr "Aggiorna"
 
-#: catalog/templates/_sidebar_edit.html:342
+#: catalog/templates/_sidebar_edit.html:344
 msgid "Suggest Edits"
 msgstr "Suggerisci Modifiche"
 
-#: catalog/templates/_sidebar_edit.html:347
+#: catalog/templates/_sidebar_edit.html:349
 msgid "proposed action"
 msgstr "azione proposta"
 
-#: catalog/templates/_sidebar_edit.html:349
+#: catalog/templates/_sidebar_edit.html:351
 msgid "link to another item"
 msgstr "collega ad un altro elemento"
 
-#: catalog/templates/_sidebar_edit.html:350
+#: catalog/templates/_sidebar_edit.html:352
 msgid "change item category"
 msgstr "cambia categoria dell'elemento"
 
-#: catalog/templates/_sidebar_edit.html:351
+#: catalog/templates/_sidebar_edit.html:353
 msgid "change item metadata"
 msgstr "cambia i metadati dell'elemento"
 
-#: catalog/templates/_sidebar_edit.html:352
+#: catalog/templates/_sidebar_edit.html:354
 msgid "remove item"
 msgstr "rimuovi elemento"
 
-#: catalog/templates/_sidebar_edit.html:353
+#: catalog/templates/_sidebar_edit.html:355
 msgid "other"
 msgstr "altro"
 
-#: catalog/templates/_sidebar_edit.html:357
-msgid ""
-"To suggest merging or association, please include the URL of the target item"
-msgstr ""
-"Per suggerire un accorpamento o associazione si prega di includere l'URL "
-"dell'oggetto di destinazione"
+#: catalog/templates/_sidebar_edit.html:359
+msgid "To suggest merging or association, please include the URL of the target item"
+msgstr "Per suggerire un accorpamento o associazione si prega di includere l'URL dell'oggetto di destinazione"
 
-#: catalog/templates/_sidebar_edit.html:358
+#: catalog/templates/_sidebar_edit.html:360
 #: catalog/templates/catalog_verify.html:116
 msgid "submit"
 msgstr "inoltra"
 
-#: catalog/templates/_sidebar_edit.html:359
-msgid ""
-"As a user of this community, you may edit some metadata of items on this "
-"site. If you are unsure whether your edits are appropriate or are unable to "
-"make a certain change, you can make suggestions here. Moderators will "
-"consider each suggestion, although there is no guarantee that they will "
-"always be fully adopted; suggestions may also be viewed or discussed by "
-"other community users. If you have suggestions that are not related to a "
-"specific item, please contact us. Thank you for your support and "
-"contribution."
-msgstr ""
-"Come membro di questa community, puoi modificare alcuni metadati di elementi "
-"presenti in questo sito. Se non sei sicuro della correttezza delle tue "
-"modifiche o non sei in grado di effettuare un determinato tipo di modifica "
-"puoi proporre i tuoi suggerimenti qui. I moderatori valuteranno ogni "
-"suggerimento, ma non viene garantito in nessun modo che i tuoi suggerimenti "
-"verranno adottati per forza. I tuoi suggerimenti potranno essere discussi da "
-"altri utenti della community. Se hai suggerimenti che non sono legati in "
-"nessun modo ad un elemento specifico, contattaci direttamente. Grazie mille "
-"per il vostro supporto e contributo."
+#: catalog/templates/_sidebar_edit.html:361
+msgid "As a user of this community, you may edit some metadata of items on this site. If you are unsure whether your edits are appropriate or are unable to make a certain change, you can make suggestions here. Moderators will consider each suggestion, although there is no guarantee that they will always be fully adopted; suggestions may also be viewed or discussed by other community users. If you have suggestions that are not related to a specific item, please contact us. Thank you for your support and contribution."
+msgstr "Come membro di questa community, puoi modificare alcuni metadati di elementi presenti in questo sito. Se non sei sicuro della correttezza delle tue modifiche o non sei in grado di effettuare un determinato tipo di modifica puoi proporre i tuoi suggerimenti qui. I moderatori valuteranno ogni suggerimento, ma non viene garantito in nessun modo che i tuoi suggerimenti verranno adottati per forza. I tuoi suggerimenti potranno essere discussi da altri utenti della community. Se hai suggerimenti che non sono legati in nessun modo ad un elemento specifico, contattaci direttamente. Grazie mille per il vostro supporto e contributo."
 
 #: catalog/templates/_sidebar_search.html:5
 #: journal/templates/_sidebar_search_journal.html:4
@@ -1787,9 +1806,7 @@ msgid "matched"
 msgstr "Visto"
 
 #: catalog/templates/_verify_status.html:21
-msgid ""
-"Sure to remove your creator verification? Anyone will be able to edit this "
-"item again."
+msgid "Sure to remove your creator verification? Anyone will be able to edit this item again."
 msgstr ""
 
 #: catalog/templates/_verify_status.html:26
@@ -1798,7 +1815,7 @@ msgstr ""
 msgid "Remove my verification"
 msgstr "Rimuovi dalla collezione"
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:309
+#: catalog/templates/_verify_status.html:31 users/views/account.py:311
 #, fuzzy
 #| msgid "Verification Code"
 msgid "Verification failed"
@@ -1841,43 +1858,11 @@ msgstr "codice a barre"
 msgid "album media"
 msgstr "copertina dell'album"
 
-#: catalog/templates/catalog_delete.html:19
-msgid "Are you sure to delete?"
-msgstr "Confermare eliminazione?"
-
-#: catalog/templates/catalog_delete.html:24
-#: catalog/templates/catalog_edit.html:52
-#: catalog/templates/catalog_merge.html:36
-#: catalog/templates/catalog_merge.html:64
-msgid "Item has been deleted."
-msgstr "L'elemento è stato cancellato."
-
-#: catalog/templates/catalog_delete.html:29
-#: catalog/templates/catalog_edit.html:55
-#: catalog/templates/catalog_merge.html:41
-#: catalog/templates/catalog_merge.html:69
-msgid "Item contains sub-items."
-msgstr "L'elemento contiene sotto-elementi."
-
-#: catalog/templates/catalog_delete.html:34
-#: catalog/templates/catalog_merge.html:46
-#: catalog/templates/catalog_merge.html:74
-msgid "Item has been merged to another item."
-msgstr "L'elemento è stato incorporato in un altro elemento."
-
-#: catalog/templates/catalog_delete.html:39
-#: catalog/templates/catalog_merge.html:51
-#: catalog/templates/catalog_merge.html:79
-msgid "Item has been marked by users."
-msgstr "L'elemento è stato segnato dagli utenti."
-
-#: catalog/templates/catalog_delete.html:48
-#: catalog/templates/catalog_merge.html:92 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:55 common/views_manage.py:139
 msgid "Yes"
 msgstr "Sì"
 
-#: catalog/templates/catalog_delete.html:49
-#: catalog/templates/catalog_merge.html:93 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:56 common/views_manage.py:139
 msgid "No"
 msgstr "No"
 
@@ -1886,36 +1871,18 @@ msgstr "No"
 msgid "Create"
 msgstr "Crea"
 
-#: catalog/templates/catalog_edit.html:68
+#: catalog/templates/catalog_edit.html:81
 #: journal/templates/collection_update_item_note.html:8
 #: journal/templates/piece_delete.html:38
 msgid "Cancel"
 msgstr "Cancella"
 
-#: catalog/templates/catalog_edit.html:104
+#: catalog/templates/catalog_edit.html:118
 msgid "open linked people page"
 msgstr ""
 
-#: catalog/templates/catalog_merge.html:22
-msgid "Are you sure to merge?"
-msgstr "Confermare l'accorpamento?"
-
-#: catalog/templates/catalog_merge.html:24
-msgid "Are you sure to cancel merge?"
-msgstr "Vuoi veramente annullare l'accorpamento?"
-
-#: catalog/templates/catalog_merge.html:27
-msgid "Are you sure to link?"
-msgstr "Confermare il collegamento?"
-
-#: catalog/templates/catalog_merge.html:86
-msgid "This operation cannot be undone. Sure to merge?"
-msgstr "Questa operazione non può essere annullata. Confermare accorpamento?"
-
 #: catalog/templates/catalog_verify.html:21
-msgid ""
-"If you are a creator of this podcast, you may verify the ownership, so that "
-"only you (and other verified creators) can edit its metadata on this site."
+msgid "If you are a creator of this podcast, you may verify the ownership, so that only you (and other verified creators) can edit its metadata on this site."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:22
@@ -1923,9 +1890,7 @@ msgid "Your recent episodes may also occasionally be featured in discovery."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:24
-msgid ""
-"To verify, prove you control one of the following identifiers of your "
-"account (click to copy):"
+msgid "To verify, prove you control one of the following identifiers of your account (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:30
@@ -1936,18 +1901,11 @@ msgid "copied"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:35
-msgid ""
-"You can prove this in a few ways, then start verification: add one of the "
-"identifiers above to the podcast feed's description; add a <code>rel=\"me\"</"
-"code> link back to one of them on the web page your feed links to (the link "
-"verification Mastodon uses); or point your feed's website at your Bluesky "
-"handle's own domain."
+msgid "You can prove this in a few ways, then start verification: add one of the identifiers above to the podcast feed's description; add a <code>rel=\"me\"</code> link back to one of them on the web page your feed links to (the link verification Mastodon uses); or point your feed's website at your Bluesky handle's own domain."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:44
-msgid ""
-"For example, add this rel=me link to the web page your feed links to (click "
-"to copy):"
+msgid "For example, add this rel=me link to the web page your feed links to (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:50
@@ -1955,9 +1913,7 @@ msgid "or, in the page's head:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:57
-msgid ""
-"Can't edit the website? Just add a line like this to your feed's description "
-"instead (click to copy):"
+msgid "Can't edit the website? Just add a line like this to your feed's description instead (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:62
@@ -1965,10 +1921,7 @@ msgid "Welcome to follow me on the Fediverse:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:66
-msgid ""
-"NeoDB does not re-check this periodically at the moment, but we recommend "
-"you keep it so that your audience can discover and connect with you in "
-"distributed social media."
+msgid "NeoDB does not re-check this periodically at the moment, but we recommend you keep it so that your audience can discover and connect with you in distributed social media."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:72
@@ -1998,12 +1951,11 @@ msgid "Send feedback"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:115
-msgid ""
-"Questions or issues with creator verification? Let the site moderators know."
+msgid "Questions or issues with creator verification? Let the site moderators know."
 msgstr ""
 
-#: catalog/templates/discover.html:28 common/views_manage.py:145
-#: common/views_manage.py:353 users/templates/users/preferences.html:34
+#: catalog/templates/discover.html:28 common/views_manage.py:35
+#: common/views_manage.py:431 users/templates/users/preferences.html:34
 msgid "Discover"
 msgstr "Scopri"
 
@@ -2041,17 +1993,17 @@ msgstr "mostra"
 msgid "hide"
 msgstr "nascondi"
 
-#: catalog/templates/discover.html:206 common/templates/_sidebar.html:14
+#: catalog/templates/discover.html:206 common/templates/_sidebar.html:13
 msgid "Unread Announcements"
 msgstr "Annunci non letti"
 
-#: catalog/templates/discover.html:212 common/templates/_sidebar.html:20
+#: catalog/templates/discover.html:212 common/templates/_sidebar.html:19
 #: social/templates/notification.html:67
 msgid "mark all as read"
 msgstr "segna tutti come letti"
 
 #: catalog/templates/discover.html:222
-#: common/templates/_sidebar_anonymous.html:55
+#: common/templates/_sidebar_anonymous.html:54
 msgid "Popular Tags"
 msgstr "Tag popolari"
 
@@ -2062,9 +2014,9 @@ msgstr "Tag popolari"
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
 #: catalog/templates/user_verified_works.html:23
-#: common/templates/_sidebar.html:127
-#: common/templates/_sidebar_anonymous.html:46
-#: common/templates/_sidebar_anonymous.html:62 journal/templates/posts.html:8
+#: common/templates/_sidebar.html:126
+#: common/templates/_sidebar_anonymous.html:45
+#: common/templates/_sidebar_anonymous.html:61 journal/templates/posts.html:7
 #: journal/templates/profile_articles.html:24
 #: journal/templates/profile_articles.html:26
 #: journal/templates/profile_items.html:65
@@ -2080,7 +2032,7 @@ msgstr "Tag popolari"
 msgid "nothing so far."
 msgstr "finora nulla."
 
-#: catalog/templates/discover.html:239 common/templates/_sidebar.html:269
+#: catalog/templates/discover.html:239 common/templates/_sidebar.html:268
 msgid "Recent Posts"
 msgstr "Post Recenti"
 
@@ -2109,15 +2061,9 @@ msgstr "Prendi in prestito oppure Acquista"
 
 #: catalog/templates/external_search_results.html:10
 #, fuzzy
-#| msgid ""
-#| "System will search other websites and instances, click title of the item "
-#| "to save them locally. "
-msgid ""
-"Some items were found from other websites and instances, click their title "
-"to save them locally."
-msgstr ""
-"Il sistema cercherà altri siti internet e istanze, clicca il titolo "
-"dell'elemento per salvarli localmente. "
+#| msgid "System will search other websites and instances, click title of the item to save them locally. "
+msgid "Some items were found from other websites and instances, click their title to save them locally."
+msgstr "Il sistema cercherà altri siti internet e istanze, clicca il titolo dell'elemento per salvarli localmente. "
 
 #: catalog/templates/fetch_pending.html:13
 msgid "Search results"
@@ -2143,9 +2089,7 @@ msgstr "Segna, commenta e colleziona"
 
 #: catalog/templates/item_base.html:142
 msgid "Login or register to review or add this item to your collection."
-msgstr ""
-"Accedi o registrati per recensire o aggiungere questo elemento alla tua "
-"collezione."
+msgstr "Accedi o registrati per recensire o aggiungere questo elemento alla tua collezione."
 
 #: catalog/templates/item_base.html:151
 msgid "Related Collections"
@@ -2220,14 +2164,14 @@ msgstr "numeri di Stagioni"
 msgid "number of Episodes"
 msgstr "numero di Episodi"
 
-#: catalog/templates/people.html:13 common/templates/_sidebar.html:77
-#: common/templates/_sidebar.html:84 journal/models/shelf.py:326
+#: catalog/templates/people.html:13 common/templates/_sidebar.html:76
+#: common/templates/_sidebar.html:83 journal/models/shelf.py:328
 #, fuzzy
 #| msgid "following you"
 msgid "following"
 msgstr "ti seguono"
 
-#: catalog/templates/people.html:15 journal/models/shelf.py:324
+#: catalog/templates/people.html:15 journal/models/shelf.py:326
 #: social/templates/notification.html:60
 msgid "follow"
 msgstr "segui"
@@ -2246,7 +2190,6 @@ msgstr ""
 #: journal/templates/_sidebar_collection_filter.html:14
 #: journal/templates/_sidebar_collection_filter.html:28
 #: journal/templates/_sidebar_user_mark_list.html:56
-#: social/templates/feed.html:42 social/templates/feed.html:44
 #: social/templates/notification.html:56
 msgid "all"
 msgstr "tutto"
@@ -2274,7 +2217,7 @@ msgstr "Completato"
 msgid "production"
 msgstr "produzione"
 
-#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:54
+#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:53
 #, fuzzy
 #| msgid "original creator"
 msgid "verified creator"
@@ -2359,14 +2302,8 @@ msgid "No items matching your search query."
 msgstr "Nessun elemento corrisponde alla tua ricerca."
 
 #: catalog/templates/search_results.html:34
-msgid ""
-"If you have URL from one of these sites, please put the full URL (e.g. "
-"<code>https://www.imdb.com/title/tt2513074/</code>) to the search box and "
-"press Enter."
-msgstr ""
-"Se hai l'URL da uno di questi siti, si prega di inserire l'intero URL (es. "
-"<code>https://www.imdb.com/title/tt2513074/</code>) nella barra di ricerca e "
-"premere Invio."
+msgid "If you have URL from one of these sites, please put the full URL (e.g. <code>https://www.imdb.com/title/tt2513074/</code>) to the search box and press Enter."
+msgstr "Se hai l'URL da uno di questi siti, si prega di inserire l'intero URL (es. <code>https://www.imdb.com/title/tt2513074/</code>) nella barra di ricerca e premere Invio."
 
 #: catalog/templates/search_results.html:48
 msgid "Searching from other sites"
@@ -2374,9 +2311,7 @@ msgstr "Ricerca da altri siti"
 
 #: catalog/templates/search_results.html:51
 msgid "Logged in user may see search results from other sites."
-msgstr ""
-"L'utente che ha fatto l'accesso può vedere i risultati di ricerca da altri "
-"siti."
+msgstr "L'utente che ha fatto l'accesso può vedere i risultati di ricerca da altri siti."
 
 #: catalog/templates/search_results_people.html:12
 #: journal/templates/profile.html:200 journal/views/profile.py:614
@@ -2406,99 +2341,192 @@ msgstr ""
 msgid "Editions"
 msgstr "Edizioni"
 
-#: catalog/views/edit.py:202 catalog/views/edit.py:205
-#: catalog/views/edit.py:306 catalog/views/edit.py:309
-#: catalog/views/verify.py:197 journal/views/collection.py:77
-#: journal/views/collection.py:102 journal/views/collection.py:556
-#: journal/views/collection.py:651 journal/views/common.py:221
-#: journal/views/mark.py:196 journal/views/post.py:117
-#: journal/views/post.py:119 journal/views/post.py:166
-#: journal/views/post.py:185 journal/views/post.py:187
-#: journal/views/post.py:228 journal/views/post.py:241
+#: catalog/views/edit.py:293 catalog/views/edit.py:296
+#: catalog/views/edit.py:440 catalog/views/edit.py:443
+#: catalog/views/verify.py:197 journal/views/collection.py:75
+#: journal/views/collection.py:100 journal/views/collection.py:538
+#: journal/views/collection.py:634 journal/views/common.py:231
+#: journal/views/mark.py:244 journal/views/post.py:119
+#: journal/views/post.py:121 journal/views/post.py:168
+#: journal/views/post.py:187 journal/views/post.py:189
+#: journal/views/post.py:230 journal/views/post.py:243
 #: journal/views/review.py:154 journal/views/review.py:158
-#: users/views/actions.py:179
+#: users/views/actions.py:178
 msgid "Invalid parameter"
 msgstr "Parametro non valido"
 
-#: catalog/views/edit.py:220
+#: catalog/views/edit.py:313
 msgid "Item in use."
 msgstr "Elemento in uso."
 
-#: catalog/views/edit.py:222
+#: catalog/views/edit.py:315
 msgid "Item cannot be deleted."
 msgstr "L'elemento non può essere eliminato."
 
-#: catalog/views/edit.py:247 catalog/views/edit.py:303
-#: catalog/views/edit.py:427 catalog/views/edit.py:519
-#: catalog/views/edit.py:552 catalog/views/verify.py:158
+#: catalog/views/edit.py:319 catalog/views/edit.py:515
+msgid "Are you sure to delete?"
+msgstr "Confermare eliminazione?"
+
+#: catalog/views/edit.py:323 catalog/views/edit.py:518
+#: catalog/views/edit.py:617
+#, fuzzy
+#| msgid "This operation cannot be undone. Sure to merge?"
+msgid "This operation cannot be undone."
+msgstr "Questa operazione non può essere annullata. Confermare accorpamento?"
+
+#: catalog/views/edit.py:344 catalog/views/edit.py:437
+#: catalog/views/edit.py:603 catalog/views/edit.py:705
+#: catalog/views/edit.py:752 catalog/views/verify.py:158
 #: catalog/views/verify.py:206 journal/views/article.py:44
 #: journal/views/article.py:133 journal/views/article.py:153
 #: journal/views/collection.py:248 journal/views/collection.py:341
-#: journal/views/collection.py:360 journal/views/collection.py:384
-#: journal/views/collection.py:457 journal/views/collection.py:500
-#: journal/views/collection.py:539 journal/views/collection.py:551
-#: journal/views/collection.py:576 journal/views/collection.py:613
-#: journal/views/common.py:300 journal/views/mark.py:281
-#: journal/views/post.py:58 journal/views/post.py:78 journal/views/post.py:100
-#: journal/views/post.py:170 journal/views/post.py:199
-#: journal/views/post.py:272 journal/views/post.py:287
-#: journal/views/post.py:394 journal/views/post.py:549
+#: journal/views/collection.py:354 journal/views/collection.py:372
+#: journal/views/collection.py:439 journal/views/collection.py:482
+#: journal/views/collection.py:521 journal/views/collection.py:533
+#: journal/views/collection.py:558 journal/views/collection.py:595
+#: journal/views/common.py:304 journal/views/mark.py:317
+#: journal/views/post.py:60 journal/views/post.py:80 journal/views/post.py:102
+#: journal/views/post.py:172 journal/views/post.py:201
+#: journal/views/post.py:274 journal/views/post.py:289
+#: journal/views/post.py:390 journal/views/post.py:539
 #: journal/views/review.py:64 journal/views/review.py:81
 #: journal/views/review.py:106
 msgid "Insufficient permission"
 msgstr "Permessi insufficienti"
 
-#: catalog/views/edit.py:374
+#: catalog/views/edit.py:346
+#, fuzzy
+#| msgid "Item has been deleted."
+msgid "Item is not deleted"
+msgstr "L'elemento è stato cancellato."
+
+#: catalog/views/edit.py:389
+#, fuzzy
+#| msgid "Switching may remove some metadata. Sure to proceed?"
+msgid "Switching may remove some metadata."
+msgstr "Cambiare potrebbe rimuovere alcuni metadati. Vuoi procedere?"
+
+#: catalog/views/edit.py:395
+#, fuzzy
+#| msgid "The following items are merged into this item"
+msgid "The following seasons will be detached from this show"
+msgstr "I seguenti elementi sono stati accorpati in questo elemento"
+
+#: catalog/views/edit.py:400
+msgid "Links to IMDB and TMDB will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:403
+#, fuzzy
+#| msgid "Are you sure to merge?"
+msgid "Are you sure to switch category?"
+msgstr "Confermare l'accorpamento?"
+
+#: catalog/views/edit.py:451
+#, fuzzy
+#| msgid "Are you sure to delete this post?"
+msgid "Are you sure to remove the link to this site?"
+msgstr "Vuoi veramente eliminare questo post?"
+
+#: catalog/views/edit.py:457
+#, fuzzy
+#| msgid "You may not be able to undo this operation, sure to remove?"
+msgid "You may not be able to undo this operation."
+msgstr "Potresti non essere in grado di annullare questa operazione, sicuro di voler rimuovere?"
+
+#: catalog/views/edit.py:483
+#, fuzzy
+#| msgid "Link to parent item"
+msgid "Current parent item"
+msgstr "Collega ad elemento genitore"
+
+#: catalog/views/edit.py:487
+msgid "The link to the parent item will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:490 catalog/views/edit.py:680
+msgid "Are you sure to link?"
+msgstr "Confermare il collegamento?"
+
+#: catalog/views/edit.py:521
+msgid "The following seasons will be deleted"
+msgstr ""
+
+#: catalog/views/edit.py:525
+msgid "The following seasons will be kept"
+msgstr ""
+
+#: catalog/views/edit.py:550
 msgid "TV Season with IMDB id and season number required."
 msgstr "Richiesta stagione TV con l'id IMDB e numero di stagione."
 
-#: catalog/views/edit.py:380
+#: catalog/views/edit.py:556
 msgid "Updating episodes"
 msgstr "Aggiornando episodi"
 
-#: catalog/views/edit.py:405
+#: catalog/views/edit.py:581
 msgid "This person has no supported source to fetch works from."
 msgstr ""
 
-#: catalog/views/edit.py:412
+#: catalog/views/edit.py:588
 msgid "Already pulling works for this person, try again later."
 msgstr ""
 
-#: catalog/views/edit.py:416
+#: catalog/views/edit.py:592
 msgid "Pulling works in background."
 msgstr ""
 
-#: catalog/views/edit.py:438
+#: catalog/views/edit.py:609
+msgid "Are you sure to merge?"
+msgstr "Confermare l'accorpamento?"
+
+#: catalog/views/edit.py:611
+msgid "Are you sure to cancel merge?"
+msgstr "Vuoi veramente annullare l'accorpamento?"
+
+#: catalog/views/edit.py:622
 msgid "Cannot be merged to an item already deleted or merged"
 msgstr "Non è possibile accorpare ad un elemento già eliminato o accorpato"
 
-#: catalog/views/edit.py:443
+#: catalog/views/edit.py:627
 msgid "Cannot merge items in different categories"
 msgstr "Impossibile accorpare elementi in categorie differenti"
 
-#: catalog/views/edit.py:447
+#: catalog/views/edit.py:631
 #, fuzzy
 #| msgid "Cannot merge items in different categories"
 msgid "Cannot merge an item to itself"
 msgstr "Impossibile accorpare elementi in categorie differenti"
 
-#: catalog/views/edit.py:488
+#: catalog/views/edit.py:672
 msgid "Cannot be linked to an item already deleted or merged"
 msgstr "Impossibile collegare ad un elemento già eliminato o accorpato"
 
-#: catalog/views/edit.py:492
+#: catalog/views/edit.py:676
 msgid "Cannot link items other than editions"
 msgstr "Impossibile collegare altri elementi all'infuori delle edizioni"
 
-#: catalog/views/search.py:96
+#: catalog/views/edit.py:710
+#, fuzzy
+#| msgid "Are you sure to link?"
+msgid "Are you sure to unlink?"
+msgstr "Confermare il collegamento?"
+
+#: catalog/views/edit.py:715
+#, fuzzy
+#| msgid "This edition belongs to the following work"
+msgid "This edition will be unlinked from the following work"
+msgstr "Questa edizione appartiene al seguente lavoro"
+
+#: catalog/views/search.py:113
 msgid "the internet"
 msgstr ""
 
-#: catalog/views/search.py:359
+#: catalog/views/search.py:410
 msgid "Invalid URL"
 msgstr "URL non valido"
 
-#: catalog/views/search.py:362
+#: catalog/views/search.py:413
 #, fuzzy
 #| msgid "Unsupported item type."
 msgid "Unsupported URL"
@@ -2524,9 +2552,9 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:122 common/utils.py:163
+#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
 #: journal/views/article.py:186 journal/views/review.py:182
-#: users/views/actions.py:45 users/views/actions.py:131
+#: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
 msgstr "Utente non trovato"
 
@@ -2540,15 +2568,15 @@ msgstr ""
 msgid "Creator verification removed."
 msgstr "Invia codice di verifica"
 
-#: catalog/views/view.py:74 catalog/views/view.py:99
+#: catalog/views/view.py:77 catalog/views/view.py:102
 msgid "Item not found"
 msgstr "Elemento non trovato"
 
-#: catalog/views/view.py:78 catalog/views/view.py:107 catalog/views/view.py:190
+#: catalog/views/view.py:81 catalog/views/view.py:110 catalog/views/view.py:193
 msgid "Item no longer exists"
 msgstr "L'elemento non esiste più"
 
-#: catalog/views/view.py:187
+#: catalog/views/view.py:190
 #, fuzzy
 #| msgid "Invalid file."
 msgid "Invalid role"
@@ -3096,759 +3124,759 @@ msgctxt "genre"
 msgid "Health"
 msgstr ""
 
-#: common/models/lang.py:54
+#: common/models/lang.py:56
 msgid "Afar"
 msgstr "Afar"
 
-#: common/models/lang.py:55
+#: common/models/lang.py:57
 msgid "Afrikaans"
 msgstr "Afrikaans"
 
-#: common/models/lang.py:56
+#: common/models/lang.py:58
 msgid "Akan"
 msgstr "Akan"
 
-#: common/models/lang.py:57
+#: common/models/lang.py:59
 msgid "Aragonese"
 msgstr "Aragonese"
 
-#: common/models/lang.py:58
+#: common/models/lang.py:60
 msgid "Assamese"
 msgstr "Assamese"
 
-#: common/models/lang.py:59
+#: common/models/lang.py:61
 msgid "Avaric"
 msgstr "Avaro"
 
-#: common/models/lang.py:60
+#: common/models/lang.py:62
 msgid "Avestan"
 msgstr "Avestico"
 
-#: common/models/lang.py:61
+#: common/models/lang.py:63
 msgid "Aymara"
 msgstr "Aymara"
 
-#: common/models/lang.py:62
+#: common/models/lang.py:64
 msgid "Azerbaijani"
 msgstr "Azerbaigiano"
 
-#: common/models/lang.py:63
+#: common/models/lang.py:65
 msgid "Bashkir"
 msgstr "Baschiro"
 
-#: common/models/lang.py:64
+#: common/models/lang.py:66
 msgid "Bambara"
 msgstr "Bambara"
 
-#: common/models/lang.py:65
+#: common/models/lang.py:67
 msgid "Bislama"
 msgstr "Bislama"
 
-#: common/models/lang.py:66
+#: common/models/lang.py:68
 msgid "Tibetan"
 msgstr "Tibetano"
 
-#: common/models/lang.py:67
+#: common/models/lang.py:69
 msgid "Breton"
 msgstr "Bretone"
 
-#: common/models/lang.py:68
+#: common/models/lang.py:70
 msgid "Catalan"
 msgstr "Catalano"
 
-#: common/models/lang.py:69
+#: common/models/lang.py:71
 msgid "Czech"
 msgstr "Ceco"
 
-#: common/models/lang.py:70
+#: common/models/lang.py:72
 msgid "Chechen"
 msgstr "Ceceno"
 
-#: common/models/lang.py:71
+#: common/models/lang.py:73
 msgid "Slavic"
 msgstr "Slavo"
 
-#: common/models/lang.py:72
+#: common/models/lang.py:74
 msgid "Chuvash"
 msgstr "Ciuvascio"
 
-#: common/models/lang.py:73
+#: common/models/lang.py:75
 msgid "Cornish"
 msgstr "Cornico"
 
-#: common/models/lang.py:74
+#: common/models/lang.py:76
 msgid "Corsican"
 msgstr "Corso"
 
-#: common/models/lang.py:75
+#: common/models/lang.py:77
 msgid "Cree"
 msgstr "Cree"
 
-#: common/models/lang.py:76
+#: common/models/lang.py:78
 msgid "Welsh"
 msgstr "Gallese"
 
-#: common/models/lang.py:79
+#: common/models/lang.py:81
 msgid "Divehi"
 msgstr "Maldiviano"
 
-#: common/models/lang.py:80
+#: common/models/lang.py:82
 msgid "Dzongkha"
 msgstr "Dzongkha"
 
-#: common/models/lang.py:81
+#: common/models/lang.py:83
 msgid "Esperanto"
 msgstr "Esperanto"
 
-#: common/models/lang.py:82
+#: common/models/lang.py:84
 msgid "Estonian"
 msgstr "Estone"
 
-#: common/models/lang.py:83
+#: common/models/lang.py:85
 msgid "Basque"
 msgstr "Basco"
 
-#: common/models/lang.py:84
+#: common/models/lang.py:86
 msgid "Faroese"
 msgstr "Faroense"
 
-#: common/models/lang.py:85
+#: common/models/lang.py:87
 msgid "Fijian"
 msgstr "Figiano"
 
-#: common/models/lang.py:86
+#: common/models/lang.py:88
 msgid "Finnish"
 msgstr "Finlandese"
 
-#: common/models/lang.py:88
+#: common/models/lang.py:90
 msgid "Frisian"
 msgstr "Frisone"
 
-#: common/models/lang.py:89
+#: common/models/lang.py:91
 msgid "Fulah"
 msgstr "Fula"
 
-#: common/models/lang.py:90
+#: common/models/lang.py:92
 msgid "Gaelic"
 msgstr "Gaelico"
 
-#: common/models/lang.py:91
+#: common/models/lang.py:93
 msgid "Irish"
 msgstr "Irlandese"
 
-#: common/models/lang.py:92
+#: common/models/lang.py:94
 msgid "Galician"
 msgstr "Galiziano"
 
-#: common/models/lang.py:93
+#: common/models/lang.py:95
 msgid "Manx"
 msgstr "Mannese"
 
-#: common/models/lang.py:94
+#: common/models/lang.py:96
 msgid "Guarani"
 msgstr "Guaraní"
 
-#: common/models/lang.py:95
+#: common/models/lang.py:97
 msgid "Gujarati"
 msgstr "Gujarati"
 
-#: common/models/lang.py:96
+#: common/models/lang.py:98
 msgid "Haitian; Haitian Creole"
 msgstr "Haitiano; Creolo Haitiano"
 
-#: common/models/lang.py:97
+#: common/models/lang.py:99
 msgid "Hausa"
 msgstr "Hausa"
 
-#: common/models/lang.py:98
+#: common/models/lang.py:100
 msgid "Serbo-Croatian"
 msgstr "Serbo-Croato"
 
-#: common/models/lang.py:99
+#: common/models/lang.py:101
 msgid "Herero"
 msgstr "Herero"
 
-#: common/models/lang.py:100
+#: common/models/lang.py:102
 msgid "Hiri Motu"
 msgstr "Hiri Motu"
 
-#: common/models/lang.py:101
+#: common/models/lang.py:103
 msgid "Croatian"
 msgstr "Croato"
 
-#: common/models/lang.py:102
+#: common/models/lang.py:104
 msgid "Hungarian"
 msgstr "Ungherese"
 
-#: common/models/lang.py:103
+#: common/models/lang.py:105
 msgid "Igbo"
 msgstr "Igbo"
 
-#: common/models/lang.py:104
+#: common/models/lang.py:106
 msgid "Ido"
 msgstr "Ido"
 
-#: common/models/lang.py:105
+#: common/models/lang.py:107
 msgid "Yi"
 msgstr "Yi"
 
-#: common/models/lang.py:106
+#: common/models/lang.py:108
 msgid "Inuktitut"
 msgstr "Inuktitut"
 
-#: common/models/lang.py:107
+#: common/models/lang.py:109
 msgid "Interlingue"
 msgstr "Interlingue"
 
-#: common/models/lang.py:108
+#: common/models/lang.py:110
 msgid "Interlingua"
 msgstr "Interlingua"
 
-#: common/models/lang.py:109
+#: common/models/lang.py:111
 msgid "Indonesian"
 msgstr "Indonesiano"
 
-#: common/models/lang.py:110
+#: common/models/lang.py:112
 msgid "Inupiaq"
 msgstr "Inupiaq"
 
-#: common/models/lang.py:111
+#: common/models/lang.py:113
 msgid "Icelandic"
 msgstr "Islandese"
 
-#: common/models/lang.py:113
+#: common/models/lang.py:115
 msgid "Javanese"
 msgstr "Giavanese"
 
-#: common/models/lang.py:114
+#: common/models/lang.py:116
 msgid "Japanese"
 msgstr "Giapponese"
 
-#: common/models/lang.py:115
+#: common/models/lang.py:117
 msgid "Kalaallisut"
 msgstr "Groenlandese"
 
-#: common/models/lang.py:116
+#: common/models/lang.py:118
 msgid "Kannada"
 msgstr "Kannada"
 
-#: common/models/lang.py:117
+#: common/models/lang.py:119
 msgid "Kashmiri"
 msgstr "Kashmiri"
 
-#: common/models/lang.py:118
+#: common/models/lang.py:120
 msgid "Kanuri"
 msgstr "Kanuri"
 
-#: common/models/lang.py:119
+#: common/models/lang.py:121
 msgid "Kazakh"
 msgstr "Kazako"
 
-#: common/models/lang.py:120
+#: common/models/lang.py:122
 msgid "Khmer"
 msgstr "Khmer"
 
-#: common/models/lang.py:121
+#: common/models/lang.py:123
 msgid "Kikuyu"
 msgstr "Gikuyu"
 
-#: common/models/lang.py:122
+#: common/models/lang.py:124
 msgid "Kinyarwanda"
 msgstr "Kinyarwanda"
 
-#: common/models/lang.py:123
+#: common/models/lang.py:125
 msgid "Kirghiz"
 msgstr "Kirghiso"
 
-#: common/models/lang.py:124
+#: common/models/lang.py:126
 msgid "Komi"
 msgstr "Komi"
 
-#: common/models/lang.py:125
+#: common/models/lang.py:127
 msgid "Kongo"
 msgstr "Kikongo"
 
-#: common/models/lang.py:126
+#: common/models/lang.py:128
 msgid "Korean"
 msgstr "Coreano"
 
-#: common/models/lang.py:127
+#: common/models/lang.py:129
 msgid "Kuanyama"
 msgstr "Kwanyama"
 
-#: common/models/lang.py:128
+#: common/models/lang.py:130
 msgid "Kurdish"
 msgstr "Curdo"
 
-#: common/models/lang.py:129
+#: common/models/lang.py:131
 msgid "Lao"
 msgstr "Laotiano"
 
-#: common/models/lang.py:130
+#: common/models/lang.py:132
 msgid "Latin"
 msgstr "Latino"
 
-#: common/models/lang.py:131
+#: common/models/lang.py:133
 msgid "Latvian"
 msgstr "Lettone"
 
-#: common/models/lang.py:132
+#: common/models/lang.py:134
 msgid "Limburgish"
 msgstr "Limburghese"
 
-#: common/models/lang.py:133
+#: common/models/lang.py:135
 msgid "Lingala"
 msgstr "Lingala"
 
-#: common/models/lang.py:134
+#: common/models/lang.py:136
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: common/models/lang.py:135
+#: common/models/lang.py:137
 msgid "Letzeburgesch"
 msgstr "Lussemburghese"
 
-#: common/models/lang.py:136
+#: common/models/lang.py:138
 msgid "Luba-Katanga"
 msgstr "Luba-Katanga"
 
-#: common/models/lang.py:137
+#: common/models/lang.py:139
 msgid "Ganda"
 msgstr "Luganda"
 
-#: common/models/lang.py:138
+#: common/models/lang.py:140
 msgid "Marshall"
 msgstr "Marshallese"
 
-#: common/models/lang.py:139
+#: common/models/lang.py:141
 msgid "Malayalam"
 msgstr "Malayalam"
 
-#: common/models/lang.py:140
+#: common/models/lang.py:142
 msgid "Marathi"
 msgstr "Marathi"
 
-#: common/models/lang.py:141
+#: common/models/lang.py:143
 msgid "Malagasy"
 msgstr "Malagascio"
 
-#: common/models/lang.py:142
+#: common/models/lang.py:144
 msgid "Maltese"
 msgstr "Maltese"
 
-#: common/models/lang.py:143
+#: common/models/lang.py:145
 msgid "Moldavian"
 msgstr "Moldavo"
 
-#: common/models/lang.py:144
+#: common/models/lang.py:146
 msgid "Mongolian"
 msgstr "Mongolo"
 
-#: common/models/lang.py:145
+#: common/models/lang.py:147
 msgid "Maori"
 msgstr "Maori"
 
-#: common/models/lang.py:146
+#: common/models/lang.py:148
 msgid "Malay"
 msgstr "Malese"
 
-#: common/models/lang.py:147
+#: common/models/lang.py:149
 msgid "Burmese"
 msgstr "Birmano"
 
-#: common/models/lang.py:148
+#: common/models/lang.py:150
 msgid "Nauru"
 msgstr "Nauruano"
 
-#: common/models/lang.py:149
+#: common/models/lang.py:151
 msgid "Navajo"
 msgstr "Navajo"
 
-#: common/models/lang.py:150 common/models/lang.py:151
+#: common/models/lang.py:152 common/models/lang.py:153
 msgid "Ndebele"
 msgstr "Ndebele"
 
-#: common/models/lang.py:152
+#: common/models/lang.py:154
 msgid "Ndonga"
 msgstr "Ndonga"
 
-#: common/models/lang.py:153
+#: common/models/lang.py:155
 msgid "Nepali"
 msgstr "Nepalese"
 
-#: common/models/lang.py:154
+#: common/models/lang.py:156
 msgid "Dutch"
 msgstr "Olandese"
 
-#: common/models/lang.py:155
+#: common/models/lang.py:157
 msgid "Norwegian Nynorsk"
 msgstr "Norvegese Nynorsk"
 
-#: common/models/lang.py:156
+#: common/models/lang.py:158
 msgid "Norwegian Bokmål"
 msgstr "Norvegese Bokmål"
 
-#: common/models/lang.py:157
+#: common/models/lang.py:159
 msgid "Norwegian"
 msgstr "Norvegese"
 
-#: common/models/lang.py:158
+#: common/models/lang.py:160
 msgid "Chichewa; Nyanja"
 msgstr "Chewa; Nyanja"
 
-#: common/models/lang.py:159
+#: common/models/lang.py:161
 msgid "Occitan"
 msgstr "Occitano"
 
-#: common/models/lang.py:160
+#: common/models/lang.py:162
 msgid "Ojibwa"
 msgstr "Ojibwe"
 
-#: common/models/lang.py:161
+#: common/models/lang.py:163
 msgid "Oriya"
 msgstr "Oriya"
 
-#: common/models/lang.py:162
+#: common/models/lang.py:164
 msgid "Oromo"
 msgstr "Oromo"
 
-#: common/models/lang.py:163
+#: common/models/lang.py:165
 msgid "Ossetian; Ossetic"
 msgstr "Osseto"
 
-#: common/models/lang.py:164
+#: common/models/lang.py:166
 msgid "Pali"
 msgstr "Pali"
 
-#: common/models/lang.py:165
+#: common/models/lang.py:167
 msgid "Polish"
 msgstr "Polacco"
 
-#: common/models/lang.py:167
+#: common/models/lang.py:169
 msgid "Quechua"
 msgstr "Quechua"
 
-#: common/models/lang.py:168
+#: common/models/lang.py:170
 msgid "Raeto-Romance"
 msgstr "Lingue retoromanze"
 
-#: common/models/lang.py:169
+#: common/models/lang.py:171
 msgid "Romanian"
 msgstr "Rumeno"
 
-#: common/models/lang.py:170
+#: common/models/lang.py:172
 msgid "Rundi"
 msgstr "Kirundi"
 
-#: common/models/lang.py:171
+#: common/models/lang.py:173
 msgid "Russian"
 msgstr "Russo"
 
-#: common/models/lang.py:172
+#: common/models/lang.py:174
 msgid "Sango"
 msgstr "Sango"
 
-#: common/models/lang.py:173
+#: common/models/lang.py:175
 msgid "Sanskrit"
 msgstr "Sanscrito"
 
-#: common/models/lang.py:174
+#: common/models/lang.py:176
 msgid "Sinhalese"
 msgstr "Singalese"
 
-#: common/models/lang.py:175
+#: common/models/lang.py:177
 msgid "Slovak"
 msgstr "Slovacco"
 
-#: common/models/lang.py:176
+#: common/models/lang.py:178
 msgid "Slovenian"
 msgstr "Sloveno"
 
-#: common/models/lang.py:177
+#: common/models/lang.py:179
 msgid "Northern Sami"
 msgstr "Sami Settentrionale"
 
-#: common/models/lang.py:178
+#: common/models/lang.py:180
 msgid "Samoan"
 msgstr "Samoano"
 
-#: common/models/lang.py:179
+#: common/models/lang.py:181
 msgid "Shona"
 msgstr "Shona"
 
-#: common/models/lang.py:180
+#: common/models/lang.py:182
 msgid "Sindhi"
 msgstr "Sindhi"
 
-#: common/models/lang.py:181
+#: common/models/lang.py:183
 msgid "Somali"
 msgstr "Somalo"
 
-#: common/models/lang.py:182
+#: common/models/lang.py:184
 msgid "Sotho"
 msgstr "Sotho"
 
-#: common/models/lang.py:184
+#: common/models/lang.py:186
 msgid "Albanian"
 msgstr "Albanese"
 
-#: common/models/lang.py:185
+#: common/models/lang.py:187
 msgid "Sardinian"
 msgstr "Sardo"
 
-#: common/models/lang.py:186
+#: common/models/lang.py:188
 msgid "Serbian"
 msgstr "Serbo"
 
-#: common/models/lang.py:187
+#: common/models/lang.py:189
 msgid "Swati"
 msgstr "Swati"
 
-#: common/models/lang.py:188
+#: common/models/lang.py:190
 msgid "Sundanese"
 msgstr "Sundanese"
 
-#: common/models/lang.py:189
+#: common/models/lang.py:191
 msgid "Swahili"
 msgstr "Swahili"
 
-#: common/models/lang.py:190
+#: common/models/lang.py:192
 msgid "Swedish"
 msgstr "Svedese"
 
-#: common/models/lang.py:191
+#: common/models/lang.py:193
 msgid "Tahitian"
 msgstr "Tahitiano"
 
-#: common/models/lang.py:192
+#: common/models/lang.py:194
 msgid "Tamil"
 msgstr "Tamil"
 
-#: common/models/lang.py:193
+#: common/models/lang.py:195
 msgid "Tatar"
 msgstr "Tataro"
 
-#: common/models/lang.py:194
+#: common/models/lang.py:196
 msgid "Telugu"
 msgstr "Telugu"
 
-#: common/models/lang.py:195
+#: common/models/lang.py:197
 msgid "Tajik"
 msgstr "Tagico"
 
-#: common/models/lang.py:196
+#: common/models/lang.py:198
 msgid "Tagalog"
 msgstr "Tagalog"
 
-#: common/models/lang.py:197
+#: common/models/lang.py:199
 msgid "Thai"
 msgstr "Thailandese"
 
-#: common/models/lang.py:198
+#: common/models/lang.py:200
 msgid "Tigrinya"
 msgstr "Tigrino"
 
-#: common/models/lang.py:199
+#: common/models/lang.py:201
 msgid "Tonga"
 msgstr "Tonga"
 
-#: common/models/lang.py:200
+#: common/models/lang.py:202
 msgid "Tswana"
 msgstr "Tswana"
 
-#: common/models/lang.py:201
+#: common/models/lang.py:203
 msgid "Tsonga"
 msgstr "Tsonga"
 
-#: common/models/lang.py:202
+#: common/models/lang.py:204
 msgid "Turkmen"
 msgstr "Turkmeno"
 
-#: common/models/lang.py:203
+#: common/models/lang.py:205
 msgid "Turkish"
 msgstr "Turco"
 
-#: common/models/lang.py:204
+#: common/models/lang.py:206
 msgid "Twi"
 msgstr "Twi"
 
-#: common/models/lang.py:205
+#: common/models/lang.py:207
 msgid "Uighur"
 msgstr "Uiguro"
 
-#: common/models/lang.py:206
+#: common/models/lang.py:208
 msgid "Ukrainian"
 msgstr "Ucraino"
 
-#: common/models/lang.py:207
+#: common/models/lang.py:209
 msgid "Urdu"
 msgstr "Urdu"
 
-#: common/models/lang.py:208
+#: common/models/lang.py:210
 msgid "Uzbek"
 msgstr "Uzbeco"
 
-#: common/models/lang.py:209
+#: common/models/lang.py:211
 msgid "Venda"
 msgstr "Venda"
 
-#: common/models/lang.py:210
+#: common/models/lang.py:212
 msgid "Vietnamese"
 msgstr "Vietnamita"
 
-#: common/models/lang.py:211
+#: common/models/lang.py:213
 msgid "Volapük"
 msgstr "Volapük"
 
-#: common/models/lang.py:212
+#: common/models/lang.py:214
 msgid "Walloon"
 msgstr "Vallone"
 
-#: common/models/lang.py:213
+#: common/models/lang.py:215
 msgid "Wolof"
 msgstr "Wolof"
 
-#: common/models/lang.py:214
+#: common/models/lang.py:216
 msgid "Xhosa"
 msgstr "Xhosa"
 
-#: common/models/lang.py:215
+#: common/models/lang.py:217
 msgid "Yiddish"
 msgstr "Yiddish"
 
-#: common/models/lang.py:216
+#: common/models/lang.py:218
 msgid "Zhuang"
 msgstr "Zhuang"
 
-#: common/models/lang.py:217
+#: common/models/lang.py:219
 msgid "Zulu"
 msgstr "Zulu"
 
-#: common/models/lang.py:218
+#: common/models/lang.py:220
 msgid "Abkhazian"
 msgstr "Abcaso"
 
-#: common/models/lang.py:219
+#: common/models/lang.py:221
 msgid "Chinese"
 msgstr "Cinese"
 
-#: common/models/lang.py:220
+#: common/models/lang.py:222
 msgid "Pushto"
 msgstr "Pashtu"
 
-#: common/models/lang.py:221
+#: common/models/lang.py:223
 msgid "Amharic"
 msgstr "Amarico"
 
-#: common/models/lang.py:222
+#: common/models/lang.py:224
 msgid "Arabic"
 msgstr "Arabo"
 
-#: common/models/lang.py:223
+#: common/models/lang.py:225
 msgid "Bulgarian"
 msgstr "Bulgaro"
 
-#: common/models/lang.py:224
+#: common/models/lang.py:226
 msgid "Macedonian"
 msgstr "Macedone"
 
-#: common/models/lang.py:225
+#: common/models/lang.py:227
 msgid "Greek"
 msgstr "Greco"
 
-#: common/models/lang.py:226
+#: common/models/lang.py:228
 msgid "Persian"
 msgstr "Persiano"
 
-#: common/models/lang.py:227
+#: common/models/lang.py:229
 msgid "Hebrew"
 msgstr "Ebraico"
 
-#: common/models/lang.py:228
+#: common/models/lang.py:230
 msgid "Hindi"
 msgstr "Hindi"
 
-#: common/models/lang.py:229
+#: common/models/lang.py:231
 msgid "Armenian"
 msgstr "Armeno"
 
-#: common/models/lang.py:231
+#: common/models/lang.py:233
 msgid "Ewe"
 msgstr "Ewe"
 
-#: common/models/lang.py:232
+#: common/models/lang.py:234
 msgid "Georgian"
 msgstr "Georgiano"
 
-#: common/models/lang.py:233
+#: common/models/lang.py:235
 msgid "Punjabi"
 msgstr "Punjabi"
 
-#: common/models/lang.py:234
+#: common/models/lang.py:236
 msgid "Bengali"
 msgstr "Bengalese"
 
-#: common/models/lang.py:235
+#: common/models/lang.py:237
 msgid "Bosnian"
 msgstr "Bosniaco"
 
-#: common/models/lang.py:236
+#: common/models/lang.py:238
 msgid "Chamorro"
 msgstr "Ciamorro"
 
-#: common/models/lang.py:237
+#: common/models/lang.py:239
 msgid "Belarusian"
 msgstr "Bielorusso"
 
-#: common/models/lang.py:238
+#: common/models/lang.py:240
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: common/models/lang.py:300
+#: common/models/lang.py:302
 msgid "Simplified Chinese (Mainland)"
 msgstr "Cinese Semplificato (Cina continentale)"
 
-#: common/models/lang.py:301
+#: common/models/lang.py:303
 msgid "Traditional Chinese (Taiwan)"
 msgstr "Cinese Tradizionale (Taiwan)"
 
-#: common/models/lang.py:302
+#: common/models/lang.py:304
 msgid "Traditional Chinese (Hongkong)"
 msgstr "Cinese Tradizionale (Hong Kong)"
 
-#: common/models/lang.py:310
+#: common/models/lang.py:312
 msgid "Portuguese (Brazil)"
 msgstr "Portoghese (Brasile)"
 
-#: common/models/lang.py:313
+#: common/models/lang.py:315
 msgid "Simplified Chinese (Singapore)"
 msgstr "Cinese Semplificato (Singapore)"
 
-#: common/models/lang.py:314
+#: common/models/lang.py:316
 msgid "Simplified Chinese (Malaysia)"
 msgstr "Cinese Semplificato (Malesia)"
 
-#: common/models/lang.py:315
+#: common/models/lang.py:317
 msgid "Traditional Chinese (Macau)"
 msgstr "Cinese Tradizionale (Macau)"
 
-#: common/models/lang.py:323
+#: common/models/lang.py:325
 msgid "Mandarin Chinese"
 msgstr "Cinese Mandarino"
 
-#: common/models/lang.py:324
+#: common/models/lang.py:326
 msgid "Yue Chinese"
 msgstr "Cinese Cantonese"
 
-#: common/models/lang.py:328
+#: common/models/lang.py:330
 msgid "Min Nan Chinese"
 msgstr "Cinese Minnan"
 
-#: common/models/lang.py:329
+#: common/models/lang.py:331
 msgid "Wu Chinese"
 msgstr "Cinese Wu"
 
-#: common/models/lang.py:330
+#: common/models/lang.py:332
 msgid "Hakka Chinese"
 msgstr "Cinese Hakka"
 
@@ -3994,62 +4022,37 @@ msgid "VCD"
 msgstr ""
 
 #: common/templates/400.html:23
-msgid ""
-"You may have submitted invalid data, or the content may have been deleted by "
-"the author."
-msgstr ""
-"Potresti aver inserito dati non validi, oppure il contenuto potrebbe essere "
-"stato eliminato dall'autore."
+msgid "You may have submitted invalid data, or the content may have been deleted by the author."
+msgstr "Potresti aver inserito dati non validi, oppure il contenuto potrebbe essere stato eliminato dall'autore."
 
 #: common/templates/400.html:25 common/templates/403.html:24
 #: common/templates/404.html:24
-msgid ""
-"If you believe this is our mistake, please contact us through the link at "
-"the bottom of the page."
-msgstr ""
-"Se credi che questo sia un nostro errore, contattaci tramite il link in "
-"fondo alla pagina."
+msgid "If you believe this is our mistake, please contact us through the link at the bottom of the page."
+msgstr "Se credi che questo sia un nostro errore, contattaci tramite il link in fondo alla pagina."
 
 #: common/templates/403.html:22
-msgid ""
-"Author may require you to log in before accessing this content, or you do "
-"not have permission to view it."
-msgstr ""
-"L'autore potrebbe richiedere che tu faccia l'accesso prima di poter accedere "
-"a questo contenuto, oppure potresti non avere il permesso per poterlo "
-"visualizzare."
+msgid "Author may require you to log in before accessing this content, or you do not have permission to view it."
+msgstr "L'autore potrebbe richiedere che tu faccia l'accesso prima di poter accedere a questo contenuto, oppure potresti non avere il permesso per poterlo visualizzare."
 
 #: common/templates/404.html:20
 msgid "Something is missing"
 msgstr "Manca qualcosa"
 
 #: common/templates/404.html:22
-msgid ""
-"You may have visited an incorrect URL, or the content you are looking for "
-"has been deleted by the author."
-msgstr ""
-"Potresti aver visitato un URL non corretto, oppure il contenuto che stai "
-"cercando è stato eliminato dall'autore."
+msgid "You may have visited an incorrect URL, or the content you are looking for has been deleted by the author."
+msgstr "Potresti aver visitato un URL non corretto, oppure il contenuto che stai cercando è stato eliminato dall'autore."
 
 #: common/templates/404.html:26
 msgid "Go to Home"
 msgstr ""
 
 #: common/templates/500.html:22
-msgid ""
-"An internal error occurred. If this error occurs repeatedly, it will be "
-"recorded and handled by a human."
-msgstr ""
-"È stato prodotto un errore interno. Se questo errore accade ripetutamente, "
-"verrà registrato e gestito da un umano."
+msgid "An internal error occurred. If this error occurs repeatedly, it will be recorded and handled by a human."
+msgstr "È stato prodotto un errore interno. Se questo errore accade ripetutamente, verrà registrato e gestito da un umano."
 
 #: common/templates/500.html:24
-msgid ""
-"If you have an urgent situation or any questions, please contact us through "
-"the link at the bottom of the page."
-msgstr ""
-"Se hai una questione urgente da risolvere o qualsiasi domanda, contattaci "
-"attraverso il link in fondo alla pagina."
+msgid "If you have an urgent situation or any questions, please contact us through the link at the bottom of the page."
+msgstr "Se hai una questione urgente da risolvere o qualsiasi domanda, contattaci attraverso il link in fondo alla pagina."
 
 #: common/templates/_footer.html:6
 msgid "Rules"
@@ -4063,286 +4066,225 @@ msgstr "Termini"
 msgid "About"
 msgstr ""
 
-#: common/templates/_footer.html:12 users/templates/users/login.html:265
+#: common/templates/_footer.html:12 users/templates/users/login.html:259
 #, python-format
-msgid ""
-"You are visiting an alternative domain for %(site_name)s, please always use "
-"<a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if "
-"possible."
-msgstr ""
-"Stai visitando un dominio alternativo per %(site_name)s, si prega di usare "
-"sempre <a href=\"%(site_url)s%(request.get_full_path)s\">versione originale</"
-"a> se possibile."
+msgid "You are visiting an alternative domain for %(site_name)s, please always use <a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if possible."
+msgstr "Stai visitando un dominio alternativo per %(site_name)s, si prega di usare sempre <a href=\"%(site_url)s%(request.get_full_path)s\">versione originale</a> se possibile."
 
-#: common/templates/_header.html:19 common/templates/_header.html:164
+#: common/templates/_header.html:19 common/templates/_header.html:177
 msgid "title, creator, ISBN, item url, @user, @user@instance"
 msgstr "titolo, creatore, ISBN, URL dell'elemento, @utente. @utente@istanza"
 
-#: common/templates/_header.html:24
+#: common/templates/_header.html:34
 msgid "All Items"
 msgstr "Tutti gli elementi"
 
-#: common/templates/_header.html:31
+#: common/templates/_header.html:41
 msgid "Movie & TV"
 msgstr "Film e TV"
 
-#: common/templates/_header.html:50
+#: common/templates/_header.html:60
 msgid "People & Organizations"
 msgstr ""
 
-#: common/templates/_header.html:52
+#: common/templates/_header.html:62
 msgid "Journal"
 msgstr "Diario"
 
-#: common/templates/_header.html:54 journal/templates/user_post_list.html:10
+#: common/templates/_header.html:64 journal/templates/user_post_list.html:10
 #: journal/templates/user_post_list.html:23
 msgid "Posts"
 msgstr "Post"
 
-#: common/templates/_header.html:89
+#: common/templates/_header.html:102
 msgid "Explore"
 msgstr "Esplora"
 
-#: common/templates/_header.html:93
+#: common/templates/_header.html:106 common/views_manage.py:36
 msgid "Feed"
 msgstr "Feed"
 
-#: common/templates/_header.html:98 journal/templates/profile.html:13
+#: common/templates/_header.html:111 journal/templates/profile.html:13
 #: users/templates/users/preferences.html:46
 msgid "Home"
 msgstr "Home"
 
-#: common/templates/_header.html:114 common/templates/common/scan.html:9
+#: common/templates/_header.html:127 common/templates/common/scan.html:9
 #: common/templates/common/scan.html:42
 #, fuzzy
 #| msgid "barcode"
 msgid "Scan Barcode"
 msgstr "codice a barre"
 
-#: common/templates/_header.html:118 social/templates/notification.html:12
+#: common/templates/_header.html:131 social/templates/notification.html:12
 #: social/templates/notification.html:53
 msgid "Notification"
 msgstr "Notifiche"
 
-#: common/templates/_header.html:122 users/models/task.py:21
+#: common/templates/_header.html:135 users/models/task.py:23
 #: users/templates/users/account.html:219
 #: users/templates/users/crossposts.html:9
 msgid "Pending"
 msgstr "In attesa"
 
-#: common/templates/_header.html:125
+#: common/templates/_header.html:138
 msgid "Data"
 msgstr "Dati"
 
-#: common/templates/_header.html:128 common/templates/_header.html:146
+#: common/templates/_header.html:141 common/templates/_header.html:159
 #: users/templates/users/preferences.html:12
 #: users/templates/users/preferences.html:23
 #: users/templates/users/preferences_anonymous.html:13
 msgid "Preferences"
 msgstr "Preferenze"
 
-#: common/templates/_header.html:131
+#: common/templates/_header.html:144
 msgid "Account"
 msgstr "Account"
 
-#: common/templates/_header.html:135
+#: common/templates/_header.html:148
 msgid "Manage"
 msgstr "Gestisci"
 
-#: common/templates/_header.html:139
+#: common/templates/_header.html:152
 msgid "Logout"
 msgstr "Esci"
 
-#: common/templates/_header.html:143
+#: common/templates/_header.html:156
 msgid "Sign up or Login"
 msgstr "Iscriviti o Accedi"
 
-#: common/templates/_header.html:160
-msgid ""
-"title or content  category:tv  status:complete  rating:8..10  "
-"date:2021-09-11..2022-02"
-msgstr ""
-"titolo o contenuto  categoria:tv  status:completo  valutazione:8..10  "
-"data:2021-09-11..2022-02"
+#: common/templates/_header.html:173
+msgid "title or content  category:tv  status:complete  rating:8..10  date:2021-09-11..2022-02"
+msgstr "titolo o contenuto  categoria:tv  status:completo  valutazione:8..10  data:2021-09-11..2022-02"
 
-#: common/templates/_header.html:162
+#: common/templates/_header.html:175
 msgid "name of a person or company"
 msgstr ""
 
-#: common/templates/_header.html:179
+#: common/templates/_header.html:192
 msgid "Open"
 msgstr "Aperto"
 
-#: common/templates/_sidebar.html:62
+#: common/templates/_sidebar.html:61
 #: users/templates/users/profile_actions.html:36
 msgid "approving followers manually"
 msgstr "approvare i seguaci manualmente"
 
-#: common/templates/_sidebar.html:81 common/templates/_sidebar.html:86
+#: common/templates/_sidebar.html:80 common/templates/_sidebar.html:85
 #, fuzzy
 #| msgid "followed"
 msgid "followers"
 msgstr "seguiti"
 
-#: common/templates/_sidebar.html:112
+#: common/templates/_sidebar.html:111
 msgid "Current Targets"
 msgstr "Obbiettivi in corso"
 
-#: common/templates/_sidebar.html:125
+#: common/templates/_sidebar.html:124
 msgid "Set a collection as target, its progress will show up here."
-msgstr ""
-"Imposta come obbiettivo una collezione e i tuoi progressi verranno "
-"visualizzati quassù."
+msgstr "Imposta come obbiettivo una collezione e i tuoi progressi verranno visualizzati quassù."
 
-#: common/templates/_sidebar.html:138
+#: common/templates/_sidebar.html:137
 msgid "Recent podcast episodes"
 msgstr "Episodi podcast recenti"
 
-#: common/templates/_sidebar.html:173
+#: common/templates/_sidebar.html:172
 msgid "Currently reading"
 msgstr "Letture in corso"
 
-#: common/templates/_sidebar.html:215
+#: common/templates/_sidebar.html:214
 msgid "Currently watching"
 msgstr "Visioni in corso"
 
-#: common/templates/_sidebar.html:238 journal/forms.py:217
+#: common/templates/_sidebar.html:237 journal/forms.py:217
 #: journal/templates/user_tag_list.html:13
 #: journal/templates/user_tagmember_list.html:4
 msgid "Tags"
 msgstr "Tag"
 
-#: common/templates/_sidebar.html:244 journal/templates/user_tag_list.html:28
+#: common/templates/_sidebar.html:243 journal/templates/user_tag_list.html:28
 #: journal/templates/user_tagmember_list.html:10
 msgid "featured tag"
 msgstr "tag in evidenza"
 
-#: common/templates/_sidebar.html:247 journal/templates/user_tag_list.html:31
+#: common/templates/_sidebar.html:246 journal/templates/user_tag_list.html:31
 #: journal/templates/user_tagmember_list.html:15
 msgid "personal tag"
 msgstr "tag personale"
 
-#: common/templates/_sidebar.html:254 journal/templates/user_tag_list.html:39
+#: common/templates/_sidebar.html:253 journal/templates/user_tag_list.html:39
 msgid "no tags so far."
 msgstr "nessun tag fino ad ora."
 
-#: common/templates/_sidebar.html:258 common/templates/_sidebar.html:271
+#: common/templates/_sidebar.html:257 common/templates/_sidebar.html:270
 msgid "show all"
 msgstr "mostra tutto"
 
-#: common/templates/_sidebar_anonymous.html:16
+#: common/templates/_sidebar_anonymous.html:15
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
 #| "        <h3>Welcome 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s "
-#| "is committed to creating a free, open, and interconnected space for "
-#| "collecting and reviewing books, movies, music, games, and podcasts. Here, "
-#| "you can document your collections and thoughts, discover new content, and "
-#| "connect with others.\n"
+#| "          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is committed to creating a free, open, and interconnected space for collecting and reviewing books, movies, music, games, and podcasts. Here, you can document your collections and thoughts, discover new content, and connect with others.\n"
 #| "        </p>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log "
-#| "in to %(site_name)s is through a Fediverse (a distributed social network, "
-#| "including Mastodon/Pleroma/etc) instance account. If you haven’t "
-#| "registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" "
-#| "target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
+#| "          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in to %(site_name)s is through a Fediverse (a distributed social network, including Mastodon/Pleroma/etc) instance account. If you haven’t registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
 #| "        </p>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not "
-#| "ready to join the Fediverse, that’s perfectly fine. You can create an "
-#| "account here using your email address, and link it to the Fediverse "
-#| "whenever you’re ready.\n"
+#| "          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready to join the Fediverse, that’s perfectly fine. You can create an account here using your email address, and link it to the Fediverse whenever you’re ready.\n"
 #| "        </p>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you "
-#| "have any questions or suggestions, feel free to contact us via <a "
-#| "href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a "
-#| "href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
+#| "          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have any questions or suggestions, feel free to contact us via <a href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 #| "        </p>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-#| "href=\"%(login_url)s\">Click here</a> to register or log in.\n"
+#| "          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Click here</a> to register or log in.\n"
 #| "        </p>\n"
 #| "        "
 msgid ""
 "\n"
 "        <h3>Welcome 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is "
-"committed to creating a free, open, and interconnected space for collecting "
-"and reviewing books, movies, music, games, and podcasts. Here, you can "
-"manage your collections, share your thoughts, discover new content, and "
-"connect with others.\n"
+"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is committed to creating a free, open, and interconnected space for collecting and reviewing books, movies, music, games, and podcasts. Here, you can manage your collections, share your thoughts, discover new content, and connect with others.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in "
-"to %(site_name)s is through a Fediverse (a distributed social network, "
-"including Mastodon/Pleroma/etc) instance account. If you haven’t registered "
-"yet, you can <a href=\"https://joinmastodon.org/en/servers\" "
-"target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
+"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in to %(site_name)s is through a Fediverse (a distributed social network, including Mastodon/Pleroma/etc) instance account. If you haven’t registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log "
-"in is through a Bluesky (another distributed social network, also called "
-"ATProto) account. If you haven’t registered yet, you may <a href=\"https://"
-"bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
+"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log in is through a Bluesky (another distributed social network, also called ATProto) account. If you haven’t registered yet, you may <a href=\"https://bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready "
-"to join either Fediverse or Bluesky, that’s perfectly fine. You can create "
-"an account here using your email address, and link it to the Fediverse and "
-"Bluesky in settings whenever you’re ready.\n"
+"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready to join either Fediverse or Bluesky, that’s perfectly fine. You can create an account here using your email address, and link it to the Fediverse and Bluesky in settings whenever you’re ready.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have "
-"any questions or suggestions, please feel free to contact us via <a "
-"href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://"
-"discord.gg/uprvcH8gqD\">Discord</a>.\n"
+"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have any questions or suggestions, please feel free to contact us via <a href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-"href=\"%(login_url)s\">Click here</a> to register or log in.\n"
+"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Click here</a> to register or log in.\n"
 "        </p>\n"
 "        "
 msgstr ""
 "\n"
 "        <h3>Benvenuti 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s si "
-"impegna a creare uno spazio gratis, libero, aperto e interconnesso per "
-"collezionare e recensire libri, film, musica, giochi e podcast. Qui puoi "
-"documentare le tue collezioni e i tuoi pensieri, scoprire nuovi contenuti e "
-"connetterti con gli altri utenti.\n"
+"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s si impegna a creare uno spazio gratis, libero, aperto e interconnesso per collezionare e recensire libri, film, musica, giochi e podcast. Qui puoi documentare le tue collezioni e i tuoi pensieri, scoprire nuovi contenuti e connetterti con gli altri utenti.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-globe\"></i> &nbsp; Il miglior modo di "
-"accedere a %(site_name)s è attraverso un account che fa parte di un'istanza "
-"del Fediverso (il social network decentralizzato che include Mastodon/"
-"Pleroma/etc). Se non ti sei ancora registrato puoi <a href=\"https://"
-"joinmastodon.org/en/servers\" target=\"_blank\">scegliere un'istanza del "
-"Fediverso e iscriverti</a>.\n"
+"          <i class=\"fa-solid fa-globe\"></i> &nbsp; Il miglior modo di accedere a %(site_name)s è attraverso un account che fa parte di un'istanza del Fediverso (il social network decentralizzato che include Mastodon/Pleroma/etc). Se non ti sei ancora registrato puoi <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">scegliere un'istanza del Fediverso e iscriverti</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; Se non sei pronto ad "
-"unirti al Fediverso, va bene lo stesso. Puoi creare un account qui usando il "
-"tuo indirizzo email e collegare il profilo al Fediverso appena ti senti "
-"pronto.\n"
+"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; Se non sei pronto ad unirti al Fediverso, va bene lo stesso. Puoi creare un account qui usando il tuo indirizzo email e collegare il profilo al Fediverso appena ti senti pronto.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; Se hai "
-"qualsiasi domanda o suggerimento, sentiti libero di contattarci tramite <a "
-"href=\"https://mastodon.social/@neodb\">Fediverso</a> oppure <a "
-"href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
+"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; Se hai qualsiasi domanda o suggerimento, sentiti libero di contattarci tramite <a href=\"https://mastodon.social/@neodb\">Fediverso</a> oppure <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-"href=\"%(login_url)s\">Clicca qui</a> per registrarti o fare l'accesso.\n"
+"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Clicca qui</a> per registrarti o fare l'accesso.\n"
 "        </p>\n"
 "        "
 
-#: common/templates/_sidebar_anonymous.html:43
+#: common/templates/_sidebar_anonymous.html:42
 #: users/templates/users/announcements.html:12
 #: users/templates/users/announcements.html:39
 msgid "Announcements"
@@ -4370,7 +4312,7 @@ msgstr "Codice Sorgente"
 msgid "Registration"
 msgstr "Registrazione fallita"
 
-#: common/templates/common/about.html:35 common/views_manage.py:493
+#: common/templates/common/about.html:35 common/views_manage.py:594
 #, fuzzy
 #| msgid "Mentioned Only"
 msgid "Invite Only"
@@ -4382,7 +4324,7 @@ msgstr "Solo Menzionati"
 msgid "Open Registration"
 msgstr "Registrazione fallita"
 
-#: common/templates/common/about.html:40 common/views_manage.py:556
+#: common/templates/common/about.html:40 common/views_manage.py:657
 #, fuzzy
 #| msgid "Preferences"
 msgid "Preferred Languages"
@@ -4437,9 +4379,7 @@ msgid "Error"
 msgstr "Errore"
 
 #: common/templates/common/scan.html:45
-msgid ""
-"Point the camera at a book ISBN or product barcode (EAN / UPC). You will be "
-"redirected to the search once a code is detected."
+msgid "Point the camera at a book ISBN or product barcode (EAN / UPC). You will be redirected to the search once a code is detected."
 msgstr ""
 
 #: common/templates/common/scan.html:50
@@ -4450,7 +4390,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:628
+#: common/templates/common/scan.html:60 common/views_manage.py:738
 #, fuzzy
 #| msgid "Search results"
 msgid "Search"
@@ -4484,21 +4424,33 @@ msgstr ""
 msgid "Camera unavailable. Use manual entry below."
 msgstr ""
 
-#: common/templates/manage/settings.html:9
+#: common/templates/manage/base.html:9
 #, fuzzy
 #| msgid "Additional Settings"
 msgid "Site Settings"
 msgstr "Impostazioni aggiuntive"
 
-#: common/templates/manage/settings.html:109
+#: common/templates/manage/base.html:127
 msgid "Takahe Admin"
 msgstr ""
 
-#: common/templates/manage/settings.html:112
+#: common/templates/manage/base.html:130
 #, fuzzy
 #| msgid "Database"
 msgid "Database Admin"
 msgstr "Database"
+
+#: common/templates/manage/environment.html:6
+msgid "These settings come from environment variables and cannot be changed here. Edit .env and restart the server to change them. Passwords and keys are hidden."
+msgstr ""
+
+#: common/templates/manage/environment.html:23
+msgid "(empty)"
+msgstr ""
+
+#: common/templates/manage/environment.html:26
+msgid "default"
+msgstr ""
 
 #: common/templatetags/duration.py:59
 msgid "just now"
@@ -4516,7 +4468,7 @@ msgstr "seguiti"
 msgid "following you"
 msgstr "ti seguono"
 
-#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:95
+#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:90
 msgid "you"
 msgstr "tu"
 
@@ -4524,874 +4476,887 @@ msgstr "tu"
 msgid "unavailable"
 msgstr "non disponibile"
 
-#: common/utils.py:126 common/utils.py:167 users/views/actions.py:134
+#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr "L'utente non esiste più"
 
-#: common/utils.py:133 common/utils.py:135 common/utils.py:138
-#: common/utils.py:174 common/utils.py:178 journal/views/profile.py:499
+#: common/utils.py:135 common/utils.py:137 common/utils.py:140
+#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
 msgid "Access denied"
 msgstr "Accesso negato"
 
-#: common/utils.py:141 common/utils.py:143 journal/views/article.py:204
+#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr "Richiesto l'accesso"
 
-#: common/views_manage.py:144 common/views_manage.py:295
+#: common/views_manage.py:34 common/views_manage.py:373
 #, fuzzy
 #| msgid "reading"
 msgid "Branding"
 msgstr "leggendo"
 
-#: common/views_manage.py:146
+#: common/views_manage.py:37
 #, fuzzy
 #| msgid "comments"
 msgid "Recommendations"
 msgstr "Commenti"
 
-#: common/views_manage.py:147
+#: common/views_manage.py:38
 #, fuzzy
 #| msgid "Access denied"
 msgid "Access"
 msgstr "Accesso negato"
 
-#: common/views_manage.py:148 common/views_manage.py:623
+#: common/views_manage.py:39 common/views_manage.py:733
 #, fuzzy
 #| msgid "duration"
 msgid "Federation"
 msgstr "durata"
 
-#: common/views_manage.py:149
+#: common/views_manage.py:40
 #, fuzzy
 #| msgid "Catalan"
 msgid "Catalog"
 msgstr "Catalano"
 
-#: common/views_manage.py:150
+#: common/views_manage.py:41
 msgid "API Keys"
 msgstr ""
 
-#: common/views_manage.py:151
+#: common/views_manage.py:42
 #, fuzzy
 #| msgid "Download"
 msgid "Downloader"
 msgstr "Scarica"
 
-#: common/views_manage.py:152 common/views_manage.py:303
+#: common/views_manage.py:43 common/views_manage.py:381
 #: users/templates/users/steam_import.html:113
 msgid "Advanced"
 msgstr ""
 
-#: common/views_manage.py:202
+#: common/views_manage.py:44
+msgid "Environment"
+msgstr ""
+
+#: common/views_manage.py:280
 #, fuzzy
 #| msgid "Invalid user."
 msgid "Invalid value."
 msgstr "Utente non valido."
 
-#: common/views_manage.py:206
+#: common/views_manage.py:284
 msgid "Invalid configuration. Please check your input."
 msgstr ""
 
-#: common/views_manage.py:211
+#: common/views_manage.py:289
 #, fuzzy
 #| msgid "Settings saved."
 msgid "Settings have been saved."
 msgstr "Impostazioni salvate."
 
-#: common/views_manage.py:231
+#: common/views_manage.py:309
 msgid "Site Name"
 msgstr ""
 
-#: common/views_manage.py:234
+#: common/views_manage.py:312
 #, fuzzy
 #| msgid "Title and Description"
 msgid "Site Description"
 msgstr "Titolo e Descrizione"
 
-#: common/views_manage.py:235
+#: common/views_manage.py:313
 msgid "Short description shown in metadata and about page."
 msgstr ""
 
-#: common/views_manage.py:238
+#: common/views_manage.py:316
 msgid "Site Logo URL"
 msgstr ""
 
-#: common/views_manage.py:239
+#: common/views_manage.py:317
 msgid "URL path to the site logo image."
 msgstr ""
 
-#: common/views_manage.py:242
+#: common/views_manage.py:320
 msgid "Site Icon URL"
 msgstr ""
 
-#: common/views_manage.py:243
+#: common/views_manage.py:321
 msgid "URL path to the site icon/favicon."
 msgstr ""
 
-#: common/views_manage.py:246
+#: common/views_manage.py:324
 msgid "Default User Avatar URL"
 msgstr ""
 
-#: common/views_manage.py:247
+#: common/views_manage.py:325
 msgid "URL path to the default user avatar."
 msgstr ""
 
-#: common/views_manage.py:250
+#: common/views_manage.py:328
 msgid "Site Color Theme"
 msgstr ""
 
-#: common/views_manage.py:251
+#: common/views_manage.py:329
 msgid "PicoCSS color theme."
 msgstr ""
 
-#: common/views_manage.py:276
+#: common/views_manage.py:354
 #, fuzzy
 #| msgid "Production"
 msgid "Site Introduction"
 msgstr "Produzione"
 
-#: common/views_manage.py:277
+#: common/views_manage.py:355
 msgid "URL path for the intro/welcome sidebar page."
 msgstr ""
 
-#: common/views_manage.py:280
+#: common/views_manage.py:358
 msgid "Custom HTML Head"
 msgstr ""
 
-#: common/views_manage.py:281
+#: common/views_manage.py:359
 msgid "Extra HTML injected into the <head> of all pages."
 msgstr ""
 
-#: common/views_manage.py:285
+#: common/views_manage.py:363
 msgid "Footer Links"
 msgstr ""
 
-#: common/views_manage.py:286
+#: common/views_manage.py:364
 msgid "Link title mapped to URL."
 msgstr ""
 
-#: common/views_manage.py:315
+#: common/views_manage.py:393
 msgid "Minimum Marks for Discover"
 msgstr ""
 
-#: common/views_manage.py:317
+#: common/views_manage.py:395
 msgid "Number of marks required for an item to appear in discover."
 msgstr ""
 
-#: common/views_manage.py:322
+#: common/views_manage.py:400
 msgid "Update Interval (minutes)"
 msgstr ""
 
-#: common/views_manage.py:323
+#: common/views_manage.py:401
 msgid "How often to refresh the popular items list."
 msgstr ""
 
-#: common/views_manage.py:327
+#: common/views_manage.py:405
 msgid "Filter by Preferred Languages"
 msgstr ""
 
-#: common/views_manage.py:328
+#: common/views_manage.py:406
 msgid "Only show items with titles in the preferred languages."
 msgstr ""
 
-#: common/views_manage.py:331
+#: common/views_manage.py:409
 #, fuzzy
 #| msgid "show all"
 msgid "Show Local Only"
 msgstr "mostra tutto"
 
-#: common/views_manage.py:333
+#: common/views_manage.py:411
 msgid "Only show items marked by local users, not the entire network."
 msgstr ""
 
-#: common/views_manage.py:337
+#: common/views_manage.py:415
 #, fuzzy
 #| msgid "Popular Tags"
 msgid "Show Popular Posts"
 msgstr "Tag popolari"
 
-#: common/views_manage.py:338
+#: common/views_manage.py:416
 msgid "Show popular public posts instead of recent ones."
 msgstr ""
 
-#: common/views_manage.py:341
+#: common/views_manage.py:419
 #, fuzzy
 #| msgid "Popular Tags"
 msgid "Show Popular Tags"
 msgstr "Tag popolari"
 
-#: common/views_manage.py:342
+#: common/views_manage.py:420
 msgid "Show popular public tags on the discover page."
 msgstr ""
 
-#: common/views_manage.py:345
+#: common/views_manage.py:423
 #, fuzzy
 #| msgid "Spotify Podcast"
 msgid "Show Verified Podcasts"
 msgstr "Podcast Spotify"
 
-#: common/views_manage.py:347
-msgid ""
-"Show a shelf of recent episodes from podcasts with a verified creator on the "
-"discover page."
+#: common/views_manage.py:425
+msgid "Show a shelf of recent episodes from podcasts with a verified creator on the discover page."
 msgstr ""
 
-#: common/views_manage.py:386
+#: common/views_manage.py:447
+#, fuzzy
+#| msgid "your timeline"
+msgid "Show World Timeline"
+msgstr "la tua timeline"
+
+#: common/views_manage.py:449
+msgid "Offer a tab with public posts from this site and every server it federates with."
+msgstr ""
+
+#: common/views_manage.py:454
+#, fuzzy
+#| msgid "show all"
+msgid "Show Local Timeline"
+msgstr "mostra tutto"
+
+#: common/views_manage.py:455
+msgid "Offer a tab with public posts from this site only."
+msgstr ""
+
+#: common/views_manage.py:459
+#, fuzzy
+#| msgid "your timeline"
+msgid "Timelines"
+msgstr "la tua timeline"
+
+#: common/views_manage.py:487
 msgid "Enable Recommendations"
 msgstr ""
 
-#: common/views_manage.py:388
-msgid ""
-"Master switch. When off, all recommendation surfaces are hidden and the cron "
-"jobs are not scheduled."
+#: common/views_manage.py:489
+msgid "Master switch. When off, all recommendation surfaces are hidden and the cron jobs are not scheduled."
 msgstr ""
 
-#: common/views_manage.py:393
+#: common/views_manage.py:494
 msgid "Source Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:395
-msgid ""
-"Minimum public marks an item needs before similarity rows are built for it."
+#: common/views_manage.py:496
+msgid "Minimum public marks an item needs before similarity rows are built for it."
 msgstr ""
 
-#: common/views_manage.py:401
+#: common/views_manage.py:502
 msgid "Target Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:403
-msgid ""
-"Minimum public marks an item needs to be eligible as a recommendation target."
+#: common/views_manage.py:504
+msgid "Minimum public marks an item needs to be eligible as a recommendation target."
 msgstr ""
 
-#: common/views_manage.py:409
+#: common/views_manage.py:510
 msgid "Top-K Similar Items per Source"
 msgstr ""
 
-#: common/views_manage.py:410
+#: common/views_manage.py:511
 msgid "Number of similar items stored per source item."
 msgstr ""
 
-#: common/views_manage.py:414
+#: common/views_manage.py:515
 msgid "Top-N Recommendations per User"
 msgstr ""
 
-#: common/views_manage.py:415
+#: common/views_manage.py:516
 msgid "Number of personalised rows stored per user."
 msgstr ""
 
-#: common/views_manage.py:419
+#: common/views_manage.py:520
 msgid "Dampen Heavy Shelvers"
 msgstr ""
 
-#: common/views_manage.py:421
-msgid ""
-"Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-"
-"shelvers in similarity scoring."
+#: common/views_manage.py:522
+msgid "Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-shelvers in similarity scoring."
 msgstr ""
 
-#: common/views_manage.py:426
+#: common/views_manage.py:527
 msgid "Per-User Mark Cap (training)"
 msgstr ""
 
-#: common/views_manage.py:428
-msgid ""
-"Truncate each user's contribution to their N most recent marks when building "
-"the similarity matrix."
+#: common/views_manage.py:529
+msgid "Truncate each user's contribution to their N most recent marks when building the similarity matrix."
 msgstr ""
 
-#: common/views_manage.py:434
+#: common/views_manage.py:535
 msgid "Active-User Window (days)"
 msgstr ""
 
-#: common/views_manage.py:436
-msgid ""
-"Refresh personalised recommendations for users with at least one public mark "
-"in the last N days."
+#: common/views_manage.py:537
+msgid "Refresh personalised recommendations for users with at least one public mark in the last N days."
 msgstr ""
 
-#: common/views_manage.py:442
+#: common/views_manage.py:543
 msgid "Per-User Seed Cap (serving)"
 msgstr ""
 
-#: common/views_manage.py:444
-msgid ""
-"Number of recent marks used as seeds when scoring personalised "
-"recommendations for one user."
+#: common/views_manage.py:545
+msgid "Number of recent marks used as seeds when scoring personalised recommendations for one user."
 msgstr ""
 
-#: common/views_manage.py:450
+#: common/views_manage.py:551
 msgid "Lazy Refresh TTL (days)"
 msgstr ""
 
-#: common/views_manage.py:452
-msgid ""
-"How long cached on-demand recommendations are valid before the next request "
-"triggers a refresh."
+#: common/views_manage.py:553
+msgid "How long cached on-demand recommendations are valid before the next request triggers a refresh."
 msgstr ""
 
-#: common/views_manage.py:458
+#: common/views_manage.py:559
 msgid "Circles Window (days)"
 msgstr ""
 
-#: common/views_manage.py:460
-msgid ""
-"Look back N days when finding items recently marked by people the viewer "
-"follows."
+#: common/views_manage.py:561
+msgid "Look back N days when finding items recently marked by people the viewer follows."
 msgstr ""
 
-#: common/views_manage.py:467
+#: common/views_manage.py:568
 msgid "Master Switch"
 msgstr ""
 
-#: common/views_manage.py:470
+#: common/views_manage.py:571
 msgid "Similarity Builder"
 msgstr ""
 
-#: common/views_manage.py:477
+#: common/views_manage.py:578
 #, fuzzy
 #| msgid "Personal"
 msgid "Personalisation"
 msgstr "Personale"
 
-#: common/views_manage.py:495
-msgid ""
-"Require an invite token to register. Invite tokens can be generated with "
-"neodb-manage invite --create."
+#: common/views_manage.py:596
+msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
 msgstr ""
 
-#: common/views_manage.py:500
+#: common/views_manage.py:601
 msgid "Enable Local-Only Posting"
 msgstr ""
 
-#: common/views_manage.py:501
+#: common/views_manage.py:602
 msgid "Allow users to create posts visible only to local users."
 msgstr ""
 
-#: common/views_manage.py:504
+#: common/views_manage.py:605
 msgid "Mastodon Login Whitelist"
 msgstr ""
 
-#: common/views_manage.py:505
+#: common/views_manage.py:606
 msgid "One domain per line. Leave empty to allow any instance."
 msgstr ""
 
-#: common/views_manage.py:508
+#: common/views_manage.py:609
 #, fuzzy
 #| msgid "Registration failed"
 msgid "Registration Captcha Items"
 msgstr "Registrazione fallita"
 
-#: common/views_manage.py:512
-msgid ""
-"Number of item covers a new user must sort into two category rows before "
-"choosing a username. 0 disables the captcha; 5-6 is recommended. The covers "
-"carry no title text, so this cannot be solved with a screen reader: if you "
-"enable it, keep another way in, such as an invite link."
+#: common/views_manage.py:613
+msgid "Number of item covers a new user must sort into two category rows before choosing a username. 0 disables the captcha; 5-6 is recommended. The covers carry no title text, so this cannot be solved with a screen reader: if you enable it, keep another way in, such as an invite link."
 msgstr ""
 
-#: common/views_manage.py:520
+#: common/views_manage.py:621
 msgid "Registration Captcha Minimum Marks"
 msgstr ""
 
-#: common/views_manage.py:523
-msgid ""
-"Marks an item needs before the captcha treats it as well known enough to be "
-"recognizable. Categories with too few such items fall back to any item."
+#: common/views_manage.py:624
+msgid "Marks an item needs before the captcha treats it as well known enough to be recognizable. Categories with too few such items fall back to any item."
 msgstr ""
 
-#: common/views_manage.py:529
+#: common/views_manage.py:630
 msgid "Enable Mastodon Login"
 msgstr ""
 
-#: common/views_manage.py:532
+#: common/views_manage.py:633
 #, fuzzy
 #| msgid "Bluesky Login ID"
 msgid "Enable Bluesky Login"
 msgstr "Login ID Bluesky"
 
-#: common/views_manage.py:535
+#: common/views_manage.py:636
 msgid "Enable Threads Login"
 msgstr ""
 
-#: common/views_manage.py:538
+#: common/views_manage.py:639
 #, fuzzy
 #| msgid "Email"
 msgid "Email URL"
 msgstr "Email"
 
-#: common/views_manage.py:540
+#: common/views_manage.py:641
 msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
 msgstr ""
 
-#: common/views_manage.py:544
+#: common/views_manage.py:645
 #, fuzzy
 #| msgid "Email"
 msgid "Email From"
 msgstr "Email"
 
-#: common/views_manage.py:545
+#: common/views_manage.py:646
 msgid "Sender name and address for outgoing email."
 msgstr ""
 
-#: common/views_manage.py:548
+#: common/views_manage.py:649
 #, fuzzy
 #| msgid "Language"
 msgid "Default Language"
 msgstr "Lingua"
 
-#: common/views_manage.py:551
-msgid ""
-"Interface language for visitors and for users who have not chosen one "
-"themselves."
+#: common/views_manage.py:652
+msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:558
-msgid ""
-"Language codes, one per line (e.g. en, zh, ja). First language is the "
-"default."
+#: common/views_manage.py:659
+msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:564
+#: common/views_manage.py:665
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:571
+#: common/views_manage.py:672
 #, fuzzy
 #| msgid "Import Method"
 msgid "Login Methods"
 msgstr "Metodo d'importazione"
 
-#: common/views_manage.py:576 mastodon/models/common.py:28
+#: common/views_manage.py:677 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr "Email"
 
-#: common/views_manage.py:580
+#: common/views_manage.py:681
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:591
+#: common/views_manage.py:692
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:593
-msgid ""
-"Disable relay.neodb.net federation for sharing public ratings across "
-"instances."
+#: common/views_manage.py:694
+msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:598
+#: common/views_manage.py:699
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:599
+#: common/views_manage.py:700
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:603
+#: common/views_manage.py:704
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:605
+#: common/views_manage.py:706
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:610
+#: common/views_manage.py:711
 #, fuzzy
 #| msgid "Search results"
 msgid "Search Sites"
 msgstr "Risultati della ricerca"
 
-#: common/views_manage.py:611
+#: common/views_manage.py:712
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:614
+#: common/views_manage.py:715
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:615
+#: common/views_manage.py:716
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:618
+#: common/views_manage.py:719
 #, fuzzy
 #| msgid "Add tv series"
 msgid "Hidden Categories"
 msgstr "Aggiungi serie tv"
 
-#: common/views_manage.py:619
+#: common/views_manage.py:720
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:640
+#: common/views_manage.py:723
+msgid "Guest Search Page Limit"
+msgstr ""
+
+#: common/views_manage.py:725
+msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
+msgstr ""
+
+#: common/views_manage.py:751
 #, fuzzy
 #| msgid "Spotify Album"
 msgid "Spotify API Key"
 msgstr "Album Spotify"
 
-#: common/views_manage.py:641
+#: common/views_manage.py:752
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:644
+#: common/views_manage.py:755
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:645
+#: common/views_manage.py:756
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:648
+#: common/views_manage.py:759
 #, fuzzy
 #| msgid "Google Books"
 msgid "Google Books API Key"
 msgstr "Google Books"
 
-#: common/views_manage.py:649
+#: common/views_manage.py:760
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:652
+#: common/views_manage.py:763
 #, fuzzy
 #| msgid "Discogs"
 msgid "Discogs API Key"
 msgstr "Discogs"
 
-#: common/views_manage.py:654
+#: common/views_manage.py:765
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:658
+#: common/views_manage.py:769
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:770
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:662
+#: common/views_manage.py:773
 #, fuzzy
 #| msgid "client secret"
 msgid "IGDB Client Secret"
 msgstr "segreto del client"
 
-#: common/views_manage.py:665
+#: common/views_manage.py:776
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:667
-msgid ""
-"Bearer token from https://boardgamegeek.com/applications (see https://"
-"boardgamegeek.com/using_the_xml_api#toc9)."
+#: common/views_manage.py:778
+msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:672 users/templates/users/steam_import.html:26
+#: common/views_manage.py:783
+msgid "MyAnimeList Client ID"
+msgstr ""
+
+#: common/views_manage.py:785
+msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
+msgstr ""
+
+#: common/views_manage.py:790 users/templates/users/steam_import.html:26
 #, fuzzy
 #| msgid "Steam Game"
 msgid "Steam API Key"
 msgstr "Gioco Steam"
 
-#: common/views_manage.py:674
-msgid ""
-"https://steamcommunity.com/dev - fallback key for Steam importer. Users can "
-"provide their own key when importing."
+#: common/views_manage.py:792
+msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:679
+#: common/views_manage.py:797
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:680
+#: common/views_manage.py:798
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:683
+#: common/views_manage.py:801
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:686
+#: common/views_manage.py:804
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:689
+#: common/views_manage.py:807
 #, fuzzy
 #| msgid "Threads"
 msgid "Threads App ID"
 msgstr "Threads"
 
-#: common/views_manage.py:690
+#: common/views_manage.py:808
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:693
+#: common/views_manage.py:811
 #, fuzzy
 #| msgid "Threads.net"
 msgid "Threads App Secret"
 msgstr "Threads.net"
 
-#: common/views_manage.py:696
+#: common/views_manage.py:814
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:698
-msgid ""
-"Webhook URLs keyed by channel (default, report, audit, suggest, system). All "
-"channels must be Discord forum or media channels (thread mode) because "
-"notifications are posted as threads."
+#: common/views_manage.py:816
+msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:715
+#: common/views_manage.py:833
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:844
 #, fuzzy
 #| msgid "translator"
 msgid "Translation"
 msgstr "Tradotto da"
 
-#: common/views_manage.py:730
+#: common/views_manage.py:849
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:734 social/templates/feed.html:27
+#: common/views_manage.py:853 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr "Notifiche"
 
-#: common/views_manage.py:744
+#: common/views_manage.py:863
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:745
+#: common/views_manage.py:864
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:748
+#: common/views_manage.py:867
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:749
+#: common/views_manage.py:868
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:752
+#: common/views_manage.py:871
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:874
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:758
+#: common/views_manage.py:877
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:761
+#: common/views_manage.py:880
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:764
+#: common/views_manage.py:883
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:767
+#: common/views_manage.py:886
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:768
+#: common/views_manage.py:887
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:771
+#: common/views_manage.py:890
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:775
+#: common/views_manage.py:894
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:779
+#: common/views_manage.py:898
 #, fuzzy
 #| msgid "series"
 msgid "Retries"
 msgstr "Serie"
 
-#: common/views_manage.py:784
+#: common/views_manage.py:903
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:789
+#: common/views_manage.py:908
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:796
+#: common/views_manage.py:915
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:808
+#: common/views_manage.py:927
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:809
+#: common/views_manage.py:928
 #, fuzzy
 #| msgid "site domain name"
 msgid "One domain per line."
 msgstr "nome del dominio del sito"
 
-#: common/views_manage.py:812
+#: common/views_manage.py:931
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:813
+#: common/views_manage.py:932
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:935
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:818
-msgid ""
-"Timeout for requests to Mastodon instances and remote fediverse servers."
+#: common/views_manage.py:937
+msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:824
+#: common/views_manage.py:943
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:825
+#: common/views_manage.py:944
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:828
+#: common/views_manage.py:947
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:829
+#: common/views_manage.py:948
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:839
+#: common/views_manage.py:958
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:841
-msgid ""
-"Delete import/export tasks and their files after this many days. Set to 0 to "
-"disable cleanup."
+#: common/views_manage.py:960
+msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:847
+#: common/views_manage.py:966
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:849
-msgid ""
-"Post-migration job keys to skip, one per line (e.g. normalize_genre). "
-"Checked by the worker at dequeue time; skipped jobs log a warning and notify "
-"the Discord system channel."
+#: common/views_manage.py:968
+msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:855
+#: common/views_manage.py:974
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:857
-msgid ""
-"Private key (JWK) identifying this site to ATProto authorization servers. "
-"Auto-generated on first Bluesky login; clear to regenerate."
+#: common/views_manage.py:976
+msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:983
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:986
 #, fuzzy
 #| msgid "optional"
 msgid "Operational"
 msgstr "opzionale"
 
-#: common/views_manage.py:883
+#: common/views_manage.py:1002
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:885
-msgid ""
-"Genre codes offered in the Movie edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1004
+msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:1009
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:892
-msgid ""
-"Genre codes offered in the TV edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1011
+msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:897
+#: common/views_manage.py:1016
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:899
-msgid ""
-"Genre codes offered in the Music edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1018
+msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:904
+#: common/views_manage.py:1023
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:906
-msgid ""
-"Genre codes offered in the Game edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1025
+msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:911
+#: common/views_manage.py:1030
 #, fuzzy
 #| msgid "Podcast"
 msgid "Podcast Genres"
 msgstr "Podcast"
 
-#: common/views_manage.py:913
-msgid ""
-"Genre codes offered in the Podcast edit dropdown, one per line. Leave empty "
-"to use the built-in default."
+#: common/views_manage.py:1032
+msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:918
+#: common/views_manage.py:1037
 #, fuzzy
 #| msgid "Performance"
 msgid "Performance Genres"
 msgstr "Esibizione"
 
-#: common/views_manage.py:920
-msgid ""
-"Genre codes offered in the Performance edit dropdown, one per line. Leave "
-"empty to use the built-in default."
+#: common/views_manage.py:1039
+msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:926
+#: common/views_manage.py:1045
 msgid "Genres by Category"
 msgstr ""
 
-#: journal/forms.py:12
-msgid ""
-"Tips: use >!text!< for spoilers; some instances may not be able to show "
-"posts longer than 360 charactors."
+#: common/views_manage.py:1069
+msgid "Site"
 msgstr ""
-"Suggerimenti: usa &gt;!text!&lt; per gli spoiler; alcune istanze potrebbero "
-"non essere in grado di mostrare post lunghi più di 360 caratteri."
+
+#: common/views_manage.py:1079
+#, fuzzy
+#| msgid "Database"
+msgid "Database and Services"
+msgstr "Database"
+
+#: common/views_manage.py:1089
+msgid "Media and Files"
+msgstr ""
+
+#: common/views_manage.py:1098
+msgid "Monitoring"
+msgstr ""
+
+#: common/views_manage.py:1102
+msgid "Security"
+msgstr ""
+
+#: common/views_manage.py:1111
+msgid "Other Environment Variables"
+msgstr ""
+
+#: common/views_manage.py:1113
+msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
+msgstr ""
+
+#: journal/forms.py:12
+msgid "Tips: use >!text!< for spoilers; some instances may not be able to show posts longer than 360 charactors."
+msgstr "Suggerimenti: usa &gt;!text!&lt; per gli spoiler; alcune istanze potrebbero non essere in grado di mostrare post lunghi più di 360 caratteri."
 
 #: journal/forms.py:29 journal/forms.py:31 journal/forms.py:80
 #: journal/forms.py:83 journal/forms.py:153
@@ -5405,14 +5370,14 @@ msgid "Content (Markdown)"
 msgstr "Contenuto (Markdown)"
 
 #: journal/forms.py:46 journal/forms.py:124 journal/forms.py:226
-#: journal/forms.py:288 journal/views/note.py:38
+#: journal/forms.py:288 journal/views/note.py:37
 #, fuzzy
 #| msgid "Crosspost to timeline"
 msgid "Crosspost"
 msgstr "Ripubblica nella timeline"
 
 #: journal/forms.py:47 journal/forms.py:125 journal/forms.py:227
-#: journal/forms.py:289 journal/views/note.py:39
+#: journal/forms.py:289 journal/views/note.py:38
 #, fuzzy
 #| msgid "Turn on crosspost to other social networks by default"
 msgid "Crosspost to your connected social networks"
@@ -5429,10 +5394,10 @@ msgstr "Mentre si salva, sostituire spazi iniziali con spazi a tutta larghezza"
 #: journal/forms.py:59 journal/forms.py:137 journal/forms.py:162
 #: journal/forms.py:219 journal/forms.py:281
 #: journal/templates/collection_share.html:24
-#: journal/templates/wrapped_share.html:36 journal/views/note.py:31
-#: users/templates/users/data.html:45 users/templates/users/data.html:98
-#: users/templates/users/data.html:155 users/templates/users/data.html:206
-#: users/templates/users/data.html:269 users/templates/users/data.html:328
+#: journal/templates/wrapped_share.html:36 journal/views/note.py:30
+#: users/templates/users/data.html:60 users/templates/users/data.html:113
+#: users/templates/users/data.html:170 users/templates/users/data.html:221
+#: users/templates/users/data.html:284 users/templates/users/data.html:346
 #: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
@@ -5479,7 +5444,6 @@ msgid "Collaborative editing"
 msgstr "Modifica collaborativa"
 
 #: journal/forms.py:204 users/templates/users/crossposts.html:51
-#: users/templates/users/data.html:483
 msgid "Status"
 msgstr "Status"
 
@@ -5493,48 +5457,46 @@ msgstr "Commenta"
 msgid "Rating"
 msgstr "valutazione"
 
-#: journal/importers/goodreads.py:196 journal/importers/letterboxd.py:144
-#: journal/importers/rym.py:442 journal/importers/storygraph.py:500
+#: journal/importers/goodreads.py:198 journal/importers/letterboxd.py:147
+#: journal/importers/rym.py:444 journal/importers/storygraph.py:504
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr "una recensione di {item_title}"
 
-#: journal/importers/opml.py:45
+#: journal/importers/opml.py:49
 #, python-brace-format
 msgid "{username}'s podcast subscriptions"
 msgstr "Iscrizioni podcast di {username}"
 
-#: journal/importers/rym.py:168 journal/importers/storygraph.py:128
+#: journal/importers/rym.py:170 journal/importers/storygraph.py:132
 #, python-brace-format
-msgid ""
-"Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
+msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:178 journal/importers/storygraph.py:138
+#: journal/importers/rym.py:180 journal/importers/storygraph.py:142
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/importers/rym.py:233 journal/importers/storygraph.py:184
+#: journal/importers/rym.py:235 journal/importers/storygraph.py:188
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:348 journal/importers/storygraph.py:389
+#: journal/importers/rym.py:350 journal/importers/storygraph.py:393
 msgid "Matched file missing; cannot import."
 msgstr ""
 
-#: journal/importers/rym.py:376 journal/importers/storygraph.py:412
+#: journal/importers/rym.py:378 journal/importers/storygraph.py:416
 #, python-brace-format
-msgid ""
-"Import complete: {imported} imported, {skipped} skipped, {failed} failed"
+msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:212 journal/views/article.py:218
+#: journal/models/article.py:215 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
-#: journal/models/collection.py:44 journal/templates/add_to_collection.html:39
+#: journal/models/collection.py:48 journal/templates/add_to_collection.html:39
 #: journal/templates/collection_edit.html:64
 #: journal/templates/collection_share.html:63
 #: journal/templates/collection_update_item_note.html:3
@@ -5542,75 +5504,75 @@ msgstr ""
 msgid "note"
 msgstr "nota"
 
-#: journal/models/collection.py:111
+#: journal/models/collection.py:115
 #, fuzzy
 #| msgid "shared {username}'s collection"
 msgid "search query for dynamic collection"
 msgstr "condivisa la collezione di {username}"
 
-#: journal/models/collection.py:524 journal/templatetags/collection.py:35
+#: journal/models/collection.py:566 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] "%(count)d libro"
 msgstr[1] "%(count)d libri"
 
-#: journal/models/collection.py:529 journal/templatetags/collection.py:43
+#: journal/models/collection.py:571 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] "%(count)d film"
 msgstr[1] "%(count)d film"
 
-#: journal/models/collection.py:534 journal/templatetags/collection.py:51
+#: journal/models/collection.py:576 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] "%(count)d serie tv"
 msgstr[1] "%(count)d serie tv"
 
-#: journal/models/collection.py:539 journal/templatetags/collection.py:59
+#: journal/models/collection.py:581 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] "%(count)d album"
 msgstr[1] "%(count)d album"
 
-#: journal/models/collection.py:544 journal/templatetags/collection.py:67
+#: journal/models/collection.py:586 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] "%(count)d gioco"
 msgstr[1] "%(count)d giochi"
 
-#: journal/models/collection.py:549 journal/templatetags/collection.py:75
+#: journal/models/collection.py:591 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] "%(count)d podcast"
 msgstr[1] "%(count)d podcast"
 
-#: journal/models/collection.py:555 journal/templatetags/collection.py:83
+#: journal/models/collection.py:597 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] "%(count)d esibizione"
 msgstr[1] "%(count)d esibizioni"
 
-#: journal/models/collection.py:563 journal/templatetags/collection.py:91
+#: journal/models/collection.py:605 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] "%(count)d elemento"
 msgstr[1] "%(count)d elementi"
 
-#: journal/models/common.py:50 journal/templates/action_open_post.html:15
-#: journal/templates/collection_share.html:35 journal/templates/mark.html:84
+#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
-#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:54
-#: users/templates/users/data.html:107 users/templates/users/data.html:164
-#: users/templates/users/data.html:215 users/templates/users/data.html:277
-#: users/templates/users/data.html:337 users/templates/users/data.html:534
+#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
+#: users/templates/users/data.html:122 users/templates/users/data.html:179
+#: users/templates/users/data.html:230 users/templates/users/data.html:292
+#: users/templates/users/data.html:355 users/templates/users/data.html:534
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5618,13 +5580,13 @@ msgstr[1] "%(count)d elementi"
 msgid "Public"
 msgstr "Pubblico"
 
-#: journal/models/common.py:51 journal/templates/action_open_post.html:9
-#: journal/templates/collection_share.html:46 journal/templates/mark.html:91
+#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
-#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
-#: users/templates/users/data.html:115 users/templates/users/data.html:172
-#: users/templates/users/data.html:223 users/templates/users/data.html:285
-#: users/templates/users/data.html:345 users/templates/users/data.html:542
+#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
+#: users/templates/users/data.html:130 users/templates/users/data.html:187
+#: users/templates/users/data.html:238 users/templates/users/data.html:300
+#: users/templates/users/data.html:363 users/templates/users/data.html:542
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5632,12 +5594,12 @@ msgstr "Pubblico"
 msgid "Followers Only"
 msgstr "Solo Follower"
 
-#: journal/models/common.py:52 journal/templates/collection_share.html:57
-#: journal/templates/mark.html:98 journal/templates/post_compose.html:72
-#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
-#: users/templates/users/data.html:123 users/templates/users/data.html:180
-#: users/templates/users/data.html:231 users/templates/users/data.html:293
-#: users/templates/users/data.html:353 users/templates/users/data.html:550
+#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/templates/mark.html:102 journal/templates/post_compose.html:72
+#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
+#: users/templates/users/data.html:138 users/templates/users/data.html:195
+#: users/templates/users/data.html:246 users/templates/users/data.html:308
+#: users/templates/users/data.html:371 users/templates/users/data.html:550
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5645,39 +5607,33 @@ msgstr "Solo Follower"
 msgid "Mentioned Only"
 msgstr "Solo Menzionati"
 
-#: journal/models/common.py:790
+#: journal/models/common.py:806
 #, fuzzy
 #| msgid "A recent post was not posted to Mastodon, please re-authorize."
-msgid ""
-"A recent post was not posted to Bluesky, please login NeoDB using ATProto "
-"again to re-authorize."
-msgstr ""
-"Un post recente non è stato pubblicato su Mastodon, si prega di re-"
-"autorizzare."
+msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
+msgstr "Un post recente non è stato pubblicato su Mastodon, si prega di re-autorizzare."
 
-#: journal/models/common.py:987
+#: journal/models/common.py:1003
 msgid "A recent post was not posted to Threads."
 msgstr "Un post recente non è stato pubblicato su Threads."
 
-#: journal/models/common.py:1020
+#: journal/models/common.py:1036
 #, fuzzy
 #| msgid "A recent post was not posted to Mastodon."
 msgid "A recent post was not boosted on Mastodon."
 msgstr "Un post recente non è stato pubblicato su Mastodon."
 
-#: journal/models/common.py:1030
+#: journal/models/common.py:1046
 #, fuzzy
 #| msgid "Item no longer exists"
 msgid "Original post no longer exists."
 msgstr "L'elemento non esiste più"
 
-#: journal/models/common.py:1044
+#: journal/models/common.py:1060
 msgid "A recent post was not posted to Mastodon, please re-authorize."
-msgstr ""
-"Un post recente non è stato pubblicato su Mastodon, si prega di re-"
-"autorizzare."
+msgstr "Un post recente non è stato pubblicato su Mastodon, si prega di re-autorizzare."
 
-#: journal/models/common.py:1053
+#: journal/models/common.py:1069
 msgid "A recent post was not posted to Mastodon."
 msgstr "Un post recente non è stato pubblicato su Mastodon."
 
@@ -5687,7 +5643,7 @@ msgstr "Un post recente non è stato pubblicato su Mastodon."
 msgid "Authorization expired"
 msgstr "Autenticazione fallita"
 
-#: journal/models/crosspost.py:17 users/models/task.py:24
+#: journal/models/crosspost.py:17 users/models/task.py:26
 msgid "Failed"
 msgstr "Fallito"
 
@@ -5695,85 +5651,85 @@ msgstr "Fallito"
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:469
+#: journal/models/mark.py:475
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:473
+#: journal/models/mark.py:479
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:480
+#: journal/models/mark.py:486
 #, fuzzy
 #| msgid "Invalid parameter"
 msgid "Invalid progress type."
 msgstr "Parametro non valido"
 
-#: journal/models/mark.py:482
+#: journal/models/mark.py:488
 #, fuzzy
 #| msgid "Invalid response from Fediverse instance."
 msgid "Invalid progress type for this item."
 msgstr "Risposta non valida dall'istanza del fediverso."
 
-#: journal/models/note.py:34 users/templates/users/rym_import.html:73
+#: journal/models/note.py:47 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr "Pagina"
 
-#: journal/models/note.py:35
+#: journal/models/note.py:48
 msgid "Chapter"
 msgstr "Capitolo"
 
-#: journal/models/note.py:38
+#: journal/models/note.py:51
 msgid "Part"
 msgstr "Parte"
 
-#: journal/models/note.py:39
+#: journal/models/note.py:52
 msgid "Episode"
 msgstr "Episodio"
 
-#: journal/models/note.py:40
+#: journal/models/note.py:53
 msgid "Track"
 msgstr "Traccia"
 
-#: journal/models/note.py:41
+#: journal/models/note.py:54
 msgid "Cycle"
 msgstr "Ciclo"
 
-#: journal/models/note.py:42
+#: journal/models/note.py:55
 msgid "Timestamp"
 msgstr "Timbro temporale"
 
-#: journal/models/note.py:43
+#: journal/models/note.py:56
 msgid "Percentage"
 msgstr "Percentuale"
 
-#: journal/models/note.py:60
+#: journal/models/note.py:77
 #, python-brace-format
 msgid "Page {value}"
 msgstr "Pagina {value}"
 
-#: journal/models/note.py:61
+#: journal/models/note.py:78
 #, python-brace-format
 msgid "Chapter {value}"
 msgstr "Capitolo {value}"
 
-#: journal/models/note.py:64
+#: journal/models/note.py:81
 #, python-brace-format
 msgid "Part {value}"
 msgstr "Parte {value}"
 
-#: journal/models/note.py:65
+#: journal/models/note.py:82
 #, python-brace-format
 msgid "Episode {value}"
 msgstr "Episodio {value}"
 
-#: journal/models/note.py:66
+#: journal/models/note.py:83
 #, python-brace-format
 msgid "Track {value}"
 msgstr "Traccia {value}"
 
-#: journal/models/note.py:67
+#: journal/models/note.py:84
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr "Ciclo {value}"
@@ -5781,448 +5737,447 @@ msgstr "Ciclo {value}"
 #: journal/models/renderers.py:208
 #, python-brace-format
 msgid "regarding {item_title}, may contain spoiler or triggering content"
-msgstr ""
-"riguardo {item_title}, potrebbe contenere spoiler o contenuto sensibile"
+msgstr "riguardo {item_title}, potrebbe contenere spoiler o contenuto sensibile"
 
-#: journal/models/review.py:78
+#: journal/models/review.py:79
 #, fuzzy, python-brace-format
 #| msgid "a review of {item_title}"
 msgid "a review of {title}"
 msgstr "una recensione di {item_title}"
 
-#: journal/models/review.py:80
+#: journal/models/review.py:81
 #, fuzzy
 #| msgid "Item contains sub-items."
 msgid "(may contain spoilers)"
 msgstr "L'elemento contiene sotto-elementi."
 
-#: journal/models/shelf.py:37
+#: journal/models/shelf.py:39
 msgid "WISHLIST"
 msgstr "LISTA DEI DESIDERI"
 
-#: journal/models/shelf.py:38
+#: journal/models/shelf.py:40
 msgid "PROGRESS"
 msgstr "PROGRESSO"
 
-#: journal/models/shelf.py:39
+#: journal/models/shelf.py:41
 msgid "COMPLETE"
 msgstr "COMPLETO"
 
-#: journal/models/shelf.py:40
+#: journal/models/shelf.py:42
 msgid "DROPPED"
 msgstr "ABBANDONATO"
 
-#: journal/models/shelf.py:49
+#: journal/models/shelf.py:51
 msgid "books to read"
 msgstr "Libri da leggere"
 
-#: journal/models/shelf.py:50
+#: journal/models/shelf.py:52
 msgid "want to read"
 msgstr "voglio leggere"
 
-#: journal/models/shelf.py:51
+#: journal/models/shelf.py:53
 #, python-brace-format
 msgid "wants to read {item}"
 msgstr "vuole leggere {item}"
 
-#: journal/models/shelf.py:52
+#: journal/models/shelf.py:54
 msgid "to read"
 msgstr "da leggere"
 
-#: journal/models/shelf.py:57
+#: journal/models/shelf.py:59
 msgid "books reading"
 msgstr "Letture in corso"
 
-#: journal/models/shelf.py:58
+#: journal/models/shelf.py:60
 msgid "start reading"
 msgstr "comincia a leggere"
 
-#: journal/models/shelf.py:59
+#: journal/models/shelf.py:61
 #, python-brace-format
 msgid "started reading {item}"
 msgstr "iniziato a leggere {item}"
 
-#: journal/models/shelf.py:60
+#: journal/models/shelf.py:62
 msgid "reading"
 msgstr "leggendo"
 
-#: journal/models/shelf.py:65
+#: journal/models/shelf.py:67
 msgid "books completed"
 msgstr "Libri letti"
 
-#: journal/models/shelf.py:66
+#: journal/models/shelf.py:68
 msgid "finish reading"
 msgstr "finito di leggere"
 
-#: journal/models/shelf.py:67
+#: journal/models/shelf.py:69
 #, python-brace-format
 msgid "finished reading {item}"
 msgstr "finito di leggere {item}"
 
-#: journal/models/shelf.py:68
+#: journal/models/shelf.py:70
 msgid "read"
 msgstr "letto"
 
-#: journal/models/shelf.py:73
+#: journal/models/shelf.py:75
 msgid "books dropped"
 msgstr "libri abbandonati"
 
-#: journal/models/shelf.py:74
+#: journal/models/shelf.py:76
 msgid "stop reading"
 msgstr "smetti di leggere"
 
-#: journal/models/shelf.py:75
+#: journal/models/shelf.py:77
 #, python-brace-format
 msgid "stopped reading {item}"
 msgstr "Ha smesso di leggere {item}"
 
-#: journal/models/shelf.py:76
+#: journal/models/shelf.py:78
 msgid "stopped reading"
 msgstr "Ha smesso di leggere"
 
-#: journal/models/shelf.py:81
+#: journal/models/shelf.py:83
 msgid "books reviewed"
 msgstr "Libri recensiti"
 
-#: journal/models/shelf.py:82 journal/models/shelf.py:122
-#: journal/models/shelf.py:162 journal/models/shelf.py:202
-#: journal/models/shelf.py:242 journal/models/shelf.py:282
-#: journal/models/shelf.py:316
+#: journal/models/shelf.py:84 journal/models/shelf.py:124
+#: journal/models/shelf.py:164 journal/models/shelf.py:204
+#: journal/models/shelf.py:244 journal/models/shelf.py:284
+#: journal/models/shelf.py:318
 msgid "review"
 msgstr "recensisci"
 
-#: journal/models/shelf.py:83 journal/models/shelf.py:123
-#: journal/models/shelf.py:163 journal/models/shelf.py:203
-#: journal/models/shelf.py:243 journal/models/shelf.py:283
-#: journal/models/shelf.py:317
+#: journal/models/shelf.py:85 journal/models/shelf.py:125
+#: journal/models/shelf.py:165 journal/models/shelf.py:205
+#: journal/models/shelf.py:245 journal/models/shelf.py:285
+#: journal/models/shelf.py:319
 #, python-brace-format
 msgid "wrote a review of {item}"
 msgstr "ho scritto una recensione di {item}"
 
-#: journal/models/shelf.py:89
+#: journal/models/shelf.py:91
 msgid "movies to watch"
 msgstr "Film da vedere"
 
-#: journal/models/shelf.py:90 journal/models/shelf.py:130
+#: journal/models/shelf.py:92 journal/models/shelf.py:132
 msgid "want to watch"
 msgstr "voglio vedere"
 
-#: journal/models/shelf.py:91 journal/models/shelf.py:131
+#: journal/models/shelf.py:93 journal/models/shelf.py:133
 #, python-brace-format
 msgid "wants to watch {item}"
 msgstr "Voglio vedere {item}"
 
-#: journal/models/shelf.py:92 journal/models/shelf.py:132
+#: journal/models/shelf.py:94 journal/models/shelf.py:134
 msgid "to watch"
 msgstr "Da vedere"
 
-#: journal/models/shelf.py:97
+#: journal/models/shelf.py:99
 msgid "movies watching"
 msgstr "Film in visione"
 
-#: journal/models/shelf.py:98 journal/models/shelf.py:138
+#: journal/models/shelf.py:100 journal/models/shelf.py:140
 msgid "start watching"
 msgstr "Inizia a vedere"
 
-#: journal/models/shelf.py:99 journal/models/shelf.py:139
+#: journal/models/shelf.py:101 journal/models/shelf.py:141
 #, python-brace-format
 msgid "started watching {item}"
 msgstr "Ho iniziato a vedere {item}"
 
-#: journal/models/shelf.py:100 journal/models/shelf.py:140
+#: journal/models/shelf.py:102 journal/models/shelf.py:142
 msgid "watching"
 msgstr "In visione"
 
-#: journal/models/shelf.py:105
+#: journal/models/shelf.py:107
 msgid "movies watched"
 msgstr "Film visti"
 
-#: journal/models/shelf.py:106 journal/models/shelf.py:146
+#: journal/models/shelf.py:108 journal/models/shelf.py:148
 msgid "finish watching"
 msgstr "ha finito di vedere"
 
-#: journal/models/shelf.py:107 journal/models/shelf.py:147
+#: journal/models/shelf.py:109 journal/models/shelf.py:149
 #, python-brace-format
 msgid "finished watching {item}"
 msgstr "Ha finito di vedere {item}"
 
-#: journal/models/shelf.py:108 journal/models/shelf.py:148
+#: journal/models/shelf.py:110 journal/models/shelf.py:150
 msgid "watched"
 msgstr "Visto"
 
-#: journal/models/shelf.py:113
+#: journal/models/shelf.py:115
 msgid "movies dropped"
 msgstr "film non finiti"
 
-#: journal/models/shelf.py:114 journal/models/shelf.py:154
+#: journal/models/shelf.py:116 journal/models/shelf.py:156
 msgid "stop watching"
 msgstr "Smetti di vedere"
 
-#: journal/models/shelf.py:115 journal/models/shelf.py:155
+#: journal/models/shelf.py:117 journal/models/shelf.py:157
 #, python-brace-format
 msgid "stopped watching {item}"
 msgstr "Ha smesso di vedere {item}"
 
-#: journal/models/shelf.py:116 journal/models/shelf.py:156
+#: journal/models/shelf.py:118 journal/models/shelf.py:158
 msgid "stopped watching"
 msgstr "Ha smesso di vedere"
 
-#: journal/models/shelf.py:121
+#: journal/models/shelf.py:123
 msgid "movies reviewed"
 msgstr "Film recensiti"
 
-#: journal/models/shelf.py:129
+#: journal/models/shelf.py:131
 msgid "TV shows to watch"
 msgstr "Serie TV da vedere"
 
-#: journal/models/shelf.py:137
+#: journal/models/shelf.py:139
 msgid "TV shows watching"
 msgstr "Serie TV in visione"
 
-#: journal/models/shelf.py:145
+#: journal/models/shelf.py:147
 msgid "TV shows watched"
 msgstr "Serie TV viste"
 
-#: journal/models/shelf.py:153
+#: journal/models/shelf.py:155
 msgid "TV shows dropped"
 msgstr "Serie TV abbandonate"
 
-#: journal/models/shelf.py:161
+#: journal/models/shelf.py:163
 msgid "TV shows reviewed"
 msgstr "Serie TV recensite"
 
-#: journal/models/shelf.py:169
+#: journal/models/shelf.py:171
 msgid "albums to listen"
 msgstr "Album da ascoltare"
 
-#: journal/models/shelf.py:170 journal/models/shelf.py:250
+#: journal/models/shelf.py:172 journal/models/shelf.py:252
 msgid "want to listen"
 msgstr "vuole ascoltare"
 
-#: journal/models/shelf.py:171 journal/models/shelf.py:251
+#: journal/models/shelf.py:173 journal/models/shelf.py:253
 #, python-brace-format
 msgid "wants to listen {item}"
 msgstr "vuole ascoltare {item}"
 
-#: journal/models/shelf.py:172 journal/models/shelf.py:252
+#: journal/models/shelf.py:174 journal/models/shelf.py:254
 msgid "to listen"
 msgstr "da ascoltare"
 
-#: journal/models/shelf.py:177
+#: journal/models/shelf.py:179
 msgid "albums listening"
 msgstr "Album in ascolto"
 
-#: journal/models/shelf.py:178 journal/models/shelf.py:258
+#: journal/models/shelf.py:180 journal/models/shelf.py:260
 msgid "start listening"
 msgstr "iniziato ad ascoltare"
 
-#: journal/models/shelf.py:179 journal/models/shelf.py:259
+#: journal/models/shelf.py:181 journal/models/shelf.py:261
 #, python-brace-format
 msgid "started listening {item}"
 msgstr "iniziato as ascoltare {item}"
 
-#: journal/models/shelf.py:180 journal/models/shelf.py:260
+#: journal/models/shelf.py:182 journal/models/shelf.py:262
 msgid "listening"
 msgstr "ascoltando"
 
-#: journal/models/shelf.py:185
+#: journal/models/shelf.py:187
 msgid "albums listened"
 msgstr "Album ascoltati"
 
-#: journal/models/shelf.py:186 journal/models/shelf.py:266
+#: journal/models/shelf.py:188 journal/models/shelf.py:268
 msgid "finish listening"
 msgstr "finire di ascoltare"
 
-#: journal/models/shelf.py:187 journal/models/shelf.py:267
+#: journal/models/shelf.py:189 journal/models/shelf.py:269
 #, python-brace-format
 msgid "finished listening {item}"
 msgstr "Ha finito di ascoltare {item}"
 
-#: journal/models/shelf.py:188 journal/models/shelf.py:268
+#: journal/models/shelf.py:190 journal/models/shelf.py:270
 msgid "listened"
 msgstr "ascoltato"
 
-#: journal/models/shelf.py:193
+#: journal/models/shelf.py:195
 msgid "albums dropped"
 msgstr "album abbandonati"
 
-#: journal/models/shelf.py:194 journal/models/shelf.py:274
+#: journal/models/shelf.py:196 journal/models/shelf.py:276
 msgid "stop listening"
 msgstr "finisci di ascoltare"
 
-#: journal/models/shelf.py:195 journal/models/shelf.py:275
+#: journal/models/shelf.py:197 journal/models/shelf.py:277
 #, python-brace-format
 msgid "stopped listening {item}"
 msgstr "finito di ascoltare {item}"
 
-#: journal/models/shelf.py:196 journal/models/shelf.py:276
+#: journal/models/shelf.py:198 journal/models/shelf.py:278
 msgid "stopped listening"
 msgstr "finito di ascoltare"
 
-#: journal/models/shelf.py:201
+#: journal/models/shelf.py:203
 msgid "albums reviewed"
 msgstr "Album recensiti"
 
-#: journal/models/shelf.py:209
+#: journal/models/shelf.py:211
 msgid "games to play"
 msgstr "Giochi da giocare"
 
-#: journal/models/shelf.py:210
+#: journal/models/shelf.py:212
 msgid "want to play"
 msgstr "voler riprodurre"
 
-#: journal/models/shelf.py:211
+#: journal/models/shelf.py:213
 #, python-brace-format
 msgid "wants to play {item}"
 msgstr "vuole riprodurre {item}"
 
-#: journal/models/shelf.py:212
+#: journal/models/shelf.py:214
 msgid "to play"
 msgstr "Da giocare"
 
-#: journal/models/shelf.py:217
+#: journal/models/shelf.py:219
 msgid "games playing"
 msgstr "Giochi giocati"
 
-#: journal/models/shelf.py:218
+#: journal/models/shelf.py:220
 msgid "start playing"
 msgstr "inizia a giocare"
 
-#: journal/models/shelf.py:219
+#: journal/models/shelf.py:221
 #, python-brace-format
 msgid "started playing {item}"
 msgstr "iniziato a giocare {item}"
 
-#: journal/models/shelf.py:220
+#: journal/models/shelf.py:222
 msgid "playing"
 msgstr "Giocando"
 
-#: journal/models/shelf.py:225
+#: journal/models/shelf.py:227
 msgid "games played"
 msgstr "Giochi giocati"
 
-#: journal/models/shelf.py:226
+#: journal/models/shelf.py:228
 msgid "finish playing"
 msgstr "Ha smesso di giocare"
 
-#: journal/models/shelf.py:227
+#: journal/models/shelf.py:229
 #, python-brace-format
 msgid "finished playing {item}"
 msgstr "Ha finito di giocare {item}"
 
-#: journal/models/shelf.py:228
+#: journal/models/shelf.py:230
 msgid "played"
 msgstr "Giocato"
 
-#: journal/models/shelf.py:233
+#: journal/models/shelf.py:235
 msgid "games dropped"
 msgstr "giochi abbandonati"
 
-#: journal/models/shelf.py:234
+#: journal/models/shelf.py:236
 msgid "stop playing"
 msgstr "finisci di giocare"
 
-#: journal/models/shelf.py:235
+#: journal/models/shelf.py:237
 #, python-brace-format
 msgid "stopped playing {item}"
 msgstr "finito di giocare {item}"
 
-#: journal/models/shelf.py:236
+#: journal/models/shelf.py:238
 msgid "stopped playing"
 msgstr "Ha smesso di giocare"
 
-#: journal/models/shelf.py:241
+#: journal/models/shelf.py:243
 msgid "games reviewed"
 msgstr "Giochi recensiti"
 
-#: journal/models/shelf.py:249
+#: journal/models/shelf.py:251
 msgid "podcasts to listen"
 msgstr "Podcast da ascoltare"
 
-#: journal/models/shelf.py:257
+#: journal/models/shelf.py:259
 msgid "podcasts listening"
 msgstr "Podcast in ascolto"
 
-#: journal/models/shelf.py:265
+#: journal/models/shelf.py:267
 msgid "podcasts listened"
 msgstr "Podcast ascoltati"
 
-#: journal/models/shelf.py:273
+#: journal/models/shelf.py:275
 msgid "podcasts dropped"
 msgstr "podcast abbandonati"
 
-#: journal/models/shelf.py:281
+#: journal/models/shelf.py:283
 msgid "podcasts reviewed"
 msgstr "Podcast recensiti"
 
-#: journal/models/shelf.py:289
+#: journal/models/shelf.py:291
 msgid "performances to see"
 msgstr "Esibizioni da vedere"
 
-#: journal/models/shelf.py:290
+#: journal/models/shelf.py:292
 msgid "want to see"
 msgstr "voler vedere"
 
-#: journal/models/shelf.py:291
+#: journal/models/shelf.py:293
 #, python-brace-format
 msgid "wants to see {item}"
 msgstr "Voglio vedere {item}"
 
-#: journal/models/shelf.py:292
+#: journal/models/shelf.py:294
 msgid "to see"
 msgstr "da vedere"
 
-#: journal/models/shelf.py:299
+#: journal/models/shelf.py:301
 msgid "performances saw"
 msgstr "Esibizioni viste"
 
-#: journal/models/shelf.py:300
+#: journal/models/shelf.py:302
 msgid "finish seeing"
 msgstr "finito di vedere"
 
-#: journal/models/shelf.py:301
+#: journal/models/shelf.py:303
 #, python-brace-format
 msgid "finished seeing {item}"
 msgstr "Ha finito di vedere {item}"
 
-#: journal/models/shelf.py:302
+#: journal/models/shelf.py:304
 msgid "seen"
 msgstr "Visto"
 
-#: journal/models/shelf.py:307
+#: journal/models/shelf.py:309
 msgid "performances dropped"
 msgstr "esibizioni abbandonate"
 
-#: journal/models/shelf.py:308
+#: journal/models/shelf.py:310
 msgid "stop seeing"
 msgstr "smetti di vedere"
 
-#: journal/models/shelf.py:309
+#: journal/models/shelf.py:311
 #, python-brace-format
 msgid "stopped seeing {item}"
 msgstr "Ha smesso di vedere {item}"
 
-#: journal/models/shelf.py:310
+#: journal/models/shelf.py:312
 msgid "stopped seeing"
 msgstr "Ha smesso di vedere"
 
-#: journal/models/shelf.py:315
+#: journal/models/shelf.py:317
 msgid "performances reviewed"
 msgstr "Esibizioni recensite"
 
-#: journal/models/shelf.py:323
+#: journal/models/shelf.py:325
 #, fuzzy
 #| msgid "Users you are following"
 msgid "people following"
 msgstr "Utenti che stai seguendo"
 
-#: journal/models/shelf.py:325
+#: journal/models/shelf.py:327
 #, fuzzy, python-brace-format
 #| msgid "started playing {item}"
 msgid "started following {item}"
 msgstr "iniziato a giocare {item}"
 
-#: journal/models/shelf.py:921
+#: journal/models/shelf.py:923
 msgid "removed mark"
 msgstr "rimosso segno"
 
@@ -6252,38 +6207,22 @@ msgstr ""
 msgid "Remove from collection"
 msgstr "Rimuovi dalla collezione"
 
-#: journal/templates/_list_item.html:34
-msgid "add mark"
-msgstr "aggiungi segno"
-
-#: journal/templates/_list_item.html:42
-msgid "update mark"
-msgstr "aggiorna segno"
-
-#: journal/templates/_list_item.html:60
+#: journal/templates/_list_item.html:43
 #: journal/templates/collection_update_item_note_ok.html:3
 msgid "Update note"
 msgstr "Aggiorna nota"
 
-#: journal/templates/_list_item.html:100 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:123
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
 msgstr "Recensisci"
 
-#: journal/templates/_list_item.html:133
+#: journal/templates/_list_item.html:91
 #, fuzzy, python-format
-#| msgid ""
-#| " %(dups)s items are from the same work or have the same identifier, they "
-#| "are hidden from the search results, <a _=\"on click toggle .unfold on "
-#| "#dup\">click here to show them.</a> "
-msgid ""
-"%(dups)s item(s) are from the same work or have the same identifier, click "
-"here to display:"
-msgstr ""
-" gli elementi%(dups)s fanno parte dello stesso lavoro o hanno lo stesso "
-"identificativo, sono nascosti dai risultati di ricerca, <a _=\"on click "
-"toggle .unfold on #dup\">clicca qui per mostrarli.</a> "
+#| msgid " %(dups)s items are from the same work or have the same identifier, they are hidden from the search results, <a _=\"on click toggle .unfold on #dup\">click here to show them.</a> "
+msgid "%(dups)s item(s) are from the same work or have the same identifier, click here to display:"
+msgstr " gli elementi%(dups)s fanno parte dello stesso lavoro o hanno lo stesso identificativo, sono nascosti dai risultati di ricerca, <a _=\"on click toggle .unfold on #dup\">clicca qui per mostrarli.</a> "
 
 #: journal/templates/_sidebar_collection_filter.html:32
 #, fuzzy
@@ -6373,8 +6312,7 @@ msgstr "Boost"
 
 #: journal/templates/action_delete_post.html:7
 msgid "Are you sure to delete this post and the mark or note related with it?"
-msgstr ""
-"Se sicuro di voler eliminare questo post e il segno o nota ad esso associati?"
+msgstr "Se sicuro di voler eliminare questo post e il segno o nota ad esso associati?"
 
 #: journal/templates/action_delete_post.html:7
 msgid "Are you sure to delete this reply?"
@@ -6402,6 +6340,14 @@ msgstr "piaciuto"
 #: journal/templates/action_like_post.html:16
 msgid "Like"
 msgstr ""
+
+#: journal/templates/action_mark_item.html:10
+msgid "add mark"
+msgstr "aggiungi segno"
+
+#: journal/templates/action_mark_item.html:18
+msgid "update mark"
+msgstr "aggiorna segno"
 
 #: journal/templates/action_open_post.html:7
 #, fuzzy
@@ -6463,13 +6409,13 @@ msgstr "Aggiungi alla collezione"
 msgid "Create a new collection"
 msgstr "Crea una nuova collezione"
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:81
+#: journal/templates/article.html:104 social/templates/_event_post.html:76
 #, fuzzy
 #| msgid "wrote a review of {item}"
 msgid "wrote a review"
 msgstr "ho scritto una recensione di {item}"
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:83
+#: journal/templates/article.html:106 social/templates/_event_post.html:78
 #, fuzzy
 #| msgid "wrote a note"
 msgid "wrote an article"
@@ -6481,9 +6427,7 @@ msgstr ""
 
 #: journal/templates/article.html:155
 msgid "The author has set it to be viewable only by logged-in users."
-msgstr ""
-"L'autore ha impostato la visibilità solo per gli utenti che hanno fatto "
-"l'accesso."
+msgstr "L'autore ha impostato la visibilità solo per gli utenti che hanno fatto l'accesso."
 
 #: journal/templates/article_edit.html:13
 #, fuzzy
@@ -6591,22 +6535,21 @@ msgstr "condividi con la posizione di playback"
 msgid "Mark"
 msgstr "Interazione"
 
-#: journal/templates/mark.html:50
+#: journal/templates/mark.html:54
 msgid "not rated"
 msgstr "non valutato"
 
-#: journal/templates/mark.html:70
+#: journal/templates/mark.html:74
 msgid "add a tag and press Enter"
 msgstr "Aggiungi un tag e premi \"Invio\""
 
-#: journal/templates/mark.html:122
+#: journal/templates/mark.html:126
 msgid "change mark date"
 msgstr "Cambia la data dell'interazione"
 
-#: journal/templates/mark.html:148
+#: journal/templates/mark.html:156
 msgid "Sure to delete mark, comment and tags for this item?"
-msgstr ""
-"Sicuro di voler eliminare le interazioni, commenti e tag per questo elemento?"
+msgstr "Sicuro di voler eliminare le interazioni, commenti e tag per questo elemento?"
 
 #: journal/templates/markdown_editor.html:9
 msgid "Markdown format references"
@@ -6624,15 +6567,13 @@ msgstr "Esempi di formattazione Markdown"
 #| "\n"
 #| "  Paragraphs need to be separated by a blank line\n"
 #| "\n"
-#| "  Indentation at the beginning of the paragraph requires using a Unicode "
-#| "full-width space\n"
+#| "  Indentation at the beginning of the paragraph requires using a Unicode full-width space\n"
 #| "\n"
 #| "[Link](https://zh.wikipedia.org/wiki/Markdown)\n"
 #| "**Bold**  *Italic* ==Highlight== ~~Strikethrough~~\n"
 #| "^Super^script ~Sub~script [拼(pīn)音(yīn)]\n"
 #| "\n"
-#| "Drag and drop an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/"
-#| "Wikipedia-logo-v2.svg)\n"
+#| "Drag and drop an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 #| "\n"
 #| "> Quote\n"
 #| ">> Multi-level quote\n"
@@ -6692,8 +6633,7 @@ msgid ""
 "Content Cell  | Content Cell\n"
 "Content Cell  | Content Cell\n"
 "\n"
-"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/"
-"Wikipedia-logo-v2.svg)\n"
+"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 "\n"
 msgstr ""
 "\n"
@@ -6705,15 +6645,13 @@ msgstr ""
 "\n"
 "  I paragrafi devono essere separati da una linea vuota\n"
 "\n"
-"  L'indentazione all'inizio del paragrafo richiede l'uso di uno spazio "
-"Unicode a tutta larghezza.\n"
+"  L'indentazione all'inizio del paragrafo richiede l'uso di uno spazio Unicode a tutta larghezza.\n"
 "\n"
 "[Link](https://zh.wikipedia.org/wiki/Markdown)\n"
 "**Grassetto**  *Corsivo* ==Sottolineato== ~~Barrato~~\n"
 "^Super^script ~Sub~script [拼(pīn)音(yīn)]\n"
 "\n"
-"Trascina e rilascio un'immagine ![](https://upload.wikimedia.org/wikipedia/"
-"en/8/80/Wikipedia-logo-v2.svg)\n"
+"Trascina e rilascio un'immagine ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 "\n"
 "> Citazione\n"
 ">> Citazione multi-livello\n"
@@ -6740,7 +6678,7 @@ msgstr ""
 "Cella del Contenuto  | Cella del Contenuto\n"
 "Cella del Contenuto  | Cella del Contenuto\n"
 
-#: journal/templates/note.html:19 journal/views/note.py:23
+#: journal/templates/note.html:19 journal/views/note.py:22
 msgid "Note"
 msgstr "Nota"
 
@@ -6752,8 +6690,7 @@ msgstr "Importazione in corso."
 
 #: journal/templates/note.html:29
 msgid "Note with empty content will be deleted, sure to continue?"
-msgstr ""
-"Le note senza contenuti verranno eliminate, sicuro di voler proseguire?"
+msgstr "Le note senza contenuti verranno eliminate, sicuro di voler proseguire?"
 
 #: journal/templates/note.html:72 journal/templates/note.html:73
 #, fuzzy
@@ -6772,12 +6709,8 @@ msgid "Are you sure to delete this entire content?"
 msgstr "Sei sicuro di voler eliminare tutto il contenuto?"
 
 #: journal/templates/piece_delete.html:24
-msgid ""
-"By deleting it, you will also lose track of others' comments and feedbacks "
-"to your content."
-msgstr ""
-"Eliminandolo perderai anche traccia dei commenti e delle interazioni degli "
-"altri sul tuo contenuto."
+msgid "By deleting it, you will also lose track of others' comments and feedbacks to your content."
+msgstr "Eliminandolo perderai anche traccia dei commenti e delle interazioni degli altri sul tuo contenuto."
 
 #: journal/templates/piece_delete.html:25
 #: journal/templates/piece_delete.html:32
@@ -6870,7 +6803,7 @@ msgstr "sintesi annuale"
 msgid "Articles"
 msgstr ""
 
-#: journal/templates/profile.html:166 journal/views/collection.py:427
+#: journal/templates/profile.html:166 journal/views/collection.py:409
 #: journal/views/profile.py:401
 msgid "collection"
 msgstr "Collezione"
@@ -6906,13 +6839,8 @@ msgid "Personal"
 msgstr "Personale"
 
 #: journal/templates/tag_edit.html:52
-msgid ""
-"Personal tags are not included in public index. However, if you use this tag "
-"when marking an item publicly, it might still be visible to others."
-msgstr ""
-"I tag personali non vengono inclusi nell'indice pubblico. Tuttavia, se usi "
-"questo tag quando segni pubblicamente un elemento, potrebbe essere ancora "
-"visibile agli altri."
+msgid "Personal tags are not included in public index. However, if you use this tag when marking an item publicly, it might still be visible to others."
+msgstr "I tag personali non vengono inclusi nell'indice pubblico. Tuttavia, se usi questo tag quando segni pubblicamente un elemento, potrebbe essere ancora visibile agli altri."
 
 #: journal/templates/tag_edit.html:55
 msgid "Delete this tag"
@@ -6987,130 +6915,128 @@ msgstr "Recensioni di {0}"
 msgid "Link invalid"
 msgstr "Collegamento non valido"
 
-#: journal/views/collection.py:58 journal/views/collection.py:96
+#: journal/views/collection.py:62 journal/views/collection.py:94
 #, python-brace-format
 msgid "Collection by {0}"
 msgstr "Collezione di {0}"
 
-#: journal/views/collection.py:432
+#: journal/views/collection.py:414
 msgid "shared my collection"
 msgstr "Ha condiviso la mia collezione"
 
-#: journal/views/collection.py:435
+#: journal/views/collection.py:417
 #, python-brace-format
 msgid "shared {username}'s collection"
 msgstr "condivisa la collezione di {username}"
 
-#: journal/views/collection.py:502 journal/views/collection.py:541
-#: journal/views/collection.py:553 journal/views/collection.py:579
+#: journal/views/collection.py:484 journal/views/collection.py:523
+#: journal/views/collection.py:535 journal/views/collection.py:561
 msgid "Dynamic collection is not editable"
 msgstr ""
 
-#: journal/views/collection.py:518
+#: journal/views/collection.py:500
 #, fuzzy
 #| msgid "This username is already in use."
 msgid "The item is already in the collection."
 msgstr "Questo nome utente è già in uso."
 
-#: journal/views/collection.py:520
+#: journal/views/collection.py:502
 msgid "Unable to find the item, please use item url from this site."
-msgstr ""
-"Impossibile trovare l'elemento, si prega di usare l'elemento URL da questo "
-"sito."
+msgstr "Impossibile trovare l'elemento, si prega di usare l'elemento URL da questo sito."
 
-#: journal/views/collection.py:566
+#: journal/views/collection.py:548
 #, fuzzy
 #| msgid "Save"
 msgid "Saved."
 msgstr "Salva"
 
-#: journal/views/common.py:119 journal/views/mark.py:225
-#: journal/views/mark.py:279 journal/views/note.py:175
+#: journal/views/common.py:126 journal/views/mark.py:273
+#: journal/views/mark.py:315 journal/views/note.py:167
 #: journal/views/profile.py:42 journal/views/review.py:59
 #: journal/views/review.py:79
 msgid "Content not found"
 msgstr "Contenuto non trovato"
 
-#: journal/views/common.py:174 journal/views/mark.py:159
+#: journal/views/common.py:184 journal/views/mark.py:210
 msgid "Data saved but unable to crosspost to Fediverse instance."
 msgstr "Dati salvati ma impossibile pubblicare nell'istanza del Fediverso."
 
-#: journal/views/common.py:176
+#: journal/views/common.py:186
 msgid "Redirecting to your Fediverse instance now to re-authenticate."
-msgstr ""
-"Reindirizzando alla tua istanza del Fediverso per la re-autenticazione."
+msgstr "Reindirizzando alla tua istanza del Fediverso per la re-autenticazione."
 
-#: journal/views/common.py:183
+#: journal/views/common.py:193
 msgid "List not found."
 msgstr "Lista non trovata."
 
-#: journal/views/mark.py:150
+#: journal/views/mark.py:206
 msgid "Content too long for your Fediverse instance."
 msgstr "Contenuto troppo lungo per la tua istanza del Fediverso."
 
-#: journal/views/mark.py:178 journal/views/mark.py:238
+#: journal/views/mark.py:224 journal/views/mark.py:226
+#: journal/views/mark.py:280
 #, fuzzy
 #| msgid "Invalid tag"
 msgid "Invalid input"
 msgstr "Tag non valido"
 
-#: journal/views/note.py:23
+#: journal/views/note.py:22
 msgid "Progress"
 msgstr ""
 
-#: journal/views/note.py:28
+#: journal/views/note.py:27
 #, fuzzy
 #| msgid "Update note"
 msgid "Update progress"
 msgstr "Aggiorna nota"
 
-#: journal/views/note.py:59
+#: journal/views/note.py:58
 msgid "Progress (optional)"
 msgstr "Progresso (opzionale)"
 
-#: journal/views/note.py:61
+#: journal/views/note.py:60
 msgid "Note Content"
 msgstr "Contenuto della nota"
 
-#: journal/views/note.py:63
+#: journal/views/note.py:62
 msgid "Content Warning (optional)"
 msgstr "Allerta sul contenuto (opzionale)"
 
-#: journal/views/note.py:85
+#: journal/views/note.py:84
 msgid "Progress Type (optional)"
 msgstr "Tipo di progresso (opzionale)"
 
-#: journal/views/note.py:123 journal/views/note.py:183
+#: journal/views/note.py:115 journal/views/note.py:175
 msgid "Only in-progress items can have progress."
 msgstr ""
 
-#: journal/views/post.py:98 journal/views/post.py:392
+#: journal/views/post.py:100 journal/views/post.py:388
 msgid "Post not found"
 msgstr "Post non trovato"
 
-#: journal/views/post.py:189
+#: journal/views/post.py:191
 msgid "Visibility too high for quoting this post"
 msgstr ""
 
-#: journal/views/post.py:337 journal/views/post.py:418
+#: journal/views/post.py:339 journal/views/post.py:414
 #, fuzzy
 #| msgid "Item cannot be deleted."
 msgid "Content cannot be empty."
 msgstr "L'elemento non può essere eliminato."
 
-#: journal/views/post.py:396
+#: journal/views/post.py:392
 #, fuzzy
 #| msgid "This operation cannot be undone. Sure to merge?"
 msgid "This post cannot be edited here"
 msgstr "Questa operazione non può essere annullata. Confermare accorpamento?"
 
-#: journal/views/post.py:541
+#: journal/views/post.py:531
 #, fuzzy
 #| msgid "Invalid file."
 msgid "Invalid choices"
 msgstr "File non valido."
 
-#: journal/views/post.py:544
+#: journal/views/post.py:534
 #, fuzzy
 #| msgid "Invalid tag"
 msgid "Invalid post"
@@ -7130,64 +7056,59 @@ msgstr "{review_title} - una recensione su {item_title}"
 #, fuzzy
 #| msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgid "may contain spoiler or triggering content"
-msgstr ""
-"riguardo {item_title}, potrebbe contenere spoiler o contenuto sensibile"
+msgstr "riguardo {item_title}, potrebbe contenere spoiler o contenuto sensibile"
 
-#: journal/views/tag.py:47 journal/views/tag.py:61
+#: journal/views/tag.py:46 journal/views/tag.py:60
 msgid "Invalid tag"
 msgstr "Tag non valido"
 
-#: journal/views/tag.py:50
+#: journal/views/tag.py:49
 msgid "Tag not found"
 msgstr "Tag non trovato"
 
-#: journal/views/tag.py:72
+#: journal/views/tag.py:65
 msgid "Tag deleted."
 msgstr "Tag eliminato."
 
-#: journal/views/tag.py:82
+#: journal/views/tag.py:75
 msgid "Duplicated tag."
 msgstr "Tag duplicato."
 
-#: journal/views/tag.py:96
+#: journal/views/tag.py:83
 msgid "Tag updated."
 msgstr "Tag aggiornato."
 
-#: journal/views/wrapped.py:160
+#: journal/views/wrapped.py:161
 msgid "Summary posted to timeline."
 msgstr "Recap pubblicato nella timeline."
 
-#: mastodon/models/common.py:29
+#: mastodon/models/common.py:31
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: mastodon/models/common.py:30 users/templates/users/login.html:120
+#: mastodon/models/common.py:32 users/templates/users/login.html:114
 msgid "Threads"
 msgstr "Threads"
 
-#: mastodon/models/common.py:31
+#: mastodon/models/common.py:33
 msgid "Bluesky"
 msgstr "Bluesky"
 
-#: mastodon/models/email.py:59
+#: mastodon/models/email.py:63
 msgid ""
 "\n"
 "\n"
-"If you did not mean to register or login, please ignore this email. If you "
-"are concerned with your account security, please change the email linked "
-"with your account, or contact us."
+"If you did not mean to register or login, please ignore this email. If you are concerned with your account security, please change the email linked with your account, or contact us."
 msgstr ""
 "\n"
 "\n"
-"Se non era tua intenzione registrarti, ignora questa email. Se sei "
-"preoccupato per la sicurezza del tuo account, si consiglia di cambiare "
-"l'email associata al tuo account, oppure contattaci direttamente."
+"Se non era tua intenzione registrarti, ignora questa email. Se sei preoccupato per la sicurezza del tuo account, si consiglia di cambiare l'email associata al tuo account, oppure contattaci direttamente."
 
-#: mastodon/models/email.py:64 mastodon/models/email.py:69
+#: mastodon/models/email.py:68 mastodon/models/email.py:73
 msgid "Verification Code"
 msgstr "Codice di verifica"
 
-#: mastodon/models/email.py:66
+#: mastodon/models/email.py:70
 #, python-brace-format
 msgid ""
 "Use this code to verify your email address {email}\n"
@@ -7198,7 +7119,7 @@ msgstr ""
 "\n"
 "{code}"
 
-#: mastodon/models/email.py:70
+#: mastodon/models/email.py:74
 #, python-brace-format
 msgid ""
 "Use this code to login as {email}\n"
@@ -7209,32 +7130,27 @@ msgstr ""
 "\n"
 "{code}"
 
-#: mastodon/models/email.py:74 users/templates/users/captcha.html:13
+#: mastodon/models/email.py:78 users/templates/users/captcha.html:13
 #: users/templates/users/captcha_solved.html:9
 #: users/templates/users/login.html:20 users/templates/users/register.html:9
 #: users/templates/users/welcome.html:10
 msgid "Register"
 msgstr "Registrati"
 
-#: mastodon/models/email.py:76
+#: mastodon/models/email.py:80
 #, python-brace-format
 msgid ""
 "There is no account registered with this email address yet: {email}\n"
 "\n"
-"If you already have an account with us, just login and add this email to you "
-"account.\n"
+"If you already have an account with us, just login and add this email to you account.\n"
 "\n"
-"If you prefer to register a new account with this email, please use this "
-"verification code: {code}"
+"If you prefer to register a new account with this email, please use this verification code: {code}"
 msgstr ""
-"Non c'è ancora nessun account registrato con questo indirizzo email: "
-"{email}\n"
+"Non c'è ancora nessun account registrato con questo indirizzo email: {email}\n"
 "\n"
-"Se hai già un account con noi, accedi semplicemente e aggiungi questa email "
-"al tuo account.\n"
+"Se hai già un account con noi, accedi semplicemente e aggiungi questa email al tuo account.\n"
 "\n"
-"Se preferisci registrare un nuovo account con questa email usa questo codice "
-"di verifica: {code}"
+"Se preferisci registrare un nuovo account con questa email usa questo codice di verifica: {code}"
 
 #: mastodon/models/mastodon.py:570
 msgid "site domain name"
@@ -7276,56 +7192,61 @@ msgstr "lunghezza massima del toot"
 msgid "New Post"
 msgstr "Nuovo Post"
 
-#: mastodon/views/bluesky.py:26 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:32 mastodon/views/bluesky.py:93
 #, fuzzy
 #| msgid "Bluesky Login ID"
 msgid "Bluesky login is disabled."
 msgstr "Login ID Bluesky"
 
-#: mastodon/views/bluesky.py:28 mastodon/views/email.py:35
-#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:29
-#: users/templates/users/login.html:6 users/views/webauthn.py:133
+#: mastodon/views/bluesky.py:47 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:65 mastodon/views/bluesky.py:98
+#: mastodon/views/bluesky.py:106 mastodon/views/bluesky.py:112
+#: mastodon/views/common.py:36 mastodon/views/mastodon.py:62
+#: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
+#: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
+#: mastodon/views/threads.py:57 mastodon/views/threads.py:65
+#: mastodon/views/threads.py:71 users/views/account.py:256
+#: users/views/account.py:375
+msgid "Authentication failed"
+msgstr "Autenticazione fallita"
+
+#: mastodon/views/bluesky.py:47 mastodon/views/common.py:103
+msgid "Identity not found."
+msgstr "Identità non trovata."
+
+#: mastodon/views/bluesky.py:53 mastodon/views/email.py:35
+#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:31
+#: users/templates/users/login.html:6 users/views/webauthn.py:136
 #, fuzzy
 #| msgid "Export file expired. Please export again."
 msgid "Security check failed. Please try again."
 msgstr "File d'esportazione scaduto. Si prega di esportare nuovamente."
 
-#: mastodon/views/bluesky.py:34 mastodon/views/bluesky.py:40
-#: mastodon/views/bluesky.py:64 mastodon/views/bluesky.py:72
-#: mastodon/views/bluesky.py:78 mastodon/views/common.py:36
-#: mastodon/views/mastodon.py:62 mastodon/views/mastodon.py:70
-#: mastodon/views/mastodon.py:77 mastodon/views/mastodon.py:87
-#: mastodon/views/mastodon.py:94 mastodon/views/threads.py:55
-#: mastodon/views/threads.py:63 mastodon/views/threads.py:69
-#: users/views/account.py:254 users/views/account.py:373
-msgid "Authentication failed"
-msgstr "Autenticazione fallita"
-
-#: mastodon/views/bluesky.py:35 mastodon/views/email.py:66
+#: mastodon/views/bluesky.py:60 mastodon/views/email.py:66
 #, fuzzy
 #| msgid "System busy, please try again in a minute."
 msgid "Too many attempts, please try again later."
 msgstr "Sistema occupato, si prega di riprovare fra un minuto."
 
-#: mastodon/views/bluesky.py:40
+#: mastodon/views/bluesky.py:65
 #, fuzzy
 #| msgid "ATProto handle"
 msgid "ATProto handle is required."
 msgstr "Nome utente ATProto"
 
-#: mastodon/views/bluesky.py:50
+#: mastodon/views/bluesky.py:84
 #, fuzzy
 #| msgid "Error connecting to instance"
 msgid "Error connecting to your ATProto server"
 msgstr "Errore durante la connessione all'istanza"
 
-#: mastodon/views/bluesky.py:73
+#: mastodon/views/bluesky.py:107
 #, fuzzy
 #| msgid "Invalid response from Fediverse instance."
 msgid "Invalid response from ATProto authorization server."
 msgstr "Risposta non valida dall'istanza del fediverso."
 
-#: mastodon/views/bluesky.py:78
+#: mastodon/views/bluesky.py:112
 msgid "Invalid account data from Bluesky."
 msgstr "Informazioni dell'account Bluesky non valide."
 
@@ -7333,7 +7254,7 @@ msgstr "Informazioni dell'account Bluesky non valide."
 msgid "Invalid user."
 msgstr "Utente non valido."
 
-#: mastodon/views/common.py:52 users/views/account.py:414
+#: mastodon/views/common.py:52 users/views/account.py:416
 msgid "Registration failed"
 msgstr "Registrazione fallita"
 
@@ -7365,10 +7286,6 @@ msgstr "Informazioni d'accesso aggiornate come {handle}."
 msgid "Disconnect identity failed"
 msgstr "Disconnessione identità fallita"
 
-#: mastodon/views/common.py:103
-msgid "Identity not found."
-msgstr "Identità non trovata."
-
 #: mastodon/views/common.py:117
 msgid "You cannot disconnect last login identity."
 msgstr "Non puoi disconnettere l'ultima identità d'accesso."
@@ -7388,9 +7305,7 @@ msgstr "Verifica"
 
 #: mastodon/views/email.py:48 users/templates/users/verify.html:20
 msgid "Verification email is being sent, please check your inbox."
-msgstr ""
-"È stata inviata un'email di verifica, si prega di controllare la propria "
-"casella di posta in arrivo."
+msgstr "È stata inviata un'email di verifica, si prega di controllare la propria casella di posta in arrivo."
 
 #: mastodon/views/email.py:80
 msgid "Invalid verification code"
@@ -7412,7 +7327,7 @@ msgstr "Errore durante la connessione all'istanza"
 msgid "Invalid response from Fediverse instance."
 msgstr "Risposta non valida dall'istanza del fediverso."
 
-#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:64
+#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:66
 msgid "Invalid OAuth state. Please try again."
 msgstr ""
 
@@ -7432,21 +7347,19 @@ msgstr "Token non valido dall'istanza del Fediverso."
 msgid "Invalid account data from Fediverse instance."
 msgstr "Dati account dell'istanza del Fediverso non validi."
 
-#: mastodon/views/threads.py:69
+#: mastodon/views/threads.py:71
 msgid "Invalid account data from Threads."
 msgstr "Dati dell'account Threads non validi."
 
-#: mastodon/views/threads.py:147
+#: mastodon/views/threads.py:149
 #, fuzzy
 #| msgid "Reset completed."
 msgid "Data deletion completed"
 msgstr "Reset completato."
 
-#: mastodon/views/threads.py:149
+#: mastodon/views/threads.py:151
 #, python-brace-format
-msgid ""
-"Data linked to your Threads account has been deleted. Confirmation code: "
-"{code}"
+msgid "Data linked to your Threads account has been deleted. Confirmation code: {code}"
 msgstr ""
 
 #: social/templates/_article_teaser.html:10
@@ -7485,15 +7398,11 @@ msgstr "ricondiviso"
 msgid "play"
 msgstr "riproduci"
 
-#: social/templates/_event_post.html:50
-msgid "mark"
-msgstr "segna"
-
-#: social/templates/_event_post.html:79
+#: social/templates/_event_post.html:74
 msgid "wrote a note"
 msgstr "ha scritto una nota"
 
-#: social/templates/_event_post.html:88
+#: social/templates/_event_post.html:83
 #, fuzzy
 #| msgid "playing"
 msgid "replying to"
@@ -7508,7 +7417,7 @@ msgstr ""
 msgid "Untitled article"
 msgstr ""
 
-#: social/templates/event/boosted.html:3
+#: social/templates/event/boosted.html:2
 msgid "boosted your post"
 msgstr "ha condiviso il tuo post"
 
@@ -7522,8 +7431,7 @@ msgid ""
 "boosted your article <a href=\"%(piece_url)s\">%(piece_title)s</a>\n"
 msgstr ""
 "\n"
-"ha condiviso la tua collezione <a href=\"%(piece_url)s\">%(piece_title)s</"
-"a>\n"
+"ha condiviso la tua collezione <a href=\"%(piece_url)s\">%(piece_title)s</a>\n"
 
 #: social/templates/event/boosted_collection.html:2
 #, python-format
@@ -7532,8 +7440,7 @@ msgid ""
 "boosted your collection <a href=\"%(piece_url)s\">%(piece_title)s</a>\n"
 msgstr ""
 "\n"
-"ha condiviso la tua collezione <a href=\"%(piece_url)s\">%(piece_title)s</"
-"a>\n"
+"ha condiviso la tua collezione <a href=\"%(piece_url)s\">%(piece_title)s</a>\n"
 
 #: social/templates/event/boosted_comment.html:3
 #, python-format
@@ -7560,19 +7467,16 @@ msgid ""
 "boosted your rating on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"ha condiviso la tua valutazione su <a href=\"%(item_url)s\">%(item_title)s</"
-"a>\n"
+"ha condiviso la tua valutazione su <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/boosted_review.html:2
 #, python-format
 msgid ""
 "\n"
-"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"ha condiviso la tua valutazione <a href=\"%(piece_url)s\">%(piece_title)s</"
-"a> su <a href=\"%(item_url)s\">%(item_title)s</a>\n"
+"ha condiviso la tua valutazione <a href=\"%(piece_url)s\">%(piece_title)s</a> su <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/boosted_shelfmember.html:3
 #, python-format
@@ -7581,8 +7485,7 @@ msgid ""
 "boosted your mark on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"ha condiviso la tua interazione su <a href=\"%(item_url)s\">%(item_title)s</"
-"a>\n"
+"ha condiviso la tua interazione su <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/follow_requested.html:3
 msgid "requested to follow you"
@@ -7592,7 +7495,7 @@ msgstr "ha richiesto di seguirti"
 msgid "followed you"
 msgstr "ti ha iniziato a seguire"
 
-#: social/templates/event/liked.html:3
+#: social/templates/event/liked.html:2
 msgid "liked your post"
 msgstr "piace il tuo post"
 
@@ -7606,8 +7509,7 @@ msgid ""
 "liked your article <a href=\"%(piece_url)s\">%(piece_title)s</a>\n"
 msgstr ""
 "\n"
-"ha apprezzato la tua collezione <a href=\"%(piece_url)s\">%(piece_title)s</"
-"a>\n"
+"ha apprezzato la tua collezione <a href=\"%(piece_url)s\">%(piece_title)s</a>\n"
 
 #: social/templates/event/liked_collection.html:2
 #, python-format
@@ -7616,8 +7518,7 @@ msgid ""
 "liked your collection <a href=\"%(piece_url)s\">%(piece_title)s</a>\n"
 msgstr ""
 "\n"
-"ha apprezzato la tua collezione <a href=\"%(piece_url)s\">%(piece_title)s</"
-"a>\n"
+"ha apprezzato la tua collezione <a href=\"%(piece_url)s\">%(piece_title)s</a>\n"
 
 #: social/templates/event/liked_comment.html:3
 #, python-format
@@ -7626,8 +7527,7 @@ msgid ""
 "liked your comment on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"ha apprezzato il tuo commento su <a href=\"%(item_url)s\">%(item_title)s</"
-"a>\n"
+"ha apprezzato il tuo commento su <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/liked_note.html:3
 #, python-format
@@ -7645,19 +7545,16 @@ msgid ""
 "liked your rating on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"ha apprezzato la tua valutazione su <a href=\"%(item_url)s\">%(item_title)s</"
-"a>\n"
+"ha apprezzato la tua valutazione su <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/liked_review.html:2
 #, python-format
 msgid ""
 "\n"
-"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"ha apprezzato la tua recensione <a href=\"%(piece_url)s\">%(piece_title)s</"
-"a> su <a href=\"%(item_url)s\">%(item_title)s</a>\n"
+"ha apprezzato la tua recensione <a href=\"%(piece_url)s\">%(piece_title)s</a> su <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/liked_shelfmember.html:3
 #, python-format
@@ -7666,10 +7563,9 @@ msgid ""
 "liked your mark on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"ha apprezzato la tua interazione su <a href=\"%(item_url)s\">%(item_title)s</"
-"a>\n"
+"ha apprezzato la tua interazione su <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
-#: social/templates/event/mentioned.html:3
+#: social/templates/event/mentioned.html:2
 msgid "mentioned you"
 msgstr "ti ha menzionato"
 
@@ -7683,8 +7579,7 @@ msgid ""
 "replied to your article <a href=\"%(piece_url)s\">%(piece_title)s</a>\n"
 msgstr ""
 "\n"
-"ha risposto alla tua collezione <a href=\"%(piece_url)s\">%(piece_title)s</"
-"a>\n"
+"ha risposto alla tua collezione <a href=\"%(piece_url)s\">%(piece_title)s</a>\n"
 
 #: social/templates/event/mentioned_collection.html:2
 #, python-format
@@ -7693,8 +7588,7 @@ msgid ""
 "replied to your collection <a href=\"%(piece_url)s\">%(piece_title)s</a>\n"
 msgstr ""
 "\n"
-"ha risposto alla tua collezione <a href=\"%(piece_url)s\">%(piece_title)s</"
-"a>\n"
+"ha risposto alla tua collezione <a href=\"%(piece_url)s\">%(piece_title)s</a>\n"
 
 #: social/templates/event/mentioned_comment.html:3
 #, python-format
@@ -7721,19 +7615,16 @@ msgid ""
 "replied to your rating on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"ha risposto alla tua valutazione su <a href=\"%(item_url)s\">%(item_title)s</"
-"a>\n"
+"ha risposto alla tua valutazione su <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/mentioned_review.html:2
 #, python-format
 msgid ""
 "\n"
-"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"ha risposto alla tua recensione <a href=\"%(piece_url)s\">%(piece_title)s</"
-"a> su <a href=\"%(item_url)s\">%(item_title)s</a>\n"
+"ha risposto alla tua recensione <a href=\"%(piece_url)s\">%(piece_title)s</a> su <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/mentioned_shelfmember.html:3
 #, python-format
@@ -7742,36 +7633,48 @@ msgid ""
 "replied to your mark on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"ha risposto alla tua interazione su <a href=\"%(item_url)s\">%(item_title)s</"
-"a>\n"
+"ha risposto alla tua interazione su <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
-#: social/templates/feed.html:12 social/templates/feed.html:39
-#: social/templates/search_feed.html:12
-msgid "Activities from those you follow"
-msgstr "Attività da chi segui"
+#: social/templates/feed.html:39 users/templates/users/preferences.html:40
+msgid "Activities"
+msgstr "Attività"
 
-#: social/templates/feed.html:42 social/templates/feed.html:44
+#: social/templates/feed.html:43 social/templates/feed.html:45
+msgid "world"
+msgstr ""
+
+#: social/templates/feed.html:51 social/templates/feed.html:53
+#, fuzzy
+#| msgid "locale"
+msgid "local"
+msgstr "locale"
+
+#: social/templates/feed.html:58 social/templates/feed.html:60
+#, fuzzy
+#| msgid "sure to follow?"
+msgid "those you follow"
+msgstr "Sicuro di voler seguire l'utente?"
+
+#: social/templates/feed.html:64 social/templates/feed.html:66
 #, fuzzy
 #| msgid "What they read/watch/..."
 msgid "what they read/watch/..."
 msgstr "Cosa leggono/guardano/..."
 
-#: social/templates/feed_events.html:30
+#: social/templates/feed_events.html:29
 msgid "no matching activities."
 msgstr "nessuna attività corrispondente."
 
-#: social/templates/feed_events.html:33
+#: social/templates/feed_events.html:31
+#, fuzzy
+#| msgid "no matching activities."
+msgid "no public activities yet."
+msgstr "nessuna attività corrispondente."
+
+#: social/templates/feed_events.html:34
 #, python-format
-msgid ""
-"Find and mark some books/movies/podcasts/games, <a "
-"href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/"
-"Douban, follow some fellow %(site_name)s users on the fediverse, so their "
-"recent activities and yours will show up here."
-msgstr ""
-"Trova e segna alcuni libri/film/podcast/giochi, <a "
-"href=\"%(import_url)s\">importa i tuoi dati</a> da Goodreads/Letterboxd/"
-"Douban, segui alcuni %(site_name)s utenti nel fediverso in modo che le loro "
-"attività recenti e le tue appaiano qui."
+msgid "Find and mark some books/movies/podcasts/games, <a href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/Douban, follow some fellow %(site_name)s users on the fediverse, so their recent activities and yours will show up here."
+msgstr "Trova e segna alcuni libri/film/podcast/giochi, <a href=\"%(import_url)s\">importa i tuoi dati</a> da Goodreads/Letterboxd/Douban, segui alcuni %(site_name)s utenti nel fediverso in modo che le loro attività recenti e le tue appaiano qui."
 
 #: social/templates/notification.html:58
 msgid "mention"
@@ -7807,6 +7710,10 @@ msgstr ""
 msgid "Poll ending at %(end_time)s"
 msgstr ""
 
+#: social/templates/search_feed.html:12 social/views.py:57 social/views.py:58
+msgid "Activities from those you follow"
+msgstr "Attività da chi segui"
+
 #: social/templates/single_post.html:13 social/templates/single_post.html:32
 #, fuzzy
 #| msgid "Posts"
@@ -7821,61 +7728,69 @@ msgstr ""
 msgid "Poll"
 msgstr ""
 
-#: takahe/models.py:453
+#: social/views.py:59
+#, fuzzy
+#| msgid "Activities from those you follow"
+msgid "Activities on this site"
+msgstr "Attività da chi segui"
+
+#: social/views.py:60
+#, fuzzy
+#| msgid "Activities from those you follow"
+msgid "Activities from the fediverse"
+msgstr "Attività da chi segui"
+
+#: takahe/models.py:445
 msgid "Display Name"
 msgstr "Nome Visualizzato"
 
-#: takahe/models.py:455
+#: takahe/models.py:447
 msgid "Bio"
 msgstr "Bio"
 
-#: takahe/models.py:457
+#: takahe/models.py:449
 msgid "Manually approve new followers"
 msgstr "Approva manualmente i nuovi follower"
 
-#: takahe/models.py:461
+#: takahe/models.py:453
 #, fuzzy
 #| msgid "Include profile and posts in discovery"
 msgid "Include profile, marks and posts in discovery"
 msgstr "Autorizza la scoperta pubblica del profilo e dei post"
 
-#: takahe/models.py:464
+#: takahe/models.py:456
 msgid "Include posts in search results"
 msgstr "Includi i post nei risultati di ricerca"
 
-#: takahe/models.py:482
+#: takahe/models.py:474
 msgid "Profile picture"
 msgstr "Foto profilo"
 
-#: takahe/models.py:489
+#: takahe/models.py:481
 msgid "Header picture"
 msgstr "Foto di copertina"
 
-#: users/models/task.py:22
+#: users/models/task.py:24
 msgid "Started"
 msgstr "Iniziato"
 
-#: users/models/task.py:23
+#: users/models/task.py:25
 msgid "Complete"
 msgstr "Completato"
 
-#: users/models/user.py:69
-msgid ""
-"Enter a valid username. This value may contain only unaccented lowercase a-z "
-"and uppercase A-Z letters, numbers, and _ characters."
-msgstr ""
-"Inserisci un nome utente valido. Questo valore può contenere solo lettere "
-"minuscole a-z e lettere maiuscole A-Z senza accenti, numeri, e_simboli."
+#: users/models/user.py:71
+msgid "Enter a valid username. This value may contain only unaccented lowercase a-z and uppercase A-Z letters, numbers, and _ characters."
+msgstr "Inserisci un nome utente valido. Questo valore può contenere solo lettere minuscole a-z e lettere maiuscole A-Z senza accenti, numeri, e_simboli."
 
-#: users/models/user.py:130
+#: users/models/user.py:132
 msgid "username"
 msgstr "nome utente"
 
-#: users/models/user.py:135
+#: users/models/user.py:137
 msgid "Required. 50 characters or fewer. Letters, digits and _ only."
 msgstr "Richiesto. 50 caratteri o meno. Lettere, numeri e solo _."
 
-#: users/models/user.py:138
+#: users/models/user.py:140
 msgid "A user with that username already exists."
 msgstr "Esiste già un utente con quel nome."
 
@@ -8030,9 +7945,7 @@ msgid "Cancel import"
 msgstr "Cancella"
 
 #: users/templates/users/_rym_section.html:29
-msgid ""
-"On RateYourMusic, go to your profile and use the <b>Export your music "
-"catalog</b> option to download your library as a CSV file."
+msgid "On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:31
@@ -8041,18 +7954,12 @@ msgid "Upload the downloaded CSV file below."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:33
-msgid ""
-"Albums are matched by title + artist (and year if present) — first against "
-"the local catalog, then MusicBrainz, then Spotify. After auto-matching, "
-"you'll preview the matches in a table, edit any link or shelf status, and "
-"confirm the import."
+msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:36
 #: users/templates/users/_storygraph_section.html:38
-msgid ""
-"You can also re-upload a previously-downloaded matched CSV — the existing "
-"<code>link</code> column will be honoured as the default match."
+msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:40
@@ -8083,18 +7990,11 @@ msgid "Cancel the StoryGraph import? Progress will be discarded."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:31
-msgid ""
-"On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to "
-"download your library as a CSV file."
+msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:35
-msgid ""
-"Books are matched by ISBN — first against the local catalog, then Google "
-"Books and OpenLibrary — with a title + author search as fallback. After auto-"
-"matching, you'll preview the matches in a table, edit any link or shelf "
-"status, and confirm the import."
+msgid "Books are matched by ISBN — first against the local catalog, then Google Books and OpenLibrary — with a title + author search as fallback. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/account.html:11
@@ -8106,13 +8006,8 @@ msgid "Display name, avatar and other information"
 msgstr "Visualizza nome, avatar e altre informazioni"
 
 #: users/templates/users/account.html:23
-msgid ""
-"Updating profile information here will turn off automatic sync of display "
-"name, bio and avatar from your Mastodon instance. Sure to continue?"
-msgstr ""
-"Aggiornare le informazioni qui disabiliterà automaticamente la "
-"sincronizzazione del tuo nome visualizzato, bio e avatar dalla tua istanza "
-"Mastodon. Vuoi procedere?"
+msgid "Updating profile information here will turn off automatic sync of display name, bio and avatar from your Mastodon instance. Sure to continue?"
+msgstr "Aggiornare le informazioni qui disabiliterà automaticamente la sincronizzazione del tuo nome visualizzato, bio e avatar dalla tua istanza Mastodon. Vuoi procedere?"
 
 #: users/templates/users/account.html:26
 msgid "Username"
@@ -8124,22 +8019,12 @@ msgstr "Indirizzo email"
 
 #: users/templates/users/account.html:59 users/templates/users/register.html:47
 #, python-format
-msgid ""
-"Please click the confirmation link in the email sent to %(pending_email)s; "
-"if you haven't received it for more than a few minutes, please input and "
-"save again."
-msgstr ""
-"Si prega di cliccare il link di conferma nell'email inviata a "
-"%(pending_email)s; se dopo alcuni minuti non l'hai ancora ricevuta, "
-"inseriscila e salvala ancora."
+msgid "Please click the confirmation link in the email sent to %(pending_email)s; if you haven't received it for more than a few minutes, please input and save again."
+msgstr "Si prega di cliccare il link di conferma nell'email inviata a %(pending_email)s; se dopo alcuni minuti non l'hai ancora ricevuta, inseriscila e salvala ancora."
 
 #: users/templates/users/account.html:61 users/templates/users/register.html:50
-msgid ""
-"Email is recommended as a backup login method, if you log in via a Fediverse "
-"instance"
-msgstr ""
-"L'email è consigliata come metodo di backup per l'accesso se fai l'accesso "
-"attraverso un'istanza del Fediverso"
+msgid "Email is recommended as a backup login method, if you log in via a Fediverse instance"
+msgstr "L'email è consigliata come metodo di backup per l'accesso se fai l'accesso attraverso un'istanza del Fediverso"
 
 #: users/templates/users/account.html:73 users/templates/users/login.html:84
 msgid "Fediverse (Mastodon)"
@@ -8156,30 +8041,16 @@ msgid "Last updated"
 msgstr "Ultimo aggiornamento"
 
 #: users/templates/users/account.html:92
-msgid ""
-"If you have not yet registered with any Federated instance, you may <a "
-"href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an "
-"instance</a> and register."
-msgstr ""
-"Se non ti sei ancora registrato con un'istanza federata, puoi <a "
-"href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">scegliere "
-"un'istanza</a> e registrarti."
+msgid "If you have not yet registered with any Federated instance, you may <a href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an instance</a> and register."
+msgstr "Se non ti sei ancora registrato con un'istanza federata, puoi <a href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">scegliere un'istanza</a> e registrarti."
 
 #: users/templates/users/account.html:97
-msgid ""
-"To associate with another federated identity, please enter the domain name "
-"of the instance where the new identity is located."
-msgstr ""
-"Per associare con un'altra identità federata, si prega di inserire il nome "
-"del dominio dell'istanza nella quale si trova la nuova identità."
+msgid "To associate with another federated identity, please enter the domain name of the instance where the new identity is located."
+msgstr "Per associare con un'altra identità federata, si prega di inserire il nome del dominio dell'istanza nella quale si trova la nuova identità."
 
 #: users/templates/users/account.html:99
-msgid ""
-"If you have registered with a Federated instance, please enter the instance "
-"domain name."
-msgstr ""
-"Se ti sei registrato con un'istanza federata, si prega di inserire il nome "
-"del dominio dell'istanza."
+msgid "If you have registered with a Federated instance, please enter the instance domain name."
+msgstr "Se ti sei registrato con un'istanza federata, si prega di inserire il nome del dominio dell'istanza."
 
 #: users/templates/users/account.html:104
 #, fuzzy
@@ -8192,33 +8063,18 @@ msgid "Go to target instance and authorize with the identity"
 msgstr "Vai all'istanza selezionata e autorizza con l'identità"
 
 #: users/templates/users/account.html:113
-msgid ""
-"After replacing the association, you may use the new Fediverse identity to "
-"log in and control data visibility. Existing data such as tags, comments, "
-"and collections will not be affected."
-msgstr ""
-"Dopo aver sostituito l'associazione, puoi usare la nuova identità del "
-"fediverso per effettuare l'accesso e controllare la visibilità dei dati. I "
-"dati esistenti tra i quali tag, commenti e collezioni, non verranno "
-"modificati."
+msgid "After replacing the association, you may use the new Fediverse identity to log in and control data visibility. Existing data such as tags, comments, and collections will not be affected."
+msgstr "Dopo aver sostituito l'associazione, puoi usare la nuova identità del fediverso per effettuare l'accesso e controllare la visibilità dei dati. I dati esistenti tra i quali tag, commenti e collezioni, non verranno modificati."
 
 #: users/templates/users/account.html:115
-msgid ""
-"Once associated with Fediverse identity, you can discover more users and use "
-"the full features of this site."
-msgstr ""
-"Una volta associato con un'identità del Fediverso, potrai scoprire più "
-"utenti e usare l'interezza delle funzionalità di questo sito."
+msgid "Once associated with Fediverse identity, you can discover more users and use the full features of this site."
+msgstr "Una volta associato con un'identità del Fediverso, potrai scoprire più utenti e usare l'interezza delle funzionalità di questo sito."
 
 #: users/templates/users/account.html:123
 #: users/templates/users/account.html:160
 #: users/templates/users/account.html:206
-msgid ""
-"Once disconnected, you will no longer be able login with this identity. Are "
-"you sure to continue?"
-msgstr ""
-"Una volta disconnesso, non potrai più effettuare l'accesso con questa "
-"identità. Sei sicuro di voler procedere?"
+msgid "Once disconnected, you will no longer be able login with this identity. Are you sure to continue?"
+msgstr "Una volta disconnesso, non potrai più effettuare l'accesso con questa identità. Sei sicuro di voler procedere?"
 
 #: users/templates/users/account.html:126
 msgid "Disconnect with this identity"
@@ -8244,7 +8100,7 @@ msgstr "Associa ad un account threads.net"
 msgid "Disconnect with Threads"
 msgstr "Disconnetti con Threads"
 
-#: users/templates/users/account.html:173 users/templates/users/login.html:112
+#: users/templates/users/account.html:173 users/templates/users/login.html:106
 msgid "Bluesky (ATProto)"
 msgstr "Bluesky (ATProto)"
 
@@ -8252,7 +8108,7 @@ msgstr "Bluesky (ATProto)"
 msgid "Verified ATProto identity"
 msgstr "Identità ATProto verificata"
 
-#: users/templates/users/account.html:194 users/templates/users/login.html:216
+#: users/templates/users/account.html:194 users/templates/users/login.html:210
 msgid "ATProto handle"
 msgstr "Nome utente ATProto"
 
@@ -8277,7 +8133,7 @@ msgid "Name this passkey:"
 msgstr ""
 
 #: users/templates/users/account.html:227 users/templates/users/login.html:69
-#: users/templates/users/welcome.html:33 users/views/webauthn.py:106
+#: users/templates/users/welcome.html:33 users/views/webauthn.py:109
 msgid "Passkey"
 msgstr ""
 
@@ -8326,12 +8182,8 @@ msgid "Save sync settings"
 msgstr "Salva le impostazioni di sincronizzazione"
 
 #: users/templates/users/account.html:297
-msgid ""
-"New follow, mute and blocks in the associated identity may be automatically "
-"imported; removal has to be done manually."
-msgstr ""
-"I nuovi seguiti, silenziati e bloccati nell'identità associata potrebbero "
-"essere importati automaticamente; la rimozione deve essere fatta manualmente."
+msgid "New follow, mute and blocks in the associated identity may be automatically imported; removal has to be done manually."
+msgstr "I nuovi seguiti, silenziati e bloccati nell'identità associata potrebbero essere importati automaticamente; la rimozione deve essere fatta manualmente."
 
 #: users/templates/users/account.html:304
 msgid "Click button below to start sync now."
@@ -8367,15 +8219,11 @@ msgid "Log out everywhere"
 msgstr ""
 
 #: users/templates/users/account.html:365
-msgid ""
-"This will log you out of all browsers and devices (including the current "
-"one), and revoke all API tokens. Continue?"
+msgid "This will log you out of all browsers and devices (including the current one), and revoke all API tokens. Continue?"
 msgstr ""
 
 #: users/templates/users/account.html:368
-msgid ""
-"If you notice any suspicious activity or have logged in on a shared "
-"computer, you can log out of all sessions and revoke all API tokens."
+msgid "If you notice any suspicious activity or have logged in on a shared computer, you can log out of all sessions and revoke all API tokens."
 msgstr ""
 
 #: users/templates/users/account.html:378
@@ -8450,10 +8298,10 @@ msgstr "da ascoltare"
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:74
-#: users/templates/users/data.html:126 users/templates/users/data.html:183
-#: users/templates/users/data.html:234 users/templates/users/data.html:298
-#: users/templates/users/data.html:358 users/templates/users/data.html:553
+#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/data.html:141 users/templates/users/data.html:198
+#: users/templates/users/data.html:249 users/templates/users/data.html:313
+#: users/templates/users/data.html:376 users/templates/users/data.html:553
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr "Importa"
@@ -8485,15 +8333,9 @@ msgstr "Migra account"
 
 #: users/templates/users/account.html:488
 #, fuzzy
-#| msgid ""
-#| "Link an email so that you can migrate followers from other Fediverse "
-#| "instances."
-msgid ""
-"Linking an email to your account is highly recommended before migrating from "
-"another Fediverse instance."
-msgstr ""
-"Associa un'email in modo da poter trasferire i seguaci da altre istanze del "
-"Fediverso."
+#| msgid "Link an email so that you can migrate followers from other Fediverse instances."
+msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
+msgstr "Associa un'email in modo da poter trasferire i seguaci da altre istanze del Fediverso."
 
 #: users/templates/users/account.html:491
 #, fuzzy
@@ -8513,22 +8355,15 @@ msgstr "Elimina Profilo"
 
 #: users/templates/users/account.html:504
 msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
-msgstr ""
-"Una volta eliminato, i dati dell'account non potranno essere recuperati. "
-"Vuoi continuare?"
+msgstr "Una volta eliminato, i dati dell'account non potranno essere recuperati. Vuoi continuare?"
 
 #: users/templates/users/account.html:507
-msgid ""
-"Enter full <code>username@instance.social</code> or <code>email@domain.com</"
-"code> to confirm deletion."
-msgstr ""
-"Per confermare l'eliminazione inserire per intero "
-"<code>username@instance.social</code> o <code>email@domain.com</code>."
+msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
+msgstr "Per confermare l'eliminazione inserire per intero <code>username@instance.social</code> o <code>email@domain.com</code>."
 
 #: users/templates/users/account.html:517
 msgid "Once deleted, account data cannot be recovered."
-msgstr ""
-"Una volta eliminati, i dati dell'account non potranno essere recuperati."
+msgstr "Una volta eliminati, i dati dell'account non potranno essere recuperati."
 
 #: users/templates/users/account.html:520
 #, fuzzy
@@ -8585,9 +8420,7 @@ msgid "Token Created"
 msgstr "non valutato"
 
 #: users/templates/users/authorized_app_created.html:22
-msgid ""
-"Your new personal access token has been created. Copy it now -- you will not "
-"be able to see it again."
+msgid "Your new personal access token has been created. Copy it now -- you will not be able to see it again."
 msgstr ""
 
 #: users/templates/users/authorized_app_created.html:25
@@ -8615,9 +8448,7 @@ msgid "One quick check"
 msgstr ""
 
 #: users/templates/users/captcha.html:28
-msgid ""
-"Put every cover into the row it belongs to. Drag it, or select a cover and "
-"then select a row."
+msgid "Put every cover into the row it belongs to. Drag it, or select a cover and then select a row."
 msgstr ""
 
 #: users/templates/users/captcha.html:41 users/templates/users/captcha.html:43
@@ -8652,7 +8483,7 @@ msgstr ""
 msgid "That is all we needed. Let's get you a username."
 msgstr ""
 
-#: users/templates/users/captcha_solved.html:34
+#: users/templates/users/captcha_solved.html:32
 #: users/templates/users/login.html:63
 #: users/templates/users/verify_email.html:25
 #: users/templates/users/welcome.html:51
@@ -8672,10 +8503,7 @@ msgid "Failed Crossposts"
 msgstr ""
 
 #: users/templates/users/crossposts.html:42
-msgid ""
-"These posts could not be crossposted to your linked social accounts. Re-"
-"authorize the account if needed, then retry. In rare cases retrying may "
-"create a duplicate post."
+msgid "These posts could not be crossposted to your linked social accounts. Re-authorize the account if needed, then retry. In rare cases retrying may create a duplicate post."
 msgstr ""
 
 #: users/templates/users/crossposts.html:48
@@ -8698,265 +8526,193 @@ msgstr ""
 msgid "Data Management"
 msgstr "Gestione Dati"
 
-#: users/templates/users/data.html:27
+#: users/templates/users/data.html:39
 msgid "Import Marks and Reviews from Douban"
 msgstr "Importa Interazioni e Valutazioni da Douban"
 
-#: users/templates/users/data.html:31
-msgid ""
-"Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
-"target=\"_blank\" rel=\"noopener\">Doufen</a>"
-msgstr ""
-"Seleziona<code>.xlsx</code>esportato da <a href=\"https://doufen.org\" "
-"target=\"_blank\" rel=\"noopener\">Doufen</a>"
+#: users/templates/users/data.html:43
+msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
+msgstr "Seleziona<code>.xlsx</code>esportato da <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 
 #: users/templates/users/data.html:45
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
-"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
-"NeoDB Archive</a> below."
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON format instead; upload it under <a href=\"#import-neodb-archive\">Import NeoDB Archive</a> below."
 msgstr ""
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:256
+#: users/templates/users/data.html:49 users/templates/users/data.html:271
 msgid "Import Method"
 msgstr "Metodo d'importazione"
 
-#: users/templates/users/data.html:37
-msgid ""
-"Merge: only update when status changes from wishlist to in-progress, or from "
-"in-progress to complete."
-msgstr ""
-"Associa: aggiorna solamente quanto lo status cambia da wishlist a \"in "
-"corso\", o da \"in corso\" a completato."
+#: users/templates/users/data.html:52
+msgid "Merge: only update when status changes from wishlist to in-progress, or from in-progress to complete."
+msgstr "Associa: aggiorna solamente quanto lo status cambia da wishlist a \"in corso\", o da \"in corso\" a completato."
 
-#: users/templates/users/data.html:41
+#: users/templates/users/data.html:56
 msgid "Overwrite: update all imported status."
 msgstr "Sovrascrivi: aggiorna tutti gli status importati."
 
-#: users/templates/users/data.html:74
-msgid ""
-"Another import is in progress, starting a new import may cause issues, sure "
-"to import?"
-msgstr ""
-"Un'altra importazione è in corso, avviare una nuova importazione potrebbe "
-"causare problemi, sicuro di voler importare?"
+#: users/templates/users/data.html:89
+msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
+msgstr "Un'altra importazione è in corso, avviare una nuova importazione potrebbe causare problemi, sicuro di voler importare?"
 
-#: users/templates/users/data.html:74
+#: users/templates/users/data.html:89 users/views/data.py:1130
 msgid "Import in progress, please wait"
 msgstr "Importazione in corso, attendere prego"
 
-#: users/templates/users/data.html:81
+#: users/templates/users/data.html:96
 #, fuzzy
 #| msgid "Import Shelf or List from Goodreads"
 msgid "Import from Goodreads"
 msgstr "Importa Libreria o Lista da Goodreads"
 
-#: users/templates/users/data.html:87
-msgid ""
-"On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download "
-"your library as a CSV file."
+#: users/templates/users/data.html:102
+msgid "On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download your library as a CSV file."
 msgstr ""
 
-#: users/templates/users/data.html:90
-msgid ""
-"Upload the downloaded <code>goodreads_library_export.csv</code> file below."
+#: users/templates/users/data.html:105
+msgid "Upload the downloaded <code>goodreads_library_export.csv</code> file below."
 msgstr ""
 
-#: users/templates/users/data.html:93
+#: users/templates/users/data.html:108
 #, fuzzy
-#| msgid ""
-#| "want-to-read / currently-reading / read books and their reviews will be "
-#| "imported."
-msgid ""
-"want-to-read / currently-reading / read / did-not-finish books and their "
-"reviews will be imported."
-msgstr ""
-"voler leggere / in lettura / libri letti e le loro rispettive recensioni "
-"saranno importate."
+#| msgid "want-to-read / currently-reading / read books and their reviews will be imported."
+msgid "want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported."
+msgstr "voler leggere / in lettura / libri letti e le loro rispettive recensioni saranno importate."
 
-#: users/templates/users/data.html:134
+#: users/templates/users/data.html:149
 msgid "Import from Letterboxd"
 msgstr "Importa da Letterboxd"
 
-#: users/templates/users/data.html:140
-msgid ""
-"on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" "
-"target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap "
-"Advanced Settings in Settings, tap EXPORT YOUR DATA"
+#: users/templates/users/data.html:155
+msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
 msgstr ""
 
-#: users/templates/users/data.html:143
-msgid ""
-"download file with name like <code>letterboxd-username-2018-03-11-07-52-"
-"utc.zip</code>, do not unzip"
+#: users/templates/users/data.html:158
+msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
 msgstr ""
 
-#: users/templates/users/data.html:146
-msgid ""
-"the following files in the zip file will be processed: <code>reviews.csv</"
-"code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</"
-"code> <code>lists/*.csv</code>"
+#: users/templates/users/data.html:161
+msgid "the following files in the zip file will be processed: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
 msgstr ""
 
-#: users/templates/users/data.html:149
-msgid ""
-"exported file does not indicate whether a list is private, unlisted or "
-"public, so all imported marks, reviews and collections will be created with "
-"the visibility selected below"
+#: users/templates/users/data.html:164
+msgid "exported file does not indicate whether a list is private, unlisted or public, so all imported marks, reviews and collections will be created with the visibility selected below"
 msgstr ""
 
-#: users/templates/users/data.html:184 users/templates/users/data.html:235
+#: users/templates/users/data.html:199 users/templates/users/data.html:250
 msgid "Only forward changes(none->to-watch->watched) will be imported."
 msgstr "Solo i cambi successivi(nessuno->da vedere->visto) saranno importati."
 
-#: users/templates/users/data.html:191
+#: users/templates/users/data.html:206
 #, fuzzy
 #| msgid "Import from Letterboxd"
 msgid "Import from Trakt"
 msgstr "Importa da Letterboxd"
 
-#: users/templates/users/data.html:197
-msgid ""
-"On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" "
-"rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait "
-"for the download link to appear."
+#: users/templates/users/data.html:212
+msgid "On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait for the download link to appear."
 msgstr ""
 
-#: users/templates/users/data.html:200
+#: users/templates/users/data.html:215
 msgid "Upload the downloaded <code>.zip</code> file below, do not unzip."
 msgstr ""
 
-#: users/templates/users/data.html:202
+#: users/templates/users/data.html:217
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:243
+#: users/templates/users/data.html:258
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr ""
 
-#: users/templates/users/data.html:246
+#: users/templates/users/data.html:261
 msgid "Login with Steam"
 msgstr ""
 
-#: users/templates/users/data.html:252
+#: users/templates/users/data.html:267
 msgid "Import Podcast Subscriptions"
 msgstr "Importa Iscrizioni Podcast"
 
-#: users/templates/users/data.html:263
+#: users/templates/users/data.html:278
 msgid "Mark as listening"
 msgstr "Segna come \"in ascolto\""
 
-#: users/templates/users/data.html:267
+#: users/templates/users/data.html:282
 msgid "Import as a new collection"
 msgstr "Importa come una nuova collezione"
 
-#: users/templates/users/data.html:296
+#: users/templates/users/data.html:311
 msgid "Select OPML file"
 msgstr "Seleziona file OPML"
 
-#: users/templates/users/data.html:306
+#: users/templates/users/data.html:321
 msgid "Import NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:312
-msgid ""
-"Upload a <code>.zip</code> file containing <code>.csv</code> or "
-"<code>.ndjson</code> files exported from NeoDB."
+#: users/templates/users/data.html:327
+msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr ""
 
 #: users/templates/users/data.html:330
 #, fuzzy
-#| msgid ""
-#| "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
-#| "target=\"_blank\" rel=\"noopener\">Doufen</a>"
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
-"imported here."
-msgstr ""
-"Seleziona<code>.xlsx</code>esportato da <a href=\"https://doufen.org\" "
-"target=\"_blank\" rel=\"noopener\">Doufen</a>"
+#| msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is imported here."
+msgstr "Seleziona<code>.xlsx</code>esportato da <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 
-#: users/templates/users/data.html:314
+#: users/templates/users/data.html:332
 #, fuzzy
 #| msgid "Existing metadata might get overwritten, sure to proceed?"
 msgid "Existing data may be overwritten."
-msgstr ""
-"I metadati esistenti potrebbero essere sovrascritti, sicuro di voler "
-"procedere?"
+msgstr "I metadati esistenti potrebbero essere sovrascritti, sicuro di voler procedere?"
 
-#: users/templates/users/data.html:324
+#: users/templates/users/data.html:342
 msgid "Detected format"
 msgstr ""
 
-#: users/templates/users/data.html:385
+#: users/templates/users/data.html:403
 msgid "Detecting format..."
 msgstr ""
 
-#: users/templates/users/data.html:411
+#: users/templates/users/data.html:429
 #, fuzzy
 #| msgid "Unknown or Other"
 msgid "Unknown format"
 msgstr "Sconosciuto o Altro"
 
-#: users/templates/users/data.html:436
+#: users/templates/users/data.html:454
 #, fuzzy
 #| msgid "Error connecting to instance"
 msgid "Error detecting format"
 msgstr "Errore durante la connessione all'istanza"
 
-#: users/templates/users/data.html:460
+#: users/templates/users/data.html:478
 msgid "Export NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:464
+#: users/templates/users/data.html:482
 #, fuzzy
 #| msgid "Export marks and reviews"
 msgid "Export marks, reviews and notes in CSV"
 msgstr "Esporta interazioni e recensioni"
 
-#: users/templates/users/data.html:471
+#: users/templates/users/data.html:489
 msgid "Export everything in NDJSON"
 msgstr ""
-
-#: users/templates/users/data.html:479
-#, fuzzy
-#| msgid "Export marks and reviews"
-msgid "Export marks and reviews in XLSX (Doufen format)"
-msgstr "Esporta interazioni e recensioni"
-
-#: users/templates/users/data.html:482
-msgid "Last export"
-msgstr "Ultime esportazioni"
-
-#: users/templates/users/data.html:487
-msgid "Download"
-msgstr "Scarica"
 
 #: users/templates/users/data.html:496
 msgid "Import and Export Articles (WordPress)"
 msgstr ""
 
 #: users/templates/users/data.html:499
-msgid ""
-"Your articles are exchanged as WordPress posts in the WXR format, which "
-"WordPress and most blogging tools can read and write. Marks, reviews and "
-"notes are not included: use the NeoDB archive above for those."
+msgid "Your articles are exchanged as WordPress posts in the WXR format, which WordPress and most blogging tools can read and write. Marks, reviews and notes are not included: use the NeoDB archive above for those."
 msgstr ""
 
 #: users/templates/users/data.html:502
-msgid ""
-"Article title, body, excerpt, tags, dates and featured image are exchanged. "
-"Comments and custom fields are ignored."
+msgid "Article title, body, excerpt, tags, dates and featured image are exchanged. Comments and custom fields are ignored."
 msgstr ""
 
 #: users/templates/users/data.html:505
-msgid ""
-"The body is converted between Markdown and HTML, so formatting is kept but "
-"the text is not character-for-character identical."
+msgid "The body is converted between Markdown and HTML, so formatting is kept but the text is not character-for-character identical."
 msgstr ""
 
 #: users/templates/users/data.html:512
@@ -8966,16 +8722,11 @@ msgid "Export articles in WordPress format"
 msgstr "Esporta interazioni e recensioni"
 
 #: users/templates/users/data.html:519
-msgid ""
-"In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download "
-"an <code>.xml</code> file, then upload it below."
+msgid "In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download an <code>.xml</code> file, then upload it below."
 msgstr ""
 
 #: users/templates/users/data.html:522
-msgid ""
-"Only published posts use the visibility below. Drafts, pending, private and "
-"password-protected posts are always imported as mentioned-only, so nothing "
-"unpublished becomes public."
+msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
 #: users/templates/users/data.html:560
@@ -8983,12 +8734,8 @@ msgid "View Annual Summary"
 msgstr "Visualizza Sintesi Annuale"
 
 #: users/templates/users/fetch_identity_failed.html:4
-msgid ""
-"Unable to find the user, please check your spelling; or the server may be "
-"busy, please try again later."
-msgstr ""
-"Impossibile trovare l'utente, si prega di controllare l'ortografia; oppure "
-"il server potrebbe essere occupato, si prega di riprovare successivamente."
+msgid "Unable to find the user, please check your spelling; or the server may be busy, please try again later."
+msgstr "Impossibile trovare l'utente, si prega di controllare l'ortografia; oppure il server potrebbe essere occupato, si prega di riprovare successivamente."
 
 #: users/templates/users/fetch_identity_pending.html:13
 #: users/templates/users/fetch_identity_pending.html:22
@@ -9007,120 +8754,78 @@ msgstr "Accesso"
 msgid "logo"
 msgstr ""
 
-#: users/templates/users/login.html:127
-msgid ""
-"Sign in with a passkey saved on this device or in your password manager."
+#: users/templates/users/login.html:121
+msgid "Sign in with a passkey saved on this device or in your password manager."
 msgstr ""
 
-#: users/templates/users/login.html:132
+#: users/templates/users/login.html:126
 msgid "Sign in with Passkey"
 msgstr ""
 
-#: users/templates/users/login.html:148
+#: users/templates/users/login.html:142
 msgid "Enter your email address"
 msgstr "Inserisci il tuo indirizzo email"
 
-#: users/templates/users/login.html:152
+#: users/templates/users/login.html:146
 msgid "Send verification code"
 msgstr "Invia codice di verifica"
 
-#: users/templates/users/login.html:171
+#: users/templates/users/login.html:165
 msgid "Domain of your instance, e.g. mastodon.social"
 msgstr "Dominio della tua istanza, es: mastodon.social"
 
-#: users/templates/users/login.html:177
-msgid ""
-"Please enter domain of your instance; e.g. if your id is "
-"<i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
-msgstr ""
-"Si prega di inserire il dominio della tua istanza; es. se il tuo id è "
-"<i>@neodb@mastodon.social</i>, inserisci solamente <i>mastodon.social</i>."
+#: users/templates/users/login.html:171
+msgid "Please enter domain of your instance; e.g. if your id is <i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
+msgstr "Si prega di inserire il dominio della tua istanza; es. se il tuo id è <i>@neodb@mastodon.social</i>, inserisci solamente <i>mastodon.social</i>."
 
-#: users/templates/users/login.html:182 users/templates/users/login.html:246
+#: users/templates/users/login.html:176 users/templates/users/login.html:240
 msgid "Authorize via Fediverse instance"
 msgstr "Autorizza attraverso l'istanza del Fediverso"
 
-#: users/templates/users/login.html:187
-msgid ""
-"If you don't have a <a href=\"https://joinmastodon.org/servers\" "
-"target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or "
-"login with Email first, and link it with Fediverse (Mastodon) later in "
-"account settings."
-msgstr ""
-"Se non hai ancora un <a href=\"https://joinmastodon.org/servers\" "
-"target=\"_blank\">Account del Fediverso (Mastodon)</a> , dovresti "
-"registrarti o effettuare l'accesso con l'email prima, e poi associarla con "
-"il profilo del Fediverso (Mastodon) successivamente nelle impostazioni del "
-"profilo."
+#: users/templates/users/login.html:181
+msgid "If you don't have a <a href=\"https://joinmastodon.org/servers\" target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or login with Email first, and link it with Fediverse (Mastodon) later in account settings."
+msgstr "Se non hai ancora un <a href=\"https://joinmastodon.org/servers\" target=\"_blank\">Account del Fediverso (Mastodon)</a> , dovresti registrarti o effettuare l'accesso con l'email prima, e poi associarla con il profilo del Fediverso (Mastodon) successivamente nelle impostazioni del profilo."
 
-#: users/templates/users/login.html:200
+#: users/templates/users/login.html:194
 msgid "Authorize via Threads"
 msgstr "Autorizza attraverso Threads"
 
-#: users/templates/users/login.html:221
-msgid ""
-"Please input your ATProto handle (e.g. neodb.bsky.social, without the "
-"leading @), do not use email. If you changed handle recently, just use the "
-"latest one."
-msgstr ""
-"Si prega di inserire il proprio nome utente ATProto (es. neodb.bsky.social, "
-"senza la \"@\"), nonusare l'email. Se hai recentemente cambiato nome utente, "
-"usa quello più recente."
+#: users/templates/users/login.html:215
+msgid "Please input your ATProto handle (e.g. neodb.bsky.social, without the leading @), do not use email. If you changed handle recently, just use the latest one."
+msgstr "Si prega di inserire il proprio nome utente ATProto (es. neodb.bsky.social, senza la \"@\"), nonusare l'email. Se hai recentemente cambiato nome utente, usa quello più recente."
 
-#: users/templates/users/login.html:224
+#: users/templates/users/login.html:218
 #, fuzzy
 #| msgid "Authorize via Threads"
 msgid "Authorize via ATProto server"
 msgstr "Autorizza attraverso Threads"
 
-#: users/templates/users/login.html:231
+#: users/templates/users/login.html:225
 #, python-format
-msgid ""
-"Please choose one to register or login %(site_name)s. Have more than one of "
-"these identities? Don't worry, you may link them in account settings once "
-"logged in."
-msgstr ""
-"Si prega di usare uno per registrarsi o effettuare l'accesso %(site_name)s. "
-"Hai più di una di queste identità? Non preoccuparti, potrai associarle "
-"successivamente nelle impostazioni dell'account una volta effetuato "
-"l'accesso."
+msgid "Please choose one to register or login %(site_name)s. Have more than one of these identities? Don't worry, you may link them in account settings once logged in."
+msgstr "Si prega di usare uno per registrarsi o effettuare l'accesso %(site_name)s. Hai più di una di queste identità? Non preoccuparti, potrai associarle successivamente nelle impostazioni dell'account una volta effetuato l'accesso."
 
-#: users/templates/users/login.html:255
+#: users/templates/users/login.html:249
 msgid "Valid invitation code, please login or register."
-msgstr ""
-"Codice d'invito non valido, si prega di effettuare l'accesso oppure "
-"registrarsi."
+msgstr "Codice d'invito non valido, si prega di effettuare l'accesso oppure registrarsi."
 
-#: users/templates/users/login.html:257
-msgid ""
-"Please use invitation link to register a new account; existing user may "
-"login."
-msgstr ""
-"Si prega di usare il link d'invito per registrare un nuovo account; l'utente "
-"esistente può effettuare l'accesso."
+#: users/templates/users/login.html:251
+msgid "Please use invitation link to register a new account; existing user may login."
+msgstr "Si prega di usare il link d'invito per registrare un nuovo account; l'utente esistente può effettuare l'accesso."
 
-#: users/templates/users/login.html:259
+#: users/templates/users/login.html:253
 msgid "Invitation code invalid or expired."
 msgstr "Codice d'invito non valido o scaduto."
 
-#: users/templates/users/login.html:267
+#: users/templates/users/login.html:261
 msgid "Loading timed out, please check your network (VPN) settings."
-msgstr ""
-"Caricamento interrotto, si prega di controllare le impostazioni di rete "
-"(VPN)."
+msgstr "Caricamento interrotto, si prega di controllare le impostazioni di rete (VPN)."
 
-#: users/templates/users/login.html:273
-msgid ""
-"Continue using this site implies consent to our <a href=\"/pages/rules/"
-"\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using "
-"cookies to provide necessary functionality."
-msgstr ""
-"Continuare a usare questo sito sottointende il vostro consenso alle nostre "
-"<a href=\"/pages/rules/\">regole</a>e<a href=\"/pages/terms/\">termini</a>, "
-"incluso l'utilizzo di cookies per provvedere le funionalità necessarie al "
-"corretto funzionamento del sito."
+#: users/templates/users/login.html:267
+msgid "Continue using this site implies consent to our <a href=\"/pages/rules/\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using cookies to provide necessary functionality."
+msgstr "Continuare a usare questo sito sottointende il vostro consenso alle nostre <a href=\"/pages/rules/\">regole</a>e<a href=\"/pages/terms/\">termini</a>, incluso l'utilizzo di cookies per provvedere le funionalità necessarie al corretto funzionamento del sito."
 
-#: users/templates/users/login.html:287
+#: users/templates/users/login.html:281
 msgid "Domain of your instance (excl. @)"
 msgstr "Dominio della tua istanza (esclusa @)"
 
@@ -9130,9 +8835,7 @@ msgid "Migrate Here"
 msgstr ""
 
 #: users/templates/users/migrate_in.html:22
-msgid ""
-"To move another account to this one, first add it as an alias here, and then "
-"go to the server where it is hosted and initiate the move."
+msgid "To move another account to this one, first add it as an alias here, and then go to the server where it is hosted and initiate the move."
 msgstr ""
 
 #: users/templates/users/migrate_in.html:27
@@ -9188,16 +8891,11 @@ msgstr ""
 
 #: users/templates/users/migrate_out.html:46
 #, python-format
-msgid ""
-"To migrate to another account, first add <code>@%(handle)s</code> as an "
-"alias on the target server, and then type the target account below to start "
-"the migration."
+msgid "To migrate to another account, first add <code>@%(handle)s</code> as an alias on the target server, and then type the target account below to start the migration."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:50
-msgid ""
-"Are you sure you want to migrate your account? Your followers will be moved "
-"to the target account."
+msgid "Are you sure you want to migrate your account? Your followers will be moved to the target account."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:53
@@ -9215,10 +8913,6 @@ msgstr "comincia a leggere"
 #: users/templates/users/preferences.html:28
 msgid "Default view once logged in"
 msgstr "Visualizzazione di base una volta effettuato l'accesso"
-
-#: users/templates/users/preferences.html:40
-msgid "Activities"
-msgstr "Attività"
 
 #: users/templates/users/preferences.html:49
 msgid "Default visibility"
@@ -9247,9 +8941,7 @@ msgstr "Abilita in maniera predefinita la condivisione su altri social network"
 
 #: users/templates/users/preferences.html:111
 #: users/templates/users/register.html:88
-msgid ""
-"If a Mastodon account is linked with this identity, boosting a post will "
-"also make the same post boosted with that Mastodon account."
+msgid "If a Mastodon account is linked with this identity, boosting a post will also make the same post boosted with that Mastodon account."
 msgstr ""
 
 #: users/templates/users/preferences.html:115
@@ -9265,18 +8957,12 @@ msgid "Create a new post"
 msgstr "Crea un nuovo post"
 
 #: users/templates/users/preferences.html:130
-msgid ""
-"this method is less optimal, may generate duplicated posts and miss "
-"reactions."
-msgstr ""
-"questo metodo è meno ottimale, potrebbe generare post duplicati e mancare le "
-"reazioni."
+msgid "this method is less optimal, may generate duplicated posts and miss reactions."
+msgstr "questo metodo è meno ottimale, potrebbe generare post duplicati e mancare le reazioni."
 
 #: users/templates/users/preferences.html:140
 #: users/templates/users/register.html:97
-msgid ""
-"Always publish my public marks, reviews and articles as data records to my "
-"PDS."
+msgid "Always publish my public marks, reviews and articles as data records to my PDS."
 msgstr ""
 
 #: users/templates/users/preferences.html:145
@@ -9296,19 +8982,8 @@ msgid "Automatic bookmark for these categories"
 msgstr "Aggiungere automaticamente un segnalibro per queste categorie"
 
 #: users/templates/users/preferences.html:175
-msgid ""
-"When start to read/watch/play/... an item in these categories, a bookmark "
-"will be created automatically. Bookmarks can be viewed and managed in most "
-"<a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon "
-"compatible apps</a>; your replies to these posts will automatically become "
-"notes for the item."
-msgstr ""
-"Quando si inizia a leggere/vedere/giocare/... un elemento facente parte di "
-"queste categorie, verrà creato automaticamente un segnalibro. I segnalibri "
-"possono essere visualizzati e gestiti nella maggior parte delle <a "
-"href=\"https://joinmastodon.org/apps\" target=\"_blank\"> applicazioni "
-"compatibili con Mastodon</a>; le tue risposte a questi post diventeranno "
-"automaticamente note per l'elemento."
+msgid "When start to read/watch/play/... an item in these categories, a bookmark will be created automatically. Bookmarks can be viewed and managed in most <a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon compatible apps</a>; your replies to these posts will automatically become notes for the item."
+msgstr "Quando si inizia a leggere/vedere/giocare/... un elemento facente parte di queste categorie, verrà creato automaticamente un segnalibro. I segnalibri possono essere visualizzati e gestiti nella maggior parte delle <a href=\"https://joinmastodon.org/apps\" target=\"_blank\"> applicazioni compatibili con Mastodon</a>; le tue risposte a questi post diventeranno automaticamente note per l'elemento."
 
 #: users/templates/users/preferences.html:183
 msgid "Turn replies to my own catalog item posts into notes for the item"
@@ -9327,35 +9002,19 @@ msgid "Profile visible to anonymous web visitors and search engines"
 msgstr "Profilo visibile ai visitatori anonimi del web e ai motori di ricerca"
 
 #: users/templates/users/preferences.html:217
-msgid ""
-"this option limits web visits only; to limit fediverse visibility, choose "
-"followers only or mentioned only when posting"
-msgstr ""
-"questa opzione limita solamente le visite del web; per limitare la "
-"visibilità nel fediverso, scegliere \"solo seguaci\" o \"solo menzionati\" "
-"solo mentre si pubblica"
+msgid "this option limits web visits only; to limit fediverse visibility, choose followers only or mentioned only when posting"
+msgstr "questa opzione limita solamente le visite del web; per limitare la visibilità nel fediverso, scegliere \"solo seguaci\" o \"solo menzionati\" solo mentre si pubblica"
 
 #: users/templates/users/preferences.html:225
 msgid "Show your name on item page if you recently edited it"
-msgstr ""
-"Mostra il tuo nome nella pagina dell'elemento se l'hai modificato di recente"
+msgstr "Mostra il tuo nome nella pagina dell'elemento se l'hai modificato di recente"
 
 #: users/templates/users/preferences.html:234
 msgid "Do not show me item recommendations"
 msgstr ""
 
 #: users/templates/users/preferences.html:237
-msgid ""
-"Recommendations are generated only from public marks, processed in batch on "
-"this server. Your private and follower-only marks are never used as a signal "
-"for anyone, and we never share your data with third parties for this "
-"feature. When you share marks publicly and keep your profile discoverable, "
-"your marks help others here and across the Fediverse find things they might "
-"enjoy -- that voluntary contribution is what makes the feature work for "
-"everyone. If you'd rather not contribute, uncheck \"Include profile, marks "
-"and posts in discovery\" on your account page; this setting is published "
-"over ActivityPub, so other servers will also stop including you in their "
-"discovery features."
+msgid "Recommendations are generated only from public marks, processed in batch on this server. Your private and follower-only marks are never used as a signal for anyone, and we never share your data with third parties for this feature. When you share marks publicly and keep your profile discoverable, your marks help others here and across the Fediverse find things they might enjoy -- that voluntary contribution is what makes the feature work for everyone. If you'd rather not contribute, uncheck \"Include profile, marks and posts in discovery\" on your account page; this setting is published over ActivityPub, so other servers will also stop including you in their discovery features."
 msgstr ""
 
 #: users/templates/users/profile_actions.html:12
@@ -9453,29 +9112,15 @@ msgstr "Il tuo nome utente su %(site_name)s"
 
 #: users/templates/users/register.html:28
 msgid "2-30 alphabets, numbers or underscore, can't be changed once saved"
-msgstr ""
-"da 2 a 30 caratteri, numeri o trattini in basso _, non possono essere "
-"cambiati una volta salvati"
+msgstr "da 2 a 30 caratteri, numeri o trattini in basso _, non possono essere cambiati una volta salvati"
 
 #: users/templates/users/register.html:72
-msgid ""
-"Use display name, bio and avatar from the social network you authenticated "
-"with"
-msgstr ""
-"Usa il nome visualizzato, bio e avatar del social network con il quale ti "
-"sei autenticato"
+msgid "Use display name, bio and avatar from the social network you authenticated with"
+msgstr "Usa il nome visualizzato, bio e avatar del social network con il quale ti sei autenticato"
 
 #: users/templates/users/register.html:80
-msgid ""
-"Add follow, mute and block list from the social network you authenticated "
-"with"
-msgstr ""
-"Aggiungi seguiti, silenziati e lista bloccati dal social network con il "
-"quale ti sei autenticato"
-
-#: users/templates/users/register.html:104
-msgid "Confirm and save"
-msgstr "Conferma e salva"
+msgid "Add follow, mute and block list from the social network you authenticated with"
+msgstr "Aggiungi seguiti, silenziati e lista bloccati dal social network con il quale ti sei autenticato"
 
 #: users/templates/users/register.html:106
 msgid "Close"
@@ -9503,8 +9148,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"              Matched %(local)s locally, %(external)s externally, "
-"%(unmatched)s unmatched out of %(total)s rows.\n"
+"              Matched %(local)s locally, %(external)s externally, %(unmatched)s unmatched out of %(total)s rows.\n"
 "            "
 msgstr ""
 
@@ -9639,9 +9283,7 @@ msgid "Played"
 msgstr "Giocato"
 
 #: users/templates/users/steam_import.html:90
-msgid ""
-"Games in wishlist; or purchased in library but never played, mark date will "
-"be set as today"
+msgid "Games in wishlist; or purchased in library but never played, mark date will be set as today"
 msgstr ""
 
 #: users/templates/users/steam_import.html:91
@@ -9685,15 +9327,11 @@ msgid "Comma-separated Steam AppIDs"
 msgstr ""
 
 #: users/templates/users/steam_import.html:121
-msgid ""
-"Allow reverse override of status (e.g. playing -> want to, or played -> "
-"playing)"
+msgid "Allow reverse override of status (e.g. playing -> want to, or played -> playing)"
 msgstr ""
 
 #: users/templates/users/steam_import.html:139
-msgid ""
-"To import from Steam, your game details must be visible to public in Steam "
-"privacy settings."
+msgid "To import from Steam, your game details must be visible to public in Steam privacy settings."
 msgstr ""
 
 #: users/templates/users/storygraph_import.html:9
@@ -9744,38 +9382,23 @@ msgstr "Benvenuti"
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
-#| "              %(site_name)s is flourishing because of collaborations and "
-#| "contributions from users like you. Please read our <a href=\"/pages/"
-#| "terms\">term of service</a>, and feel free to <a "
-#| "href=\"%(support_link)s\">contact us</a> if you have any question or "
-#| "feedback.\n"
+#| "              %(site_name)s is flourishing because of collaborations and contributions from users like you. Please read our <a href=\"/pages/terms\">term of service</a>, and feel free to <a href=\"%(support_link)s\">contact us</a> if you have any question or feedback.\n"
 #| "        "
 msgid ""
 "\n"
-"              %(site_name)s is flourishing because of collaborations and "
-"contributions from users like you. Please read our <a href=\"/pages/"
-"rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</"
-"a> if you have any question or feedback.\n"
+"              %(site_name)s is flourishing because of collaborations and contributions from users like you. Please read our <a href=\"/pages/rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</a> if you have any question or feedback.\n"
 "        "
 msgstr ""
 "\n"
-"              %(site_name)s sta avendo successo grazie ai collaboratori e ai "
-"contributi effettuati da utenti come te. Leggi i nostri <a href=\"/pages/"
-"terms\">termini di servizio</a>, e sentiti libero di <a "
-"href=\"%(support_link)s\">contattarci</a> per qualsiasi domanda o per un "
-"feedback.\n"
+"              %(site_name)s sta avendo successo grazie ai collaboratori e ai contributi effettuati da utenti come te. Leggi i nostri <a href=\"/pages/terms\">termini di servizio</a>, e sentiti libero di <a href=\"%(support_link)s\">contattarci</a> per qualsiasi domanda o per un feedback.\n"
 "        "
 
 #: users/templates/users/welcome.html:37
-msgid ""
-"Set up a passkey to sign in quickly next time using your fingerprint, face, "
-"or screen lock."
+msgid "Set up a passkey to sign in quickly next time using your fingerprint, face, or screen lock."
 msgstr ""
 
 #: users/templates/users/welcome.html:39
-msgid ""
-"Creating a passkey is highly recommended, as the website or email you use to "
-"create this account may not be always available."
+msgid "Creating a passkey is highly recommended, as the website or email you use to create this account may not be always available."
 msgstr ""
 
 #: users/templates/users/welcome.html:43
@@ -9792,346 +9415,246 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:124
+#: users/views/account.py:126
 msgid "This username is already in use."
 msgstr "Questo nome utente è già in uso."
 
-#: users/views/account.py:135
+#: users/views/account.py:137
 msgid "This email address is already in use."
 msgstr "Questo indirizzo email è già in uso."
 
-#: users/views/account.py:255 users/views/account.py:374
+#: users/views/account.py:257 users/views/account.py:376
 msgid "Registration is for invitation only"
 msgstr "La registrazione è soltanto per invito"
 
-#: users/views/account.py:266 users/views/account.py:338
+#: users/views/account.py:268 users/views/account.py:340
 #, fuzzy
 #| msgid "Timestamp"
 msgid "Time is up"
 msgstr "Timbro temporale"
 
-#: users/views/account.py:267 users/views/account.py:310
-#: users/views/account.py:339
+#: users/views/account.py:269 users/views/account.py:312
+#: users/views/account.py:341
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:313
+#: users/views/account.py:315
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:325
+#: users/views/account.py:327
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:326
+#: users/views/account.py:328
 #, fuzzy
 #| msgid "System busy, please try again in a minute."
 msgid "Please try again later."
 msgstr "Sistema occupato, si prega di riprovare fra un minuto."
 
-#: users/views/account.py:415
+#: users/views/account.py:417
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:445
+#: users/views/account.py:447
 msgid "Valid username required"
 msgstr "Nome utente valido richiesto"
 
-#: users/views/account.py:526
+#: users/views/account.py:518
 msgid "Account is being deleted."
 msgstr "L'account è in fase di eliminazione."
 
-#: users/views/account.py:529
+#: users/views/account.py:521
 msgid "Account mismatch."
 msgstr "Le informazzioni del profilo non corrispondono."
 
-#: users/views/data.py:262 users/views/data.py:294
+#: users/views/data.py:264 users/views/data.py:296
 msgid "Export file not available."
 msgstr "File d'esportazione non disponibile."
 
-#: users/views/data.py:288
+#: users/views/data.py:290
 msgid "Generating exports."
 msgstr "Generando esportazioni."
 
-#: users/views/data.py:306
+#: users/views/data.py:308
 msgid "Export file expired. Please export again."
 msgstr "File d'esportazione scaduto. Si prega di esportare nuovamente."
 
-#: users/views/data.py:321 users/views/data.py:342 users/views/data.py:363
+#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
 #, fuzzy
 #| msgid "Import in progress."
 msgid "Recent export still in progress."
 msgstr "Importazione in corso."
 
-#: users/views/data.py:379 users/views/data.py:513 users/views/data.py:547
-#: users/views/data.py:772 users/views/data.py:989 users/views/data.py:1015
-#: users/views/data.py:1040 users/views/data.py:1065
+#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
+#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
+#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
 msgid "Invalid file."
 msgstr "File non valido."
 
-#: users/views/data.py:403
+#: users/views/data.py:405
 msgid "Sync in progress."
 msgstr "Sincronizzazione in corso."
 
-#: users/views/data.py:417
+#: users/views/data.py:419
 msgid "Settings saved."
 msgstr "Impostazioni salvate."
 
-#: users/views/data.py:472
+#: users/views/data.py:474
 #, fuzzy
 #| msgid "Account is being deleted."
 msgid "Account no longer linked."
 msgstr "L'account è in fase di eliminazione."
 
-#: users/views/data.py:475
+#: users/views/data.py:477
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:503
+#: users/views/data.py:505
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:583 users/views/data.py:808
+#: users/views/data.py:585 users/views/data.py:810
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:608 users/views/data.py:837
+#: users/views/data.py:610 users/views/data.py:839
 #, fuzzy
 #| msgid "Cancel"
 msgid "Cancelled."
 msgstr "Cancella"
 
-#: users/views/data.py:628
+#: users/views/data.py:630
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:636 users/views/data.py:746 users/views/data.py:867
-#: users/views/data.py:972
+#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
+#: users/views/data.py:974
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:732 users/views/data.py:958
+#: users/views/data.py:734 users/views/data.py:960
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:742 users/views/data.py:968
+#: users/views/data.py:744 users/views/data.py:970
 #, fuzzy
 #| msgid "Export file not available."
 msgid "No matched file available."
 msgstr "File d'esportazione non disponibile."
 
-#: users/views/data.py:859
+#: users/views/data.py:861
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1188
+#: users/views/data.py:1226
 #, fuzzy
 #| msgid "Login required"
 msgid "Name is required."
 msgstr "Richiesto l'accesso"
 
-#: users/views/data.py:1210
+#: users/views/data.py:1248
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1264
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1231
+#: users/views/data.py:1269
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1241 users/views/data.py:1292
+#: users/views/data.py:1279 users/views/data.py:1330
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:1248
+#: users/views/data.py:1286
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:1253
+#: users/views/data.py:1291
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:1279
+#: users/views/data.py:1317
 #, fuzzy
 #| msgid "Registration failed"
 msgid "Migration cancelled."
 msgstr "Registrazione fallita"
 
-#: users/views/data.py:1284
+#: users/views/data.py:1322
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:1297
+#: users/views/data.py:1335
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:1308
+#: users/views/data.py:1346
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:1314
+#: users/views/data.py:1352
 #, fuzzy, python-brace-format
 #| msgid "Continue login as {handle}."
 msgid "Start moving to {handle}."
 msgstr "Continua l'accesso come {handle}."
 
-#: users/views/data.py:1372
+#: users/views/data.py:1410
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1388
+#: users/views/data.py:1426
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1392
+#: users/views/data.py:1430
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1402
+#: users/views/data.py:1440
 #, python-brace-format
-msgid ""
-"Import of {count} entries received. They will be processed in the background."
+msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""
 
-#: users/views/webauthn.py:103
+#: users/views/webauthn.py:106
 #, fuzzy
 #| msgid "Registration failed"
 msgid "Passkey registration failed"
 msgstr "Registrazione fallita"
 
-#: users/views/webauthn.py:123
+#: users/views/webauthn.py:126
 msgid "Credential already registered"
 msgstr ""
 
-#: users/views/webauthn.py:165 users/views/webauthn.py:172
-#: users/views/webauthn.py:181
+#: users/views/webauthn.py:168 users/views/webauthn.py:175
+#: users/views/webauthn.py:184
 msgid "Passkey not recognized"
 msgstr ""
 
-#: users/views/webauthn.py:186
+#: users/views/webauthn.py:189
 #, fuzzy
 #| msgid "Account is being deleted."
 msgid "Account is inactive"
 msgstr "L'account è in fase di eliminazione."
 
-#: users/views/webauthn.py:202
+#: users/views/webauthn.py:205
 #, fuzzy
 #| msgid "Send verification code"
 msgid "Passkey verification failed"
 msgstr "Invia codice di verifica"
 
-#: users/views/webauthn.py:228 users/views/webauthn.py:250
+#: users/views/webauthn.py:231 users/views/webauthn.py:253
 #, fuzzy
 #| msgid "User not found"
 msgid "Passkey not found"
 msgstr "Utente non trovato"
 
-#: users/views/webauthn.py:244
+#: users/views/webauthn.py:247
 #, fuzzy
 #| msgid "Login required"
 msgid "Name is required"
 msgstr "Richiesto l'accesso"
-
-#~ msgid "Fanfic"
-#~ msgstr "Fanfiction"
-
-#~ msgid "FanFic"
-#~ msgstr "FanFiction"
-
-#~ msgid "year of publication"
-#~ msgstr "anno di pubblicazione"
-
-#~ msgid "YYYY-MM-DD"
-#~ msgstr "AAAA-MM-GG"
-
-#~ msgid "region or event"
-#~ msgstr "regione o evento"
-
-#~ msgid "Germany or Toronto International Film Festival"
-#~ msgstr "Germania o Toronto International Film Festival"
-
-#~ msgid "year"
-#~ msgstr "anno"
-
-#~ msgctxt "music"
-#~ msgid "genre"
-#~ msgstr "Genere"
-
-#~ msgid "my notes"
-#~ msgstr "Le mie note"
-
-#~ msgid "release year"
-#~ msgstr "anno d'uscita"
-
-#~ msgid "episode Length"
-#~ msgstr "Durata dell'episodio"
-
-#~ msgid "show time"
-#~ msgstr "prima trasmissione"
-
-#~ msgid "Region or Event"
-#~ msgstr "Paese o Evento"
-
-#~ msgid "boost"
-#~ msgstr "ricondividi"
-
-#~ msgid "Invalid form data"
-#~ msgstr "Formattazione dei dati non valida"
-
-#~ msgid "Username and app password is required."
-#~ msgstr "Nome utente e password dell'app richiesti."
-
-#~ msgid "All"
-#~ msgstr "Tutto"
-
-#~ msgid "Bluesky app password"
-#~ msgstr "Password dell'app Bluesky"
-
-#~ msgid ""
-#~ "App password can be created on <a href=\"https://bsky.app/settings/app-"
-#~ "passwords\" target=\"_blank\">bsky.app</a>."
-#~ msgstr ""
-#~ "La password dell'app può essere creata su<a href=\"https://bsky.app/"
-#~ "settings/app-passwords\" target=\"_blank\">bsky.app</a>."
-
-#~ msgid "Link to Goodreads Profile / Shelf / List"
-#~ msgstr "Associa al Profilo Goodreads / Libreria / Lista"
-
-#~ msgid "Last import started"
-#~ msgstr "Ultima importazione iniziata"
-
-#~ msgid "Shelf will be imported as a new collection."
-#~ msgstr "Libreria sarà importata come una nuova collezione."
-
-#~ msgid "List will be imported as a new collection."
-#~ msgstr "Lista verrà importata come una nuova collezione."
-
-#~ msgid ""
-#~ "Failed links, likely due to Letterboxd error, you may have to mark them "
-#~ "manually"
-#~ msgstr ""
-#~ "Le associazioni non riuscite, probabilmente a causa di un errore di "
-#~ "Letterboxd, dovresti poterle segnare manualmente"
-
-#~ msgid "Export Data"
-#~ msgstr "Esporta Dati"
-
-#~ msgid "back to your home page."
-#~ msgstr "ritorna alla tua pagina iniziale."
-
-#~ msgid "Turn on crosspost to timeline by default"
-#~ msgstr "Abilita in maniera predefinita la condivisione sulla timeline"
-
-#~ msgid "Username in use"
-#~ msgstr "Nome utente in uso"
-
-#~ msgid "Invalid URL."
-#~ msgstr "URL non valido."
-
-#~ msgid "File is uploaded and will be imported soon."
-#~ msgstr "Il file è stato caricato e verrà importato a breve."

--- a/neodb/locale/ja/LC_MESSAGES/django.po
+++ b/neodb/locale/ja/LC_MESSAGES/django.po
@@ -7,11 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-23 15:40-0400\n"
+"POT-Creation-Date: 2026-09-06 20:04-0400\n"
 "PO-Revision-Date: 2026-08-09 06:32+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Japanese <https://hosted.weblate.org/projects/neodb/neodb/ja/"
-">\n"
+"Language-Team: Japanese <https://hosted.weblate.org/projects/neodb/neodb/ja/>\n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,159 +18,159 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: boofilsic/settings.py:472 common/models/lang.py:230
+#: boofilsic/settings.py:501 common/models/lang.py:232
 msgid "English"
 msgstr "英語"
 
-#: boofilsic/settings.py:473 common/models/lang.py:77
+#: boofilsic/settings.py:502 common/models/lang.py:79
 msgid "Danish"
 msgstr "デンマーク語"
 
-#: boofilsic/settings.py:474 common/models/lang.py:78
+#: boofilsic/settings.py:503 common/models/lang.py:80
 msgid "German"
 msgstr "ドイツ語"
 
-#: boofilsic/settings.py:475 common/models/lang.py:183
+#: boofilsic/settings.py:504 common/models/lang.py:185
 msgid "Spanish"
 msgstr ""
 
-#: boofilsic/settings.py:476 common/models/lang.py:87
+#: boofilsic/settings.py:505 common/models/lang.py:89
 msgid "French"
 msgstr "フランス語"
 
-#: boofilsic/settings.py:477 common/models/lang.py:112
+#: boofilsic/settings.py:506 common/models/lang.py:114
 msgid "Italian"
 msgstr ""
 
-#: boofilsic/settings.py:478 common/models/lang.py:166
-#: common/models/lang.py:305
+#: boofilsic/settings.py:507 common/models/lang.py:168
+#: common/models/lang.py:307
 msgid "Portuguese"
 msgstr ""
 
-#: boofilsic/settings.py:479
+#: boofilsic/settings.py:508
 msgid "Brazilian Portuguese"
 msgstr ""
 
-#: boofilsic/settings.py:480 common/models/lang.py:316
+#: boofilsic/settings.py:509 common/models/lang.py:318
 msgid "Simplified Chinese"
 msgstr ""
 
-#: boofilsic/settings.py:481 common/models/lang.py:317
+#: boofilsic/settings.py:510 common/models/lang.py:319
 msgid "Traditional Chinese"
 msgstr ""
 
-#: catalog/forms.py:35 catalog/models/item.py:291
+#: catalog/forms.py:35 catalog/models/item.py:307
 msgid "Primary ID Type"
 msgstr ""
 
-#: catalog/forms.py:40 catalog/models/item.py:294
+#: catalog/forms.py:40 catalog/models/item.py:310
 msgid "Primary ID Value"
 msgstr ""
 
-#: catalog/forms.py:181
+#: catalog/forms.py:176
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
-#: catalog/models/book.py:139 catalog/models/book.py:158
-#: catalog/models/common.py:280 catalog/models/common.py:298
+#: catalog/models/book.py:141 catalog/models/book.py:160
+#: catalog/models/common.py:279 catalog/models/common.py:297
 msgid "locale"
 msgstr ""
 
-#: catalog/models/book.py:142 catalog/models/book.py:161
-#: catalog/models/common.py:283 catalog/models/common.py:303
+#: catalog/models/book.py:144 catalog/models/book.py:163
+#: catalog/models/common.py:282 catalog/models/common.py:302
 msgid "text content"
 msgstr ""
 
-#: catalog/models/book.py:177
+#: catalog/models/book.py:179
 msgid "Paperback"
 msgstr ""
 
-#: catalog/models/book.py:178
+#: catalog/models/book.py:180
 msgid "Hardcover"
 msgstr ""
 
-#: catalog/models/book.py:179
+#: catalog/models/book.py:181
 msgid "eBook"
 msgstr ""
 
-#: catalog/models/book.py:180
+#: catalog/models/book.py:182
 msgid "Audiobook"
 msgstr ""
 
-#: catalog/models/book.py:182
+#: catalog/models/book.py:184
 msgid "Web Fiction"
 msgstr ""
 
-#: catalog/models/book.py:183 catalog/models/game.py:38
+#: catalog/models/book.py:185 catalog/models/game.py:38
 msgid "Other"
 msgstr ""
 
-#: catalog/models/book.py:260
+#: catalog/models/book.py:262
 msgid "subtitle"
 msgstr ""
 
-#: catalog/models/book.py:270 catalog/models/movie.py:120
-#: catalog/models/performance.py:385 catalog/models/tv.py:211
-#: catalog/models/tv.py:437
+#: catalog/models/book.py:272 catalog/models/movie.py:120
+#: catalog/models/performance.py:385 catalog/models/tv.py:213
+#: catalog/models/tv.py:439
 msgid "original title"
 msgstr ""
 
-#: catalog/models/book.py:274
+#: catalog/models/book.py:276
 msgid "other title"
 msgstr ""
 
-#: catalog/models/book.py:280 catalog/models/book.py:564
-#: catalog/models/item.py:123
+#: catalog/models/book.py:282 catalog/models/book.py:566
+#: catalog/models/item.py:119
 msgid "author"
 msgstr ""
 
-#: catalog/models/book.py:287 catalog/models/item.py:124
+#: catalog/models/book.py:289 catalog/models/item.py:120
 msgid "translator"
 msgstr ""
 
-#: catalog/models/book.py:294 catalog/templates/edition.html:26
+#: catalog/models/book.py:296 catalog/templates/edition.html:26
 msgid "book format"
 msgstr ""
 
-#: catalog/models/book.py:301 catalog/models/game.py:135
-#: catalog/models/item.py:138 catalog/models/music.py:142
+#: catalog/models/book.py:303 catalog/models/game.py:135
+#: catalog/models/item.py:134 catalog/models/music.py:142
 msgid "publisher"
 msgstr ""
 
-#: catalog/models/book.py:308
+#: catalog/models/book.py:310
 msgid "publication year"
 msgstr ""
 
-#: catalog/models/book.py:314
+#: catalog/models/book.py:316
 msgid "publication month"
 msgstr ""
 
-#: catalog/models/book.py:319
+#: catalog/models/book.py:321
 msgid "binding"
 msgstr ""
 
-#: catalog/models/book.py:320
+#: catalog/models/book.py:322
 msgid "pages"
 msgstr ""
 
-#: catalog/models/book.py:321 catalog/templates/edition.html:45
+#: catalog/models/book.py:323 catalog/templates/edition.html:45
 msgid "series"
 msgstr ""
 
-#: catalog/models/book.py:322 catalog/templates/edition.html:65
+#: catalog/models/book.py:324 catalog/templates/edition.html:65
 msgid "contents"
 msgstr ""
 
-#: catalog/models/book.py:323 catalog/templates/edition.html:51
+#: catalog/models/book.py:325 catalog/templates/edition.html:51
 msgid "price"
 msgstr ""
 
-#: catalog/models/book.py:324 catalog/models/item.py:149
+#: catalog/models/book.py:326 catalog/models/item.py:145
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr ""
 
-#: catalog/models/common.py:26 common/models/lang.py:256
+#: catalog/models/common.py:26 common/models/lang.py:258
 msgid "Unknown"
 msgstr ""
 
@@ -179,11 +178,11 @@ msgstr ""
 msgid "Douban"
 msgstr ""
 
-#: catalog/models/common.py:28 catalog/models/common.py:79
+#: catalog/models/common.py:28 catalog/models/common.py:81
 msgid "Goodreads"
 msgstr ""
 
-#: catalog/models/common.py:29 catalog/models/common.py:81
+#: catalog/models/common.py:29 catalog/models/common.py:83
 msgid "Google Books"
 msgstr ""
 
@@ -191,16 +190,16 @@ msgstr ""
 msgid "BooksTW"
 msgstr ""
 
-#: catalog/models/common.py:31 catalog/models/common.py:91
-#: catalog/models/common.py:93
+#: catalog/models/common.py:31 catalog/models/common.py:93
+#: catalog/models/common.py:95
 msgid "Bibliotek.dk"
 msgstr ""
 
-#: catalog/models/common.py:32 catalog/models/common.py:92
+#: catalog/models/common.py:32 catalog/models/common.py:94
 msgid "eReolen.dk"
 msgstr ""
 
-#: catalog/models/common.py:33 catalog/models/common.py:74
+#: catalog/models/common.py:33 catalog/models/common.py:76
 #: catalog/templates/movie.html:41 catalog/templates/people.html:37
 #: catalog/templates/tvseason.html:58 catalog/templates/tvshow.html:53
 msgid "IMDb"
@@ -210,7 +209,7 @@ msgstr ""
 msgid "TMDB"
 msgstr ""
 
-#: catalog/models/common.py:35 catalog/models/common.py:94
+#: catalog/models/common.py:35 catalog/models/common.py:96
 msgid "Bandcamp"
 msgstr ""
 
@@ -226,11 +225,11 @@ msgstr ""
 msgid "Steam"
 msgstr ""
 
-#: catalog/models/common.py:39 catalog/models/common.py:114
+#: catalog/models/common.py:39 catalog/models/common.py:116
 msgid "itch.io"
 msgstr ""
 
-#: catalog/models/common.py:40 catalog/models/common.py:115
+#: catalog/models/common.py:40 catalog/models/common.py:117
 msgid "Bangumi"
 msgstr ""
 
@@ -238,7 +237,7 @@ msgstr ""
 msgid "BGG"
 msgstr ""
 
-#: catalog/models/common.py:42 catalog/models/common.py:116
+#: catalog/models/common.py:42 catalog/models/common.py:118
 msgid "Apple Podcast"
 msgstr ""
 
@@ -250,35 +249,35 @@ msgstr ""
 msgid "Discogs"
 msgstr ""
 
-#: catalog/models/common.py:45 catalog/models/common.py:117
+#: catalog/models/common.py:45 catalog/models/common.py:119
 msgid "Apple Music"
 msgstr ""
 
-#: catalog/models/common.py:46 catalog/models/common.py:119
+#: catalog/models/common.py:46 catalog/models/common.py:121
 msgid "Fediverse"
 msgstr ""
 
-#: catalog/models/common.py:47 catalog/models/common.py:120
+#: catalog/models/common.py:47 catalog/models/common.py:122
 msgid "Qidian"
 msgstr ""
 
-#: catalog/models/common.py:48 catalog/models/common.py:121
+#: catalog/models/common.py:48 catalog/models/common.py:123
 msgid "Ypshuo"
 msgstr ""
 
-#: catalog/models/common.py:49 catalog/models/common.py:122
+#: catalog/models/common.py:49 catalog/models/common.py:124
 msgid "Archive of Our Own"
 msgstr ""
 
-#: catalog/models/common.py:50 catalog/models/common.py:123
+#: catalog/models/common.py:50 catalog/models/common.py:125
 msgid "JinJiang"
 msgstr ""
 
-#: catalog/models/common.py:51 catalog/models/common.py:64
+#: catalog/models/common.py:51 catalog/models/common.py:66
 msgid "WikiData"
 msgstr ""
 
-#: catalog/models/common.py:52 catalog/models/common.py:124
+#: catalog/models/common.py:52 catalog/models/common.py:126
 msgid "Open Library"
 msgstr ""
 
@@ -290,15 +289,15 @@ msgstr ""
 msgid "WorldCat"
 msgstr ""
 
-#: catalog/models/common.py:55 catalog/models/common.py:126
+#: catalog/models/common.py:55 catalog/models/common.py:128
 msgid "MobyGames"
 msgstr ""
 
-#: catalog/models/common.py:56 catalog/models/common.py:127
+#: catalog/models/common.py:56 catalog/models/common.py:129
 msgid "StoryGraph"
 msgstr ""
 
-#: catalog/models/common.py:57 catalog/models/common.py:118
+#: catalog/models/common.py:57 catalog/models/common.py:120
 msgid "YouTube Music"
 msgstr ""
 
@@ -314,335 +313,344 @@ msgstr ""
 msgid "Readmoo"
 msgstr ""
 
-#: catalog/models/common.py:65
-msgid "ISBN10"
+#: catalog/models/common.py:61
+msgid "MyAnimeList"
 msgstr ""
 
-#: catalog/models/common.py:66 catalog/templates/edition.html:19
-msgid "ISBN"
+#: catalog/models/common.py:62 catalog/models/common.py:140
+msgid "MangaUpdates"
 msgstr ""
 
 #: catalog/models/common.py:67
-msgid "ASIN"
+msgid "ISBN10"
 msgstr ""
 
-#: catalog/models/common.py:68
-msgid "ISSN"
+#: catalog/models/common.py:68 catalog/templates/edition.html:19
+msgid "ISBN"
 msgstr ""
 
 #: catalog/models/common.py:69
-msgid "CUBN"
+msgid "ASIN"
 msgstr ""
 
 #: catalog/models/common.py:70
-msgid "ISRC"
+msgid "ISSN"
 msgstr ""
 
 #: catalog/models/common.py:71
-msgid "GTIN UPC EAN"
+msgid "CUBN"
 msgstr ""
 
 #: catalog/models/common.py:72
-msgid "OCLC Number"
+msgid "ISRC"
 msgstr ""
 
 #: catalog/models/common.py:73
-msgid "RSS Feed URL"
+msgid "GTIN UPC EAN"
+msgstr ""
+
+#: catalog/models/common.py:74
+msgid "OCLC Number"
 msgstr ""
 
 #: catalog/models/common.py:75
-msgid "TMDB TV Series"
-msgstr ""
-
-#: catalog/models/common.py:76
-msgid "TMDB TV Season"
+msgid "RSS Feed URL"
 msgstr ""
 
 #: catalog/models/common.py:77
-msgid "TMDB TV Episode"
+msgid "TMDB TV Series"
 msgstr ""
 
 #: catalog/models/common.py:78
-msgid "TMDB Movie"
+msgid "TMDB TV Season"
+msgstr ""
+
+#: catalog/models/common.py:79
+msgid "TMDB TV Episode"
 msgstr ""
 
 #: catalog/models/common.py:80
-msgid "Goodreads Work"
+msgid "TMDB Movie"
 msgstr ""
 
 #: catalog/models/common.py:82
-msgid "Douban Book"
-msgstr ""
-
-#: catalog/models/common.py:83
-msgid "Douban Book Work"
+msgid "Goodreads Work"
 msgstr ""
 
 #: catalog/models/common.py:84
-msgid "Douban Movie"
+msgid "Douban Book"
 msgstr ""
 
 #: catalog/models/common.py:85
-msgid "Douban Music"
+msgid "Douban Book Work"
 msgstr ""
 
 #: catalog/models/common.py:86
-msgid "Douban Game"
+msgid "Douban Movie"
 msgstr ""
 
 #: catalog/models/common.py:87
-msgid "Douban Drama"
+msgid "Douban Music"
 msgstr ""
 
 #: catalog/models/common.py:88
-msgid "Douban Drama Version"
+msgid "Douban Game"
 msgstr ""
 
 #: catalog/models/common.py:89
-msgid "BooksTW Book"
+msgid "Douban Drama"
 msgstr ""
 
 #: catalog/models/common.py:90
+msgid "Douban Drama Version"
+msgstr ""
+
+#: catalog/models/common.py:91
+msgid "BooksTW Book"
+msgstr ""
+
+#: catalog/models/common.py:92
 msgid "Readmoo Book"
 msgstr ""
 
-#: catalog/models/common.py:95
+#: catalog/models/common.py:97
 msgid "Spotify Album"
 msgstr ""
 
-#: catalog/models/common.py:96
+#: catalog/models/common.py:98
 msgid "Spotify Podcast"
 msgstr ""
 
-#: catalog/models/common.py:97
+#: catalog/models/common.py:99
 msgid "Discogs Release"
 msgstr ""
 
-#: catalog/models/common.py:98
+#: catalog/models/common.py:100
 msgid "Discogs Master"
 msgstr ""
 
-#: catalog/models/common.py:101
+#: catalog/models/common.py:103
 msgid "MusicBrainz Release Group"
 msgstr ""
 
-#: catalog/models/common.py:103
+#: catalog/models/common.py:105
 msgid "MusicBrainz Release"
 msgstr ""
 
-#: catalog/models/common.py:104
+#: catalog/models/common.py:106
 msgid "MusicBrainz Artist"
 msgstr ""
 
-#: catalog/models/common.py:105
+#: catalog/models/common.py:107
 msgid "Douban Personage"
 msgstr ""
 
-#: catalog/models/common.py:106
+#: catalog/models/common.py:108
 msgid "Goodreads Author"
 msgstr ""
 
-#: catalog/models/common.py:107
+#: catalog/models/common.py:109
 msgid "Spotify Artist"
 msgstr ""
 
-#: catalog/models/common.py:108
+#: catalog/models/common.py:110
 msgid "TMDB Person"
 msgstr ""
 
-#: catalog/models/common.py:109
+#: catalog/models/common.py:111
 msgid "Open Library Author"
 msgstr ""
 
-#: catalog/models/common.py:110
+#: catalog/models/common.py:112
 msgid "IGDB Company"
 msgstr ""
 
-#: catalog/models/common.py:111
+#: catalog/models/common.py:113
 msgid "IGDB Game"
 msgstr ""
 
-#: catalog/models/common.py:112
+#: catalog/models/common.py:114
 msgid "BGG Boardgame"
 msgstr ""
 
-#: catalog/models/common.py:113
+#: catalog/models/common.py:115
 msgid "Steam Game"
 msgstr ""
 
-#: catalog/models/common.py:125
+#: catalog/models/common.py:127
 msgid "Open Library Work"
 msgstr ""
 
-#: catalog/models/common.py:128
+#: catalog/models/common.py:130
 msgid "RateYourMusic Release"
 msgstr ""
 
-#: catalog/models/common.py:132
+#: catalog/models/common.py:134
 msgid "AniList Anime"
 msgstr ""
 
-#: catalog/models/common.py:133
+#: catalog/models/common.py:135
 msgid "AniList Manga"
 msgstr ""
 
-#: catalog/models/common.py:134
+#: catalog/models/common.py:136
 msgid "MyAnimeList Anime"
 msgstr ""
 
-#: catalog/models/common.py:135
+#: catalog/models/common.py:137
 msgid "MyAnimeList Manga"
 msgstr ""
 
-#: catalog/models/common.py:156
+#: catalog/models/common.py:161
 msgid "Edition"
 msgstr ""
 
-#: catalog/models/common.py:157 catalog/templates/_sidebar_edit.html:286
+#: catalog/models/common.py:162 catalog/templates/_sidebar_edit.html:289
 msgid "Work"
 msgstr ""
 
-#: catalog/models/common.py:158
+#: catalog/models/common.py:163
 msgid "TV Series"
 msgstr ""
 
-#: catalog/models/common.py:159 catalog/templates/_sidebar_edit.html:207
+#: catalog/models/common.py:164 catalog/templates/_sidebar_edit.html:202
+#: catalog/views/edit.py:385
 msgid "TV Season"
 msgstr ""
 
-#: catalog/models/common.py:160
+#: catalog/models/common.py:165
 msgid "TV Episode"
 msgstr ""
 
-#: catalog/models/common.py:161 catalog/models/common.py:177
-#: catalog/models/common.py:191 catalog/templates/_sidebar_edit.html:200
-#: journal/templates/_sidebar_user_mark_list.html:35
+#: catalog/models/common.py:166 catalog/models/common.py:182
+#: catalog/models/common.py:196 catalog/templates/_sidebar_edit.html:196
+#: catalog/views/edit.py:384 journal/templates/_sidebar_user_mark_list.html:35
 #: journal/templates/_sidebar_user_tag_filter.html:27
 msgid "Movie"
 msgstr ""
 
-#: catalog/models/common.py:162
+#: catalog/models/common.py:167
 msgid "Album"
 msgstr ""
 
-#: catalog/models/common.py:163 catalog/models/common.py:180
-#: catalog/models/common.py:194 common/templates/_header.html:43
+#: catalog/models/common.py:168 catalog/models/common.py:185
+#: catalog/models/common.py:199 common/templates/_header.html:53
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
 msgstr ""
 
-#: catalog/models/common.py:164
+#: catalog/models/common.py:169
 msgid "Podcast Program"
 msgstr ""
 
-#: catalog/models/common.py:165
+#: catalog/models/common.py:170
 msgid "Podcast Episode"
 msgstr ""
 
-#: catalog/models/common.py:166 catalog/models/common.py:182
-#: catalog/models/common.py:196 common/templates/_header.html:47
+#: catalog/models/common.py:171 catalog/models/common.py:187
+#: catalog/models/common.py:201 common/templates/_header.html:57
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
 msgstr ""
 
-#: catalog/models/common.py:167
+#: catalog/models/common.py:172
 msgid "Production"
 msgstr ""
 
-#: catalog/models/common.py:168
+#: catalog/models/common.py:173
 msgid "Exhibition"
 msgstr ""
 
-#: catalog/models/common.py:169 catalog/models/common.py:186
+#: catalog/models/common.py:174 catalog/models/common.py:191
 #: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr ""
 
-#: catalog/models/common.py:172 catalog/models/common.py:185
+#: catalog/models/common.py:177 catalog/models/common.py:190
 msgid "Person / Organization"
 msgstr ""
 
-#: catalog/models/common.py:176 catalog/models/common.py:190
-#: common/templates/_header.html:27
+#: catalog/models/common.py:181 catalog/models/common.py:195
+#: common/templates/_header.html:37
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
 msgstr ""
 
-#: catalog/models/common.py:178 catalog/models/common.py:192
+#: catalog/models/common.py:183 catalog/models/common.py:197
 #: journal/templates/_sidebar_user_mark_list.html:38
 #: journal/templates/_sidebar_user_tag_filter.html:30
 msgid "TV"
 msgstr ""
 
-#: catalog/models/common.py:179 catalog/models/common.py:193
-#: common/templates/_header.html:39
+#: catalog/models/common.py:184 catalog/models/common.py:198
+#: common/templates/_header.html:49
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr ""
 
-#: catalog/models/common.py:181 catalog/models/common.py:195
-#: catalog/templates/_sidebar_edit.html:219 common/templates/_header.html:35
+#: catalog/models/common.py:186 catalog/models/common.py:200
+#: catalog/templates/_sidebar_edit.html:213 common/templates/_header.html:45
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
 msgstr ""
 
-#: catalog/models/common.py:346 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:345 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr ""
 
-#: catalog/models/common.py:384
+#: catalog/models/common.py:383
 msgid "origin country"
 msgstr ""
 
-#: catalog/models/common.py:413 catalog/templates/album.html:33
+#: catalog/models/common.py:412 catalog/templates/album.html:33
 msgid "album type"
 msgstr ""
 
-#: catalog/models/common.py:417 catalog/templates/_platform_list.html:5
+#: catalog/models/common.py:416 catalog/templates/_platform_list.html:5
 msgid "platform"
 msgstr ""
 
-#: catalog/models/common.py:421
+#: catalog/models/common.py:420
 msgid "media format"
 msgstr ""
 
-#: catalog/models/common.py:426 catalog/templates/_language_list.html:5
-#: users/models/user.py:142
+#: catalog/models/common.py:425 catalog/templates/_language_list.html:5
+#: users/models/user.py:144
 msgid "language"
 msgstr ""
 
-#: catalog/models/creator.py:24
+#: catalog/models/creator.py:26
 msgid "pending"
 msgstr ""
 
-#: catalog/models/creator.py:25
+#: catalog/models/creator.py:27
 msgid "verified"
 msgstr ""
 
-#: catalog/models/creator.py:26
+#: catalog/models/creator.py:28
 msgid "failed"
 msgstr ""
 
-#: catalog/models/creator.py:29
+#: catalog/models/creator.py:31
 msgid "no feed url available for this item"
 msgstr ""
 
-#: catalog/models/creator.py:30
+#: catalog/models/creator.py:32
 msgid "unable to fetch or parse the feed"
 msgstr ""
 
-#: catalog/models/creator.py:31
+#: catalog/models/creator.py:33
 msgid "no audio episode found in the feed"
 msgstr ""
 
-#: catalog/models/creator.py:34
+#: catalog/models/creator.py:36
 msgid "no matching identity found in the feed or its linked website"
 msgstr ""
 
@@ -678,16 +686,16 @@ msgstr ""
 msgid "Special Edition"
 msgstr ""
 
-#: catalog/models/game.py:111 catalog/models/item.py:130
+#: catalog/models/game.py:111 catalog/models/item.py:126
 msgid "designer"
 msgstr ""
 
-#: catalog/models/game.py:119 catalog/models/item.py:129
+#: catalog/models/game.py:119 catalog/models/item.py:125
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr ""
 
-#: catalog/models/game.py:127 catalog/models/item.py:139
+#: catalog/models/game.py:127 catalog/models/item.py:135
 msgid "developer"
 msgstr ""
 
@@ -696,8 +704,8 @@ msgid "date of publication"
 msgstr ""
 
 #: catalog/models/game.py:147 catalog/models/movie.py:156
-#: catalog/models/music.py:128 catalog/models/tv.py:247
-#: catalog/models/tv.py:473
+#: catalog/models/music.py:128 catalog/models/tv.py:249
+#: catalog/models/tv.py:475
 msgid "YYYY, YYYY-MM or YYYY-MM-DD"
 msgstr ""
 
@@ -708,7 +716,7 @@ msgstr ""
 #: catalog/models/game.py:180 catalog/models/movie.py:158
 #: catalog/models/people.py:178 catalog/models/performance.py:258
 #: catalog/models/performance.py:465 catalog/models/podcast.py:89
-#: catalog/models/tv.py:249 catalog/models/tv.py:476
+#: catalog/models/tv.py:251 catalog/models/tv.py:478
 #: catalog/templates/game.html:33 catalog/templates/movie.html:48
 #: catalog/templates/people.html:44 catalog/templates/performance.html:35
 #: catalog/templates/performanceproduction.html:35
@@ -717,146 +725,146 @@ msgstr ""
 msgid "website"
 msgstr ""
 
-#: catalog/models/item.py:125 catalog/models/movie.py:123
+#: catalog/models/item.py:121 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
-#: catalog/models/tv.py:214 catalog/models/tv.py:440
+#: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr ""
 
-#: catalog/models/item.py:126 catalog/models/movie.py:130
+#: catalog/models/item.py:122 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
-#: catalog/models/tv.py:221 catalog/models/tv.py:447
+#: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr ""
 
-#: catalog/models/item.py:127 catalog/models/movie.py:137
+#: catalog/models/item.py:123 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
-#: catalog/models/tv.py:228 catalog/models/tv.py:454
+#: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr ""
 
-#: catalog/models/item.py:128 catalog/models/movie.py:144
-#: catalog/models/tv.py:235 catalog/models/tv.py:461
+#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/tv.py:237 catalog/models/tv.py:463
 msgid "producer"
 msgstr ""
 
-#: catalog/models/item.py:131 catalog/models/performance.py:203
+#: catalog/models/item.py:127 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr ""
 
-#: catalog/models/item.py:132 catalog/models/performance.py:210
+#: catalog/models/item.py:128 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr ""
 
-#: catalog/models/item.py:133 catalog/models/performance.py:224
+#: catalog/models/item.py:129 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr ""
 
-#: catalog/models/item.py:134 catalog/models/podcast.py:80
+#: catalog/models/item.py:130 catalog/models/podcast.py:80
 msgid "host"
 msgstr ""
 
-#: catalog/models/item.py:135 catalog/models/performance.py:196
+#: catalog/models/item.py:131 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr ""
 
-#: catalog/models/item.py:136 catalog/models/performance.py:238
+#: catalog/models/item.py:132 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr ""
 
-#: catalog/models/item.py:140
+#: catalog/models/item.py:136
 msgid "production company"
 msgstr ""
 
-#: catalog/models/item.py:141
+#: catalog/models/item.py:137
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:142
+#: catalog/models/item.py:138
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:139
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:144 catalog/models/performance.py:231
+#: catalog/models/item.py:140 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr ""
 
-#: catalog/models/item.py:147
+#: catalog/models/item.py:143
 msgid "voice actor"
 msgstr ""
 
-#: catalog/models/item.py:148 catalog/templates/edition.html:30
+#: catalog/models/item.py:144 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr ""
 
-#: catalog/models/item.py:173 catalog/models/people.py:476
+#: catalog/models/item.py:169 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr ""
 
-#: catalog/models/item.py:174 catalog/models/people.py:155
+#: catalog/models/item.py:170 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr ""
 
-#: catalog/models/item.py:176 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:288 catalog/models/item.py:320
-#: journal/models/collection.py:96
+#: catalog/models/item.py:304 catalog/models/item.py:336
+#: journal/models/collection.py:100
 msgid "title"
 msgstr ""
 
-#: catalog/models/item.py:289 catalog/models/item.py:328
-#: journal/models/collection.py:97
+#: catalog/models/item.py:305 catalog/models/item.py:344
+#: journal/models/collection.py:101
 msgid "description"
 msgstr ""
 
-#: catalog/models/item.py:300 catalog/models/people.py:484
+#: catalog/models/item.py:316 catalog/models/people.py:484
 msgid "metadata"
 msgstr ""
 
-#: catalog/models/item.py:302 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
 msgid "cover"
 msgstr ""
 
-#: catalog/models/item.py:1485
+#: catalog/models/item.py:1526
 msgid "source site"
 msgstr ""
 
-#: catalog/models/item.py:1487
+#: catalog/models/item.py:1528
 msgid "ID on source site"
 msgstr ""
 
-#: catalog/models/item.py:1489
+#: catalog/models/item.py:1530
 msgid "source url"
 msgstr ""
 
-#: catalog/models/item.py:1505
+#: catalog/models/item.py:1546
 msgid "IdType of the source site"
 msgstr ""
 
-#: catalog/models/item.py:1511
+#: catalog/models/item.py:1552
 msgid "Primary Id on the source site"
 msgstr ""
 
-#: catalog/models/item.py:1514
+#: catalog/models/item.py:1555
 msgid "url to the resource"
 msgstr ""
 
 #: catalog/models/movie.py:152 catalog/models/music.py:124
-#: catalog/models/tv.py:243 catalog/models/tv.py:469
+#: catalog/models/tv.py:245 catalog/models/tv.py:471
 #: catalog/templates/_item_card_metadata_album.html:16
 #: catalog/templates/album.html:17 catalog/templates/game.html:22
 #: catalog/templates/movie.html:36 catalog/templates/tvseason.html:53
@@ -871,7 +879,7 @@ msgid "length"
 msgstr ""
 
 #: catalog/models/movie.py:162 catalog/models/music.py:131
-#: catalog/models/tv.py:259 catalog/models/tv.py:486
+#: catalog/models/tv.py:261 catalog/models/tv.py:488
 msgid "seconds"
 msgstr ""
 
@@ -1037,32 +1045,85 @@ msgstr ""
 msgid "closing date"
 msgstr ""
 
-#: catalog/models/tv.py:186 catalog/templates/tvseason.html:38
+#: catalog/models/tv.py:188 catalog/templates/tvseason.html:38
 #: catalog/templates/tvshow.html:33
 msgid "number of seasons"
 msgstr ""
 
-#: catalog/models/tv.py:189 catalog/models/tv.py:415
+#: catalog/models/tv.py:191 catalog/models/tv.py:417
 #: catalog/templates/tvseason.html:43 catalog/templates/tvshow.html:38
 msgid "number of episodes"
 msgstr ""
 
-#: catalog/models/tv.py:256 catalog/models/tv.py:483
+#: catalog/models/tv.py:258 catalog/models/tv.py:485
 msgid "episode length"
 msgstr ""
 
-#: catalog/models/tv.py:412 catalog/templates/tvseason.html:33
+#: catalog/models/tv.py:414 catalog/templates/tvseason.html:33
 msgid "season number"
 msgstr ""
 
-#: catalog/models/tv.py:530
+#: catalog/models/tv.py:532
 #, python-brace-format
 msgid "{show_title} Season {season_number}"
 msgstr ""
 
-#: catalog/models/tv.py:684
+#: catalog/models/tv.py:686
 #, python-brace-format
 msgid "{season_title} E{episode_number}"
+msgstr ""
+
+#: catalog/templates/_catalog_confirm_item.html:7
+#: catalog/templates/catalog_edit.html:62
+msgid "Item has been deleted."
+msgstr ""
+
+#: catalog/templates/_catalog_confirm_item.html:12
+#: catalog/templates/catalog_edit.html:65
+msgid "Item contains sub-items."
+msgstr ""
+
+#: catalog/templates/_catalog_confirm_item.html:17
+msgid "Item has been merged to another item."
+msgstr ""
+
+#: catalog/templates/_catalog_confirm_item.html:22
+msgid "Item has been marked by users."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:11
+#, fuzzy
+#| msgid "Confirm and save"
+msgid "Confirm changes"
+msgstr "確認して保存"
+
+#: catalog/templates/_catalog_edit_preview.html:16
+msgid "Please correct the errors below."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:24
+msgid "Field"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:25
+msgid "From"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:26
+msgid "To"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:45
+msgid "No changes detected."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:54
+#: users/templates/users/register.html:104
+msgid "Confirm and save"
+msgstr "確認して保存"
+
+#: catalog/templates/_catalog_edit_preview.html:57
+msgid "Back to editing"
 msgstr ""
 
 #: catalog/templates/_country_list.html:5
@@ -1070,9 +1131,7 @@ msgid "region"
 msgstr ""
 
 #: catalog/templates/_fetch_failed.html:4
-msgid ""
-"Unable to fetch from the link, please check again. Some sites may require "
-"login for certain links, please manually create them here."
+msgid "Unable to fetch from the link, please check again. Some sites may require login for certain links, please manually create them here."
 msgstr ""
 
 #: catalog/templates/_item_card_metadata_album.html:7
@@ -1128,7 +1187,7 @@ msgstr ""
 #: journal/templates/profile_posts.html:21
 #: journal/templates/user_follow_list_items.html:63
 #: journal/templates/user_post_list_items.html:24
-#: social/templates/events.html:43 social/templates/feed_events.html:28
+#: social/templates/events.html:43 social/templates/feed_events.html:27
 msgid "nothing more."
 msgstr ""
 
@@ -1217,7 +1276,7 @@ msgid "Add note"
 msgstr ""
 
 #: catalog/templates/_item_user_pieces.html:83
-#: common/templates/_sidebar.html:196 journal/templates/profile_items.html:46
+#: common/templates/_sidebar.html:195 journal/templates/profile_items.html:46
 #, fuzzy
 #| msgid "Sync in progress."
 msgid "Set progress"
@@ -1245,6 +1304,10 @@ msgstr ""
 
 #: catalog/templates/_item_user_pieces.html:214
 msgid "mark history"
+msgstr ""
+
+#: catalog/templates/_search_suggest.html:2
+msgid "Suggestions"
 msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:8
@@ -1276,15 +1339,15 @@ msgid "Edit Options"
 msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
-#: catalog/views/edit.py:82 catalog/views/edit.py:143 catalog/views/edit.py:197
-#: catalog/views/edit.py:218 catalog/views/edit.py:259
-#: catalog/views/edit.py:328 catalog/views/edit.py:332
-#: catalog/views/edit.py:351 catalog/views/edit.py:400
-#: catalog/views/edit.py:425 catalog/views/edit.py:440
-#: catalog/views/edit.py:480 catalog/views/edit.py:490
-#: catalog/views/edit.py:517 catalog/views/edit.py:582
-#: catalog/views/edit.py:637 catalog/views/edit.py:659
-#: catalog/views/search.py:367
+#: catalog/views/edit.py:160 catalog/views/edit.py:221
+#: catalog/views/edit.py:288 catalog/views/edit.py:309
+#: catalog/views/edit.py:364 catalog/views/edit.py:471
+#: catalog/views/edit.py:475 catalog/views/edit.py:509
+#: catalog/views/edit.py:576 catalog/views/edit.py:601
+#: catalog/views/edit.py:624 catalog/views/edit.py:664
+#: catalog/views/edit.py:674 catalog/views/edit.py:703
+#: catalog/views/edit.py:782 catalog/views/edit.py:837
+#: catalog/views/edit.py:859 catalog/views/search.py:418
 msgid "Editing this item is restricted."
 msgstr ""
 
@@ -1316,7 +1379,7 @@ msgstr "このメールアドレスは既に使用されています。"
 msgid "The following items are merged into this item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:70
+#: catalog/templates/_sidebar_edit.html:70 catalog/views/edit.py:456
 msgid "External website"
 msgstr ""
 
@@ -1336,35 +1399,31 @@ msgstr ""
 msgid "Fetch again"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:97
-msgid "You may not be able to undo this operation, sure to remove?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:102
+#: catalog/templates/_sidebar_edit.html:100
 msgid "Remove link to site"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:110
+#: catalog/templates/_sidebar_edit.html:108
 msgid "Choose cover"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:119
+#: catalog/templates/_sidebar_edit.html:117
+#: catalog/templates/_sidebar_edit.html:118
 #: catalog/templates/_sidebar_edit.html:120
-#: catalog/templates/_sidebar_edit.html:122
 msgid "Current cover"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:139
+#: catalog/templates/_sidebar_edit.html:137
 msgid "Select an image to use as the cover of this item."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:140
-#: catalog/templates/catalog_edit.html:65
-#: common/templates/manage/settings.html:136
+#: catalog/templates/_sidebar_edit.html:138
+#: catalog/templates/catalog_edit.html:78
+#: common/templates/manage/settings.html:19
 #: journal/templates/add_to_collection.html:43
 #: journal/templates/article_edit.html:60
 #: journal/templates/collection_edit.html:39 journal/templates/comment.html:41
-#: journal/templates/mark.html:134 journal/templates/note.html:65
+#: journal/templates/mark.html:138 journal/templates/note.html:65
 #: journal/templates/post_compose.html:103
 #: journal/templates/review_edit.html:46 journal/templates/tag_edit.html:51
 #: users/templates/users/_pref_device.html:37
@@ -1373,181 +1432,157 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:147
+#: catalog/templates/_sidebar_edit.html:145
 msgid "Edit sub-items"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:160
+#: catalog/templates/_sidebar_edit.html:158
 msgid "create"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:166
+#: catalog/templates/_sidebar_edit.html:164
 msgid "Fetch all episodes"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:171
+#: catalog/templates/_sidebar_edit.html:169
 msgid "Fetch all"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:172
-msgid ""
-"Due to differences in how Douban, IMDB, and TMDB handle season data, a small "
-"number of TV shows and animations may not return correct results. Please "
-"manually verify and clean up after updating."
+#: catalog/templates/_sidebar_edit.html:170
+msgid "Due to differences in how Douban, IMDB, and TMDB handle season data, a small number of TV shows and animations may not return correct results. Please manually verify and clean up after updating."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:173
+#: catalog/templates/_sidebar_edit.html:171
 msgid "Up to 250 episodes will be fetched for a season."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:176
-msgid ""
-"To fetch all episodes, season numbers and IMDB information are required. If "
-"filling this out is inconvenient, you can also manually create sub-entries."
+#: catalog/templates/_sidebar_edit.html:174
+msgid "To fetch all episodes, season numbers and IMDB information are required. If filling this out is inconvenient, you can also manually create sub-entries."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:182
-#: catalog/templates/_sidebar_edit.html:194
-#: catalog/templates/_sidebar_edit.html:213
+#: catalog/templates/_sidebar_edit.html:180
+#: catalog/templates/_sidebar_edit.html:191
+#: catalog/templates/_sidebar_edit.html:208
 msgid "switch category"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:185
-msgid "Switching may remove some metadata. Sure to proceed?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:188
+#: catalog/templates/_sidebar_edit.html:185 catalog/views/edit.py:383
 msgid "TV Show"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:227
+#: catalog/templates/_sidebar_edit.html:221
 msgid "Link to parent item"
 msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:230
-msgid "Sure to link?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:237
 msgid "Update link"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:243
+#: catalog/templates/_sidebar_edit.html:236
 msgid "Cleanup seasons"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:246
-#: catalog/templates/catalog_delete.html:45
-msgid "This operation cannot be undone. Sure to delete?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:250
+#: catalog/templates/_sidebar_edit.html:242
 msgid "remove seasons not marked"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:256
-#: catalog/templates/catalog_merge.html:12
+#: catalog/templates/_sidebar_edit.html:248
 msgid "Merge"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:262
+#: catalog/templates/_sidebar_edit.html:254
 msgid "URL of target item, or empty if undo merge"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:268
-#: catalog/templates/_sidebar_edit.html:348
+#: catalog/templates/_sidebar_edit.html:260
+#: catalog/templates/_sidebar_edit.html:350
 msgid "merge to another item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:273
-#: catalog/templates/_sidebar_edit.html:277
-#: catalog/templates/catalog_delete.html:12
+#: catalog/templates/_sidebar_edit.html:265
+#: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
 #: journal/templates/article.html:199 journal/templates/collection.html:188
-#: journal/templates/mark.html:149 journal/templates/note.html:82
+#: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
 #: users/templates/users/account.html:254
 msgid "Delete"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:287
+#: catalog/templates/_sidebar_edit.html:275
+#: catalog/templates/_sidebar_edit.html:279
+msgid "Undo delete"
+msgstr ""
+
+#: catalog/templates/_sidebar_edit.html:280
+msgid "Links to external sites and parent item were removed on delete and will not be restored."
+msgstr ""
+
+#: catalog/templates/_sidebar_edit.html:290
 msgid "This edition belongs to the following work"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:292
-msgid "Sure to unlink?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:298
+#: catalog/templates/_sidebar_edit.html:300
 msgid "Unlink from work"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:304
+#: catalog/templates/_sidebar_edit.html:306
 msgid "Link"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:315
+#: catalog/templates/_sidebar_edit.html:317
 msgid "Link to another edition from same work"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:324
+#: catalog/templates/_sidebar_edit.html:326
 msgid "Restriction"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:337
+#: catalog/templates/_sidebar_edit.html:339
 #: journal/templates/collection_update_item_note.html:4
 msgid "Update"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:342
+#: catalog/templates/_sidebar_edit.html:344
 msgid "Suggest Edits"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:347
+#: catalog/templates/_sidebar_edit.html:349
 msgid "proposed action"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:349
+#: catalog/templates/_sidebar_edit.html:351
 msgid "link to another item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:350
+#: catalog/templates/_sidebar_edit.html:352
 msgid "change item category"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:351
+#: catalog/templates/_sidebar_edit.html:353
 msgid "change item metadata"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:352
+#: catalog/templates/_sidebar_edit.html:354
 msgid "remove item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:353
+#: catalog/templates/_sidebar_edit.html:355
 msgid "other"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:357
-msgid ""
-"To suggest merging or association, please include the URL of the target item"
+#: catalog/templates/_sidebar_edit.html:359
+msgid "To suggest merging or association, please include the URL of the target item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:358
+#: catalog/templates/_sidebar_edit.html:360
 #: catalog/templates/catalog_verify.html:116
 msgid "submit"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:359
-msgid ""
-"As a user of this community, you may edit some metadata of items on this "
-"site. If you are unsure whether your edits are appropriate or are unable to "
-"make a certain change, you can make suggestions here. Moderators will "
-"consider each suggestion, although there is no guarantee that they will "
-"always be fully adopted; suggestions may also be viewed or discussed by "
-"other community users. If you have suggestions that are not related to a "
-"specific item, please contact us. Thank you for your support and "
-"contribution."
+#: catalog/templates/_sidebar_edit.html:361
+msgid "As a user of this community, you may edit some metadata of items on this site. If you are unsure whether your edits are appropriate or are unable to make a certain change, you can make suggestions here. Moderators will consider each suggestion, although there is no guarantee that they will always be fully adopted; suggestions may also be viewed or discussed by other community users. If you have suggestions that are not related to a specific item, please contact us. Thank you for your support and contribution."
 msgstr ""
 
 #: catalog/templates/_sidebar_search.html:5
@@ -1647,9 +1682,7 @@ msgid "matched"
 msgstr ""
 
 #: catalog/templates/_verify_status.html:21
-msgid ""
-"Sure to remove your creator verification? Anyone will be able to edit this "
-"item again."
+msgid "Sure to remove your creator verification? Anyone will be able to edit this item again."
 msgstr ""
 
 #: catalog/templates/_verify_status.html:26
@@ -1658,7 +1691,7 @@ msgstr ""
 msgid "Remove my verification"
 msgstr "確認コードを送信"
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:309
+#: catalog/templates/_verify_status.html:31 users/views/account.py:311
 #, fuzzy
 #| msgid "Send verification code"
 msgid "Verification failed"
@@ -1701,43 +1734,11 @@ msgstr ""
 msgid "album media"
 msgstr ""
 
-#: catalog/templates/catalog_delete.html:19
-msgid "Are you sure to delete?"
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:24
-#: catalog/templates/catalog_edit.html:52
-#: catalog/templates/catalog_merge.html:36
-#: catalog/templates/catalog_merge.html:64
-msgid "Item has been deleted."
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:29
-#: catalog/templates/catalog_edit.html:55
-#: catalog/templates/catalog_merge.html:41
-#: catalog/templates/catalog_merge.html:69
-msgid "Item contains sub-items."
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:34
-#: catalog/templates/catalog_merge.html:46
-#: catalog/templates/catalog_merge.html:74
-msgid "Item has been merged to another item."
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:39
-#: catalog/templates/catalog_merge.html:51
-#: catalog/templates/catalog_merge.html:79
-msgid "Item has been marked by users."
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:48
-#: catalog/templates/catalog_merge.html:92 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:55 common/views_manage.py:139
 msgid "Yes"
 msgstr ""
 
-#: catalog/templates/catalog_delete.html:49
-#: catalog/templates/catalog_merge.html:93 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:56 common/views_manage.py:139
 msgid "No"
 msgstr ""
 
@@ -1746,36 +1747,18 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: catalog/templates/catalog_edit.html:68
+#: catalog/templates/catalog_edit.html:81
 #: journal/templates/collection_update_item_note.html:8
 #: journal/templates/piece_delete.html:38
 msgid "Cancel"
 msgstr ""
 
-#: catalog/templates/catalog_edit.html:104
+#: catalog/templates/catalog_edit.html:118
 msgid "open linked people page"
 msgstr ""
 
-#: catalog/templates/catalog_merge.html:22
-msgid "Are you sure to merge?"
-msgstr ""
-
-#: catalog/templates/catalog_merge.html:24
-msgid "Are you sure to cancel merge?"
-msgstr ""
-
-#: catalog/templates/catalog_merge.html:27
-msgid "Are you sure to link?"
-msgstr ""
-
-#: catalog/templates/catalog_merge.html:86
-msgid "This operation cannot be undone. Sure to merge?"
-msgstr ""
-
 #: catalog/templates/catalog_verify.html:21
-msgid ""
-"If you are a creator of this podcast, you may verify the ownership, so that "
-"only you (and other verified creators) can edit its metadata on this site."
+msgid "If you are a creator of this podcast, you may verify the ownership, so that only you (and other verified creators) can edit its metadata on this site."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:22
@@ -1783,9 +1766,7 @@ msgid "Your recent episodes may also occasionally be featured in discovery."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:24
-msgid ""
-"To verify, prove you control one of the following identifiers of your "
-"account (click to copy):"
+msgid "To verify, prove you control one of the following identifiers of your account (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:30
@@ -1796,18 +1777,11 @@ msgid "copied"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:35
-msgid ""
-"You can prove this in a few ways, then start verification: add one of the "
-"identifiers above to the podcast feed's description; add a <code>rel=\"me\"</"
-"code> link back to one of them on the web page your feed links to (the link "
-"verification Mastodon uses); or point your feed's website at your Bluesky "
-"handle's own domain."
+msgid "You can prove this in a few ways, then start verification: add one of the identifiers above to the podcast feed's description; add a <code>rel=\"me\"</code> link back to one of them on the web page your feed links to (the link verification Mastodon uses); or point your feed's website at your Bluesky handle's own domain."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:44
-msgid ""
-"For example, add this rel=me link to the web page your feed links to (click "
-"to copy):"
+msgid "For example, add this rel=me link to the web page your feed links to (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:50
@@ -1815,9 +1789,7 @@ msgid "or, in the page's head:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:57
-msgid ""
-"Can't edit the website? Just add a line like this to your feed's description "
-"instead (click to copy):"
+msgid "Can't edit the website? Just add a line like this to your feed's description instead (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:62
@@ -1825,10 +1797,7 @@ msgid "Welcome to follow me on the Fediverse:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:66
-msgid ""
-"NeoDB does not re-check this periodically at the moment, but we recommend "
-"you keep it so that your audience can discover and connect with you in "
-"distributed social media."
+msgid "NeoDB does not re-check this periodically at the moment, but we recommend you keep it so that your audience can discover and connect with you in distributed social media."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:72
@@ -1858,12 +1827,11 @@ msgid "Send feedback"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:115
-msgid ""
-"Questions or issues with creator verification? Let the site moderators know."
+msgid "Questions or issues with creator verification? Let the site moderators know."
 msgstr ""
 
-#: catalog/templates/discover.html:28 common/views_manage.py:145
-#: common/views_manage.py:353 users/templates/users/preferences.html:34
+#: catalog/templates/discover.html:28 common/views_manage.py:35
+#: common/views_manage.py:431 users/templates/users/preferences.html:34
 msgid "Discover"
 msgstr ""
 
@@ -1901,17 +1869,17 @@ msgstr ""
 msgid "hide"
 msgstr ""
 
-#: catalog/templates/discover.html:206 common/templates/_sidebar.html:14
+#: catalog/templates/discover.html:206 common/templates/_sidebar.html:13
 msgid "Unread Announcements"
 msgstr ""
 
-#: catalog/templates/discover.html:212 common/templates/_sidebar.html:20
+#: catalog/templates/discover.html:212 common/templates/_sidebar.html:19
 #: social/templates/notification.html:67
 msgid "mark all as read"
 msgstr ""
 
 #: catalog/templates/discover.html:222
-#: common/templates/_sidebar_anonymous.html:55
+#: common/templates/_sidebar_anonymous.html:54
 msgid "Popular Tags"
 msgstr ""
 
@@ -1922,9 +1890,9 @@ msgstr ""
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
 #: catalog/templates/user_verified_works.html:23
-#: common/templates/_sidebar.html:127
-#: common/templates/_sidebar_anonymous.html:46
-#: common/templates/_sidebar_anonymous.html:62 journal/templates/posts.html:8
+#: common/templates/_sidebar.html:126
+#: common/templates/_sidebar_anonymous.html:45
+#: common/templates/_sidebar_anonymous.html:61 journal/templates/posts.html:7
 #: journal/templates/profile_articles.html:24
 #: journal/templates/profile_articles.html:26
 #: journal/templates/profile_items.html:65
@@ -1940,7 +1908,7 @@ msgstr ""
 msgid "nothing so far."
 msgstr ""
 
-#: catalog/templates/discover.html:239 common/templates/_sidebar.html:269
+#: catalog/templates/discover.html:239 common/templates/_sidebar.html:268
 msgid "Recent Posts"
 msgstr ""
 
@@ -1966,9 +1934,7 @@ msgid "Borrow or Buy"
 msgstr ""
 
 #: catalog/templates/external_search_results.html:10
-msgid ""
-"Some items were found from other websites and instances, click their title "
-"to save them locally."
+msgid "Some items were found from other websites and instances, click their title to save them locally."
 msgstr ""
 
 #: catalog/templates/fetch_pending.html:13
@@ -2068,12 +2034,12 @@ msgstr ""
 msgid "number of Episodes"
 msgstr ""
 
-#: catalog/templates/people.html:13 common/templates/_sidebar.html:77
-#: common/templates/_sidebar.html:84 journal/models/shelf.py:326
+#: catalog/templates/people.html:13 common/templates/_sidebar.html:76
+#: common/templates/_sidebar.html:83 journal/models/shelf.py:328
 msgid "following"
 msgstr ""
 
-#: catalog/templates/people.html:15 journal/models/shelf.py:324
+#: catalog/templates/people.html:15 journal/models/shelf.py:326
 #: social/templates/notification.html:60
 msgid "follow"
 msgstr ""
@@ -2092,7 +2058,6 @@ msgstr ""
 #: journal/templates/_sidebar_collection_filter.html:14
 #: journal/templates/_sidebar_collection_filter.html:28
 #: journal/templates/_sidebar_user_mark_list.html:56
-#: social/templates/feed.html:42 social/templates/feed.html:44
 #: social/templates/notification.html:56
 msgid "all"
 msgstr ""
@@ -2120,7 +2085,7 @@ msgstr "リセットが完了しました。"
 msgid "production"
 msgstr ""
 
-#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:54
+#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:53
 msgid "verified creator"
 msgstr ""
 
@@ -2203,10 +2168,7 @@ msgid "No items matching your search query."
 msgstr ""
 
 #: catalog/templates/search_results.html:34
-msgid ""
-"If you have URL from one of these sites, please put the full URL (e.g. "
-"<code>https://www.imdb.com/title/tt2513074/</code>) to the search box and "
-"press Enter."
+msgid "If you have URL from one of these sites, please put the full URL (e.g. <code>https://www.imdb.com/title/tt2513074/</code>) to the search box and press Enter."
 msgstr ""
 
 #: catalog/templates/search_results.html:48
@@ -2243,97 +2205,178 @@ msgstr ""
 msgid "Editions"
 msgstr ""
 
-#: catalog/views/edit.py:202 catalog/views/edit.py:205
-#: catalog/views/edit.py:306 catalog/views/edit.py:309
-#: catalog/views/verify.py:197 journal/views/collection.py:77
-#: journal/views/collection.py:102 journal/views/collection.py:556
-#: journal/views/collection.py:651 journal/views/common.py:221
-#: journal/views/mark.py:196 journal/views/post.py:117
-#: journal/views/post.py:119 journal/views/post.py:166
-#: journal/views/post.py:185 journal/views/post.py:187
-#: journal/views/post.py:228 journal/views/post.py:241
+#: catalog/views/edit.py:293 catalog/views/edit.py:296
+#: catalog/views/edit.py:440 catalog/views/edit.py:443
+#: catalog/views/verify.py:197 journal/views/collection.py:75
+#: journal/views/collection.py:100 journal/views/collection.py:538
+#: journal/views/collection.py:634 journal/views/common.py:231
+#: journal/views/mark.py:244 journal/views/post.py:119
+#: journal/views/post.py:121 journal/views/post.py:168
+#: journal/views/post.py:187 journal/views/post.py:189
+#: journal/views/post.py:230 journal/views/post.py:243
 #: journal/views/review.py:154 journal/views/review.py:158
-#: users/views/actions.py:179
+#: users/views/actions.py:178
 msgid "Invalid parameter"
 msgstr ""
 
-#: catalog/views/edit.py:220
+#: catalog/views/edit.py:313
 msgid "Item in use."
 msgstr ""
 
-#: catalog/views/edit.py:222
+#: catalog/views/edit.py:315
 msgid "Item cannot be deleted."
 msgstr ""
 
-#: catalog/views/edit.py:247 catalog/views/edit.py:303
-#: catalog/views/edit.py:427 catalog/views/edit.py:519
-#: catalog/views/edit.py:552 catalog/views/verify.py:158
+#: catalog/views/edit.py:319 catalog/views/edit.py:515
+msgid "Are you sure to delete?"
+msgstr ""
+
+#: catalog/views/edit.py:323 catalog/views/edit.py:518
+#: catalog/views/edit.py:617
+msgid "This operation cannot be undone."
+msgstr ""
+
+#: catalog/views/edit.py:344 catalog/views/edit.py:437
+#: catalog/views/edit.py:603 catalog/views/edit.py:705
+#: catalog/views/edit.py:752 catalog/views/verify.py:158
 #: catalog/views/verify.py:206 journal/views/article.py:44
 #: journal/views/article.py:133 journal/views/article.py:153
 #: journal/views/collection.py:248 journal/views/collection.py:341
-#: journal/views/collection.py:360 journal/views/collection.py:384
-#: journal/views/collection.py:457 journal/views/collection.py:500
-#: journal/views/collection.py:539 journal/views/collection.py:551
-#: journal/views/collection.py:576 journal/views/collection.py:613
-#: journal/views/common.py:300 journal/views/mark.py:281
-#: journal/views/post.py:58 journal/views/post.py:78 journal/views/post.py:100
-#: journal/views/post.py:170 journal/views/post.py:199
-#: journal/views/post.py:272 journal/views/post.py:287
-#: journal/views/post.py:394 journal/views/post.py:549
+#: journal/views/collection.py:354 journal/views/collection.py:372
+#: journal/views/collection.py:439 journal/views/collection.py:482
+#: journal/views/collection.py:521 journal/views/collection.py:533
+#: journal/views/collection.py:558 journal/views/collection.py:595
+#: journal/views/common.py:304 journal/views/mark.py:317
+#: journal/views/post.py:60 journal/views/post.py:80 journal/views/post.py:102
+#: journal/views/post.py:172 journal/views/post.py:201
+#: journal/views/post.py:274 journal/views/post.py:289
+#: journal/views/post.py:390 journal/views/post.py:539
 #: journal/views/review.py:64 journal/views/review.py:81
 #: journal/views/review.py:106
 msgid "Insufficient permission"
 msgstr ""
 
-#: catalog/views/edit.py:374
+#: catalog/views/edit.py:346
+#, fuzzy
+#| msgid "Account is being deleted."
+msgid "Item is not deleted"
+msgstr "アカウントの削除が進行中です。"
+
+#: catalog/views/edit.py:389
+msgid "Switching may remove some metadata."
+msgstr ""
+
+#: catalog/views/edit.py:395
+msgid "The following seasons will be detached from this show"
+msgstr ""
+
+#: catalog/views/edit.py:400
+msgid "Links to IMDB and TMDB will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:403
+#, fuzzy
+#| msgid "are you sure to unblock?"
+msgid "Are you sure to switch category?"
+msgstr "ブロックを解除しますか？"
+
+#: catalog/views/edit.py:451
+#, fuzzy
+#| msgid "are you sure to unblock?"
+msgid "Are you sure to remove the link to this site?"
+msgstr "ブロックを解除しますか？"
+
+#: catalog/views/edit.py:457
+msgid "You may not be able to undo this operation."
+msgstr ""
+
+#: catalog/views/edit.py:483
+msgid "Current parent item"
+msgstr ""
+
+#: catalog/views/edit.py:487
+msgid "The link to the parent item will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:490 catalog/views/edit.py:680
+msgid "Are you sure to link?"
+msgstr ""
+
+#: catalog/views/edit.py:521
+msgid "The following seasons will be deleted"
+msgstr ""
+
+#: catalog/views/edit.py:525
+msgid "The following seasons will be kept"
+msgstr ""
+
+#: catalog/views/edit.py:550
 msgid "TV Season with IMDB id and season number required."
 msgstr ""
 
-#: catalog/views/edit.py:380
+#: catalog/views/edit.py:556
 msgid "Updating episodes"
 msgstr ""
 
-#: catalog/views/edit.py:405
+#: catalog/views/edit.py:581
 msgid "This person has no supported source to fetch works from."
 msgstr ""
 
-#: catalog/views/edit.py:412
+#: catalog/views/edit.py:588
 msgid "Already pulling works for this person, try again later."
 msgstr ""
 
-#: catalog/views/edit.py:416
+#: catalog/views/edit.py:592
 msgid "Pulling works in background."
 msgstr ""
 
-#: catalog/views/edit.py:438
+#: catalog/views/edit.py:609
+msgid "Are you sure to merge?"
+msgstr ""
+
+#: catalog/views/edit.py:611
+msgid "Are you sure to cancel merge?"
+msgstr ""
+
+#: catalog/views/edit.py:622
 msgid "Cannot be merged to an item already deleted or merged"
 msgstr ""
 
-#: catalog/views/edit.py:443
+#: catalog/views/edit.py:627
 msgid "Cannot merge items in different categories"
 msgstr ""
 
-#: catalog/views/edit.py:447
+#: catalog/views/edit.py:631
 msgid "Cannot merge an item to itself"
 msgstr ""
 
-#: catalog/views/edit.py:488
+#: catalog/views/edit.py:672
 msgid "Cannot be linked to an item already deleted or merged"
 msgstr ""
 
-#: catalog/views/edit.py:492
+#: catalog/views/edit.py:676
 msgid "Cannot link items other than editions"
 msgstr ""
 
-#: catalog/views/search.py:96
+#: catalog/views/edit.py:710
+#, fuzzy
+#| msgid "are you sure to unblock?"
+msgid "Are you sure to unlink?"
+msgstr "ブロックを解除しますか？"
+
+#: catalog/views/edit.py:715
+msgid "This edition will be unlinked from the following work"
+msgstr ""
+
+#: catalog/views/search.py:113
 msgid "the internet"
 msgstr ""
 
-#: catalog/views/search.py:359
+#: catalog/views/search.py:410
 msgid "Invalid URL"
 msgstr ""
 
-#: catalog/views/search.py:362
+#: catalog/views/search.py:413
 msgid "Unsupported URL"
 msgstr ""
 
@@ -2357,9 +2400,9 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:122 common/utils.py:163
+#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
 #: journal/views/article.py:186 journal/views/review.py:182
-#: users/views/actions.py:45 users/views/actions.py:131
+#: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
 msgstr ""
 
@@ -2373,15 +2416,15 @@ msgstr ""
 msgid "Creator verification removed."
 msgstr "確認コードを送信"
 
-#: catalog/views/view.py:74 catalog/views/view.py:99
+#: catalog/views/view.py:77 catalog/views/view.py:102
 msgid "Item not found"
 msgstr ""
 
-#: catalog/views/view.py:78 catalog/views/view.py:107 catalog/views/view.py:190
+#: catalog/views/view.py:81 catalog/views/view.py:110 catalog/views/view.py:193
 msgid "Item no longer exists"
 msgstr ""
 
-#: catalog/views/view.py:187
+#: catalog/views/view.py:190
 #, fuzzy
 #| msgid "Invalid file."
 msgid "Invalid role"
@@ -2877,759 +2920,759 @@ msgctxt "genre"
 msgid "Health"
 msgstr ""
 
-#: common/models/lang.py:54
+#: common/models/lang.py:56
 msgid "Afar"
 msgstr ""
 
-#: common/models/lang.py:55
+#: common/models/lang.py:57
 msgid "Afrikaans"
 msgstr ""
 
-#: common/models/lang.py:56
+#: common/models/lang.py:58
 msgid "Akan"
 msgstr ""
 
-#: common/models/lang.py:57
+#: common/models/lang.py:59
 msgid "Aragonese"
 msgstr ""
 
-#: common/models/lang.py:58
+#: common/models/lang.py:60
 msgid "Assamese"
 msgstr ""
 
-#: common/models/lang.py:59
+#: common/models/lang.py:61
 msgid "Avaric"
 msgstr ""
 
-#: common/models/lang.py:60
+#: common/models/lang.py:62
 msgid "Avestan"
 msgstr ""
 
-#: common/models/lang.py:61
+#: common/models/lang.py:63
 msgid "Aymara"
 msgstr ""
 
-#: common/models/lang.py:62
+#: common/models/lang.py:64
 msgid "Azerbaijani"
 msgstr ""
 
-#: common/models/lang.py:63
+#: common/models/lang.py:65
 msgid "Bashkir"
 msgstr ""
 
-#: common/models/lang.py:64
+#: common/models/lang.py:66
 msgid "Bambara"
 msgstr ""
 
-#: common/models/lang.py:65
+#: common/models/lang.py:67
 msgid "Bislama"
 msgstr ""
 
-#: common/models/lang.py:66
+#: common/models/lang.py:68
 msgid "Tibetan"
 msgstr ""
 
-#: common/models/lang.py:67
+#: common/models/lang.py:69
 msgid "Breton"
 msgstr ""
 
-#: common/models/lang.py:68
+#: common/models/lang.py:70
 msgid "Catalan"
 msgstr ""
 
-#: common/models/lang.py:69
+#: common/models/lang.py:71
 msgid "Czech"
 msgstr ""
 
-#: common/models/lang.py:70
+#: common/models/lang.py:72
 msgid "Chechen"
 msgstr ""
 
-#: common/models/lang.py:71
+#: common/models/lang.py:73
 msgid "Slavic"
 msgstr ""
 
-#: common/models/lang.py:72
+#: common/models/lang.py:74
 msgid "Chuvash"
 msgstr ""
 
-#: common/models/lang.py:73
+#: common/models/lang.py:75
 msgid "Cornish"
 msgstr ""
 
-#: common/models/lang.py:74
+#: common/models/lang.py:76
 msgid "Corsican"
 msgstr ""
 
-#: common/models/lang.py:75
+#: common/models/lang.py:77
 msgid "Cree"
 msgstr ""
 
-#: common/models/lang.py:76
+#: common/models/lang.py:78
 msgid "Welsh"
 msgstr ""
 
-#: common/models/lang.py:79
+#: common/models/lang.py:81
 msgid "Divehi"
 msgstr ""
 
-#: common/models/lang.py:80
+#: common/models/lang.py:82
 msgid "Dzongkha"
 msgstr ""
 
-#: common/models/lang.py:81
+#: common/models/lang.py:83
 msgid "Esperanto"
 msgstr ""
 
-#: common/models/lang.py:82
+#: common/models/lang.py:84
 msgid "Estonian"
 msgstr ""
 
-#: common/models/lang.py:83
+#: common/models/lang.py:85
 msgid "Basque"
 msgstr ""
 
-#: common/models/lang.py:84
+#: common/models/lang.py:86
 msgid "Faroese"
 msgstr ""
 
-#: common/models/lang.py:85
+#: common/models/lang.py:87
 msgid "Fijian"
 msgstr ""
 
-#: common/models/lang.py:86
+#: common/models/lang.py:88
 msgid "Finnish"
 msgstr ""
 
-#: common/models/lang.py:88
+#: common/models/lang.py:90
 msgid "Frisian"
 msgstr ""
 
-#: common/models/lang.py:89
+#: common/models/lang.py:91
 msgid "Fulah"
 msgstr ""
 
-#: common/models/lang.py:90
+#: common/models/lang.py:92
 msgid "Gaelic"
 msgstr ""
 
-#: common/models/lang.py:91
+#: common/models/lang.py:93
 msgid "Irish"
 msgstr ""
 
-#: common/models/lang.py:92
+#: common/models/lang.py:94
 msgid "Galician"
 msgstr ""
 
-#: common/models/lang.py:93
+#: common/models/lang.py:95
 msgid "Manx"
 msgstr ""
 
-#: common/models/lang.py:94
+#: common/models/lang.py:96
 msgid "Guarani"
 msgstr ""
 
-#: common/models/lang.py:95
+#: common/models/lang.py:97
 msgid "Gujarati"
 msgstr ""
 
-#: common/models/lang.py:96
+#: common/models/lang.py:98
 msgid "Haitian; Haitian Creole"
 msgstr ""
 
-#: common/models/lang.py:97
+#: common/models/lang.py:99
 msgid "Hausa"
 msgstr ""
 
-#: common/models/lang.py:98
+#: common/models/lang.py:100
 msgid "Serbo-Croatian"
 msgstr ""
 
-#: common/models/lang.py:99
+#: common/models/lang.py:101
 msgid "Herero"
 msgstr ""
 
-#: common/models/lang.py:100
+#: common/models/lang.py:102
 msgid "Hiri Motu"
 msgstr ""
 
-#: common/models/lang.py:101
+#: common/models/lang.py:103
 msgid "Croatian"
 msgstr ""
 
-#: common/models/lang.py:102
+#: common/models/lang.py:104
 msgid "Hungarian"
 msgstr ""
 
-#: common/models/lang.py:103
+#: common/models/lang.py:105
 msgid "Igbo"
 msgstr ""
 
-#: common/models/lang.py:104
+#: common/models/lang.py:106
 msgid "Ido"
 msgstr ""
 
-#: common/models/lang.py:105
+#: common/models/lang.py:107
 msgid "Yi"
 msgstr ""
 
-#: common/models/lang.py:106
+#: common/models/lang.py:108
 msgid "Inuktitut"
 msgstr ""
 
-#: common/models/lang.py:107
+#: common/models/lang.py:109
 msgid "Interlingue"
 msgstr ""
 
-#: common/models/lang.py:108
+#: common/models/lang.py:110
 msgid "Interlingua"
 msgstr ""
 
-#: common/models/lang.py:109
+#: common/models/lang.py:111
 msgid "Indonesian"
 msgstr ""
 
-#: common/models/lang.py:110
+#: common/models/lang.py:112
 msgid "Inupiaq"
 msgstr ""
 
-#: common/models/lang.py:111
+#: common/models/lang.py:113
 msgid "Icelandic"
 msgstr ""
 
-#: common/models/lang.py:113
+#: common/models/lang.py:115
 msgid "Javanese"
 msgstr ""
 
-#: common/models/lang.py:114
+#: common/models/lang.py:116
 msgid "Japanese"
 msgstr ""
 
-#: common/models/lang.py:115
+#: common/models/lang.py:117
 msgid "Kalaallisut"
 msgstr ""
 
-#: common/models/lang.py:116
+#: common/models/lang.py:118
 msgid "Kannada"
 msgstr ""
 
-#: common/models/lang.py:117
+#: common/models/lang.py:119
 msgid "Kashmiri"
 msgstr ""
 
-#: common/models/lang.py:118
+#: common/models/lang.py:120
 msgid "Kanuri"
 msgstr ""
 
-#: common/models/lang.py:119
+#: common/models/lang.py:121
 msgid "Kazakh"
 msgstr ""
 
-#: common/models/lang.py:120
+#: common/models/lang.py:122
 msgid "Khmer"
 msgstr ""
 
-#: common/models/lang.py:121
+#: common/models/lang.py:123
 msgid "Kikuyu"
 msgstr ""
 
-#: common/models/lang.py:122
+#: common/models/lang.py:124
 msgid "Kinyarwanda"
 msgstr ""
 
-#: common/models/lang.py:123
+#: common/models/lang.py:125
 msgid "Kirghiz"
 msgstr ""
 
-#: common/models/lang.py:124
+#: common/models/lang.py:126
 msgid "Komi"
 msgstr ""
 
-#: common/models/lang.py:125
+#: common/models/lang.py:127
 msgid "Kongo"
 msgstr ""
 
-#: common/models/lang.py:126
+#: common/models/lang.py:128
 msgid "Korean"
 msgstr ""
 
-#: common/models/lang.py:127
+#: common/models/lang.py:129
 msgid "Kuanyama"
 msgstr ""
 
-#: common/models/lang.py:128
+#: common/models/lang.py:130
 msgid "Kurdish"
 msgstr ""
 
-#: common/models/lang.py:129
+#: common/models/lang.py:131
 msgid "Lao"
 msgstr ""
 
-#: common/models/lang.py:130
+#: common/models/lang.py:132
 msgid "Latin"
 msgstr ""
 
-#: common/models/lang.py:131
+#: common/models/lang.py:133
 msgid "Latvian"
 msgstr ""
 
-#: common/models/lang.py:132
+#: common/models/lang.py:134
 msgid "Limburgish"
 msgstr ""
 
-#: common/models/lang.py:133
+#: common/models/lang.py:135
 msgid "Lingala"
 msgstr ""
 
-#: common/models/lang.py:134
+#: common/models/lang.py:136
 msgid "Lithuanian"
 msgstr ""
 
-#: common/models/lang.py:135
+#: common/models/lang.py:137
 msgid "Letzeburgesch"
 msgstr ""
 
-#: common/models/lang.py:136
+#: common/models/lang.py:138
 msgid "Luba-Katanga"
 msgstr ""
 
-#: common/models/lang.py:137
+#: common/models/lang.py:139
 msgid "Ganda"
 msgstr ""
 
-#: common/models/lang.py:138
+#: common/models/lang.py:140
 msgid "Marshall"
 msgstr ""
 
-#: common/models/lang.py:139
+#: common/models/lang.py:141
 msgid "Malayalam"
 msgstr ""
 
-#: common/models/lang.py:140
+#: common/models/lang.py:142
 msgid "Marathi"
 msgstr ""
 
-#: common/models/lang.py:141
+#: common/models/lang.py:143
 msgid "Malagasy"
 msgstr ""
 
-#: common/models/lang.py:142
+#: common/models/lang.py:144
 msgid "Maltese"
 msgstr ""
 
-#: common/models/lang.py:143
+#: common/models/lang.py:145
 msgid "Moldavian"
 msgstr ""
 
-#: common/models/lang.py:144
+#: common/models/lang.py:146
 msgid "Mongolian"
 msgstr ""
 
-#: common/models/lang.py:145
+#: common/models/lang.py:147
 msgid "Maori"
 msgstr ""
 
-#: common/models/lang.py:146
+#: common/models/lang.py:148
 msgid "Malay"
 msgstr ""
 
-#: common/models/lang.py:147
+#: common/models/lang.py:149
 msgid "Burmese"
 msgstr ""
 
-#: common/models/lang.py:148
+#: common/models/lang.py:150
 msgid "Nauru"
 msgstr ""
 
-#: common/models/lang.py:149
+#: common/models/lang.py:151
 msgid "Navajo"
 msgstr ""
 
-#: common/models/lang.py:150 common/models/lang.py:151
+#: common/models/lang.py:152 common/models/lang.py:153
 msgid "Ndebele"
 msgstr ""
 
-#: common/models/lang.py:152
+#: common/models/lang.py:154
 msgid "Ndonga"
 msgstr ""
 
-#: common/models/lang.py:153
+#: common/models/lang.py:155
 msgid "Nepali"
 msgstr ""
 
-#: common/models/lang.py:154
+#: common/models/lang.py:156
 msgid "Dutch"
 msgstr ""
 
-#: common/models/lang.py:155
+#: common/models/lang.py:157
 msgid "Norwegian Nynorsk"
 msgstr ""
 
-#: common/models/lang.py:156
+#: common/models/lang.py:158
 msgid "Norwegian Bokmål"
 msgstr ""
 
-#: common/models/lang.py:157
+#: common/models/lang.py:159
 msgid "Norwegian"
 msgstr ""
 
-#: common/models/lang.py:158
+#: common/models/lang.py:160
 msgid "Chichewa; Nyanja"
 msgstr ""
 
-#: common/models/lang.py:159
+#: common/models/lang.py:161
 msgid "Occitan"
 msgstr ""
 
-#: common/models/lang.py:160
+#: common/models/lang.py:162
 msgid "Ojibwa"
 msgstr ""
 
-#: common/models/lang.py:161
+#: common/models/lang.py:163
 msgid "Oriya"
 msgstr ""
 
-#: common/models/lang.py:162
+#: common/models/lang.py:164
 msgid "Oromo"
 msgstr ""
 
-#: common/models/lang.py:163
+#: common/models/lang.py:165
 msgid "Ossetian; Ossetic"
 msgstr ""
 
-#: common/models/lang.py:164
+#: common/models/lang.py:166
 msgid "Pali"
 msgstr ""
 
-#: common/models/lang.py:165
+#: common/models/lang.py:167
 msgid "Polish"
 msgstr ""
 
-#: common/models/lang.py:167
+#: common/models/lang.py:169
 msgid "Quechua"
 msgstr ""
 
-#: common/models/lang.py:168
+#: common/models/lang.py:170
 msgid "Raeto-Romance"
 msgstr ""
 
-#: common/models/lang.py:169
+#: common/models/lang.py:171
 msgid "Romanian"
 msgstr ""
 
-#: common/models/lang.py:170
+#: common/models/lang.py:172
 msgid "Rundi"
 msgstr ""
 
-#: common/models/lang.py:171
+#: common/models/lang.py:173
 msgid "Russian"
 msgstr ""
 
-#: common/models/lang.py:172
+#: common/models/lang.py:174
 msgid "Sango"
 msgstr ""
 
-#: common/models/lang.py:173
+#: common/models/lang.py:175
 msgid "Sanskrit"
 msgstr ""
 
-#: common/models/lang.py:174
+#: common/models/lang.py:176
 msgid "Sinhalese"
 msgstr ""
 
-#: common/models/lang.py:175
+#: common/models/lang.py:177
 msgid "Slovak"
 msgstr ""
 
-#: common/models/lang.py:176
+#: common/models/lang.py:178
 msgid "Slovenian"
 msgstr ""
 
-#: common/models/lang.py:177
+#: common/models/lang.py:179
 msgid "Northern Sami"
 msgstr ""
 
-#: common/models/lang.py:178
+#: common/models/lang.py:180
 msgid "Samoan"
 msgstr ""
 
-#: common/models/lang.py:179
+#: common/models/lang.py:181
 msgid "Shona"
 msgstr ""
 
-#: common/models/lang.py:180
+#: common/models/lang.py:182
 msgid "Sindhi"
 msgstr ""
 
-#: common/models/lang.py:181
+#: common/models/lang.py:183
 msgid "Somali"
 msgstr ""
 
-#: common/models/lang.py:182
+#: common/models/lang.py:184
 msgid "Sotho"
 msgstr ""
 
-#: common/models/lang.py:184
+#: common/models/lang.py:186
 msgid "Albanian"
 msgstr ""
 
-#: common/models/lang.py:185
+#: common/models/lang.py:187
 msgid "Sardinian"
 msgstr ""
 
-#: common/models/lang.py:186
+#: common/models/lang.py:188
 msgid "Serbian"
 msgstr ""
 
-#: common/models/lang.py:187
+#: common/models/lang.py:189
 msgid "Swati"
 msgstr ""
 
-#: common/models/lang.py:188
+#: common/models/lang.py:190
 msgid "Sundanese"
 msgstr "スンダ語"
 
-#: common/models/lang.py:189
+#: common/models/lang.py:191
 msgid "Swahili"
 msgstr "スワヒリ語"
 
-#: common/models/lang.py:190
+#: common/models/lang.py:192
 msgid "Swedish"
 msgstr "スウェーデン語"
 
-#: common/models/lang.py:191
+#: common/models/lang.py:193
 msgid "Tahitian"
 msgstr "タヒチ語"
 
-#: common/models/lang.py:192
+#: common/models/lang.py:194
 msgid "Tamil"
 msgstr "タミル語"
 
-#: common/models/lang.py:193
+#: common/models/lang.py:195
 msgid "Tatar"
 msgstr "タタール語"
 
-#: common/models/lang.py:194
+#: common/models/lang.py:196
 msgid "Telugu"
 msgstr "テルグ語"
 
-#: common/models/lang.py:195
+#: common/models/lang.py:197
 msgid "Tajik"
 msgstr "タジク語"
 
-#: common/models/lang.py:196
+#: common/models/lang.py:198
 msgid "Tagalog"
 msgstr "タガログ語"
 
-#: common/models/lang.py:197
+#: common/models/lang.py:199
 msgid "Thai"
 msgstr "タイ語"
 
-#: common/models/lang.py:198
+#: common/models/lang.py:200
 msgid "Tigrinya"
 msgstr "ティグリニャ語"
 
-#: common/models/lang.py:199
+#: common/models/lang.py:201
 msgid "Tonga"
 msgstr "トンガ語"
 
-#: common/models/lang.py:200
+#: common/models/lang.py:202
 msgid "Tswana"
 msgstr "ツワナ語"
 
-#: common/models/lang.py:201
+#: common/models/lang.py:203
 msgid "Tsonga"
 msgstr "ツォンガ語"
 
-#: common/models/lang.py:202
+#: common/models/lang.py:204
 msgid "Turkmen"
 msgstr "トルクメン語"
 
-#: common/models/lang.py:203
+#: common/models/lang.py:205
 msgid "Turkish"
 msgstr "トルコ語"
 
-#: common/models/lang.py:204
+#: common/models/lang.py:206
 msgid "Twi"
 msgstr "トウィ語"
 
-#: common/models/lang.py:205
+#: common/models/lang.py:207
 msgid "Uighur"
 msgstr "ウイグル語"
 
-#: common/models/lang.py:206
+#: common/models/lang.py:208
 msgid "Ukrainian"
 msgstr "ウクライナ語"
 
-#: common/models/lang.py:207
+#: common/models/lang.py:209
 msgid "Urdu"
 msgstr "ウルドゥー語"
 
-#: common/models/lang.py:208
+#: common/models/lang.py:210
 msgid "Uzbek"
 msgstr "ウズベク語"
 
-#: common/models/lang.py:209
+#: common/models/lang.py:211
 msgid "Venda"
 msgstr "ヴェンダ語"
 
-#: common/models/lang.py:210
+#: common/models/lang.py:212
 msgid "Vietnamese"
 msgstr "ベトナム語"
 
-#: common/models/lang.py:211
+#: common/models/lang.py:213
 msgid "Volapük"
 msgstr "ヴォラピュク語"
 
-#: common/models/lang.py:212
+#: common/models/lang.py:214
 msgid "Walloon"
 msgstr "ワロン語"
 
-#: common/models/lang.py:213
+#: common/models/lang.py:215
 msgid "Wolof"
 msgstr "ウォロフ語"
 
-#: common/models/lang.py:214
+#: common/models/lang.py:216
 msgid "Xhosa"
 msgstr "コサ語"
 
-#: common/models/lang.py:215
+#: common/models/lang.py:217
 msgid "Yiddish"
 msgstr "イディッシュ語"
 
-#: common/models/lang.py:216
+#: common/models/lang.py:218
 msgid "Zhuang"
 msgstr "チワン語"
 
-#: common/models/lang.py:217
+#: common/models/lang.py:219
 msgid "Zulu"
 msgstr "ズールー語"
 
-#: common/models/lang.py:218
+#: common/models/lang.py:220
 msgid "Abkhazian"
 msgstr "アブハズ語"
 
-#: common/models/lang.py:219
+#: common/models/lang.py:221
 msgid "Chinese"
 msgstr "中国語"
 
-#: common/models/lang.py:220
+#: common/models/lang.py:222
 msgid "Pushto"
 msgstr "パシュトー語"
 
-#: common/models/lang.py:221
+#: common/models/lang.py:223
 msgid "Amharic"
 msgstr "アムハラ語"
 
-#: common/models/lang.py:222
+#: common/models/lang.py:224
 msgid "Arabic"
 msgstr "アラビア語"
 
-#: common/models/lang.py:223
+#: common/models/lang.py:225
 msgid "Bulgarian"
 msgstr "ブルガリア語"
 
-#: common/models/lang.py:224
+#: common/models/lang.py:226
 msgid "Macedonian"
 msgstr "マケドニア語"
 
-#: common/models/lang.py:225
+#: common/models/lang.py:227
 msgid "Greek"
 msgstr "ギリシャ語"
 
-#: common/models/lang.py:226
+#: common/models/lang.py:228
 msgid "Persian"
 msgstr "ペルシア語"
 
-#: common/models/lang.py:227
+#: common/models/lang.py:229
 msgid "Hebrew"
 msgstr "ヘブライ語"
 
-#: common/models/lang.py:228
+#: common/models/lang.py:230
 msgid "Hindi"
 msgstr "ヒンディー語"
 
-#: common/models/lang.py:229
+#: common/models/lang.py:231
 msgid "Armenian"
 msgstr "アルメニア語"
 
-#: common/models/lang.py:231
+#: common/models/lang.py:233
 msgid "Ewe"
 msgstr "エウェ語"
 
-#: common/models/lang.py:232
+#: common/models/lang.py:234
 msgid "Georgian"
 msgstr "グルジア語"
 
-#: common/models/lang.py:233
+#: common/models/lang.py:235
 msgid "Punjabi"
 msgstr "パンジャブ語"
 
-#: common/models/lang.py:234
+#: common/models/lang.py:236
 msgid "Bengali"
 msgstr "ベンガル語"
 
-#: common/models/lang.py:235
+#: common/models/lang.py:237
 msgid "Bosnian"
 msgstr "ボスニア語"
 
-#: common/models/lang.py:236
+#: common/models/lang.py:238
 msgid "Chamorro"
 msgstr "チャモロ語"
 
-#: common/models/lang.py:237
+#: common/models/lang.py:239
 msgid "Belarusian"
 msgstr "ベラルーシ語"
 
-#: common/models/lang.py:238
+#: common/models/lang.py:240
 msgid "Yoruba"
 msgstr "ヨルバ語"
 
-#: common/models/lang.py:300
+#: common/models/lang.py:302
 msgid "Simplified Chinese (Mainland)"
 msgstr "簡体字中国語 (中国本土)"
 
-#: common/models/lang.py:301
+#: common/models/lang.py:303
 msgid "Traditional Chinese (Taiwan)"
 msgstr "繁体字中国語 (台湾)"
 
-#: common/models/lang.py:302
+#: common/models/lang.py:304
 msgid "Traditional Chinese (Hongkong)"
 msgstr "繁体字中国語 (香港)"
 
-#: common/models/lang.py:310
+#: common/models/lang.py:312
 msgid "Portuguese (Brazil)"
 msgstr "ポルトガル語 (ブラジル)"
 
-#: common/models/lang.py:313
+#: common/models/lang.py:315
 msgid "Simplified Chinese (Singapore)"
 msgstr "簡体字中国語(シンガポール)"
 
-#: common/models/lang.py:314
+#: common/models/lang.py:316
 msgid "Simplified Chinese (Malaysia)"
 msgstr "簡体中文(マレーシア)"
 
-#: common/models/lang.py:315
+#: common/models/lang.py:317
 msgid "Traditional Chinese (Macau)"
 msgstr "繁体字中国語 (マカオ)"
 
-#: common/models/lang.py:323
+#: common/models/lang.py:325
 msgid "Mandarin Chinese"
 msgstr "標準中国語 (マンダリン)"
 
-#: common/models/lang.py:324
+#: common/models/lang.py:326
 msgid "Yue Chinese"
 msgstr "広東語 (粤語)"
 
-#: common/models/lang.py:328
+#: common/models/lang.py:330
 msgid "Min Nan Chinese"
 msgstr "閩南語"
 
-#: common/models/lang.py:329
+#: common/models/lang.py:331
 msgid "Wu Chinese"
 msgstr "呉語"
 
-#: common/models/lang.py:330
+#: common/models/lang.py:332
 msgid "Hakka Chinese"
 msgstr "客家語"
 
@@ -3759,22 +3802,16 @@ msgid "VCD"
 msgstr ""
 
 #: common/templates/400.html:23
-msgid ""
-"You may have submitted invalid data, or the content may have been deleted by "
-"the author."
+msgid "You may have submitted invalid data, or the content may have been deleted by the author."
 msgstr ""
 
 #: common/templates/400.html:25 common/templates/403.html:24
 #: common/templates/404.html:24
-msgid ""
-"If you believe this is our mistake, please contact us through the link at "
-"the bottom of the page."
+msgid "If you believe this is our mistake, please contact us through the link at the bottom of the page."
 msgstr ""
 
 #: common/templates/403.html:22
-msgid ""
-"Author may require you to log in before accessing this content, or you do "
-"not have permission to view it."
+msgid "Author may require you to log in before accessing this content, or you do not have permission to view it."
 msgstr ""
 
 #: common/templates/404.html:20
@@ -3782,9 +3819,7 @@ msgid "Something is missing"
 msgstr ""
 
 #: common/templates/404.html:22
-msgid ""
-"You may have visited an incorrect URL, or the content you are looking for "
-"has been deleted by the author."
+msgid "You may have visited an incorrect URL, or the content you are looking for has been deleted by the author."
 msgstr ""
 
 #: common/templates/404.html:26
@@ -3792,15 +3827,11 @@ msgid "Go to Home"
 msgstr ""
 
 #: common/templates/500.html:22
-msgid ""
-"An internal error occurred. If this error occurs repeatedly, it will be "
-"recorded and handled by a human."
+msgid "An internal error occurred. If this error occurs repeatedly, it will be recorded and handled by a human."
 msgstr ""
 
 #: common/templates/500.html:24
-msgid ""
-"If you have an urgent situation or any questions, please contact us through "
-"the link at the bottom of the page."
+msgid "If you have an urgent situation or any questions, please contact us through the link at the bottom of the page."
 msgstr ""
 
 #: common/templates/_footer.html:6
@@ -3815,207 +3846,184 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: common/templates/_footer.html:12 users/templates/users/login.html:265
+#: common/templates/_footer.html:12 users/templates/users/login.html:259
 #, python-format
-msgid ""
-"You are visiting an alternative domain for %(site_name)s, please always use "
-"<a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if "
-"possible."
+msgid "You are visiting an alternative domain for %(site_name)s, please always use <a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if possible."
 msgstr ""
 
-#: common/templates/_header.html:19 common/templates/_header.html:164
+#: common/templates/_header.html:19 common/templates/_header.html:177
 msgid "title, creator, ISBN, item url, @user, @user@instance"
 msgstr ""
 
-#: common/templates/_header.html:24
+#: common/templates/_header.html:34
 msgid "All Items"
 msgstr ""
 
-#: common/templates/_header.html:31
+#: common/templates/_header.html:41
 msgid "Movie & TV"
 msgstr ""
 
-#: common/templates/_header.html:50
+#: common/templates/_header.html:60
 msgid "People & Organizations"
 msgstr ""
 
-#: common/templates/_header.html:52
+#: common/templates/_header.html:62
 msgid "Journal"
 msgstr ""
 
-#: common/templates/_header.html:54 journal/templates/user_post_list.html:10
+#: common/templates/_header.html:64 journal/templates/user_post_list.html:10
 #: journal/templates/user_post_list.html:23
 msgid "Posts"
 msgstr ""
 
-#: common/templates/_header.html:89
+#: common/templates/_header.html:102
 msgid "Explore"
 msgstr ""
 
-#: common/templates/_header.html:93
+#: common/templates/_header.html:106 common/views_manage.py:36
 msgid "Feed"
 msgstr ""
 
-#: common/templates/_header.html:98 journal/templates/profile.html:13
+#: common/templates/_header.html:111 journal/templates/profile.html:13
 #: users/templates/users/preferences.html:46
 msgid "Home"
 msgstr ""
 
-#: common/templates/_header.html:114 common/templates/common/scan.html:9
+#: common/templates/_header.html:127 common/templates/common/scan.html:9
 #: common/templates/common/scan.html:42
 msgid "Scan Barcode"
 msgstr ""
 
-#: common/templates/_header.html:118 social/templates/notification.html:12
+#: common/templates/_header.html:131 social/templates/notification.html:12
 #: social/templates/notification.html:53
 msgid "Notification"
 msgstr ""
 
-#: common/templates/_header.html:122 users/models/task.py:21
+#: common/templates/_header.html:135 users/models/task.py:23
 #: users/templates/users/account.html:219
 #: users/templates/users/crossposts.html:9
 msgid "Pending"
 msgstr ""
 
-#: common/templates/_header.html:125
+#: common/templates/_header.html:138
 msgid "Data"
 msgstr ""
 
-#: common/templates/_header.html:128 common/templates/_header.html:146
+#: common/templates/_header.html:141 common/templates/_header.html:159
 #: users/templates/users/preferences.html:12
 #: users/templates/users/preferences.html:23
 #: users/templates/users/preferences_anonymous.html:13
 msgid "Preferences"
 msgstr ""
 
-#: common/templates/_header.html:131
+#: common/templates/_header.html:144
 msgid "Account"
 msgstr ""
 
-#: common/templates/_header.html:135
+#: common/templates/_header.html:148
 msgid "Manage"
 msgstr ""
 
-#: common/templates/_header.html:139
+#: common/templates/_header.html:152
 msgid "Logout"
 msgstr ""
 
-#: common/templates/_header.html:143
+#: common/templates/_header.html:156
 msgid "Sign up or Login"
 msgstr ""
 
-#: common/templates/_header.html:160
-msgid ""
-"title or content  category:tv  status:complete  rating:8..10  "
-"date:2021-09-11..2022-02"
+#: common/templates/_header.html:173
+msgid "title or content  category:tv  status:complete  rating:8..10  date:2021-09-11..2022-02"
 msgstr ""
 
-#: common/templates/_header.html:162
+#: common/templates/_header.html:175
 msgid "name of a person or company"
 msgstr ""
 
-#: common/templates/_header.html:179
+#: common/templates/_header.html:192
 msgid "Open"
 msgstr ""
 
-#: common/templates/_sidebar.html:62
+#: common/templates/_sidebar.html:61
 #: users/templates/users/profile_actions.html:36
 msgid "approving followers manually"
 msgstr ""
 
-#: common/templates/_sidebar.html:81 common/templates/_sidebar.html:86
+#: common/templates/_sidebar.html:80 common/templates/_sidebar.html:85
 msgid "followers"
 msgstr ""
 
-#: common/templates/_sidebar.html:112
+#: common/templates/_sidebar.html:111
 msgid "Current Targets"
 msgstr ""
 
-#: common/templates/_sidebar.html:125
+#: common/templates/_sidebar.html:124
 msgid "Set a collection as target, its progress will show up here."
 msgstr ""
 
-#: common/templates/_sidebar.html:138
+#: common/templates/_sidebar.html:137
 msgid "Recent podcast episodes"
 msgstr ""
 
-#: common/templates/_sidebar.html:173
+#: common/templates/_sidebar.html:172
 msgid "Currently reading"
 msgstr ""
 
-#: common/templates/_sidebar.html:215
+#: common/templates/_sidebar.html:214
 msgid "Currently watching"
 msgstr ""
 
-#: common/templates/_sidebar.html:238 journal/forms.py:217
+#: common/templates/_sidebar.html:237 journal/forms.py:217
 #: journal/templates/user_tag_list.html:13
 #: journal/templates/user_tagmember_list.html:4
 msgid "Tags"
 msgstr ""
 
-#: common/templates/_sidebar.html:244 journal/templates/user_tag_list.html:28
+#: common/templates/_sidebar.html:243 journal/templates/user_tag_list.html:28
 #: journal/templates/user_tagmember_list.html:10
 msgid "featured tag"
 msgstr ""
 
-#: common/templates/_sidebar.html:247 journal/templates/user_tag_list.html:31
+#: common/templates/_sidebar.html:246 journal/templates/user_tag_list.html:31
 #: journal/templates/user_tagmember_list.html:15
 msgid "personal tag"
 msgstr ""
 
-#: common/templates/_sidebar.html:254 journal/templates/user_tag_list.html:39
+#: common/templates/_sidebar.html:253 journal/templates/user_tag_list.html:39
 msgid "no tags so far."
 msgstr ""
 
-#: common/templates/_sidebar.html:258 common/templates/_sidebar.html:271
+#: common/templates/_sidebar.html:257 common/templates/_sidebar.html:270
 msgid "show all"
 msgstr ""
 
-#: common/templates/_sidebar_anonymous.html:16
+#: common/templates/_sidebar_anonymous.html:15
 #, python-format
 msgid ""
 "\n"
 "        <h3>Welcome 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is "
-"committed to creating a free, open, and interconnected space for collecting "
-"and reviewing books, movies, music, games, and podcasts. Here, you can "
-"manage your collections, share your thoughts, discover new content, and "
-"connect with others.\n"
+"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is committed to creating a free, open, and interconnected space for collecting and reviewing books, movies, music, games, and podcasts. Here, you can manage your collections, share your thoughts, discover new content, and connect with others.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in "
-"to %(site_name)s is through a Fediverse (a distributed social network, "
-"including Mastodon/Pleroma/etc) instance account. If you haven’t registered "
-"yet, you can <a href=\"https://joinmastodon.org/en/servers\" "
-"target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
+"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in to %(site_name)s is through a Fediverse (a distributed social network, including Mastodon/Pleroma/etc) instance account. If you haven’t registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log "
-"in is through a Bluesky (another distributed social network, also called "
-"ATProto) account. If you haven’t registered yet, you may <a href=\"https://"
-"bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
+"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log in is through a Bluesky (another distributed social network, also called ATProto) account. If you haven’t registered yet, you may <a href=\"https://bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready "
-"to join either Fediverse or Bluesky, that’s perfectly fine. You can create "
-"an account here using your email address, and link it to the Fediverse and "
-"Bluesky in settings whenever you’re ready.\n"
+"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready to join either Fediverse or Bluesky, that’s perfectly fine. You can create an account here using your email address, and link it to the Fediverse and Bluesky in settings whenever you’re ready.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have "
-"any questions or suggestions, please feel free to contact us via <a "
-"href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://"
-"discord.gg/uprvcH8gqD\">Discord</a>.\n"
+"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have any questions or suggestions, please feel free to contact us via <a href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-"href=\"%(login_url)s\">Click here</a> to register or log in.\n"
+"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Click here</a> to register or log in.\n"
 "        </p>\n"
 "        "
 msgstr ""
 
-#: common/templates/_sidebar_anonymous.html:43
+#: common/templates/_sidebar_anonymous.html:42
 #: users/templates/users/announcements.html:12
 #: users/templates/users/announcements.html:39
 msgid "Announcements"
@@ -4037,7 +4045,7 @@ msgstr ""
 msgid "Registration"
 msgstr ""
 
-#: common/templates/common/about.html:35 common/views_manage.py:493
+#: common/templates/common/about.html:35 common/views_manage.py:594
 msgid "Invite Only"
 msgstr ""
 
@@ -4045,7 +4053,7 @@ msgstr ""
 msgid "Open Registration"
 msgstr ""
 
-#: common/templates/common/about.html:40 common/views_manage.py:556
+#: common/templates/common/about.html:40 common/views_manage.py:657
 msgid "Preferred Languages"
 msgstr ""
 
@@ -4096,9 +4104,7 @@ msgid "Error"
 msgstr ""
 
 #: common/templates/common/scan.html:45
-msgid ""
-"Point the camera at a book ISBN or product barcode (EAN / UPC). You will be "
-"redirected to the search once a code is detected."
+msgid "Point the camera at a book ISBN or product barcode (EAN / UPC). You will be redirected to the search once a code is detected."
 msgstr ""
 
 #: common/templates/common/scan.html:50
@@ -4109,7 +4115,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:628
+#: common/templates/common/scan.html:60 common/views_manage.py:738
 msgid "Search"
 msgstr ""
 
@@ -4141,18 +4147,30 @@ msgstr ""
 msgid "Camera unavailable. Use manual entry below."
 msgstr ""
 
-#: common/templates/manage/settings.html:9
+#: common/templates/manage/base.html:9
 #, fuzzy
 #| msgid "Additional Settings"
 msgid "Site Settings"
 msgstr "追加設定"
 
-#: common/templates/manage/settings.html:109
+#: common/templates/manage/base.html:127
 msgid "Takahe Admin"
 msgstr ""
 
-#: common/templates/manage/settings.html:112
+#: common/templates/manage/base.html:130
 msgid "Database Admin"
+msgstr ""
+
+#: common/templates/manage/environment.html:6
+msgid "These settings come from environment variables and cannot be changed here. Edit .env and restart the server to change them. Passwords and keys are hidden."
+msgstr ""
+
+#: common/templates/manage/environment.html:23
+msgid "(empty)"
+msgstr ""
+
+#: common/templates/manage/environment.html:26
+msgid "default"
 msgstr ""
 
 #: common/templatetags/duration.py:59
@@ -4171,7 +4189,7 @@ msgstr ""
 msgid "following you"
 msgstr ""
 
-#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:95
+#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:90
 msgid "you"
 msgstr ""
 
@@ -4179,815 +4197,822 @@ msgstr ""
 msgid "unavailable"
 msgstr ""
 
-#: common/utils.py:126 common/utils.py:167 users/views/actions.py:134
+#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr ""
 
-#: common/utils.py:133 common/utils.py:135 common/utils.py:138
-#: common/utils.py:174 common/utils.py:178 journal/views/profile.py:499
+#: common/utils.py:135 common/utils.py:137 common/utils.py:140
+#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
 msgid "Access denied"
 msgstr ""
 
-#: common/utils.py:141 common/utils.py:143 journal/views/article.py:204
+#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr ""
 
-#: common/views_manage.py:144 common/views_manage.py:295
+#: common/views_manage.py:34 common/views_manage.py:373
 msgid "Branding"
 msgstr ""
 
-#: common/views_manage.py:146
+#: common/views_manage.py:37
 msgid "Recommendations"
 msgstr ""
 
-#: common/views_manage.py:147
+#: common/views_manage.py:38
 #, fuzzy
 #| msgid "Accept"
 msgid "Access"
 msgstr "承認"
 
-#: common/views_manage.py:148 common/views_manage.py:623
+#: common/views_manage.py:39 common/views_manage.py:733
 msgid "Federation"
 msgstr ""
 
-#: common/views_manage.py:149
+#: common/views_manage.py:40
 #, fuzzy
 #| msgid "Tagalog"
 msgid "Catalog"
 msgstr "タガログ語"
 
-#: common/views_manage.py:150
+#: common/views_manage.py:41
 msgid "API Keys"
 msgstr ""
 
-#: common/views_manage.py:151
+#: common/views_manage.py:42
 #, fuzzy
 #| msgid "Download"
 msgid "Downloader"
 msgstr "ダウンロード"
 
-#: common/views_manage.py:152 common/views_manage.py:303
+#: common/views_manage.py:43 common/views_manage.py:381
 #: users/templates/users/steam_import.html:113
 msgid "Advanced"
 msgstr ""
 
-#: common/views_manage.py:202
+#: common/views_manage.py:44
+msgid "Environment"
+msgstr ""
+
+#: common/views_manage.py:280
 #, fuzzy
 #| msgid "Invalid file."
 msgid "Invalid value."
 msgstr "無効なファイルです。"
 
-#: common/views_manage.py:206
+#: common/views_manage.py:284
 msgid "Invalid configuration. Please check your input."
 msgstr ""
 
-#: common/views_manage.py:211
+#: common/views_manage.py:289
 #, fuzzy
 #| msgid "Settings saved."
 msgid "Settings have been saved."
 msgstr "設定が保存されました。"
 
-#: common/views_manage.py:231
+#: common/views_manage.py:309
 msgid "Site Name"
 msgstr ""
 
-#: common/views_manage.py:234
+#: common/views_manage.py:312
 msgid "Site Description"
 msgstr ""
 
-#: common/views_manage.py:235
+#: common/views_manage.py:313
 msgid "Short description shown in metadata and about page."
 msgstr ""
 
-#: common/views_manage.py:238
+#: common/views_manage.py:316
 msgid "Site Logo URL"
 msgstr ""
 
-#: common/views_manage.py:239
+#: common/views_manage.py:317
 msgid "URL path to the site logo image."
 msgstr ""
 
-#: common/views_manage.py:242
+#: common/views_manage.py:320
 msgid "Site Icon URL"
 msgstr ""
 
-#: common/views_manage.py:243
+#: common/views_manage.py:321
 msgid "URL path to the site icon/favicon."
 msgstr ""
 
-#: common/views_manage.py:246
+#: common/views_manage.py:324
 msgid "Default User Avatar URL"
 msgstr ""
 
-#: common/views_manage.py:247
+#: common/views_manage.py:325
 msgid "URL path to the default user avatar."
 msgstr ""
 
-#: common/views_manage.py:250
+#: common/views_manage.py:328
 msgid "Site Color Theme"
 msgstr ""
 
-#: common/views_manage.py:251
+#: common/views_manage.py:329
 msgid "PicoCSS color theme."
 msgstr ""
 
-#: common/views_manage.py:276
+#: common/views_manage.py:354
 msgid "Site Introduction"
 msgstr ""
 
-#: common/views_manage.py:277
+#: common/views_manage.py:355
 msgid "URL path for the intro/welcome sidebar page."
 msgstr ""
 
-#: common/views_manage.py:280
+#: common/views_manage.py:358
 msgid "Custom HTML Head"
 msgstr ""
 
-#: common/views_manage.py:281
+#: common/views_manage.py:359
 msgid "Extra HTML injected into the <head> of all pages."
 msgstr ""
 
-#: common/views_manage.py:285
+#: common/views_manage.py:363
 msgid "Footer Links"
 msgstr ""
 
-#: common/views_manage.py:286
+#: common/views_manage.py:364
 msgid "Link title mapped to URL."
 msgstr ""
 
-#: common/views_manage.py:315
+#: common/views_manage.py:393
 msgid "Minimum Marks for Discover"
 msgstr ""
 
-#: common/views_manage.py:317
+#: common/views_manage.py:395
 msgid "Number of marks required for an item to appear in discover."
 msgstr ""
 
-#: common/views_manage.py:322
+#: common/views_manage.py:400
 msgid "Update Interval (minutes)"
 msgstr ""
 
-#: common/views_manage.py:323
+#: common/views_manage.py:401
 msgid "How often to refresh the popular items list."
 msgstr ""
 
-#: common/views_manage.py:327
+#: common/views_manage.py:405
 msgid "Filter by Preferred Languages"
 msgstr ""
 
-#: common/views_manage.py:328
+#: common/views_manage.py:406
 msgid "Only show items with titles in the preferred languages."
 msgstr ""
 
-#: common/views_manage.py:331
+#: common/views_manage.py:409
 msgid "Show Local Only"
 msgstr ""
 
-#: common/views_manage.py:333
+#: common/views_manage.py:411
 msgid "Only show items marked by local users, not the entire network."
 msgstr ""
 
-#: common/views_manage.py:337
+#: common/views_manage.py:415
 msgid "Show Popular Posts"
 msgstr ""
 
-#: common/views_manage.py:338
+#: common/views_manage.py:416
 msgid "Show popular public posts instead of recent ones."
 msgstr ""
 
-#: common/views_manage.py:341
+#: common/views_manage.py:419
 msgid "Show Popular Tags"
 msgstr ""
 
-#: common/views_manage.py:342
+#: common/views_manage.py:420
 msgid "Show popular public tags on the discover page."
 msgstr ""
 
-#: common/views_manage.py:345
+#: common/views_manage.py:423
 msgid "Show Verified Podcasts"
 msgstr ""
 
-#: common/views_manage.py:347
-msgid ""
-"Show a shelf of recent episodes from podcasts with a verified creator on the "
-"discover page."
+#: common/views_manage.py:425
+msgid "Show a shelf of recent episodes from podcasts with a verified creator on the discover page."
 msgstr ""
 
-#: common/views_manage.py:386
+#: common/views_manage.py:447
+msgid "Show World Timeline"
+msgstr ""
+
+#: common/views_manage.py:449
+msgid "Offer a tab with public posts from this site and every server it federates with."
+msgstr ""
+
+#: common/views_manage.py:454
+msgid "Show Local Timeline"
+msgstr ""
+
+#: common/views_manage.py:455
+msgid "Offer a tab with public posts from this site only."
+msgstr ""
+
+#: common/views_manage.py:459
+msgid "Timelines"
+msgstr ""
+
+#: common/views_manage.py:487
 msgid "Enable Recommendations"
 msgstr ""
 
-#: common/views_manage.py:388
-msgid ""
-"Master switch. When off, all recommendation surfaces are hidden and the cron "
-"jobs are not scheduled."
+#: common/views_manage.py:489
+msgid "Master switch. When off, all recommendation surfaces are hidden and the cron jobs are not scheduled."
 msgstr ""
 
-#: common/views_manage.py:393
+#: common/views_manage.py:494
 msgid "Source Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:395
-msgid ""
-"Minimum public marks an item needs before similarity rows are built for it."
+#: common/views_manage.py:496
+msgid "Minimum public marks an item needs before similarity rows are built for it."
 msgstr ""
 
-#: common/views_manage.py:401
+#: common/views_manage.py:502
 msgid "Target Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:403
-msgid ""
-"Minimum public marks an item needs to be eligible as a recommendation target."
+#: common/views_manage.py:504
+msgid "Minimum public marks an item needs to be eligible as a recommendation target."
 msgstr ""
 
-#: common/views_manage.py:409
+#: common/views_manage.py:510
 msgid "Top-K Similar Items per Source"
 msgstr ""
 
-#: common/views_manage.py:410
+#: common/views_manage.py:511
 msgid "Number of similar items stored per source item."
 msgstr ""
 
-#: common/views_manage.py:414
+#: common/views_manage.py:515
 msgid "Top-N Recommendations per User"
 msgstr ""
 
-#: common/views_manage.py:415
+#: common/views_manage.py:516
 msgid "Number of personalised rows stored per user."
 msgstr ""
 
-#: common/views_manage.py:419
+#: common/views_manage.py:520
 msgid "Dampen Heavy Shelvers"
 msgstr ""
 
-#: common/views_manage.py:421
-msgid ""
-"Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-"
-"shelvers in similarity scoring."
+#: common/views_manage.py:522
+msgid "Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-shelvers in similarity scoring."
 msgstr ""
 
-#: common/views_manage.py:426
+#: common/views_manage.py:527
 msgid "Per-User Mark Cap (training)"
 msgstr ""
 
-#: common/views_manage.py:428
-msgid ""
-"Truncate each user's contribution to their N most recent marks when building "
-"the similarity matrix."
+#: common/views_manage.py:529
+msgid "Truncate each user's contribution to their N most recent marks when building the similarity matrix."
 msgstr ""
 
-#: common/views_manage.py:434
+#: common/views_manage.py:535
 msgid "Active-User Window (days)"
 msgstr ""
 
-#: common/views_manage.py:436
-msgid ""
-"Refresh personalised recommendations for users with at least one public mark "
-"in the last N days."
+#: common/views_manage.py:537
+msgid "Refresh personalised recommendations for users with at least one public mark in the last N days."
 msgstr ""
 
-#: common/views_manage.py:442
+#: common/views_manage.py:543
 msgid "Per-User Seed Cap (serving)"
 msgstr ""
 
-#: common/views_manage.py:444
-msgid ""
-"Number of recent marks used as seeds when scoring personalised "
-"recommendations for one user."
+#: common/views_manage.py:545
+msgid "Number of recent marks used as seeds when scoring personalised recommendations for one user."
 msgstr ""
 
-#: common/views_manage.py:450
+#: common/views_manage.py:551
 msgid "Lazy Refresh TTL (days)"
 msgstr ""
 
-#: common/views_manage.py:452
-msgid ""
-"How long cached on-demand recommendations are valid before the next request "
-"triggers a refresh."
+#: common/views_manage.py:553
+msgid "How long cached on-demand recommendations are valid before the next request triggers a refresh."
 msgstr ""
 
-#: common/views_manage.py:458
+#: common/views_manage.py:559
 msgid "Circles Window (days)"
 msgstr ""
 
-#: common/views_manage.py:460
-msgid ""
-"Look back N days when finding items recently marked by people the viewer "
-"follows."
+#: common/views_manage.py:561
+msgid "Look back N days when finding items recently marked by people the viewer follows."
 msgstr ""
 
-#: common/views_manage.py:467
+#: common/views_manage.py:568
 msgid "Master Switch"
 msgstr ""
 
-#: common/views_manage.py:470
+#: common/views_manage.py:571
 msgid "Similarity Builder"
 msgstr ""
 
-#: common/views_manage.py:477
+#: common/views_manage.py:578
 #, fuzzy
 #| msgid "Persian"
 msgid "Personalisation"
 msgstr "ペルシア語"
 
-#: common/views_manage.py:495
-msgid ""
-"Require an invite token to register. Invite tokens can be generated with "
-"neodb-manage invite --create."
+#: common/views_manage.py:596
+msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
 msgstr ""
 
-#: common/views_manage.py:500
+#: common/views_manage.py:601
 msgid "Enable Local-Only Posting"
 msgstr ""
 
-#: common/views_manage.py:501
+#: common/views_manage.py:602
 msgid "Allow users to create posts visible only to local users."
 msgstr ""
 
-#: common/views_manage.py:504
+#: common/views_manage.py:605
 msgid "Mastodon Login Whitelist"
 msgstr ""
 
-#: common/views_manage.py:505
+#: common/views_manage.py:606
 msgid "One domain per line. Leave empty to allow any instance."
 msgstr ""
 
-#: common/views_manage.py:508
+#: common/views_manage.py:609
 msgid "Registration Captcha Items"
 msgstr ""
 
-#: common/views_manage.py:512
-msgid ""
-"Number of item covers a new user must sort into two category rows before "
-"choosing a username. 0 disables the captcha; 5-6 is recommended. The covers "
-"carry no title text, so this cannot be solved with a screen reader: if you "
-"enable it, keep another way in, such as an invite link."
+#: common/views_manage.py:613
+msgid "Number of item covers a new user must sort into two category rows before choosing a username. 0 disables the captcha; 5-6 is recommended. The covers carry no title text, so this cannot be solved with a screen reader: if you enable it, keep another way in, such as an invite link."
 msgstr ""
 
-#: common/views_manage.py:520
+#: common/views_manage.py:621
 msgid "Registration Captcha Minimum Marks"
 msgstr ""
 
-#: common/views_manage.py:523
-msgid ""
-"Marks an item needs before the captcha treats it as well known enough to be "
-"recognizable. Categories with too few such items fall back to any item."
+#: common/views_manage.py:624
+msgid "Marks an item needs before the captcha treats it as well known enough to be recognizable. Categories with too few such items fall back to any item."
 msgstr ""
 
-#: common/views_manage.py:529
+#: common/views_manage.py:630
 msgid "Enable Mastodon Login"
 msgstr ""
 
-#: common/views_manage.py:532
+#: common/views_manage.py:633
 msgid "Enable Bluesky Login"
 msgstr ""
 
-#: common/views_manage.py:535
+#: common/views_manage.py:636
 msgid "Enable Threads Login"
 msgstr ""
 
-#: common/views_manage.py:538
+#: common/views_manage.py:639
 msgid "Email URL"
 msgstr ""
 
-#: common/views_manage.py:540
+#: common/views_manage.py:641
 msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
 msgstr ""
 
-#: common/views_manage.py:544
+#: common/views_manage.py:645
 msgid "Email From"
 msgstr ""
 
-#: common/views_manage.py:545
+#: common/views_manage.py:646
 msgid "Sender name and address for outgoing email."
 msgstr ""
 
-#: common/views_manage.py:548
+#: common/views_manage.py:649
 #, fuzzy
 #| msgid "Language"
 msgid "Default Language"
 msgstr "言語"
 
-#: common/views_manage.py:551
-msgid ""
-"Interface language for visitors and for users who have not chosen one "
-"themselves."
+#: common/views_manage.py:652
+msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:558
-msgid ""
-"Language codes, one per line (e.g. en, zh, ja). First language is the "
-"default."
+#: common/views_manage.py:659
+msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:564
+#: common/views_manage.py:665
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:571
+#: common/views_manage.py:672
 #, fuzzy
 #| msgid "Import Method"
 msgid "Login Methods"
 msgstr "インポート方法"
 
-#: common/views_manage.py:576 mastodon/models/common.py:28
+#: common/views_manage.py:677 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr ""
 
-#: common/views_manage.py:580
+#: common/views_manage.py:681
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:591
+#: common/views_manage.py:692
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:593
-msgid ""
-"Disable relay.neodb.net federation for sharing public ratings across "
-"instances."
+#: common/views_manage.py:694
+msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:598
+#: common/views_manage.py:699
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:599
+#: common/views_manage.py:700
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:603
+#: common/views_manage.py:704
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:605
+#: common/views_manage.py:706
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:610
+#: common/views_manage.py:711
 msgid "Search Sites"
 msgstr ""
 
-#: common/views_manage.py:611
+#: common/views_manage.py:712
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:614
+#: common/views_manage.py:715
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:615
+#: common/views_manage.py:716
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:618
+#: common/views_manage.py:719
 msgid "Hidden Categories"
 msgstr ""
 
-#: common/views_manage.py:619
+#: common/views_manage.py:720
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:640
-msgid "Spotify API Key"
-msgstr ""
-
-#: common/views_manage.py:641
-msgid "https://developer.spotify.com/"
-msgstr ""
-
-#: common/views_manage.py:644
-msgid "TMDB API Key"
-msgstr ""
-
-#: common/views_manage.py:645
-msgid "https://developer.themoviedb.org/"
-msgstr ""
-
-#: common/views_manage.py:648
-msgid "Google Books API Key"
-msgstr ""
-
-#: common/views_manage.py:649
-msgid "https://developers.google.com/books/"
-msgstr ""
-
-#: common/views_manage.py:652
-msgid "Discogs API Key"
-msgstr ""
-
-#: common/views_manage.py:654
-msgid "Personal access token from https://www.discogs.com/settings/developers"
-msgstr ""
-
-#: common/views_manage.py:658
-msgid "IGDB Client ID"
-msgstr ""
-
-#: common/views_manage.py:659
-msgid "https://api-docs.igdb.com/"
-msgstr ""
-
-#: common/views_manage.py:662
-msgid "IGDB Client Secret"
-msgstr ""
-
-#: common/views_manage.py:665
-msgid "BoardGameGeek API Token"
-msgstr ""
-
-#: common/views_manage.py:667
-msgid ""
-"Bearer token from https://boardgamegeek.com/applications (see https://"
-"boardgamegeek.com/using_the_xml_api#toc9)."
-msgstr ""
-
-#: common/views_manage.py:672 users/templates/users/steam_import.html:26
-msgid "Steam API Key"
-msgstr ""
-
-#: common/views_manage.py:674
-msgid ""
-"https://steamcommunity.com/dev - fallback key for Steam importer. Users can "
-"provide their own key when importing."
-msgstr ""
-
-#: common/views_manage.py:679
-msgid "DeepL API Key"
-msgstr ""
-
-#: common/views_manage.py:680
-msgid "For translation features."
-msgstr ""
-
-#: common/views_manage.py:683
-msgid "LibreTranslate API URL"
-msgstr ""
-
-#: common/views_manage.py:686
-msgid "LibreTranslate API Key"
-msgstr ""
-
-#: common/views_manage.py:689
-msgid "Threads App ID"
-msgstr ""
-
-#: common/views_manage.py:690
-msgid "OAuth app ID for Threads login."
-msgstr ""
-
-#: common/views_manage.py:693
-msgid "Threads App Secret"
-msgstr ""
-
-#: common/views_manage.py:696
-msgid "Discord Webhooks"
-msgstr ""
-
-#: common/views_manage.py:698
-msgid ""
-"Webhook URLs keyed by channel (default, report, audit, suggest, system). All "
-"channels must be Discord forum or media channels (thread mode) because "
-"notifications are posted as threads."
-msgstr ""
-
-#: common/views_manage.py:715
-msgid "Catalog APIs"
+#: common/views_manage.py:723
+msgid "Guest Search Page Limit"
 msgstr ""
 
 #: common/views_manage.py:725
+msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
+msgstr ""
+
+#: common/views_manage.py:751
+msgid "Spotify API Key"
+msgstr ""
+
+#: common/views_manage.py:752
+msgid "https://developer.spotify.com/"
+msgstr ""
+
+#: common/views_manage.py:755
+msgid "TMDB API Key"
+msgstr ""
+
+#: common/views_manage.py:756
+msgid "https://developer.themoviedb.org/"
+msgstr ""
+
+#: common/views_manage.py:759
+msgid "Google Books API Key"
+msgstr ""
+
+#: common/views_manage.py:760
+msgid "https://developers.google.com/books/"
+msgstr ""
+
+#: common/views_manage.py:763
+msgid "Discogs API Key"
+msgstr ""
+
+#: common/views_manage.py:765
+msgid "Personal access token from https://www.discogs.com/settings/developers"
+msgstr ""
+
+#: common/views_manage.py:769
+msgid "IGDB Client ID"
+msgstr ""
+
+#: common/views_manage.py:770
+msgid "https://api-docs.igdb.com/"
+msgstr ""
+
+#: common/views_manage.py:773
+msgid "IGDB Client Secret"
+msgstr ""
+
+#: common/views_manage.py:776
+msgid "BoardGameGeek API Token"
+msgstr ""
+
+#: common/views_manage.py:778
+msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
+msgstr ""
+
+#: common/views_manage.py:783
+msgid "MyAnimeList Client ID"
+msgstr ""
+
+#: common/views_manage.py:785
+msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
+msgstr ""
+
+#: common/views_manage.py:790 users/templates/users/steam_import.html:26
+msgid "Steam API Key"
+msgstr ""
+
+#: common/views_manage.py:792
+msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
+msgstr ""
+
+#: common/views_manage.py:797
+msgid "DeepL API Key"
+msgstr ""
+
+#: common/views_manage.py:798
+msgid "For translation features."
+msgstr ""
+
+#: common/views_manage.py:801
+msgid "LibreTranslate API URL"
+msgstr ""
+
+#: common/views_manage.py:804
+msgid "LibreTranslate API Key"
+msgstr ""
+
+#: common/views_manage.py:807
+msgid "Threads App ID"
+msgstr ""
+
+#: common/views_manage.py:808
+msgid "OAuth app ID for Threads login."
+msgstr ""
+
+#: common/views_manage.py:811
+msgid "Threads App Secret"
+msgstr ""
+
+#: common/views_manage.py:814
+msgid "Discord Webhooks"
+msgstr ""
+
+#: common/views_manage.py:816
+msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
+msgstr ""
+
+#: common/views_manage.py:833
+msgid "Catalog APIs"
+msgstr ""
+
+#: common/views_manage.py:844
 msgid "Translation"
 msgstr ""
 
-#: common/views_manage.py:730
+#: common/views_manage.py:849
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:734 social/templates/feed.html:27
+#: common/views_manage.py:853 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr ""
 
-#: common/views_manage.py:744
+#: common/views_manage.py:863
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:745
+#: common/views_manage.py:864
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:748
+#: common/views_manage.py:867
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:749
+#: common/views_manage.py:868
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:752
+#: common/views_manage.py:871
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:874
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:758
+#: common/views_manage.py:877
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:761
+#: common/views_manage.py:880
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:764
+#: common/views_manage.py:883
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:767
+#: common/views_manage.py:886
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:768
+#: common/views_manage.py:887
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:771
+#: common/views_manage.py:890
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:775
+#: common/views_manage.py:894
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:779
+#: common/views_manage.py:898
 msgid "Retries"
 msgstr ""
 
-#: common/views_manage.py:784
+#: common/views_manage.py:903
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:789
+#: common/views_manage.py:908
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:796
+#: common/views_manage.py:915
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:808
+#: common/views_manage.py:927
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:809
+#: common/views_manage.py:928
 msgid "One domain per line."
 msgstr ""
 
-#: common/views_manage.py:812
+#: common/views_manage.py:931
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:813
+#: common/views_manage.py:932
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:935
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:818
-msgid ""
-"Timeout for requests to Mastodon instances and remote fediverse servers."
+#: common/views_manage.py:937
+msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:824
+#: common/views_manage.py:943
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:825
+#: common/views_manage.py:944
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:828
+#: common/views_manage.py:947
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:829
+#: common/views_manage.py:948
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:839
+#: common/views_manage.py:958
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:841
-msgid ""
-"Delete import/export tasks and their files after this many days. Set to 0 to "
-"disable cleanup."
+#: common/views_manage.py:960
+msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:847
+#: common/views_manage.py:966
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:849
-msgid ""
-"Post-migration job keys to skip, one per line (e.g. normalize_genre). "
-"Checked by the worker at dequeue time; skipped jobs log a warning and notify "
-"the Discord system channel."
+#: common/views_manage.py:968
+msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:855
+#: common/views_manage.py:974
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:857
-msgid ""
-"Private key (JWK) identifying this site to ATProto authorization servers. "
-"Auto-generated on first Bluesky login; clear to regenerate."
+#: common/views_manage.py:976
+msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:983
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:986
 msgid "Operational"
 msgstr ""
 
-#: common/views_manage.py:883
+#: common/views_manage.py:1002
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:885
-msgid ""
-"Genre codes offered in the Movie edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1004
+msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:1009
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:892
-msgid ""
-"Genre codes offered in the TV edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1011
+msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:897
+#: common/views_manage.py:1016
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:899
-msgid ""
-"Genre codes offered in the Music edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1018
+msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:904
+#: common/views_manage.py:1023
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:906
-msgid ""
-"Genre codes offered in the Game edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1025
+msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:911
+#: common/views_manage.py:1030
 msgid "Podcast Genres"
 msgstr ""
 
-#: common/views_manage.py:913
-msgid ""
-"Genre codes offered in the Podcast edit dropdown, one per line. Leave empty "
-"to use the built-in default."
+#: common/views_manage.py:1032
+msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:918
+#: common/views_manage.py:1037
 msgid "Performance Genres"
 msgstr ""
 
-#: common/views_manage.py:920
-msgid ""
-"Genre codes offered in the Performance edit dropdown, one per line. Leave "
-"empty to use the built-in default."
+#: common/views_manage.py:1039
+msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:926
+#: common/views_manage.py:1045
 msgid "Genres by Category"
 msgstr ""
 
+#: common/views_manage.py:1069
+msgid "Site"
+msgstr ""
+
+#: common/views_manage.py:1079
+msgid "Database and Services"
+msgstr ""
+
+#: common/views_manage.py:1089
+msgid "Media and Files"
+msgstr ""
+
+#: common/views_manage.py:1098
+msgid "Monitoring"
+msgstr ""
+
+#: common/views_manage.py:1102
+msgid "Security"
+msgstr ""
+
+#: common/views_manage.py:1111
+msgid "Other Environment Variables"
+msgstr ""
+
+#: common/views_manage.py:1113
+msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
+msgstr ""
+
 #: journal/forms.py:12
-msgid ""
-"Tips: use >!text!< for spoilers; some instances may not be able to show "
-"posts longer than 360 charactors."
+msgid "Tips: use >!text!< for spoilers; some instances may not be able to show posts longer than 360 charactors."
 msgstr ""
 
 #: journal/forms.py:29 journal/forms.py:31 journal/forms.py:80
@@ -5002,12 +5027,12 @@ msgid "Content (Markdown)"
 msgstr ""
 
 #: journal/forms.py:46 journal/forms.py:124 journal/forms.py:226
-#: journal/forms.py:288 journal/views/note.py:38
+#: journal/forms.py:288 journal/views/note.py:37
 msgid "Crosspost"
 msgstr ""
 
 #: journal/forms.py:47 journal/forms.py:125 journal/forms.py:227
-#: journal/forms.py:289 journal/views/note.py:39
+#: journal/forms.py:289 journal/views/note.py:38
 msgid "Crosspost to your connected social networks"
 msgstr ""
 
@@ -5022,10 +5047,10 @@ msgstr ""
 #: journal/forms.py:59 journal/forms.py:137 journal/forms.py:162
 #: journal/forms.py:219 journal/forms.py:281
 #: journal/templates/collection_share.html:24
-#: journal/templates/wrapped_share.html:36 journal/views/note.py:31
-#: users/templates/users/data.html:45 users/templates/users/data.html:98
-#: users/templates/users/data.html:155 users/templates/users/data.html:206
-#: users/templates/users/data.html:269 users/templates/users/data.html:328
+#: journal/templates/wrapped_share.html:36 journal/views/note.py:30
+#: users/templates/users/data.html:60 users/templates/users/data.html:113
+#: users/templates/users/data.html:170 users/templates/users/data.html:221
+#: users/templates/users/data.html:284 users/templates/users/data.html:346
 #: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
@@ -5064,7 +5089,6 @@ msgid "Collaborative editing"
 msgstr ""
 
 #: journal/forms.py:204 users/templates/users/crossposts.html:51
-#: users/templates/users/data.html:483
 msgid "Status"
 msgstr "状態"
 
@@ -5076,48 +5100,46 @@ msgstr ""
 msgid "Rating"
 msgstr ""
 
-#: journal/importers/goodreads.py:196 journal/importers/letterboxd.py:144
-#: journal/importers/rym.py:442 journal/importers/storygraph.py:500
+#: journal/importers/goodreads.py:198 journal/importers/letterboxd.py:147
+#: journal/importers/rym.py:444 journal/importers/storygraph.py:504
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr ""
 
-#: journal/importers/opml.py:45
+#: journal/importers/opml.py:49
 #, python-brace-format
 msgid "{username}'s podcast subscriptions"
 msgstr ""
 
-#: journal/importers/rym.py:168 journal/importers/storygraph.py:128
+#: journal/importers/rym.py:170 journal/importers/storygraph.py:132
 #, python-brace-format
-msgid ""
-"Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
+msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:178 journal/importers/storygraph.py:138
+#: journal/importers/rym.py:180 journal/importers/storygraph.py:142
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/importers/rym.py:233 journal/importers/storygraph.py:184
+#: journal/importers/rym.py:235 journal/importers/storygraph.py:188
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:348 journal/importers/storygraph.py:389
+#: journal/importers/rym.py:350 journal/importers/storygraph.py:393
 msgid "Matched file missing; cannot import."
 msgstr ""
 
-#: journal/importers/rym.py:376 journal/importers/storygraph.py:412
+#: journal/importers/rym.py:378 journal/importers/storygraph.py:416
 #, python-brace-format
-msgid ""
-"Import complete: {imported} imported, {skipped} skipped, {failed} failed"
+msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:212 journal/views/article.py:218
+#: journal/models/article.py:215 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
-#: journal/models/collection.py:44 journal/templates/add_to_collection.html:39
+#: journal/models/collection.py:48 journal/templates/add_to_collection.html:39
 #: journal/templates/collection_edit.html:64
 #: journal/templates/collection_share.html:63
 #: journal/templates/collection_update_item_note.html:3
@@ -5125,65 +5147,65 @@ msgstr ""
 msgid "note"
 msgstr ""
 
-#: journal/models/collection.py:111
+#: journal/models/collection.py:115
 msgid "search query for dynamic collection"
 msgstr ""
 
-#: journal/models/collection.py:524 journal/templatetags/collection.py:35
+#: journal/models/collection.py:566 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] ""
 
-#: journal/models/collection.py:529 journal/templatetags/collection.py:43
+#: journal/models/collection.py:571 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] ""
 
-#: journal/models/collection.py:534 journal/templatetags/collection.py:51
+#: journal/models/collection.py:576 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] ""
 
-#: journal/models/collection.py:539 journal/templatetags/collection.py:59
+#: journal/models/collection.py:581 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] ""
 
-#: journal/models/collection.py:544 journal/templatetags/collection.py:67
+#: journal/models/collection.py:586 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] ""
 
-#: journal/models/collection.py:549 journal/templatetags/collection.py:75
+#: journal/models/collection.py:591 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] ""
 
-#: journal/models/collection.py:555 journal/templatetags/collection.py:83
+#: journal/models/collection.py:597 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] ""
 
-#: journal/models/collection.py:563 journal/templatetags/collection.py:91
+#: journal/models/collection.py:605 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] ""
 
-#: journal/models/common.py:50 journal/templates/action_open_post.html:15
-#: journal/templates/collection_share.html:35 journal/templates/mark.html:84
+#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
-#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:54
-#: users/templates/users/data.html:107 users/templates/users/data.html:164
-#: users/templates/users/data.html:215 users/templates/users/data.html:277
-#: users/templates/users/data.html:337 users/templates/users/data.html:534
+#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
+#: users/templates/users/data.html:122 users/templates/users/data.html:179
+#: users/templates/users/data.html:230 users/templates/users/data.html:292
+#: users/templates/users/data.html:355 users/templates/users/data.html:534
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5191,13 +5213,13 @@ msgstr[0] ""
 msgid "Public"
 msgstr ""
 
-#: journal/models/common.py:51 journal/templates/action_open_post.html:9
-#: journal/templates/collection_share.html:46 journal/templates/mark.html:91
+#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
-#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
-#: users/templates/users/data.html:115 users/templates/users/data.html:172
-#: users/templates/users/data.html:223 users/templates/users/data.html:285
-#: users/templates/users/data.html:345 users/templates/users/data.html:542
+#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
+#: users/templates/users/data.html:130 users/templates/users/data.html:187
+#: users/templates/users/data.html:238 users/templates/users/data.html:300
+#: users/templates/users/data.html:363 users/templates/users/data.html:542
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5205,12 +5227,12 @@ msgstr ""
 msgid "Followers Only"
 msgstr ""
 
-#: journal/models/common.py:52 journal/templates/collection_share.html:57
-#: journal/templates/mark.html:98 journal/templates/post_compose.html:72
-#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
-#: users/templates/users/data.html:123 users/templates/users/data.html:180
-#: users/templates/users/data.html:231 users/templates/users/data.html:293
-#: users/templates/users/data.html:353 users/templates/users/data.html:550
+#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/templates/mark.html:102 journal/templates/post_compose.html:72
+#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
+#: users/templates/users/data.html:138 users/templates/users/data.html:195
+#: users/templates/users/data.html:246 users/templates/users/data.html:308
+#: users/templates/users/data.html:371 users/templates/users/data.html:550
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5218,29 +5240,27 @@ msgstr ""
 msgid "Mentioned Only"
 msgstr ""
 
-#: journal/models/common.py:790
-msgid ""
-"A recent post was not posted to Bluesky, please login NeoDB using ATProto "
-"again to re-authorize."
+#: journal/models/common.py:806
+msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr ""
 
-#: journal/models/common.py:987
+#: journal/models/common.py:1003
 msgid "A recent post was not posted to Threads."
 msgstr ""
 
-#: journal/models/common.py:1020
+#: journal/models/common.py:1036
 msgid "A recent post was not boosted on Mastodon."
 msgstr ""
 
-#: journal/models/common.py:1030
+#: journal/models/common.py:1046
 msgid "Original post no longer exists."
 msgstr ""
 
-#: journal/models/common.py:1044
+#: journal/models/common.py:1060
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr ""
 
-#: journal/models/common.py:1053
+#: journal/models/common.py:1069
 msgid "A recent post was not posted to Mastodon."
 msgstr ""
 
@@ -5250,7 +5270,7 @@ msgstr ""
 msgid "Authorization expired"
 msgstr "Threadsで認証して登録またはログイン"
 
-#: journal/models/crosspost.py:17 users/models/task.py:24
+#: journal/models/crosspost.py:17 users/models/task.py:26
 msgid "Failed"
 msgstr ""
 
@@ -5258,83 +5278,83 @@ msgstr ""
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:469
+#: journal/models/mark.py:475
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:473
+#: journal/models/mark.py:479
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:480
+#: journal/models/mark.py:486
 #, fuzzy
 #| msgid "Sync in progress."
 msgid "Invalid progress type."
 msgstr "同期中です。"
 
-#: journal/models/mark.py:482
+#: journal/models/mark.py:488
 msgid "Invalid progress type for this item."
 msgstr ""
 
-#: journal/models/note.py:34 users/templates/users/rym_import.html:73
+#: journal/models/note.py:47 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr ""
 
-#: journal/models/note.py:35
+#: journal/models/note.py:48
 msgid "Chapter"
 msgstr ""
 
-#: journal/models/note.py:38
+#: journal/models/note.py:51
 msgid "Part"
 msgstr ""
 
-#: journal/models/note.py:39
+#: journal/models/note.py:52
 msgid "Episode"
 msgstr ""
 
-#: journal/models/note.py:40
+#: journal/models/note.py:53
 msgid "Track"
 msgstr ""
 
-#: journal/models/note.py:41
+#: journal/models/note.py:54
 msgid "Cycle"
 msgstr ""
 
-#: journal/models/note.py:42
+#: journal/models/note.py:55
 msgid "Timestamp"
 msgstr ""
 
-#: journal/models/note.py:43
+#: journal/models/note.py:56
 msgid "Percentage"
 msgstr ""
 
-#: journal/models/note.py:60
+#: journal/models/note.py:77
 #, python-brace-format
 msgid "Page {value}"
 msgstr ""
 
-#: journal/models/note.py:61
+#: journal/models/note.py:78
 #, python-brace-format
 msgid "Chapter {value}"
 msgstr ""
 
-#: journal/models/note.py:64
+#: journal/models/note.py:81
 #, python-brace-format
 msgid "Part {value}"
 msgstr ""
 
-#: journal/models/note.py:65
+#: journal/models/note.py:82
 #, python-brace-format
 msgid "Episode {value}"
 msgstr ""
 
-#: journal/models/note.py:66
+#: journal/models/note.py:83
 #, python-brace-format
 msgid "Track {value}"
 msgstr ""
 
-#: journal/models/note.py:67
+#: journal/models/note.py:84
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr ""
@@ -5344,441 +5364,441 @@ msgstr ""
 msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr ""
 
-#: journal/models/review.py:78
+#: journal/models/review.py:79
 #, python-brace-format
 msgid "a review of {title}"
 msgstr ""
 
-#: journal/models/review.py:80
+#: journal/models/review.py:81
 msgid "(may contain spoilers)"
 msgstr ""
 
-#: journal/models/shelf.py:37
+#: journal/models/shelf.py:39
 msgid "WISHLIST"
 msgstr ""
 
-#: journal/models/shelf.py:38
+#: journal/models/shelf.py:40
 msgid "PROGRESS"
 msgstr ""
 
-#: journal/models/shelf.py:39
+#: journal/models/shelf.py:41
 msgid "COMPLETE"
 msgstr ""
 
-#: journal/models/shelf.py:40
+#: journal/models/shelf.py:42
 msgid "DROPPED"
 msgstr ""
 
-#: journal/models/shelf.py:49
+#: journal/models/shelf.py:51
 msgid "books to read"
 msgstr ""
 
-#: journal/models/shelf.py:50
+#: journal/models/shelf.py:52
 msgid "want to read"
 msgstr ""
 
-#: journal/models/shelf.py:51
+#: journal/models/shelf.py:53
 #, python-brace-format
 msgid "wants to read {item}"
 msgstr ""
 
-#: journal/models/shelf.py:52
+#: journal/models/shelf.py:54
 msgid "to read"
 msgstr ""
 
-#: journal/models/shelf.py:57
+#: journal/models/shelf.py:59
 msgid "books reading"
 msgstr ""
 
-#: journal/models/shelf.py:58
+#: journal/models/shelf.py:60
 msgid "start reading"
 msgstr ""
 
-#: journal/models/shelf.py:59
+#: journal/models/shelf.py:61
 #, python-brace-format
 msgid "started reading {item}"
 msgstr ""
 
-#: journal/models/shelf.py:60
+#: journal/models/shelf.py:62
 msgid "reading"
 msgstr ""
 
-#: journal/models/shelf.py:65
+#: journal/models/shelf.py:67
 msgid "books completed"
 msgstr ""
 
-#: journal/models/shelf.py:66
+#: journal/models/shelf.py:68
 msgid "finish reading"
 msgstr ""
 
-#: journal/models/shelf.py:67
+#: journal/models/shelf.py:69
 #, python-brace-format
 msgid "finished reading {item}"
 msgstr ""
 
-#: journal/models/shelf.py:68
+#: journal/models/shelf.py:70
 msgid "read"
 msgstr ""
 
-#: journal/models/shelf.py:73
+#: journal/models/shelf.py:75
 msgid "books dropped"
 msgstr ""
 
-#: journal/models/shelf.py:74
+#: journal/models/shelf.py:76
 msgid "stop reading"
 msgstr ""
 
-#: journal/models/shelf.py:75
+#: journal/models/shelf.py:77
 #, python-brace-format
 msgid "stopped reading {item}"
 msgstr ""
 
-#: journal/models/shelf.py:76
+#: journal/models/shelf.py:78
 msgid "stopped reading"
 msgstr ""
 
-#: journal/models/shelf.py:81
+#: journal/models/shelf.py:83
 msgid "books reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:82 journal/models/shelf.py:122
-#: journal/models/shelf.py:162 journal/models/shelf.py:202
-#: journal/models/shelf.py:242 journal/models/shelf.py:282
-#: journal/models/shelf.py:316
+#: journal/models/shelf.py:84 journal/models/shelf.py:124
+#: journal/models/shelf.py:164 journal/models/shelf.py:204
+#: journal/models/shelf.py:244 journal/models/shelf.py:284
+#: journal/models/shelf.py:318
 msgid "review"
 msgstr ""
 
-#: journal/models/shelf.py:83 journal/models/shelf.py:123
-#: journal/models/shelf.py:163 journal/models/shelf.py:203
-#: journal/models/shelf.py:243 journal/models/shelf.py:283
-#: journal/models/shelf.py:317
+#: journal/models/shelf.py:85 journal/models/shelf.py:125
+#: journal/models/shelf.py:165 journal/models/shelf.py:205
+#: journal/models/shelf.py:245 journal/models/shelf.py:285
+#: journal/models/shelf.py:319
 #, python-brace-format
 msgid "wrote a review of {item}"
 msgstr ""
 
-#: journal/models/shelf.py:89
+#: journal/models/shelf.py:91
 msgid "movies to watch"
 msgstr ""
 
-#: journal/models/shelf.py:90 journal/models/shelf.py:130
+#: journal/models/shelf.py:92 journal/models/shelf.py:132
 msgid "want to watch"
 msgstr ""
 
-#: journal/models/shelf.py:91 journal/models/shelf.py:131
+#: journal/models/shelf.py:93 journal/models/shelf.py:133
 #, python-brace-format
 msgid "wants to watch {item}"
 msgstr ""
 
-#: journal/models/shelf.py:92 journal/models/shelf.py:132
+#: journal/models/shelf.py:94 journal/models/shelf.py:134
 msgid "to watch"
 msgstr ""
 
-#: journal/models/shelf.py:97
+#: journal/models/shelf.py:99
 msgid "movies watching"
 msgstr ""
 
-#: journal/models/shelf.py:98 journal/models/shelf.py:138
+#: journal/models/shelf.py:100 journal/models/shelf.py:140
 msgid "start watching"
 msgstr ""
 
-#: journal/models/shelf.py:99 journal/models/shelf.py:139
+#: journal/models/shelf.py:101 journal/models/shelf.py:141
 #, python-brace-format
 msgid "started watching {item}"
 msgstr ""
 
-#: journal/models/shelf.py:100 journal/models/shelf.py:140
+#: journal/models/shelf.py:102 journal/models/shelf.py:142
 msgid "watching"
 msgstr ""
 
-#: journal/models/shelf.py:105
+#: journal/models/shelf.py:107
 msgid "movies watched"
 msgstr ""
 
-#: journal/models/shelf.py:106 journal/models/shelf.py:146
+#: journal/models/shelf.py:108 journal/models/shelf.py:148
 msgid "finish watching"
 msgstr ""
 
-#: journal/models/shelf.py:107 journal/models/shelf.py:147
+#: journal/models/shelf.py:109 journal/models/shelf.py:149
 #, python-brace-format
 msgid "finished watching {item}"
 msgstr ""
 
-#: journal/models/shelf.py:108 journal/models/shelf.py:148
+#: journal/models/shelf.py:110 journal/models/shelf.py:150
 msgid "watched"
 msgstr ""
 
-#: journal/models/shelf.py:113
+#: journal/models/shelf.py:115
 msgid "movies dropped"
 msgstr ""
 
-#: journal/models/shelf.py:114 journal/models/shelf.py:154
+#: journal/models/shelf.py:116 journal/models/shelf.py:156
 msgid "stop watching"
 msgstr ""
 
-#: journal/models/shelf.py:115 journal/models/shelf.py:155
+#: journal/models/shelf.py:117 journal/models/shelf.py:157
 #, python-brace-format
 msgid "stopped watching {item}"
 msgstr ""
 
-#: journal/models/shelf.py:116 journal/models/shelf.py:156
+#: journal/models/shelf.py:118 journal/models/shelf.py:158
 msgid "stopped watching"
 msgstr ""
 
-#: journal/models/shelf.py:121
+#: journal/models/shelf.py:123
 msgid "movies reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:129
+#: journal/models/shelf.py:131
 msgid "TV shows to watch"
 msgstr ""
 
-#: journal/models/shelf.py:137
+#: journal/models/shelf.py:139
 msgid "TV shows watching"
 msgstr ""
 
-#: journal/models/shelf.py:145
+#: journal/models/shelf.py:147
 msgid "TV shows watched"
 msgstr ""
 
-#: journal/models/shelf.py:153
+#: journal/models/shelf.py:155
 msgid "TV shows dropped"
 msgstr ""
 
-#: journal/models/shelf.py:161
+#: journal/models/shelf.py:163
 msgid "TV shows reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:169
+#: journal/models/shelf.py:171
 msgid "albums to listen"
 msgstr ""
 
-#: journal/models/shelf.py:170 journal/models/shelf.py:250
+#: journal/models/shelf.py:172 journal/models/shelf.py:252
 msgid "want to listen"
 msgstr ""
 
-#: journal/models/shelf.py:171 journal/models/shelf.py:251
+#: journal/models/shelf.py:173 journal/models/shelf.py:253
 #, python-brace-format
 msgid "wants to listen {item}"
 msgstr ""
 
-#: journal/models/shelf.py:172 journal/models/shelf.py:252
+#: journal/models/shelf.py:174 journal/models/shelf.py:254
 msgid "to listen"
 msgstr ""
 
-#: journal/models/shelf.py:177
+#: journal/models/shelf.py:179
 msgid "albums listening"
 msgstr ""
 
-#: journal/models/shelf.py:178 journal/models/shelf.py:258
+#: journal/models/shelf.py:180 journal/models/shelf.py:260
 msgid "start listening"
 msgstr ""
 
-#: journal/models/shelf.py:179 journal/models/shelf.py:259
+#: journal/models/shelf.py:181 journal/models/shelf.py:261
 #, python-brace-format
 msgid "started listening {item}"
 msgstr ""
 
-#: journal/models/shelf.py:180 journal/models/shelf.py:260
+#: journal/models/shelf.py:182 journal/models/shelf.py:262
 msgid "listening"
 msgstr ""
 
-#: journal/models/shelf.py:185
+#: journal/models/shelf.py:187
 msgid "albums listened"
 msgstr ""
 
-#: journal/models/shelf.py:186 journal/models/shelf.py:266
+#: journal/models/shelf.py:188 journal/models/shelf.py:268
 msgid "finish listening"
 msgstr ""
 
-#: journal/models/shelf.py:187 journal/models/shelf.py:267
+#: journal/models/shelf.py:189 journal/models/shelf.py:269
 #, python-brace-format
 msgid "finished listening {item}"
 msgstr ""
 
-#: journal/models/shelf.py:188 journal/models/shelf.py:268
+#: journal/models/shelf.py:190 journal/models/shelf.py:270
 msgid "listened"
 msgstr ""
 
-#: journal/models/shelf.py:193
+#: journal/models/shelf.py:195
 msgid "albums dropped"
 msgstr ""
 
-#: journal/models/shelf.py:194 journal/models/shelf.py:274
+#: journal/models/shelf.py:196 journal/models/shelf.py:276
 msgid "stop listening"
 msgstr ""
 
-#: journal/models/shelf.py:195 journal/models/shelf.py:275
+#: journal/models/shelf.py:197 journal/models/shelf.py:277
 #, python-brace-format
 msgid "stopped listening {item}"
 msgstr ""
 
-#: journal/models/shelf.py:196 journal/models/shelf.py:276
+#: journal/models/shelf.py:198 journal/models/shelf.py:278
 msgid "stopped listening"
 msgstr ""
 
-#: journal/models/shelf.py:201
+#: journal/models/shelf.py:203
 msgid "albums reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:209
+#: journal/models/shelf.py:211
 msgid "games to play"
 msgstr ""
 
-#: journal/models/shelf.py:210
+#: journal/models/shelf.py:212
 msgid "want to play"
 msgstr ""
 
-#: journal/models/shelf.py:211
+#: journal/models/shelf.py:213
 #, python-brace-format
 msgid "wants to play {item}"
 msgstr ""
 
-#: journal/models/shelf.py:212
+#: journal/models/shelf.py:214
 msgid "to play"
 msgstr ""
 
-#: journal/models/shelf.py:217
+#: journal/models/shelf.py:219
 msgid "games playing"
 msgstr ""
 
-#: journal/models/shelf.py:218
+#: journal/models/shelf.py:220
 msgid "start playing"
 msgstr ""
 
-#: journal/models/shelf.py:219
+#: journal/models/shelf.py:221
 #, python-brace-format
 msgid "started playing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:220
+#: journal/models/shelf.py:222
 msgid "playing"
 msgstr ""
 
-#: journal/models/shelf.py:225
+#: journal/models/shelf.py:227
 msgid "games played"
 msgstr ""
 
-#: journal/models/shelf.py:226
+#: journal/models/shelf.py:228
 msgid "finish playing"
 msgstr ""
 
-#: journal/models/shelf.py:227
+#: journal/models/shelf.py:229
 #, python-brace-format
 msgid "finished playing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:228
+#: journal/models/shelf.py:230
 msgid "played"
 msgstr ""
 
-#: journal/models/shelf.py:233
+#: journal/models/shelf.py:235
 msgid "games dropped"
 msgstr ""
 
-#: journal/models/shelf.py:234
+#: journal/models/shelf.py:236
 msgid "stop playing"
 msgstr ""
 
-#: journal/models/shelf.py:235
+#: journal/models/shelf.py:237
 #, python-brace-format
 msgid "stopped playing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:236
+#: journal/models/shelf.py:238
 msgid "stopped playing"
 msgstr ""
 
-#: journal/models/shelf.py:241
+#: journal/models/shelf.py:243
 msgid "games reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:249
+#: journal/models/shelf.py:251
 msgid "podcasts to listen"
 msgstr ""
 
-#: journal/models/shelf.py:257
+#: journal/models/shelf.py:259
 msgid "podcasts listening"
 msgstr ""
 
-#: journal/models/shelf.py:265
+#: journal/models/shelf.py:267
 msgid "podcasts listened"
 msgstr ""
 
-#: journal/models/shelf.py:273
+#: journal/models/shelf.py:275
 msgid "podcasts dropped"
 msgstr ""
 
-#: journal/models/shelf.py:281
+#: journal/models/shelf.py:283
 msgid "podcasts reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:289
+#: journal/models/shelf.py:291
 msgid "performances to see"
 msgstr ""
 
-#: journal/models/shelf.py:290
+#: journal/models/shelf.py:292
 msgid "want to see"
 msgstr ""
 
-#: journal/models/shelf.py:291
+#: journal/models/shelf.py:293
 #, python-brace-format
 msgid "wants to see {item}"
 msgstr ""
 
-#: journal/models/shelf.py:292
+#: journal/models/shelf.py:294
 msgid "to see"
 msgstr ""
 
-#: journal/models/shelf.py:299
+#: journal/models/shelf.py:301
 msgid "performances saw"
 msgstr ""
 
-#: journal/models/shelf.py:300
+#: journal/models/shelf.py:302
 msgid "finish seeing"
 msgstr ""
 
-#: journal/models/shelf.py:301
+#: journal/models/shelf.py:303
 #, python-brace-format
 msgid "finished seeing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:302
+#: journal/models/shelf.py:304
 msgid "seen"
 msgstr ""
 
-#: journal/models/shelf.py:307
+#: journal/models/shelf.py:309
 msgid "performances dropped"
 msgstr ""
 
-#: journal/models/shelf.py:308
+#: journal/models/shelf.py:310
 msgid "stop seeing"
 msgstr ""
 
-#: journal/models/shelf.py:309
+#: journal/models/shelf.py:311
 #, python-brace-format
 msgid "stopped seeing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:310
+#: journal/models/shelf.py:312
 msgid "stopped seeing"
 msgstr ""
 
-#: journal/models/shelf.py:315
+#: journal/models/shelf.py:317
 msgid "performances reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:323
+#: journal/models/shelf.py:325
 #, fuzzy
 #| msgid "Users you are following"
 msgid "people following"
 msgstr "フォロー中のユーザー"
 
-#: journal/models/shelf.py:325
+#: journal/models/shelf.py:327
 #, python-brace-format
 msgid "started following {item}"
 msgstr ""
 
-#: journal/models/shelf.py:921
+#: journal/models/shelf.py:923
 msgid "removed mark"
 msgstr ""
 
@@ -5806,30 +5826,20 @@ msgstr ""
 msgid "Remove from collection"
 msgstr ""
 
-#: journal/templates/_list_item.html:34
-msgid "add mark"
-msgstr ""
-
-#: journal/templates/_list_item.html:42
-msgid "update mark"
-msgstr ""
-
-#: journal/templates/_list_item.html:60
+#: journal/templates/_list_item.html:43
 #: journal/templates/collection_update_item_note_ok.html:3
 msgid "Update note"
 msgstr ""
 
-#: journal/templates/_list_item.html:100 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:123
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
 msgstr ""
 
-#: journal/templates/_list_item.html:133
+#: journal/templates/_list_item.html:91
 #, python-format
-msgid ""
-"%(dups)s item(s) are from the same work or have the same identifier, click "
-"here to display:"
+msgid "%(dups)s item(s) are from the same work or have the same identifier, click here to display:"
 msgstr ""
 
 #: journal/templates/_sidebar_collection_filter.html:32
@@ -5939,6 +5949,14 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
+#: journal/templates/action_mark_item.html:10
+msgid "add mark"
+msgstr ""
+
+#: journal/templates/action_mark_item.html:18
+msgid "update mark"
+msgstr ""
+
 #: journal/templates/action_open_post.html:7
 msgid "Quiet Public"
 msgstr ""
@@ -5991,11 +6009,11 @@ msgstr ""
 msgid "Create a new collection"
 msgstr ""
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:81
+#: journal/templates/article.html:104 social/templates/_event_post.html:76
 msgid "wrote a review"
 msgstr ""
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:83
+#: journal/templates/article.html:106 social/templates/_event_post.html:78
 msgid "wrote an article"
 msgstr ""
 
@@ -6109,19 +6127,19 @@ msgstr ""
 msgid "Mark"
 msgstr ""
 
-#: journal/templates/mark.html:50
+#: journal/templates/mark.html:54
 msgid "not rated"
 msgstr ""
 
-#: journal/templates/mark.html:70
+#: journal/templates/mark.html:74
 msgid "add a tag and press Enter"
 msgstr ""
 
-#: journal/templates/mark.html:122
+#: journal/templates/mark.html:126
 msgid "change mark date"
 msgstr ""
 
-#: journal/templates/mark.html:148
+#: journal/templates/mark.html:156
 msgid "Sure to delete mark, comment and tags for this item?"
 msgstr ""
 
@@ -6164,12 +6182,11 @@ msgid ""
 "Content Cell  | Content Cell\n"
 "Content Cell  | Content Cell\n"
 "\n"
-"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/"
-"Wikipedia-logo-v2.svg)\n"
+"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 "\n"
 msgstr ""
 
-#: journal/templates/note.html:19 journal/views/note.py:23
+#: journal/templates/note.html:19 journal/views/note.py:22
 msgid "Note"
 msgstr ""
 
@@ -6200,9 +6217,7 @@ msgid "Are you sure to delete this entire content?"
 msgstr ""
 
 #: journal/templates/piece_delete.html:24
-msgid ""
-"By deleting it, you will also lose track of others' comments and feedbacks "
-"to your content."
+msgid "By deleting it, you will also lose track of others' comments and feedbacks to your content."
 msgstr ""
 
 #: journal/templates/piece_delete.html:25
@@ -6286,7 +6301,7 @@ msgstr ""
 msgid "Articles"
 msgstr ""
 
-#: journal/templates/profile.html:166 journal/views/collection.py:427
+#: journal/templates/profile.html:166 journal/views/collection.py:409
 #: journal/views/profile.py:401
 msgid "collection"
 msgstr ""
@@ -6320,9 +6335,7 @@ msgid "Personal"
 msgstr ""
 
 #: journal/templates/tag_edit.html:52
-msgid ""
-"Personal tags are not included in public index. However, if you use this tag "
-"when marking an item publicly, it might still be visible to others."
+msgid "Personal tags are not included in public index. However, if you use this tag when marking an item publicly, it might still be visible to others."
 msgstr ""
 
 #: journal/templates/tag_edit.html:55
@@ -6391,119 +6404,120 @@ msgstr ""
 msgid "Link invalid"
 msgstr ""
 
-#: journal/views/collection.py:58 journal/views/collection.py:96
+#: journal/views/collection.py:62 journal/views/collection.py:94
 #, python-brace-format
 msgid "Collection by {0}"
 msgstr ""
 
-#: journal/views/collection.py:432
+#: journal/views/collection.py:414
 msgid "shared my collection"
 msgstr ""
 
-#: journal/views/collection.py:435
+#: journal/views/collection.py:417
 #, python-brace-format
 msgid "shared {username}'s collection"
 msgstr ""
 
-#: journal/views/collection.py:502 journal/views/collection.py:541
-#: journal/views/collection.py:553 journal/views/collection.py:579
+#: journal/views/collection.py:484 journal/views/collection.py:523
+#: journal/views/collection.py:535 journal/views/collection.py:561
 msgid "Dynamic collection is not editable"
 msgstr ""
 
-#: journal/views/collection.py:518
+#: journal/views/collection.py:500
 msgid "The item is already in the collection."
 msgstr ""
 
-#: journal/views/collection.py:520
+#: journal/views/collection.py:502
 msgid "Unable to find the item, please use item url from this site."
 msgstr ""
 
-#: journal/views/collection.py:566
+#: journal/views/collection.py:548
 msgid "Saved."
 msgstr ""
 
-#: journal/views/common.py:119 journal/views/mark.py:225
-#: journal/views/mark.py:279 journal/views/note.py:175
+#: journal/views/common.py:126 journal/views/mark.py:273
+#: journal/views/mark.py:315 journal/views/note.py:167
 #: journal/views/profile.py:42 journal/views/review.py:59
 #: journal/views/review.py:79
 msgid "Content not found"
 msgstr ""
 
-#: journal/views/common.py:174 journal/views/mark.py:159
+#: journal/views/common.py:184 journal/views/mark.py:210
 msgid "Data saved but unable to crosspost to Fediverse instance."
 msgstr ""
 
-#: journal/views/common.py:176
+#: journal/views/common.py:186
 msgid "Redirecting to your Fediverse instance now to re-authenticate."
 msgstr ""
 
-#: journal/views/common.py:183
+#: journal/views/common.py:193
 msgid "List not found."
 msgstr ""
 
-#: journal/views/mark.py:150
+#: journal/views/mark.py:206
 msgid "Content too long for your Fediverse instance."
 msgstr ""
 
-#: journal/views/mark.py:178 journal/views/mark.py:238
+#: journal/views/mark.py:224 journal/views/mark.py:226
+#: journal/views/mark.py:280
 #, fuzzy
 #| msgid "Invalid file."
 msgid "Invalid input"
 msgstr "無効なファイルです。"
 
-#: journal/views/note.py:23
+#: journal/views/note.py:22
 msgid "Progress"
 msgstr ""
 
-#: journal/views/note.py:28
+#: journal/views/note.py:27
 #, fuzzy
 #| msgid "Import in progress."
 msgid "Update progress"
 msgstr "インポート中です。"
 
-#: journal/views/note.py:59
+#: journal/views/note.py:58
 msgid "Progress (optional)"
 msgstr ""
 
-#: journal/views/note.py:61
+#: journal/views/note.py:60
 msgid "Note Content"
 msgstr ""
 
-#: journal/views/note.py:63
+#: journal/views/note.py:62
 msgid "Content Warning (optional)"
 msgstr ""
 
-#: journal/views/note.py:85
+#: journal/views/note.py:84
 msgid "Progress Type (optional)"
 msgstr ""
 
-#: journal/views/note.py:123 journal/views/note.py:183
+#: journal/views/note.py:115 journal/views/note.py:175
 msgid "Only in-progress items can have progress."
 msgstr ""
 
-#: journal/views/post.py:98 journal/views/post.py:392
+#: journal/views/post.py:100 journal/views/post.py:388
 msgid "Post not found"
 msgstr ""
 
-#: journal/views/post.py:189
+#: journal/views/post.py:191
 msgid "Visibility too high for quoting this post"
 msgstr ""
 
-#: journal/views/post.py:337 journal/views/post.py:418
+#: journal/views/post.py:339 journal/views/post.py:414
 msgid "Content cannot be empty."
 msgstr ""
 
-#: journal/views/post.py:396
+#: journal/views/post.py:392
 msgid "This post cannot be edited here"
 msgstr ""
 
-#: journal/views/post.py:541
+#: journal/views/post.py:531
 #, fuzzy
 #| msgid "Invalid file."
 msgid "Invalid choices"
 msgstr "無効なファイルです。"
 
-#: journal/views/post.py:544
+#: journal/views/post.py:534
 #, fuzzy
 #| msgid "Invalid URL."
 msgid "Invalid post"
@@ -6523,56 +6537,54 @@ msgstr ""
 msgid "may contain spoiler or triggering content"
 msgstr ""
 
-#: journal/views/tag.py:47 journal/views/tag.py:61
+#: journal/views/tag.py:46 journal/views/tag.py:60
 msgid "Invalid tag"
 msgstr ""
 
-#: journal/views/tag.py:50
+#: journal/views/tag.py:49
 msgid "Tag not found"
 msgstr ""
 
-#: journal/views/tag.py:72
+#: journal/views/tag.py:65
 msgid "Tag deleted."
 msgstr ""
 
-#: journal/views/tag.py:82
+#: journal/views/tag.py:75
 msgid "Duplicated tag."
 msgstr ""
 
-#: journal/views/tag.py:96
+#: journal/views/tag.py:83
 msgid "Tag updated."
 msgstr ""
 
-#: journal/views/wrapped.py:160
+#: journal/views/wrapped.py:161
 msgid "Summary posted to timeline."
 msgstr ""
 
-#: mastodon/models/common.py:29
+#: mastodon/models/common.py:31
 msgid "Mastodon"
 msgstr ""
 
-#: mastodon/models/common.py:30 users/templates/users/login.html:120
+#: mastodon/models/common.py:32 users/templates/users/login.html:114
 msgid "Threads"
 msgstr ""
 
-#: mastodon/models/common.py:31
+#: mastodon/models/common.py:33
 msgid "Bluesky"
 msgstr ""
 
-#: mastodon/models/email.py:59
+#: mastodon/models/email.py:63
 msgid ""
 "\n"
 "\n"
-"If you did not mean to register or login, please ignore this email. If you "
-"are concerned with your account security, please change the email linked "
-"with your account, or contact us."
+"If you did not mean to register or login, please ignore this email. If you are concerned with your account security, please change the email linked with your account, or contact us."
 msgstr ""
 
-#: mastodon/models/email.py:64 mastodon/models/email.py:69
+#: mastodon/models/email.py:68 mastodon/models/email.py:73
 msgid "Verification Code"
 msgstr ""
 
-#: mastodon/models/email.py:66
+#: mastodon/models/email.py:70
 #, python-brace-format
 msgid ""
 "Use this code to verify your email address {email}\n"
@@ -6580,7 +6592,7 @@ msgid ""
 "{code}"
 msgstr ""
 
-#: mastodon/models/email.py:70
+#: mastodon/models/email.py:74
 #, python-brace-format
 msgid ""
 "Use this code to login as {email}\n"
@@ -6588,23 +6600,21 @@ msgid ""
 "{code}"
 msgstr ""
 
-#: mastodon/models/email.py:74 users/templates/users/captcha.html:13
+#: mastodon/models/email.py:78 users/templates/users/captcha.html:13
 #: users/templates/users/captcha_solved.html:9
 #: users/templates/users/login.html:20 users/templates/users/register.html:9
 #: users/templates/users/welcome.html:10
 msgid "Register"
 msgstr ""
 
-#: mastodon/models/email.py:76
+#: mastodon/models/email.py:80
 #, python-brace-format
 msgid ""
 "There is no account registered with this email address yet: {email}\n"
 "\n"
-"If you already have an account with us, just login and add this email to you "
-"account.\n"
+"If you already have an account with us, just login and add this email to you account.\n"
 "\n"
-"If you prefer to register a new account with this email, please use this "
-"verification code: {code}"
+"If you prefer to register a new account with this email, please use this verification code: {code}"
 msgstr ""
 
 #: mastodon/models/mastodon.py:570
@@ -6647,49 +6657,53 @@ msgstr ""
 msgid "New Post"
 msgstr ""
 
-#: mastodon/views/bluesky.py:26 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:32 mastodon/views/bluesky.py:93
 msgid "Bluesky login is disabled."
 msgstr ""
 
-#: mastodon/views/bluesky.py:28 mastodon/views/email.py:35
-#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:29
-#: users/templates/users/login.html:6 users/views/webauthn.py:133
-#, fuzzy
-#| msgid "Export file expired. Please export again."
-msgid "Security check failed. Please try again."
-msgstr ""
-"エクスポートファイルの有効期限が切れました。再度エクスポートしてください。"
-
-#: mastodon/views/bluesky.py:34 mastodon/views/bluesky.py:40
-#: mastodon/views/bluesky.py:64 mastodon/views/bluesky.py:72
-#: mastodon/views/bluesky.py:78 mastodon/views/common.py:36
-#: mastodon/views/mastodon.py:62 mastodon/views/mastodon.py:70
-#: mastodon/views/mastodon.py:77 mastodon/views/mastodon.py:87
-#: mastodon/views/mastodon.py:94 mastodon/views/threads.py:55
-#: mastodon/views/threads.py:63 mastodon/views/threads.py:69
-#: users/views/account.py:254 users/views/account.py:373
+#: mastodon/views/bluesky.py:47 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:65 mastodon/views/bluesky.py:98
+#: mastodon/views/bluesky.py:106 mastodon/views/bluesky.py:112
+#: mastodon/views/common.py:36 mastodon/views/mastodon.py:62
+#: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
+#: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
+#: mastodon/views/threads.py:57 mastodon/views/threads.py:65
+#: mastodon/views/threads.py:71 users/views/account.py:256
+#: users/views/account.py:375
 msgid "Authentication failed"
 msgstr ""
 
-#: mastodon/views/bluesky.py:35 mastodon/views/email.py:66
+#: mastodon/views/bluesky.py:47 mastodon/views/common.py:103
+msgid "Identity not found."
+msgstr ""
+
+#: mastodon/views/bluesky.py:53 mastodon/views/email.py:35
+#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:31
+#: users/templates/users/login.html:6 users/views/webauthn.py:136
+#, fuzzy
+#| msgid "Export file expired. Please export again."
+msgid "Security check failed. Please try again."
+msgstr "エクスポートファイルの有効期限が切れました。再度エクスポートしてください。"
+
+#: mastodon/views/bluesky.py:60 mastodon/views/email.py:66
 msgid "Too many attempts, please try again later."
 msgstr ""
 
-#: mastodon/views/bluesky.py:40
+#: mastodon/views/bluesky.py:65
 #, fuzzy
 #| msgid "ATProto handle"
 msgid "ATProto handle is required."
 msgstr "ATProto ユーザー識別子"
 
-#: mastodon/views/bluesky.py:50
+#: mastodon/views/bluesky.py:84
 msgid "Error connecting to your ATProto server"
 msgstr ""
 
-#: mastodon/views/bluesky.py:73
+#: mastodon/views/bluesky.py:107
 msgid "Invalid response from ATProto authorization server."
 msgstr ""
 
-#: mastodon/views/bluesky.py:78
+#: mastodon/views/bluesky.py:112
 msgid "Invalid account data from Bluesky."
 msgstr ""
 
@@ -6697,7 +6711,7 @@ msgstr ""
 msgid "Invalid user."
 msgstr ""
 
-#: mastodon/views/common.py:52 users/views/account.py:414
+#: mastodon/views/common.py:52 users/views/account.py:416
 msgid "Registration failed"
 msgstr ""
 
@@ -6727,10 +6741,6 @@ msgstr ""
 #: mastodon/views/common.py:103 mastodon/views/common.py:107
 #: mastodon/views/common.py:116
 msgid "Disconnect identity failed"
-msgstr ""
-
-#: mastodon/views/common.py:103
-msgid "Identity not found."
 msgstr ""
 
 #: mastodon/views/common.py:117
@@ -6774,7 +6784,7 @@ msgstr ""
 msgid "Invalid response from Fediverse instance."
 msgstr ""
 
-#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:64
+#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:66
 msgid "Invalid OAuth state. Please try again."
 msgstr ""
 
@@ -6794,21 +6804,19 @@ msgstr ""
 msgid "Invalid account data from Fediverse instance."
 msgstr ""
 
-#: mastodon/views/threads.py:69
+#: mastodon/views/threads.py:71
 msgid "Invalid account data from Threads."
 msgstr ""
 
-#: mastodon/views/threads.py:147
+#: mastodon/views/threads.py:149
 #, fuzzy
 #| msgid "Reset completed."
 msgid "Data deletion completed"
 msgstr "リセットが完了しました。"
 
-#: mastodon/views/threads.py:149
+#: mastodon/views/threads.py:151
 #, python-brace-format
-msgid ""
-"Data linked to your Threads account has been deleted. Confirmation code: "
-"{code}"
+msgid "Data linked to your Threads account has been deleted. Confirmation code: {code}"
 msgstr ""
 
 #: social/templates/_article_teaser.html:10
@@ -6839,15 +6847,11 @@ msgstr ""
 msgid "play"
 msgstr ""
 
-#: social/templates/_event_post.html:50
-msgid "mark"
-msgstr ""
-
-#: social/templates/_event_post.html:79
+#: social/templates/_event_post.html:74
 msgid "wrote a note"
 msgstr ""
 
-#: social/templates/_event_post.html:88
+#: social/templates/_event_post.html:83
 msgid "replying to"
 msgstr ""
 
@@ -6860,7 +6864,7 @@ msgstr ""
 msgid "Untitled article"
 msgstr ""
 
-#: social/templates/event/boosted.html:3
+#: social/templates/event/boosted.html:2
 msgid "boosted your post"
 msgstr ""
 
@@ -6903,8 +6907,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
 #: social/templates/event/boosted_shelfmember.html:3
@@ -6922,7 +6925,7 @@ msgstr ""
 msgid "followed you"
 msgstr ""
 
-#: social/templates/event/liked.html:3
+#: social/templates/event/liked.html:2
 msgid "liked your post"
 msgstr ""
 
@@ -6965,8 +6968,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
 #: social/templates/event/liked_shelfmember.html:3
@@ -6976,7 +6978,7 @@ msgid ""
 "liked your mark on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
-#: social/templates/event/mentioned.html:3
+#: social/templates/event/mentioned.html:2
 msgid "mentioned you"
 msgstr ""
 
@@ -7019,8 +7021,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
 #: social/templates/event/mentioned_shelfmember.html:3
@@ -7030,26 +7031,39 @@ msgid ""
 "replied to your mark on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
-#: social/templates/feed.html:12 social/templates/feed.html:39
-#: social/templates/search_feed.html:12
-msgid "Activities from those you follow"
+#: social/templates/feed.html:39 users/templates/users/preferences.html:40
+msgid "Activities"
 msgstr ""
 
-#: social/templates/feed.html:42 social/templates/feed.html:44
+#: social/templates/feed.html:43 social/templates/feed.html:45
+msgid "world"
+msgstr ""
+
+#: social/templates/feed.html:51 social/templates/feed.html:53
+msgid "local"
+msgstr ""
+
+#: social/templates/feed.html:58 social/templates/feed.html:60
+#, fuzzy
+#| msgid "Users you are following"
+msgid "those you follow"
+msgstr "フォロー中のユーザー"
+
+#: social/templates/feed.html:64 social/templates/feed.html:66
 msgid "what they read/watch/..."
 msgstr ""
 
-#: social/templates/feed_events.html:30
+#: social/templates/feed_events.html:29
 msgid "no matching activities."
 msgstr ""
 
-#: social/templates/feed_events.html:33
+#: social/templates/feed_events.html:31
+msgid "no public activities yet."
+msgstr ""
+
+#: social/templates/feed_events.html:34
 #, python-format
-msgid ""
-"Find and mark some books/movies/podcasts/games, <a "
-"href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/"
-"Douban, follow some fellow %(site_name)s users on the fediverse, so their "
-"recent activities and yours will show up here."
+msgid "Find and mark some books/movies/podcasts/games, <a href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/Douban, follow some fellow %(site_name)s users on the fediverse, so their recent activities and yours will show up here."
 msgstr ""
 
 #: social/templates/notification.html:58
@@ -7082,6 +7096,10 @@ msgstr ""
 msgid "Poll ending at %(end_time)s"
 msgstr ""
 
+#: social/templates/search_feed.html:12 social/views.py:57 social/views.py:58
+msgid "Activities from those you follow"
+msgstr ""
+
 #: social/templates/single_post.html:13 social/templates/single_post.html:32
 msgid "Post"
 msgstr ""
@@ -7094,59 +7112,67 @@ msgstr ""
 msgid "Poll"
 msgstr ""
 
-#: takahe/models.py:453
+#: social/views.py:59
+msgid "Activities on this site"
+msgstr ""
+
+#: social/views.py:60
+#, fuzzy
+#| msgid "Searching the fediverse"
+msgid "Activities from the fediverse"
+msgstr "連合宇宙を検索中"
+
+#: takahe/models.py:445
 msgid "Display Name"
 msgstr ""
 
-#: takahe/models.py:455
+#: takahe/models.py:447
 msgid "Bio"
 msgstr ""
 
-#: takahe/models.py:457
+#: takahe/models.py:449
 msgid "Manually approve new followers"
 msgstr "新しいフォロワーを手動で承認"
 
-#: takahe/models.py:461
+#: takahe/models.py:453
 msgid "Include profile, marks and posts in discovery"
 msgstr ""
 
-#: takahe/models.py:464
+#: takahe/models.py:456
 #, fuzzy
 #| msgid "Hide these categories in search results"
 msgid "Include posts in search results"
 msgstr "検索結果から以下のカテゴリを非表示にする"
 
-#: takahe/models.py:482
+#: takahe/models.py:474
 msgid "Profile picture"
 msgstr ""
 
-#: takahe/models.py:489
+#: takahe/models.py:481
 msgid "Header picture"
 msgstr ""
 
-#: users/models/task.py:22
+#: users/models/task.py:24
 msgid "Started"
 msgstr ""
 
-#: users/models/task.py:23
+#: users/models/task.py:25
 msgid "Complete"
 msgstr ""
 
-#: users/models/user.py:69
-msgid ""
-"Enter a valid username. This value may contain only unaccented lowercase a-z "
-"and uppercase A-Z letters, numbers, and _ characters."
+#: users/models/user.py:71
+msgid "Enter a valid username. This value may contain only unaccented lowercase a-z and uppercase A-Z letters, numbers, and _ characters."
 msgstr ""
 
-#: users/models/user.py:130
+#: users/models/user.py:132
 msgid "username"
 msgstr ""
 
-#: users/models/user.py:135
+#: users/models/user.py:137
 msgid "Required. 50 characters or fewer. Letters, digits and _ only."
 msgstr ""
 
-#: users/models/user.py:138
+#: users/models/user.py:140
 msgid "A user with that username already exists."
 msgstr ""
 
@@ -7287,9 +7313,7 @@ msgid "Cancel import"
 msgstr ""
 
 #: users/templates/users/_rym_section.html:29
-msgid ""
-"On RateYourMusic, go to your profile and use the <b>Export your music "
-"catalog</b> option to download your library as a CSV file."
+msgid "On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:31
@@ -7298,18 +7322,12 @@ msgid "Upload the downloaded CSV file below."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:33
-msgid ""
-"Albums are matched by title + artist (and year if present) — first against "
-"the local catalog, then MusicBrainz, then Spotify. After auto-matching, "
-"you'll preview the matches in a table, edit any link or shelf status, and "
-"confirm the import."
+msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:36
 #: users/templates/users/_storygraph_section.html:38
-msgid ""
-"You can also re-upload a previously-downloaded matched CSV — the existing "
-"<code>link</code> column will be honoured as the default match."
+msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:40
@@ -7340,18 +7358,11 @@ msgid "Cancel the StoryGraph import? Progress will be discarded."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:31
-msgid ""
-"On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to "
-"download your library as a CSV file."
+msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:35
-msgid ""
-"Books are matched by ISBN — first against the local catalog, then Google "
-"Books and OpenLibrary — with a title + author search as fallback. After auto-"
-"matching, you'll preview the matches in a table, edit any link or shelf "
-"status, and confirm the import."
+msgid "Books are matched by ISBN — first against the local catalog, then Google Books and OpenLibrary — with a title + author search as fallback. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/account.html:11
@@ -7363,9 +7374,7 @@ msgid "Display name, avatar and other information"
 msgstr ""
 
 #: users/templates/users/account.html:23
-msgid ""
-"Updating profile information here will turn off automatic sync of display "
-"name, bio and avatar from your Mastodon instance. Sure to continue?"
+msgid "Updating profile information here will turn off automatic sync of display name, bio and avatar from your Mastodon instance. Sure to continue?"
 msgstr ""
 
 #: users/templates/users/account.html:26
@@ -7378,16 +7387,11 @@ msgstr ""
 
 #: users/templates/users/account.html:59 users/templates/users/register.html:47
 #, python-format
-msgid ""
-"Please click the confirmation link in the email sent to %(pending_email)s; "
-"if you haven't received it for more than a few minutes, please input and "
-"save again."
+msgid "Please click the confirmation link in the email sent to %(pending_email)s; if you haven't received it for more than a few minutes, please input and save again."
 msgstr ""
 
 #: users/templates/users/account.html:61 users/templates/users/register.html:50
-msgid ""
-"Email is recommended as a backup login method, if you log in via a Fediverse "
-"instance"
+msgid "Email is recommended as a backup login method, if you log in via a Fediverse instance"
 msgstr ""
 
 #: users/templates/users/account.html:73 users/templates/users/login.html:84
@@ -7405,22 +7409,15 @@ msgid "Last updated"
 msgstr ""
 
 #: users/templates/users/account.html:92
-msgid ""
-"If you have not yet registered with any Federated instance, you may <a "
-"href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an "
-"instance</a> and register."
+msgid "If you have not yet registered with any Federated instance, you may <a href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an instance</a> and register."
 msgstr ""
 
 #: users/templates/users/account.html:97
-msgid ""
-"To associate with another federated identity, please enter the domain name "
-"of the instance where the new identity is located."
+msgid "To associate with another federated identity, please enter the domain name of the instance where the new identity is located."
 msgstr ""
 
 #: users/templates/users/account.html:99
-msgid ""
-"If you have registered with a Federated instance, please enter the instance "
-"domain name."
+msgid "If you have registered with a Federated instance, please enter the instance domain name."
 msgstr ""
 
 #: users/templates/users/account.html:104
@@ -7434,24 +7431,17 @@ msgid "Go to target instance and authorize with the identity"
 msgstr ""
 
 #: users/templates/users/account.html:113
-msgid ""
-"After replacing the association, you may use the new Fediverse identity to "
-"log in and control data visibility. Existing data such as tags, comments, "
-"and collections will not be affected."
+msgid "After replacing the association, you may use the new Fediverse identity to log in and control data visibility. Existing data such as tags, comments, and collections will not be affected."
 msgstr ""
 
 #: users/templates/users/account.html:115
-msgid ""
-"Once associated with Fediverse identity, you can discover more users and use "
-"the full features of this site."
+msgid "Once associated with Fediverse identity, you can discover more users and use the full features of this site."
 msgstr ""
 
 #: users/templates/users/account.html:123
 #: users/templates/users/account.html:160
 #: users/templates/users/account.html:206
-msgid ""
-"Once disconnected, you will no longer be able login with this identity. Are "
-"you sure to continue?"
+msgid "Once disconnected, you will no longer be able login with this identity. Are you sure to continue?"
 msgstr ""
 
 #: users/templates/users/account.html:126
@@ -7478,7 +7468,7 @@ msgstr ""
 msgid "Disconnect with Threads"
 msgstr ""
 
-#: users/templates/users/account.html:173 users/templates/users/login.html:112
+#: users/templates/users/account.html:173 users/templates/users/login.html:106
 msgid "Bluesky (ATProto)"
 msgstr ""
 
@@ -7486,7 +7476,7 @@ msgstr ""
 msgid "Verified ATProto identity"
 msgstr ""
 
-#: users/templates/users/account.html:194 users/templates/users/login.html:216
+#: users/templates/users/account.html:194 users/templates/users/login.html:210
 msgid "ATProto handle"
 msgstr "ATProto ユーザー識別子"
 
@@ -7511,7 +7501,7 @@ msgid "Name this passkey:"
 msgstr ""
 
 #: users/templates/users/account.html:227 users/templates/users/login.html:69
-#: users/templates/users/welcome.html:33 users/views/webauthn.py:106
+#: users/templates/users/welcome.html:33 users/views/webauthn.py:109
 msgid "Passkey"
 msgstr ""
 
@@ -7556,16 +7546,8 @@ msgid "Save sync settings"
 msgstr "同期設定を保存"
 
 #: users/templates/users/account.html:297
-msgid ""
-"New follow, mute and blocks in the associated identity may be automatically "
-"imported; removal has to be done manually."
-msgstr ""
-"上記の設定に従って、本サイトは連合宇宙インスタンスなどのソーシャルネットワー"
-"クで新しく追加したフォロー、ミュート、非表示リストを毎日自動的にインポートし"
-"ます。連合宇宙インスタンスでフォローしているユーザーが本サイトに参加した場"
-"合、自動的にフォローされます。連合宇宙インスタンスでフォロー、ミュート、非表"
-"示を解除しても、本サイトでは自動的に解除されませんが、手動で削除することがで"
-"きます。"
+msgid "New follow, mute and blocks in the associated identity may be automatically imported; removal has to be done manually."
+msgstr "上記の設定に従って、本サイトは連合宇宙インスタンスなどのソーシャルネットワークで新しく追加したフォロー、ミュート、非表示リストを毎日自動的にインポートします。連合宇宙インスタンスでフォローしているユーザーが本サイトに参加した場合、自動的にフォローされます。連合宇宙インスタンスでフォロー、ミュート、非表示を解除しても、本サイトでは自動的に解除されませんが、手動で削除することができます。"
 
 #: users/templates/users/account.html:304
 msgid "Click button below to start sync now."
@@ -7601,15 +7583,11 @@ msgid "Log out everywhere"
 msgstr ""
 
 #: users/templates/users/account.html:365
-msgid ""
-"This will log you out of all browsers and devices (including the current "
-"one), and revoke all API tokens. Continue?"
+msgid "This will log you out of all browsers and devices (including the current one), and revoke all API tokens. Continue?"
 msgstr ""
 
 #: users/templates/users/account.html:368
-msgid ""
-"If you notice any suspicious activity or have logged in on a shared "
-"computer, you can log out of all sessions and revoke all API tokens."
+msgid "If you notice any suspicious activity or have logged in on a shared computer, you can log out of all sessions and revoke all API tokens."
 msgstr ""
 
 #: users/templates/users/account.html:378
@@ -7676,10 +7654,10 @@ msgstr ""
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:74
-#: users/templates/users/data.html:126 users/templates/users/data.html:183
-#: users/templates/users/data.html:234 users/templates/users/data.html:298
-#: users/templates/users/data.html:358 users/templates/users/data.html:553
+#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/data.html:141 users/templates/users/data.html:198
+#: users/templates/users/data.html:249 users/templates/users/data.html:313
+#: users/templates/users/data.html:376 users/templates/users/data.html:553
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr "インポート"
@@ -7708,12 +7686,8 @@ msgid "Migrate Account"
 msgstr "アカウント移行"
 
 #: users/templates/users/account.html:488
-msgid ""
-"Linking an email to your account is highly recommended before migrating from "
-"another Fediverse instance."
-msgstr ""
-"他のインスタンスから移行する前に、メールアドレスを関連付けることをお勧めしま"
-"す。"
+msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
+msgstr "他のインスタンスから移行する前に、メールアドレスを関連付けることをお勧めします。"
 
 #: users/templates/users/account.html:491
 #, fuzzy
@@ -7736,12 +7710,8 @@ msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
 msgstr "一度削除すると、アカウントデータは復元できません。続行しますか？"
 
 #: users/templates/users/account.html:507
-msgid ""
-"Enter full <code>username@instance.social</code> or <code>email@domain.com</"
-"code> to confirm deletion."
-msgstr ""
-"削除を確認するために、完全な<code>ユーザー名@インスタンス名</code>または"
-"<code>メール@アドレス</code>を入力してください"
+msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
+msgstr "削除を確認するために、完全な<code>ユーザー名@インスタンス名</code>または<code>メール@アドレス</code>を入力してください"
 
 #: users/templates/users/account.html:517
 msgid "Once deleted, account data cannot be recovered."
@@ -7794,9 +7764,7 @@ msgid "Token Created"
 msgstr ""
 
 #: users/templates/users/authorized_app_created.html:22
-msgid ""
-"Your new personal access token has been created. Copy it now -- you will not "
-"be able to see it again."
+msgid "Your new personal access token has been created. Copy it now -- you will not be able to see it again."
 msgstr ""
 
 #: users/templates/users/authorized_app_created.html:25
@@ -7824,9 +7792,7 @@ msgid "One quick check"
 msgstr ""
 
 #: users/templates/users/captcha.html:28
-msgid ""
-"Put every cover into the row it belongs to. Drag it, or select a cover and "
-"then select a row."
+msgid "Put every cover into the row it belongs to. Drag it, or select a cover and then select a row."
 msgstr ""
 
 #: users/templates/users/captcha.html:41 users/templates/users/captcha.html:43
@@ -7858,7 +7824,7 @@ msgstr ""
 msgid "That is all we needed. Let's get you a username."
 msgstr ""
 
-#: users/templates/users/captcha_solved.html:34
+#: users/templates/users/captcha_solved.html:32
 #: users/templates/users/login.html:63
 #: users/templates/users/verify_email.html:25
 #: users/templates/users/welcome.html:51
@@ -7878,10 +7844,7 @@ msgid "Failed Crossposts"
 msgstr ""
 
 #: users/templates/users/crossposts.html:42
-msgid ""
-"These posts could not be crossposted to your linked social accounts. Re-"
-"authorize the account if needed, then retry. In rare cases retrying may "
-"create a duplicate post."
+msgid "These posts could not be crossposted to your linked social accounts. Re-authorize the account if needed, then retry. In rare cases retrying may create a duplicate post."
 msgstr ""
 
 #: users/templates/users/crossposts.html:48
@@ -7900,265 +7863,187 @@ msgstr ""
 msgid "Data Management"
 msgstr "データ管理"
 
-#: users/templates/users/data.html:27
+#: users/templates/users/data.html:39
 msgid "Import Marks and Reviews from Douban"
 msgstr "豆瓣からマークとレビューをインポート"
 
-#: users/templates/users/data.html:31
-msgid ""
-"Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
-"target=\"_blank\" rel=\"noopener\">Doufen</a>"
-msgstr ""
-"<a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">豆伴(豆"
-"坟)</a>でエクスポート時に<mark>書籍・映画・音楽・ゲーム・ドラマ</mark>と"
-"<mark>レビュー</mark>にチェックを入れてください。<br>豆伴(豆坟)からエクスポー"
-"トした<code>.xlsx</code>ファイルを選択してください"
+#: users/templates/users/data.html:43
+msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
+msgstr "<a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">豆伴(豆坟)</a>でエクスポート時に<mark>書籍・映画・音楽・ゲーム・ドラマ</mark>と<mark>レビュー</mark>にチェックを入れてください。<br>豆伴(豆坟)からエクスポートした<code>.xlsx</code>ファイルを選択してください"
 
 #: users/templates/users/data.html:45
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
-"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
-"NeoDB Archive</a> below."
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON format instead; upload it under <a href=\"#import-neodb-archive\">Import NeoDB Archive</a> below."
 msgstr ""
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:256
+#: users/templates/users/data.html:49 users/templates/users/data.html:271
 msgid "Import Method"
 msgstr "インポート方法"
 
-#: users/templates/users/data.html:37
-msgid ""
-"Merge: only update when status changes from wishlist to in-progress, or from "
-"in-progress to complete."
-msgstr ""
-"自動マージ：未マーク→読みたい→読書中→読了など正方向の変化のみを更新し、その他"
-"のマークや既存のレビューは更新しません（推奨）"
+#: users/templates/users/data.html:52
+msgid "Merge: only update when status changes from wishlist to in-progress, or from in-progress to complete."
+msgstr "自動マージ：未マーク→読みたい→読書中→読了など正方向の変化のみを更新し、その他のマークや既存のレビューは更新しません（推奨）"
 
-#: users/templates/users/data.html:41
+#: users/templates/users/data.html:56
 msgid "Overwrite: update all imported status."
-msgstr ""
-"強制上書き：既存のマークとレビューを上書きします。インポートファイルに含まれ"
-"ていないアイテムのマークとレビューは変更されません。"
+msgstr "強制上書き：既存のマークとレビューを上書きします。インポートファイルに含まれていないアイテムのマークとレビューは変更されません。"
 
-#: users/templates/users/data.html:74
-msgid ""
-"Another import is in progress, starting a new import may cause issues, sure "
-"to import?"
-msgstr ""
-"短期間に繰り返しアップロードすると予期しない結果が生じる可能性があります。今"
-"すぐインポートしますか？"
+#: users/templates/users/data.html:89
+msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
+msgstr "短期間に繰り返しアップロードすると予期しない結果が生じる可能性があります。今すぐインポートしますか？"
 
-#: users/templates/users/data.html:74
+#: users/templates/users/data.html:89 users/views/data.py:1130
 msgid "Import in progress, please wait"
-msgstr ""
-"バックアップファイルがアップロードされました。インポートが完了するまでお待ち"
-"いただくか、ページを更新して最新の進捗状況を確認してください"
+msgstr "バックアップファイルがアップロードされました。インポートが完了するまでお待ちいただくか、ページを更新して最新の進捗状況を確認してください"
 
-#: users/templates/users/data.html:81
+#: users/templates/users/data.html:96
 #, fuzzy
 #| msgid "Import Shelf or List from Goodreads"
 msgid "Import from Goodreads"
 msgstr "Goodreadsの本棚またはリストをインポート"
 
-#: users/templates/users/data.html:87
-msgid ""
-"On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download "
-"your library as a CSV file."
+#: users/templates/users/data.html:102
+msgid "On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download your library as a CSV file."
 msgstr ""
 
-#: users/templates/users/data.html:90
-msgid ""
-"Upload the downloaded <code>goodreads_library_export.csv</code> file below."
+#: users/templates/users/data.html:105
+msgid "Upload the downloaded <code>goodreads_library_export.csv</code> file below."
 msgstr ""
 
-#: users/templates/users/data.html:93
+#: users/templates/users/data.html:108
 #, fuzzy
-#| msgid ""
-#| "want-to-read / currently-reading / read books and their reviews will be "
-#| "imported."
-msgid ""
-"want-to-read / currently-reading / read / did-not-finish books and their "
-"reviews will be imported."
-msgstr ""
-"Goodreadsのユーザープロフィールリンクを提出すると、読みたい、読書中、読了リス"
-"トがインポートされ、各本のレビューは本サイトの短評としてインポートされます。"
+#| msgid "want-to-read / currently-reading / read books and their reviews will be imported."
+msgid "want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported."
+msgstr "Goodreadsのユーザープロフィールリンクを提出すると、読みたい、読書中、読了リストがインポートされ、各本のレビューは本サイトの短評としてインポートされます。"
 
-#: users/templates/users/data.html:134
+#: users/templates/users/data.html:149
 msgid "Import from Letterboxd"
 msgstr "Letterboxdからマークをインポート"
 
-#: users/templates/users/data.html:140
-msgid ""
-"on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" "
-"target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap "
-"Advanced Settings in Settings, tap EXPORT YOUR DATA"
+#: users/templates/users/data.html:155
+msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
 msgstr ""
 
-#: users/templates/users/data.html:143
-msgid ""
-"download file with name like <code>letterboxd-username-2018-03-11-07-52-"
-"utc.zip</code>, do not unzip"
+#: users/templates/users/data.html:158
+msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
 msgstr ""
 
-#: users/templates/users/data.html:146
-msgid ""
-"the following files in the zip file will be processed: <code>reviews.csv</"
-"code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</"
-"code> <code>lists/*.csv</code>"
+#: users/templates/users/data.html:161
+msgid "the following files in the zip file will be processed: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
 msgstr ""
 
-#: users/templates/users/data.html:149
-msgid ""
-"exported file does not indicate whether a list is private, unlisted or "
-"public, so all imported marks, reviews and collections will be created with "
-"the visibility selected below"
+#: users/templates/users/data.html:164
+msgid "exported file does not indicate whether a list is private, unlisted or public, so all imported marks, reviews and collections will be created with the visibility selected below"
 msgstr ""
 
-#: users/templates/users/data.html:184 users/templates/users/data.html:235
+#: users/templates/users/data.html:199 users/templates/users/data.html:250
 msgid "Only forward changes(none->to-watch->watched) will be imported."
-msgstr ""
-"インポート時は正方向の変化（未マーク→観たい→観た）のみ更新されます。360文字未"
-"満のレビューは短評として追加されます。"
+msgstr "インポート時は正方向の変化（未マーク→観たい→観た）のみ更新されます。360文字未満のレビューは短評として追加されます。"
 
-#: users/templates/users/data.html:191
+#: users/templates/users/data.html:206
 #, fuzzy
 #| msgid "Import from Letterboxd"
 msgid "Import from Trakt"
 msgstr "Letterboxdからマークをインポート"
 
-#: users/templates/users/data.html:197
-msgid ""
-"On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" "
-"rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait "
-"for the download link to appear."
+#: users/templates/users/data.html:212
+msgid "On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait for the download link to appear."
 msgstr ""
 
-#: users/templates/users/data.html:200
+#: users/templates/users/data.html:215
 msgid "Upload the downloaded <code>.zip</code> file below, do not unzip."
 msgstr ""
 
-#: users/templates/users/data.html:202
+#: users/templates/users/data.html:217
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:243
+#: users/templates/users/data.html:258
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr ""
 
-#: users/templates/users/data.html:246
+#: users/templates/users/data.html:261
 msgid "Login with Steam"
 msgstr ""
 
-#: users/templates/users/data.html:252
+#: users/templates/users/data.html:267
 msgid "Import Podcast Subscriptions"
 msgstr "ポッドキャスト購読リストをインポート (OPML)"
 
-#: users/templates/users/data.html:263
+#: users/templates/users/data.html:278
 msgid "Mark as listening"
 msgstr "聴取中としてマーク"
 
-#: users/templates/users/data.html:267
+#: users/templates/users/data.html:282
 msgid "Import as a new collection"
 msgstr "新しいコレクションとしてインポート"
 
-#: users/templates/users/data.html:296
+#: users/templates/users/data.html:311
 msgid "Select OPML file"
 msgstr "OPMLファイルを選択"
 
-#: users/templates/users/data.html:306
+#: users/templates/users/data.html:321
 msgid "Import NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:312
-msgid ""
-"Upload a <code>.zip</code> file containing <code>.csv</code> or "
-"<code>.ndjson</code> files exported from NeoDB."
+#: users/templates/users/data.html:327
+msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr ""
 
 #: users/templates/users/data.html:330
 #, fuzzy
-#| msgid ""
-#| "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
-#| "target=\"_blank\" rel=\"noopener\">Doufen</a>"
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
-"imported here."
-msgstr ""
-"<a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">豆伴(豆"
-"坟)</a>でエクスポート時に<mark>書籍・映画・音楽・ゲーム・ドラマ</mark>と"
-"<mark>レビュー</mark>にチェックを入れてください。<br>豆伴(豆坟)からエクスポー"
-"トした<code>.xlsx</code>ファイルを選択してください"
+#| msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is imported here."
+msgstr "<a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">豆伴(豆坟)</a>でエクスポート時に<mark>書籍・映画・音楽・ゲーム・ドラマ</mark>と<mark>レビュー</mark>にチェックを入れてください。<br>豆伴(豆坟)からエクスポートした<code>.xlsx</code>ファイルを選択してください"
 
-#: users/templates/users/data.html:314
+#: users/templates/users/data.html:332
 msgid "Existing data may be overwritten."
 msgstr ""
 
-#: users/templates/users/data.html:324
+#: users/templates/users/data.html:342
 msgid "Detected format"
 msgstr ""
 
-#: users/templates/users/data.html:385
+#: users/templates/users/data.html:403
 msgid "Detecting format..."
 msgstr ""
 
-#: users/templates/users/data.html:411
+#: users/templates/users/data.html:429
 #, fuzzy
 #| msgid "Unknown or Other"
 msgid "Unknown format"
 msgstr "不明またはその他"
 
-#: users/templates/users/data.html:436
+#: users/templates/users/data.html:454
 msgid "Error detecting format"
 msgstr ""
 
-#: users/templates/users/data.html:460
+#: users/templates/users/data.html:478
 msgid "Export NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:464
+#: users/templates/users/data.html:482
 msgid "Export marks, reviews and notes in CSV"
 msgstr "マーク、短評、レビューをエクスポート（CSV形式）"
 
-#: users/templates/users/data.html:471
+#: users/templates/users/data.html:489
 msgid "Export everything in NDJSON"
 msgstr "マーク、短評、レビューをエクスポート（NDJSON形式）"
-
-#: users/templates/users/data.html:479
-msgid "Export marks and reviews in XLSX (Doufen format)"
-msgstr "マーク、短評、レビューをエクスポート（豆坟xlsx形式）"
-
-#: users/templates/users/data.html:482
-msgid "Last export"
-msgstr "最近のエクスポート"
-
-#: users/templates/users/data.html:487
-msgid "Download"
-msgstr "ダウンロード"
 
 #: users/templates/users/data.html:496
 msgid "Import and Export Articles (WordPress)"
 msgstr ""
 
 #: users/templates/users/data.html:499
-msgid ""
-"Your articles are exchanged as WordPress posts in the WXR format, which "
-"WordPress and most blogging tools can read and write. Marks, reviews and "
-"notes are not included: use the NeoDB archive above for those."
+msgid "Your articles are exchanged as WordPress posts in the WXR format, which WordPress and most blogging tools can read and write. Marks, reviews and notes are not included: use the NeoDB archive above for those."
 msgstr ""
 
 #: users/templates/users/data.html:502
-msgid ""
-"Article title, body, excerpt, tags, dates and featured image are exchanged. "
-"Comments and custom fields are ignored."
+msgid "Article title, body, excerpt, tags, dates and featured image are exchanged. Comments and custom fields are ignored."
 msgstr ""
 
 #: users/templates/users/data.html:505
-msgid ""
-"The body is converted between Markdown and HTML, so formatting is kept but "
-"the text is not character-for-character identical."
+msgid "The body is converted between Markdown and HTML, so formatting is kept but the text is not character-for-character identical."
 msgstr ""
 
 #: users/templates/users/data.html:512
@@ -8168,16 +8053,11 @@ msgid "Export articles in WordPress format"
 msgstr "マーク、短評、レビューをエクスポート（豆坟xlsx形式）"
 
 #: users/templates/users/data.html:519
-msgid ""
-"In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download "
-"an <code>.xml</code> file, then upload it below."
+msgid "In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download an <code>.xml</code> file, then upload it below."
 msgstr ""
 
 #: users/templates/users/data.html:522
-msgid ""
-"Only published posts use the visibility below. Drafts, pending, private and "
-"password-protected posts are always imported as mentioned-only, so nothing "
-"unpublished becomes public."
+msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
 #: users/templates/users/data.html:560
@@ -8185,12 +8065,8 @@ msgid "View Annual Summary"
 msgstr "年間サマリーを表示"
 
 #: users/templates/users/fetch_identity_failed.html:4
-msgid ""
-"Unable to find the user, please check your spelling; or the server may be "
-"busy, please try again later."
-msgstr ""
-"ユーザーが見つかりません。スペルを確認してください。またはサーバーがビジー状"
-"態の可能性があります。後でもう一度お試しください。"
+msgid "Unable to find the user, please check your spelling; or the server may be busy, please try again later."
+msgstr "ユーザーが見つかりません。スペルを確認してください。またはサーバーがビジー状態の可能性があります。後でもう一度お試しください。"
 
 #: users/templates/users/fetch_identity_pending.html:13
 #: users/templates/users/fetch_identity_pending.html:22
@@ -8209,114 +8085,78 @@ msgstr "ログイン"
 msgid "logo"
 msgstr ""
 
-#: users/templates/users/login.html:127
-msgid ""
-"Sign in with a passkey saved on this device or in your password manager."
+#: users/templates/users/login.html:121
+msgid "Sign in with a passkey saved on this device or in your password manager."
 msgstr ""
 
-#: users/templates/users/login.html:132
+#: users/templates/users/login.html:126
 msgid "Sign in with Passkey"
 msgstr ""
 
-#: users/templates/users/login.html:148
+#: users/templates/users/login.html:142
 msgid "Enter your email address"
 msgstr "メールアドレスを入力"
 
-#: users/templates/users/login.html:152
+#: users/templates/users/login.html:146
 msgid "Send verification code"
 msgstr "確認コードを送信"
 
-#: users/templates/users/login.html:171
+#: users/templates/users/login.html:165
 msgid "Domain of your instance, e.g. mastodon.social"
-msgstr ""
-"インスタンスのドメイン（@と@の前の部分を含まない）、例：mastodon.social"
+msgstr "インスタンスのドメイン（@と@の前の部分を含まない）、例：mastodon.social"
 
-#: users/templates/users/login.html:177
-msgid ""
-"Please enter domain of your instance; e.g. if your id is "
-"<i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
-msgstr ""
-"インスタンスのドメイン（@と@の前の部分を含まない）を入力してください。例え"
-"ば、あなたの連合アカウントが<i>@neodb@mastodon.social</i>の場合、"
-"<i>mastodon.social</i>のみを入力してください。"
+#: users/templates/users/login.html:171
+msgid "Please enter domain of your instance; e.g. if your id is <i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
+msgstr "インスタンスのドメイン（@と@の前の部分を含まない）を入力してください。例えば、あなたの連合アカウントが<i>@neodb@mastodon.social</i>の場合、<i>mastodon.social</i>のみを入力してください。"
 
-#: users/templates/users/login.html:182 users/templates/users/login.html:246
+#: users/templates/users/login.html:176 users/templates/users/login.html:240
 msgid "Authorize via Fediverse instance"
 msgstr "連合インスタンスで認証して登録またはログイン"
 
-#: users/templates/users/login.html:187
-msgid ""
-"If you don't have a <a href=\"https://joinmastodon.org/servers\" "
-"target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or "
-"login with Email first, and link it with Fediverse (Mastodon) later in "
-"account settings."
-msgstr ""
-"<a href=\"https://joinmastodon.org/servers\" target=\"_blank\">連合インスタン"
-"ス</a>アカウントをまだ持っていない、または登録が便利でない場合は、まずメール"
-"やその他のプラットフォームで登録・ログインし、後で関連付けることもできます。"
+#: users/templates/users/login.html:181
+msgid "If you don't have a <a href=\"https://joinmastodon.org/servers\" target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or login with Email first, and link it with Fediverse (Mastodon) later in account settings."
+msgstr "<a href=\"https://joinmastodon.org/servers\" target=\"_blank\">連合インスタンス</a>アカウントをまだ持っていない、または登録が便利でない場合は、まずメールやその他のプラットフォームで登録・ログインし、後で関連付けることもできます。"
 
-#: users/templates/users/login.html:200
+#: users/templates/users/login.html:194
 msgid "Authorize via Threads"
 msgstr "Threadsで認証して登録またはログイン"
 
-#: users/templates/users/login.html:221
-msgid ""
-"Please input your ATProto handle (e.g. neodb.bsky.social, without the "
-"leading @), do not use email. If you changed handle recently, just use the "
-"latest one."
-msgstr ""
-"ATProtoユーザー識別子を入力してください（例：neodb.bsky.social、先頭の@は含め"
-"ないでください）。メールアドレスは使用しないでください。最近識別子を変更した"
-"場合は、最新のものを使用してください。"
+#: users/templates/users/login.html:215
+msgid "Please input your ATProto handle (e.g. neodb.bsky.social, without the leading @), do not use email. If you changed handle recently, just use the latest one."
+msgstr "ATProtoユーザー識別子を入力してください（例：neodb.bsky.social、先頭の@は含めないでください）。メールアドレスは使用しないでください。最近識別子を変更した場合は、最新のものを使用してください。"
 
-#: users/templates/users/login.html:224
+#: users/templates/users/login.html:218
 #, fuzzy
 #| msgid "Authorize via Threads"
 msgid "Authorize via ATProto server"
 msgstr "Threadsで認証して登録またはログイン"
 
-#: users/templates/users/login.html:231
+#: users/templates/users/login.html:225
 #, python-format
-msgid ""
-"Please choose one to register or login %(site_name)s. Have more than one of "
-"these identities? Don't worry, you may link them in account settings once "
-"logged in."
-msgstr ""
-"%(site_name)sに登録またはログインする方法を一つ選んでください。複数のソーシャ"
-"ルIDをお持ちの場合でも、ログイン後にアカウント設定で連携できます。"
+msgid "Please choose one to register or login %(site_name)s. Have more than one of these identities? Don't worry, you may link them in account settings once logged in."
+msgstr "%(site_name)sに登録またはログインする方法を一つ選んでください。複数のソーシャルIDをお持ちの場合でも、ログイン後にアカウント設定で連携できます。"
 
-#: users/templates/users/login.html:255
+#: users/templates/users/login.html:249
 msgid "Valid invitation code, please login or register."
 msgstr "有効な招待リンクです。新規ユーザー登録ができます"
 
-#: users/templates/users/login.html:257
-msgid ""
-"Please use invitation link to register a new account; existing user may "
-"login."
-msgstr ""
-"現在、招待制登録となっています。既存アカウントは直接ログインできますが、新規"
-"ユーザーは有効な招待リンクを使用して登録してください"
+#: users/templates/users/login.html:251
+msgid "Please use invitation link to register a new account; existing user may login."
+msgstr "現在、招待制登録となっています。既存アカウントは直接ログインできますが、新規ユーザーは有効な招待リンクを使用して登録してください"
 
-#: users/templates/users/login.html:259
+#: users/templates/users/login.html:253
 msgid "Invitation code invalid or expired."
-msgstr ""
-"招待リンクが無効です。既存アカウントは直接ログインできますが、新規ユーザーは"
-"有効な招待リンクを使用して登録してください"
+msgstr "招待リンクが無効です。既存アカウントは直接ログインできますが、新規ユーザーは有効な招待リンクを使用して登録してください"
+
+#: users/templates/users/login.html:261
+msgid "Loading timed out, please check your network (VPN) settings."
+msgstr "一部のモジュールの読み込みがタイムアウトしました。ネットワーク設定を確認してください。"
 
 #: users/templates/users/login.html:267
-msgid "Loading timed out, please check your network (VPN) settings."
-msgstr ""
-"一部のモジュールの読み込みがタイムアウトしました。ネットワーク設定を確認して"
-"ください。"
-
-#: users/templates/users/login.html:273
-msgid ""
-"Continue using this site implies consent to our <a href=\"/pages/rules/"
-"\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using "
-"cookies to provide necessary functionality."
+msgid "Continue using this site implies consent to our <a href=\"/pages/rules/\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using cookies to provide necessary functionality."
 msgstr ""
 
-#: users/templates/users/login.html:287
+#: users/templates/users/login.html:281
 msgid "Domain of your instance (excl. @)"
 msgstr ""
 
@@ -8326,9 +8166,7 @@ msgid "Migrate Here"
 msgstr ""
 
 #: users/templates/users/migrate_in.html:22
-msgid ""
-"To move another account to this one, first add it as an alias here, and then "
-"go to the server where it is hosted and initiate the move."
+msgid "To move another account to this one, first add it as an alias here, and then go to the server where it is hosted and initiate the move."
 msgstr ""
 
 #: users/templates/users/migrate_in.html:27
@@ -8378,16 +8216,11 @@ msgstr ""
 
 #: users/templates/users/migrate_out.html:46
 #, python-format
-msgid ""
-"To migrate to another account, first add <code>@%(handle)s</code> as an "
-"alias on the target server, and then type the target account below to start "
-"the migration."
+msgid "To migrate to another account, first add <code>@%(handle)s</code> as an alias on the target server, and then type the target account below to start the migration."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:50
-msgid ""
-"Are you sure you want to migrate your account? Your followers will be moved "
-"to the target account."
+msgid "Are you sure you want to migrate your account? Your followers will be moved to the target account."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:53
@@ -8402,10 +8235,6 @@ msgstr ""
 
 #: users/templates/users/preferences.html:28
 msgid "Default view once logged in"
-msgstr ""
-
-#: users/templates/users/preferences.html:40
-msgid "Activities"
 msgstr ""
 
 #: users/templates/users/preferences.html:49
@@ -8435,9 +8264,7 @@ msgstr ""
 
 #: users/templates/users/preferences.html:111
 #: users/templates/users/register.html:88
-msgid ""
-"If a Mastodon account is linked with this identity, boosting a post will "
-"also make the same post boosted with that Mastodon account."
+msgid "If a Mastodon account is linked with this identity, boosting a post will also make the same post boosted with that Mastodon account."
 msgstr ""
 
 #: users/templates/users/preferences.html:115
@@ -8453,18 +8280,12 @@ msgid "Create a new post"
 msgstr "新しい投稿を作成"
 
 #: users/templates/users/preferences.html:130
-msgid ""
-"this method is less optimal, may generate duplicated posts and miss "
-"reactions."
-msgstr ""
-"この方法は最適ではなく、重複投稿が発生したり、リアクションが記録されない可能"
-"性があります。"
+msgid "this method is less optimal, may generate duplicated posts and miss reactions."
+msgstr "この方法は最適ではなく、重複投稿が発生したり、リアクションが記録されない可能性があります。"
 
 #: users/templates/users/preferences.html:140
 #: users/templates/users/register.html:97
-msgid ""
-"Always publish my public marks, reviews and articles as data records to my "
-"PDS."
+msgid "Always publish my public marks, reviews and articles as data records to my PDS."
 msgstr ""
 
 #: users/templates/users/preferences.html:145
@@ -8484,12 +8305,7 @@ msgid "Automatic bookmark for these categories"
 msgstr "以下のカテゴリを自動的にブックマーク"
 
 #: users/templates/users/preferences.html:175
-msgid ""
-"When start to read/watch/play/... an item in these categories, a bookmark "
-"will be created automatically. Bookmarks can be viewed and managed in most "
-"<a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon "
-"compatible apps</a>; your replies to these posts will automatically become "
-"notes for the item."
+msgid "When start to read/watch/play/... an item in these categories, a bookmark will be created automatically. Bookmarks can be viewed and managed in most <a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon compatible apps</a>; your replies to these posts will automatically become notes for the item."
 msgstr ""
 
 #: users/templates/users/preferences.html:183
@@ -8509,12 +8325,8 @@ msgid "Profile visible to anonymous web visitors and search engines"
 msgstr "匿名訪問者や検索エンジンからプロフィールを閲覧可能にする"
 
 #: users/templates/users/preferences.html:217
-msgid ""
-"this option limits web visits only; to limit fediverse visibility, choose "
-"followers only or mentioned only when posting"
-msgstr ""
-"このオプションはWeb訪問者のみを制限します。フェディバースでの可視性を制限する"
-"には、投稿時にフォロワー限定やメンションのみを選択してください。"
+msgid "this option limits web visits only; to limit fediverse visibility, choose followers only or mentioned only when posting"
+msgstr "このオプションはWeb訪問者のみを制限します。フェディバースでの可視性を制限するには、投稿時にフォロワー限定やメンションのみを選択してください。"
 
 #: users/templates/users/preferences.html:225
 msgid "Show your name on item page if you recently edited it"
@@ -8525,17 +8337,7 @@ msgid "Do not show me item recommendations"
 msgstr ""
 
 #: users/templates/users/preferences.html:237
-msgid ""
-"Recommendations are generated only from public marks, processed in batch on "
-"this server. Your private and follower-only marks are never used as a signal "
-"for anyone, and we never share your data with third parties for this "
-"feature. When you share marks publicly and keep your profile discoverable, "
-"your marks help others here and across the Fediverse find things they might "
-"enjoy -- that voluntary contribution is what makes the feature work for "
-"everyone. If you'd rather not contribute, uncheck \"Include profile, marks "
-"and posts in discovery\" on your account page; this setting is published "
-"over ActivityPub, so other servers will also stop including you in their "
-"discovery features."
+msgid "Recommendations are generated only from public marks, processed in batch on this server. Your private and follower-only marks are never used as a signal for anyone, and we never share your data with third parties for this feature. When you share marks publicly and keep your profile discoverable, your marks help others here and across the Fediverse find things they might enjoy -- that voluntary contribution is what makes the feature work for everyone. If you'd rather not contribute, uncheck \"Include profile, marks and posts in discovery\" on your account page; this setting is published over ActivityPub, so other servers will also stop including you in their discovery features."
 msgstr ""
 
 #: users/templates/users/profile_actions.html:12
@@ -8636,20 +8438,12 @@ msgid "2-30 alphabets, numbers or underscore, can't be changed once saved"
 msgstr ""
 
 #: users/templates/users/register.html:72
-msgid ""
-"Use display name, bio and avatar from the social network you authenticated "
-"with"
+msgid "Use display name, bio and avatar from the social network you authenticated with"
 msgstr ""
 
 #: users/templates/users/register.html:80
-msgid ""
-"Add follow, mute and block list from the social network you authenticated "
-"with"
+msgid "Add follow, mute and block list from the social network you authenticated with"
 msgstr ""
-
-#: users/templates/users/register.html:104
-msgid "Confirm and save"
-msgstr "確認して保存"
 
 #: users/templates/users/register.html:106
 msgid "Close"
@@ -8677,8 +8471,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"              Matched %(local)s locally, %(external)s externally, "
-"%(unmatched)s unmatched out of %(total)s rows.\n"
+"              Matched %(local)s locally, %(external)s externally, %(unmatched)s unmatched out of %(total)s rows.\n"
 "            "
 msgstr ""
 
@@ -8803,9 +8596,7 @@ msgid "Played"
 msgstr ""
 
 #: users/templates/users/steam_import.html:90
-msgid ""
-"Games in wishlist; or purchased in library but never played, mark date will "
-"be set as today"
+msgid "Games in wishlist; or purchased in library but never played, mark date will be set as today"
 msgstr ""
 
 #: users/templates/users/steam_import.html:91
@@ -8845,15 +8636,11 @@ msgid "Comma-separated Steam AppIDs"
 msgstr ""
 
 #: users/templates/users/steam_import.html:121
-msgid ""
-"Allow reverse override of status (e.g. playing -> want to, or played -> "
-"playing)"
+msgid "Allow reverse override of status (e.g. playing -> want to, or played -> playing)"
 msgstr ""
 
 #: users/templates/users/steam_import.html:139
-msgid ""
-"To import from Steam, your game details must be visible to public in Steam "
-"privacy settings."
+msgid "To import from Steam, your game details must be visible to public in Steam privacy settings."
 msgstr ""
 
 #: users/templates/users/storygraph_import.html:9
@@ -8898,23 +8685,16 @@ msgstr "ようこそ"
 #, python-format
 msgid ""
 "\n"
-"              %(site_name)s is flourishing because of collaborations and "
-"contributions from users like you. Please read our <a href=\"/pages/"
-"rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</"
-"a> if you have any question or feedback.\n"
+"              %(site_name)s is flourishing because of collaborations and contributions from users like you. Please read our <a href=\"/pages/rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</a> if you have any question or feedback.\n"
 "        "
 msgstr ""
 
 #: users/templates/users/welcome.html:37
-msgid ""
-"Set up a passkey to sign in quickly next time using your fingerprint, face, "
-"or screen lock."
+msgid "Set up a passkey to sign in quickly next time using your fingerprint, face, or screen lock."
 msgstr ""
 
 #: users/templates/users/welcome.html:39
-msgid ""
-"Creating a passkey is highly recommended, as the website or email you use to "
-"create this account may not be always available."
+msgid "Creating a passkey is highly recommended, as the website or email you use to create this account may not be always available."
 msgstr ""
 
 #: users/templates/users/welcome.html:43
@@ -8929,265 +8709,231 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:124
+#: users/views/account.py:126
 msgid "This username is already in use."
 msgstr "このユーザー名は既に使用されています。"
 
-#: users/views/account.py:135
+#: users/views/account.py:137
 msgid "This email address is already in use."
 msgstr "このメールアドレスは既に使用されています。"
 
-#: users/views/account.py:255 users/views/account.py:374
+#: users/views/account.py:257 users/views/account.py:376
 msgid "Registration is for invitation only"
 msgstr "登録は招待制のみです。"
 
-#: users/views/account.py:266 users/views/account.py:338
+#: users/views/account.py:268 users/views/account.py:340
 msgid "Time is up"
 msgstr ""
 
-#: users/views/account.py:267 users/views/account.py:310
-#: users/views/account.py:339
+#: users/views/account.py:269 users/views/account.py:312
+#: users/views/account.py:341
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:313
+#: users/views/account.py:315
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:325
+#: users/views/account.py:327
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:326
+#: users/views/account.py:328
 msgid "Please try again later."
 msgstr ""
 
-#: users/views/account.py:415
+#: users/views/account.py:417
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:445
+#: users/views/account.py:447
 msgid "Valid username required"
 msgstr "有効なユーザー名を入力してください。"
 
-#: users/views/account.py:526
+#: users/views/account.py:518
 msgid "Account is being deleted."
 msgstr "アカウントの削除が進行中です。"
 
-#: users/views/account.py:529
+#: users/views/account.py:521
 msgid "Account mismatch."
 msgstr "アカウントが一致しません。"
 
-#: users/views/data.py:262 users/views/data.py:294
+#: users/views/data.py:264 users/views/data.py:296
 msgid "Export file not available."
 msgstr "エクスポートファイルが利用できません。"
 
-#: users/views/data.py:288
+#: users/views/data.py:290
 msgid "Generating exports."
 msgstr "エクスポートを生成しています。"
 
-#: users/views/data.py:306
+#: users/views/data.py:308
 msgid "Export file expired. Please export again."
-msgstr ""
-"エクスポートファイルの有効期限が切れました。再度エクスポートしてください。"
+msgstr "エクスポートファイルの有効期限が切れました。再度エクスポートしてください。"
 
-#: users/views/data.py:321 users/views/data.py:342 users/views/data.py:363
+#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
 msgid "Recent export still in progress."
 msgstr "最新のエクスポートが進行中です。"
 
-#: users/views/data.py:379 users/views/data.py:513 users/views/data.py:547
-#: users/views/data.py:772 users/views/data.py:989 users/views/data.py:1015
-#: users/views/data.py:1040 users/views/data.py:1065
+#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
+#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
+#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
 msgid "Invalid file."
 msgstr "無効なファイルです。"
 
-#: users/views/data.py:403
+#: users/views/data.py:405
 msgid "Sync in progress."
 msgstr "同期中です。"
 
-#: users/views/data.py:417
+#: users/views/data.py:419
 msgid "Settings saved."
 msgstr "設定が保存されました。"
 
-#: users/views/data.py:472
+#: users/views/data.py:474
 #, fuzzy
 #| msgid "Account is being deleted."
 msgid "Account no longer linked."
 msgstr "アカウントの削除が進行中です。"
 
-#: users/views/data.py:475
+#: users/views/data.py:477
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:503
+#: users/views/data.py:505
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:583 users/views/data.py:808
+#: users/views/data.py:585 users/views/data.py:810
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:608 users/views/data.py:837
+#: users/views/data.py:610 users/views/data.py:839
 msgid "Cancelled."
 msgstr ""
 
-#: users/views/data.py:628
+#: users/views/data.py:630
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:636 users/views/data.py:746 users/views/data.py:867
-#: users/views/data.py:972
+#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
+#: users/views/data.py:974
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:732 users/views/data.py:958
+#: users/views/data.py:734 users/views/data.py:960
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:742 users/views/data.py:968
+#: users/views/data.py:744 users/views/data.py:970
 #, fuzzy
 #| msgid "Export file not available."
 msgid "No matched file available."
 msgstr "エクスポートファイルが利用できません。"
 
-#: users/views/data.py:859
+#: users/views/data.py:861
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1188
+#: users/views/data.py:1226
 #, fuzzy
 #| msgid "Valid username required"
 msgid "Name is required."
 msgstr "有効なユーザー名を入力してください。"
 
-#: users/views/data.py:1210
+#: users/views/data.py:1248
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1264
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1231
+#: users/views/data.py:1269
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1241 users/views/data.py:1292
+#: users/views/data.py:1279 users/views/data.py:1330
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:1248
+#: users/views/data.py:1286
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:1253
+#: users/views/data.py:1291
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:1279
+#: users/views/data.py:1317
 msgid "Migration cancelled."
 msgstr ""
 
-#: users/views/data.py:1284
+#: users/views/data.py:1322
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:1297
+#: users/views/data.py:1335
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:1308
+#: users/views/data.py:1346
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:1314
+#: users/views/data.py:1352
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr ""
 
-#: users/views/data.py:1372
+#: users/views/data.py:1410
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1388
+#: users/views/data.py:1426
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1392
+#: users/views/data.py:1430
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1402
+#: users/views/data.py:1440
 #, python-brace-format
-msgid ""
-"Import of {count} entries received. They will be processed in the background."
+msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""
 
-#: users/views/webauthn.py:103
+#: users/views/webauthn.py:106
 msgid "Passkey registration failed"
 msgstr ""
 
-#: users/views/webauthn.py:123
+#: users/views/webauthn.py:126
 msgid "Credential already registered"
 msgstr ""
 
-#: users/views/webauthn.py:165 users/views/webauthn.py:172
-#: users/views/webauthn.py:181
+#: users/views/webauthn.py:168 users/views/webauthn.py:175
+#: users/views/webauthn.py:184
 msgid "Passkey not recognized"
 msgstr ""
 
-#: users/views/webauthn.py:186
+#: users/views/webauthn.py:189
 #, fuzzy
 #| msgid "Account is being deleted."
 msgid "Account is inactive"
 msgstr "アカウントの削除が進行中です。"
 
-#: users/views/webauthn.py:202
+#: users/views/webauthn.py:205
 #, fuzzy
 #| msgid "Send verification code"
 msgid "Passkey verification failed"
 msgstr "確認コードを送信"
 
-#: users/views/webauthn.py:228 users/views/webauthn.py:250
+#: users/views/webauthn.py:231 users/views/webauthn.py:253
 msgid "Passkey not found"
 msgstr ""
 
-#: users/views/webauthn.py:244
+#: users/views/webauthn.py:247
 #, fuzzy
 #| msgid "Valid username required"
 msgid "Name is required"
 msgstr "有効なユーザー名を入力してください。"
-
-#~ msgid "Link to Goodreads Profile / Shelf / List"
-#~ msgstr "Goodreadsのプロフィール・本棚・リストへのリンク"
-
-#~ msgid "Last import started"
-#~ msgstr "最近のインポート時間"
-
-#~ msgid "Shelf will be imported as a new collection."
-#~ msgstr ""
-#~ "Goodreadsの本棚はコレクションとしてインポートされ、各本のレビューはコレク"
-#~ "ションアイテムのメモとしてインポートされます。"
-
-#~ msgid "List will be imported as a new collection."
-#~ msgstr ""
-#~ "Goodreadsのリストはコレクションとしてインポートされ、各本のレビューはコレ"
-#~ "クションアイテムのメモとしてインポートされます。"
-
-#~ msgid ""
-#~ "Failed links, likely due to Letterboxd error, you may have to mark them "
-#~ "manually"
-#~ msgstr ""
-#~ "インポートに失敗したリンク（通常はLetterboxdの情報エラーによるもの、手動で"
-#~ "マークを追加してください）"
-
-#~ msgid "Export Data"
-#~ msgstr "データをエクスポート"
-
-#~ msgid "Username in use"
-#~ msgstr "このユーザー名は既に使用されています。"
-
-#~ msgid "File is uploaded and will be imported soon."
-#~ msgstr "ファイルはアップロードされ、間もなくインポートされます。"

--- a/neodb/locale/lmo/LC_MESSAGES/django.po
+++ b/neodb/locale/lmo/LC_MESSAGES/django.po
@@ -7,11 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-23 15:40-0400\n"
+"POT-Creation-Date: 2026-09-06 20:04-0400\n"
 "PO-Revision-Date: 2026-08-09 06:32+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Lombard <https://hosted.weblate.org/projects/neodb/neodb/lmo/"
-">\n"
+"Language-Team: Lombard <https://hosted.weblate.org/projects/neodb/neodb/lmo/>\n"
 "Language: lmo\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,159 +18,159 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: boofilsic/settings.py:472 common/models/lang.py:230
+#: boofilsic/settings.py:501 common/models/lang.py:232
 msgid "English"
 msgstr "Ingles"
 
-#: boofilsic/settings.py:473 common/models/lang.py:77
+#: boofilsic/settings.py:502 common/models/lang.py:79
 msgid "Danish"
 msgstr "Danés"
 
-#: boofilsic/settings.py:474 common/models/lang.py:78
+#: boofilsic/settings.py:503 common/models/lang.py:80
 msgid "German"
 msgstr "Todesc"
 
-#: boofilsic/settings.py:475 common/models/lang.py:183
+#: boofilsic/settings.py:504 common/models/lang.py:185
 msgid "Spanish"
 msgstr ""
 
-#: boofilsic/settings.py:476 common/models/lang.py:87
+#: boofilsic/settings.py:505 common/models/lang.py:89
 msgid "French"
 msgstr "Frances"
 
-#: boofilsic/settings.py:477 common/models/lang.py:112
+#: boofilsic/settings.py:506 common/models/lang.py:114
 msgid "Italian"
 msgstr "Italian"
 
-#: boofilsic/settings.py:478 common/models/lang.py:166
-#: common/models/lang.py:305
+#: boofilsic/settings.py:507 common/models/lang.py:168
+#: common/models/lang.py:307
 msgid "Portuguese"
 msgstr "Portoghés"
 
-#: boofilsic/settings.py:479
+#: boofilsic/settings.py:508
 msgid "Brazilian Portuguese"
 msgstr ""
 
-#: boofilsic/settings.py:480 common/models/lang.py:316
+#: boofilsic/settings.py:509 common/models/lang.py:318
 msgid "Simplified Chinese"
 msgstr ""
 
-#: boofilsic/settings.py:481 common/models/lang.py:317
+#: boofilsic/settings.py:510 common/models/lang.py:319
 msgid "Traditional Chinese"
 msgstr ""
 
-#: catalog/forms.py:35 catalog/models/item.py:291
+#: catalog/forms.py:35 catalog/models/item.py:307
 msgid "Primary ID Type"
 msgstr ""
 
-#: catalog/forms.py:40 catalog/models/item.py:294
+#: catalog/forms.py:40 catalog/models/item.py:310
 msgid "Primary ID Value"
 msgstr ""
 
-#: catalog/forms.py:181
+#: catalog/forms.py:176
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
-#: catalog/models/book.py:139 catalog/models/book.py:158
-#: catalog/models/common.py:280 catalog/models/common.py:298
+#: catalog/models/book.py:141 catalog/models/book.py:160
+#: catalog/models/common.py:279 catalog/models/common.py:297
 msgid "locale"
 msgstr ""
 
-#: catalog/models/book.py:142 catalog/models/book.py:161
-#: catalog/models/common.py:283 catalog/models/common.py:303
+#: catalog/models/book.py:144 catalog/models/book.py:163
+#: catalog/models/common.py:282 catalog/models/common.py:302
 msgid "text content"
 msgstr ""
 
-#: catalog/models/book.py:177
+#: catalog/models/book.py:179
 msgid "Paperback"
 msgstr ""
 
-#: catalog/models/book.py:178
+#: catalog/models/book.py:180
 msgid "Hardcover"
 msgstr ""
 
-#: catalog/models/book.py:179
+#: catalog/models/book.py:181
 msgid "eBook"
 msgstr ""
 
-#: catalog/models/book.py:180
+#: catalog/models/book.py:182
 msgid "Audiobook"
 msgstr ""
 
-#: catalog/models/book.py:182
+#: catalog/models/book.py:184
 msgid "Web Fiction"
 msgstr ""
 
-#: catalog/models/book.py:183 catalog/models/game.py:38
+#: catalog/models/book.py:185 catalog/models/game.py:38
 msgid "Other"
 msgstr ""
 
-#: catalog/models/book.py:260
+#: catalog/models/book.py:262
 msgid "subtitle"
 msgstr ""
 
-#: catalog/models/book.py:270 catalog/models/movie.py:120
-#: catalog/models/performance.py:385 catalog/models/tv.py:211
-#: catalog/models/tv.py:437
+#: catalog/models/book.py:272 catalog/models/movie.py:120
+#: catalog/models/performance.py:385 catalog/models/tv.py:213
+#: catalog/models/tv.py:439
 msgid "original title"
 msgstr ""
 
-#: catalog/models/book.py:274
+#: catalog/models/book.py:276
 msgid "other title"
 msgstr ""
 
-#: catalog/models/book.py:280 catalog/models/book.py:564
-#: catalog/models/item.py:123
+#: catalog/models/book.py:282 catalog/models/book.py:566
+#: catalog/models/item.py:119
 msgid "author"
 msgstr ""
 
-#: catalog/models/book.py:287 catalog/models/item.py:124
+#: catalog/models/book.py:289 catalog/models/item.py:120
 msgid "translator"
 msgstr ""
 
-#: catalog/models/book.py:294 catalog/templates/edition.html:26
+#: catalog/models/book.py:296 catalog/templates/edition.html:26
 msgid "book format"
 msgstr ""
 
-#: catalog/models/book.py:301 catalog/models/game.py:135
-#: catalog/models/item.py:138 catalog/models/music.py:142
+#: catalog/models/book.py:303 catalog/models/game.py:135
+#: catalog/models/item.py:134 catalog/models/music.py:142
 msgid "publisher"
 msgstr ""
 
-#: catalog/models/book.py:308
+#: catalog/models/book.py:310
 msgid "publication year"
 msgstr ""
 
-#: catalog/models/book.py:314
+#: catalog/models/book.py:316
 msgid "publication month"
 msgstr ""
 
-#: catalog/models/book.py:319
+#: catalog/models/book.py:321
 msgid "binding"
 msgstr ""
 
-#: catalog/models/book.py:320
+#: catalog/models/book.py:322
 msgid "pages"
 msgstr ""
 
-#: catalog/models/book.py:321 catalog/templates/edition.html:45
+#: catalog/models/book.py:323 catalog/templates/edition.html:45
 msgid "series"
 msgstr ""
 
-#: catalog/models/book.py:322 catalog/templates/edition.html:65
+#: catalog/models/book.py:324 catalog/templates/edition.html:65
 msgid "contents"
 msgstr ""
 
-#: catalog/models/book.py:323 catalog/templates/edition.html:51
+#: catalog/models/book.py:325 catalog/templates/edition.html:51
 msgid "price"
 msgstr ""
 
-#: catalog/models/book.py:324 catalog/models/item.py:149
+#: catalog/models/book.py:326 catalog/models/item.py:145
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr ""
 
-#: catalog/models/common.py:26 common/models/lang.py:256
+#: catalog/models/common.py:26 common/models/lang.py:258
 msgid "Unknown"
 msgstr ""
 
@@ -179,12 +178,12 @@ msgstr ""
 msgid "Douban"
 msgstr ""
 
-#: catalog/models/common.py:28 catalog/models/common.py:79
+#: catalog/models/common.py:28 catalog/models/common.py:81
 #, fuzzy
 msgid "Goodreads"
 msgstr "Goodreads"
 
-#: catalog/models/common.py:29 catalog/models/common.py:81
+#: catalog/models/common.py:29 catalog/models/common.py:83
 msgid "Google Books"
 msgstr ""
 
@@ -192,16 +191,16 @@ msgstr ""
 msgid "BooksTW"
 msgstr ""
 
-#: catalog/models/common.py:31 catalog/models/common.py:91
-#: catalog/models/common.py:93
+#: catalog/models/common.py:31 catalog/models/common.py:93
+#: catalog/models/common.py:95
 msgid "Bibliotek.dk"
 msgstr ""
 
-#: catalog/models/common.py:32 catalog/models/common.py:92
+#: catalog/models/common.py:32 catalog/models/common.py:94
 msgid "eReolen.dk"
 msgstr ""
 
-#: catalog/models/common.py:33 catalog/models/common.py:74
+#: catalog/models/common.py:33 catalog/models/common.py:76
 #: catalog/templates/movie.html:41 catalog/templates/people.html:37
 #: catalog/templates/tvseason.html:58 catalog/templates/tvshow.html:53
 #, fuzzy
@@ -212,7 +211,7 @@ msgstr "IMDb"
 msgid "TMDB"
 msgstr ""
 
-#: catalog/models/common.py:35 catalog/models/common.py:94
+#: catalog/models/common.py:35 catalog/models/common.py:96
 msgid "Bandcamp"
 msgstr ""
 
@@ -228,11 +227,11 @@ msgstr ""
 msgid "Steam"
 msgstr ""
 
-#: catalog/models/common.py:39 catalog/models/common.py:114
+#: catalog/models/common.py:39 catalog/models/common.py:116
 msgid "itch.io"
 msgstr ""
 
-#: catalog/models/common.py:40 catalog/models/common.py:115
+#: catalog/models/common.py:40 catalog/models/common.py:117
 msgid "Bangumi"
 msgstr ""
 
@@ -240,7 +239,7 @@ msgstr ""
 msgid "BGG"
 msgstr ""
 
-#: catalog/models/common.py:42 catalog/models/common.py:116
+#: catalog/models/common.py:42 catalog/models/common.py:118
 msgid "Apple Podcast"
 msgstr ""
 
@@ -252,35 +251,35 @@ msgstr ""
 msgid "Discogs"
 msgstr ""
 
-#: catalog/models/common.py:45 catalog/models/common.py:117
+#: catalog/models/common.py:45 catalog/models/common.py:119
 msgid "Apple Music"
 msgstr ""
 
-#: catalog/models/common.py:46 catalog/models/common.py:119
+#: catalog/models/common.py:46 catalog/models/common.py:121
 msgid "Fediverse"
 msgstr ""
 
-#: catalog/models/common.py:47 catalog/models/common.py:120
+#: catalog/models/common.py:47 catalog/models/common.py:122
 msgid "Qidian"
 msgstr ""
 
-#: catalog/models/common.py:48 catalog/models/common.py:121
+#: catalog/models/common.py:48 catalog/models/common.py:123
 msgid "Ypshuo"
 msgstr ""
 
-#: catalog/models/common.py:49 catalog/models/common.py:122
+#: catalog/models/common.py:49 catalog/models/common.py:124
 msgid "Archive of Our Own"
 msgstr ""
 
-#: catalog/models/common.py:50 catalog/models/common.py:123
+#: catalog/models/common.py:50 catalog/models/common.py:125
 msgid "JinJiang"
 msgstr ""
 
-#: catalog/models/common.py:51 catalog/models/common.py:64
+#: catalog/models/common.py:51 catalog/models/common.py:66
 msgid "WikiData"
 msgstr ""
 
-#: catalog/models/common.py:52 catalog/models/common.py:124
+#: catalog/models/common.py:52 catalog/models/common.py:126
 msgid "Open Library"
 msgstr ""
 
@@ -292,15 +291,15 @@ msgstr ""
 msgid "WorldCat"
 msgstr ""
 
-#: catalog/models/common.py:55 catalog/models/common.py:126
+#: catalog/models/common.py:55 catalog/models/common.py:128
 msgid "MobyGames"
 msgstr ""
 
-#: catalog/models/common.py:56 catalog/models/common.py:127
+#: catalog/models/common.py:56 catalog/models/common.py:129
 msgid "StoryGraph"
 msgstr ""
 
-#: catalog/models/common.py:57 catalog/models/common.py:118
+#: catalog/models/common.py:57 catalog/models/common.py:120
 msgid "YouTube Music"
 msgstr ""
 
@@ -316,336 +315,345 @@ msgstr ""
 msgid "Readmoo"
 msgstr ""
 
-#: catalog/models/common.py:65
-msgid "ISBN10"
+#: catalog/models/common.py:61
+msgid "MyAnimeList"
 msgstr ""
 
-#: catalog/models/common.py:66 catalog/templates/edition.html:19
-msgid "ISBN"
+#: catalog/models/common.py:62 catalog/models/common.py:140
+msgid "MangaUpdates"
 msgstr ""
 
 #: catalog/models/common.py:67
-msgid "ASIN"
+msgid "ISBN10"
 msgstr ""
 
-#: catalog/models/common.py:68
-msgid "ISSN"
+#: catalog/models/common.py:68 catalog/templates/edition.html:19
+msgid "ISBN"
 msgstr ""
 
 #: catalog/models/common.py:69
-msgid "CUBN"
+msgid "ASIN"
 msgstr ""
 
 #: catalog/models/common.py:70
-msgid "ISRC"
+msgid "ISSN"
 msgstr ""
 
 #: catalog/models/common.py:71
-msgid "GTIN UPC EAN"
+msgid "CUBN"
 msgstr ""
 
 #: catalog/models/common.py:72
-msgid "OCLC Number"
+msgid "ISRC"
 msgstr ""
 
 #: catalog/models/common.py:73
-msgid "RSS Feed URL"
+msgid "GTIN UPC EAN"
+msgstr ""
+
+#: catalog/models/common.py:74
+msgid "OCLC Number"
 msgstr ""
 
 #: catalog/models/common.py:75
-msgid "TMDB TV Series"
-msgstr ""
-
-#: catalog/models/common.py:76
-msgid "TMDB TV Season"
+msgid "RSS Feed URL"
 msgstr ""
 
 #: catalog/models/common.py:77
-msgid "TMDB TV Episode"
+msgid "TMDB TV Series"
 msgstr ""
 
 #: catalog/models/common.py:78
-msgid "TMDB Movie"
+msgid "TMDB TV Season"
+msgstr ""
+
+#: catalog/models/common.py:79
+msgid "TMDB TV Episode"
 msgstr ""
 
 #: catalog/models/common.py:80
-msgid "Goodreads Work"
+msgid "TMDB Movie"
 msgstr ""
 
 #: catalog/models/common.py:82
-msgid "Douban Book"
-msgstr ""
-
-#: catalog/models/common.py:83
-msgid "Douban Book Work"
+msgid "Goodreads Work"
 msgstr ""
 
 #: catalog/models/common.py:84
-msgid "Douban Movie"
+msgid "Douban Book"
 msgstr ""
 
 #: catalog/models/common.py:85
-msgid "Douban Music"
+msgid "Douban Book Work"
 msgstr ""
 
 #: catalog/models/common.py:86
-msgid "Douban Game"
+msgid "Douban Movie"
 msgstr ""
 
 #: catalog/models/common.py:87
-msgid "Douban Drama"
+msgid "Douban Music"
 msgstr ""
 
 #: catalog/models/common.py:88
-msgid "Douban Drama Version"
+msgid "Douban Game"
 msgstr ""
 
 #: catalog/models/common.py:89
-msgid "BooksTW Book"
+msgid "Douban Drama"
 msgstr ""
 
 #: catalog/models/common.py:90
+msgid "Douban Drama Version"
+msgstr ""
+
+#: catalog/models/common.py:91
+msgid "BooksTW Book"
+msgstr ""
+
+#: catalog/models/common.py:92
 msgid "Readmoo Book"
 msgstr ""
 
-#: catalog/models/common.py:95
+#: catalog/models/common.py:97
 msgid "Spotify Album"
 msgstr ""
 
-#: catalog/models/common.py:96
+#: catalog/models/common.py:98
 msgid "Spotify Podcast"
 msgstr ""
 
-#: catalog/models/common.py:97
+#: catalog/models/common.py:99
 msgid "Discogs Release"
 msgstr ""
 
-#: catalog/models/common.py:98
+#: catalog/models/common.py:100
 msgid "Discogs Master"
 msgstr ""
 
-#: catalog/models/common.py:101
+#: catalog/models/common.py:103
 msgid "MusicBrainz Release Group"
 msgstr ""
 
-#: catalog/models/common.py:103
+#: catalog/models/common.py:105
 msgid "MusicBrainz Release"
 msgstr ""
 
-#: catalog/models/common.py:104
+#: catalog/models/common.py:106
 msgid "MusicBrainz Artist"
 msgstr ""
 
-#: catalog/models/common.py:105
+#: catalog/models/common.py:107
 msgid "Douban Personage"
 msgstr ""
 
-#: catalog/models/common.py:106
+#: catalog/models/common.py:108
 #, fuzzy
 msgid "Goodreads Author"
 msgstr "Goodreads"
 
-#: catalog/models/common.py:107
+#: catalog/models/common.py:109
 msgid "Spotify Artist"
 msgstr ""
 
-#: catalog/models/common.py:108
+#: catalog/models/common.py:110
 msgid "TMDB Person"
 msgstr ""
 
-#: catalog/models/common.py:109
+#: catalog/models/common.py:111
 msgid "Open Library Author"
 msgstr ""
 
-#: catalog/models/common.py:110
+#: catalog/models/common.py:112
 msgid "IGDB Company"
 msgstr ""
 
-#: catalog/models/common.py:111
+#: catalog/models/common.py:113
 msgid "IGDB Game"
 msgstr ""
 
-#: catalog/models/common.py:112
+#: catalog/models/common.py:114
 msgid "BGG Boardgame"
 msgstr ""
 
-#: catalog/models/common.py:113
+#: catalog/models/common.py:115
 msgid "Steam Game"
 msgstr ""
 
-#: catalog/models/common.py:125
+#: catalog/models/common.py:127
 msgid "Open Library Work"
 msgstr ""
 
-#: catalog/models/common.py:128
+#: catalog/models/common.py:130
 msgid "RateYourMusic Release"
 msgstr ""
 
-#: catalog/models/common.py:132
+#: catalog/models/common.py:134
 msgid "AniList Anime"
 msgstr ""
 
-#: catalog/models/common.py:133
+#: catalog/models/common.py:135
 msgid "AniList Manga"
 msgstr ""
 
-#: catalog/models/common.py:134
+#: catalog/models/common.py:136
 msgid "MyAnimeList Anime"
 msgstr ""
 
-#: catalog/models/common.py:135
+#: catalog/models/common.py:137
 msgid "MyAnimeList Manga"
 msgstr ""
 
-#: catalog/models/common.py:156
+#: catalog/models/common.py:161
 msgid "Edition"
 msgstr ""
 
-#: catalog/models/common.py:157 catalog/templates/_sidebar_edit.html:286
+#: catalog/models/common.py:162 catalog/templates/_sidebar_edit.html:289
 msgid "Work"
 msgstr ""
 
-#: catalog/models/common.py:158
+#: catalog/models/common.py:163
 msgid "TV Series"
 msgstr ""
 
-#: catalog/models/common.py:159 catalog/templates/_sidebar_edit.html:207
+#: catalog/models/common.py:164 catalog/templates/_sidebar_edit.html:202
+#: catalog/views/edit.py:385
 msgid "TV Season"
 msgstr ""
 
-#: catalog/models/common.py:160
+#: catalog/models/common.py:165
 msgid "TV Episode"
 msgstr ""
 
-#: catalog/models/common.py:161 catalog/models/common.py:177
-#: catalog/models/common.py:191 catalog/templates/_sidebar_edit.html:200
-#: journal/templates/_sidebar_user_mark_list.html:35
+#: catalog/models/common.py:166 catalog/models/common.py:182
+#: catalog/models/common.py:196 catalog/templates/_sidebar_edit.html:196
+#: catalog/views/edit.py:384 journal/templates/_sidebar_user_mark_list.html:35
 #: journal/templates/_sidebar_user_tag_filter.html:27
 msgid "Movie"
 msgstr ""
 
-#: catalog/models/common.py:162
+#: catalog/models/common.py:167
 msgid "Album"
 msgstr ""
 
-#: catalog/models/common.py:163 catalog/models/common.py:180
-#: catalog/models/common.py:194 common/templates/_header.html:43
+#: catalog/models/common.py:168 catalog/models/common.py:185
+#: catalog/models/common.py:199 common/templates/_header.html:53
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
 msgstr ""
 
-#: catalog/models/common.py:164
+#: catalog/models/common.py:169
 msgid "Podcast Program"
 msgstr ""
 
-#: catalog/models/common.py:165
+#: catalog/models/common.py:170
 msgid "Podcast Episode"
 msgstr ""
 
-#: catalog/models/common.py:166 catalog/models/common.py:182
-#: catalog/models/common.py:196 common/templates/_header.html:47
+#: catalog/models/common.py:171 catalog/models/common.py:187
+#: catalog/models/common.py:201 common/templates/_header.html:57
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
 msgstr ""
 
-#: catalog/models/common.py:167
+#: catalog/models/common.py:172
 msgid "Production"
 msgstr ""
 
-#: catalog/models/common.py:168
+#: catalog/models/common.py:173
 msgid "Exhibition"
 msgstr ""
 
-#: catalog/models/common.py:169 catalog/models/common.py:186
+#: catalog/models/common.py:174 catalog/models/common.py:191
 #: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr ""
 
-#: catalog/models/common.py:172 catalog/models/common.py:185
+#: catalog/models/common.py:177 catalog/models/common.py:190
 msgid "Person / Organization"
 msgstr ""
 
-#: catalog/models/common.py:176 catalog/models/common.py:190
-#: common/templates/_header.html:27
+#: catalog/models/common.py:181 catalog/models/common.py:195
+#: common/templates/_header.html:37
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
 msgstr ""
 
-#: catalog/models/common.py:178 catalog/models/common.py:192
+#: catalog/models/common.py:183 catalog/models/common.py:197
 #: journal/templates/_sidebar_user_mark_list.html:38
 #: journal/templates/_sidebar_user_tag_filter.html:30
 msgid "TV"
 msgstr ""
 
-#: catalog/models/common.py:179 catalog/models/common.py:193
-#: common/templates/_header.html:39
+#: catalog/models/common.py:184 catalog/models/common.py:198
+#: common/templates/_header.html:49
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr ""
 
-#: catalog/models/common.py:181 catalog/models/common.py:195
-#: catalog/templates/_sidebar_edit.html:219 common/templates/_header.html:35
+#: catalog/models/common.py:186 catalog/models/common.py:200
+#: catalog/templates/_sidebar_edit.html:213 common/templates/_header.html:45
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
 msgstr ""
 
-#: catalog/models/common.py:346 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:345 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr ""
 
-#: catalog/models/common.py:384
+#: catalog/models/common.py:383
 msgid "origin country"
 msgstr ""
 
-#: catalog/models/common.py:413 catalog/templates/album.html:33
+#: catalog/models/common.py:412 catalog/templates/album.html:33
 msgid "album type"
 msgstr ""
 
-#: catalog/models/common.py:417 catalog/templates/_platform_list.html:5
+#: catalog/models/common.py:416 catalog/templates/_platform_list.html:5
 msgid "platform"
 msgstr ""
 
-#: catalog/models/common.py:421
+#: catalog/models/common.py:420
 msgid "media format"
 msgstr ""
 
-#: catalog/models/common.py:426 catalog/templates/_language_list.html:5
-#: users/models/user.py:142
+#: catalog/models/common.py:425 catalog/templates/_language_list.html:5
+#: users/models/user.py:144
 msgid "language"
 msgstr ""
 
-#: catalog/models/creator.py:24
+#: catalog/models/creator.py:26
 msgid "pending"
 msgstr ""
 
-#: catalog/models/creator.py:25
+#: catalog/models/creator.py:27
 msgid "verified"
 msgstr ""
 
-#: catalog/models/creator.py:26
+#: catalog/models/creator.py:28
 msgid "failed"
 msgstr ""
 
-#: catalog/models/creator.py:29
+#: catalog/models/creator.py:31
 msgid "no feed url available for this item"
 msgstr ""
 
-#: catalog/models/creator.py:30
+#: catalog/models/creator.py:32
 msgid "unable to fetch or parse the feed"
 msgstr ""
 
-#: catalog/models/creator.py:31
+#: catalog/models/creator.py:33
 msgid "no audio episode found in the feed"
 msgstr ""
 
-#: catalog/models/creator.py:34
+#: catalog/models/creator.py:36
 msgid "no matching identity found in the feed or its linked website"
 msgstr ""
 
@@ -681,16 +689,16 @@ msgstr ""
 msgid "Special Edition"
 msgstr ""
 
-#: catalog/models/game.py:111 catalog/models/item.py:130
+#: catalog/models/game.py:111 catalog/models/item.py:126
 msgid "designer"
 msgstr ""
 
-#: catalog/models/game.py:119 catalog/models/item.py:129
+#: catalog/models/game.py:119 catalog/models/item.py:125
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr ""
 
-#: catalog/models/game.py:127 catalog/models/item.py:139
+#: catalog/models/game.py:127 catalog/models/item.py:135
 msgid "developer"
 msgstr ""
 
@@ -699,8 +707,8 @@ msgid "date of publication"
 msgstr ""
 
 #: catalog/models/game.py:147 catalog/models/movie.py:156
-#: catalog/models/music.py:128 catalog/models/tv.py:247
-#: catalog/models/tv.py:473
+#: catalog/models/music.py:128 catalog/models/tv.py:249
+#: catalog/models/tv.py:475
 msgid "YYYY, YYYY-MM or YYYY-MM-DD"
 msgstr ""
 
@@ -711,7 +719,7 @@ msgstr ""
 #: catalog/models/game.py:180 catalog/models/movie.py:158
 #: catalog/models/people.py:178 catalog/models/performance.py:258
 #: catalog/models/performance.py:465 catalog/models/podcast.py:89
-#: catalog/models/tv.py:249 catalog/models/tv.py:476
+#: catalog/models/tv.py:251 catalog/models/tv.py:478
 #: catalog/templates/game.html:33 catalog/templates/movie.html:48
 #: catalog/templates/people.html:44 catalog/templates/performance.html:35
 #: catalog/templates/performanceproduction.html:35
@@ -720,146 +728,146 @@ msgstr ""
 msgid "website"
 msgstr ""
 
-#: catalog/models/item.py:125 catalog/models/movie.py:123
+#: catalog/models/item.py:121 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
-#: catalog/models/tv.py:214 catalog/models/tv.py:440
+#: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr ""
 
-#: catalog/models/item.py:126 catalog/models/movie.py:130
+#: catalog/models/item.py:122 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
-#: catalog/models/tv.py:221 catalog/models/tv.py:447
+#: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr ""
 
-#: catalog/models/item.py:127 catalog/models/movie.py:137
+#: catalog/models/item.py:123 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
-#: catalog/models/tv.py:228 catalog/models/tv.py:454
+#: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr ""
 
-#: catalog/models/item.py:128 catalog/models/movie.py:144
-#: catalog/models/tv.py:235 catalog/models/tv.py:461
+#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/tv.py:237 catalog/models/tv.py:463
 msgid "producer"
 msgstr ""
 
-#: catalog/models/item.py:131 catalog/models/performance.py:203
+#: catalog/models/item.py:127 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr ""
 
-#: catalog/models/item.py:132 catalog/models/performance.py:210
+#: catalog/models/item.py:128 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr ""
 
-#: catalog/models/item.py:133 catalog/models/performance.py:224
+#: catalog/models/item.py:129 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr ""
 
-#: catalog/models/item.py:134 catalog/models/podcast.py:80
+#: catalog/models/item.py:130 catalog/models/podcast.py:80
 msgid "host"
 msgstr ""
 
-#: catalog/models/item.py:135 catalog/models/performance.py:196
+#: catalog/models/item.py:131 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr ""
 
-#: catalog/models/item.py:136 catalog/models/performance.py:238
+#: catalog/models/item.py:132 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr ""
 
-#: catalog/models/item.py:140
+#: catalog/models/item.py:136
 msgid "production company"
 msgstr ""
 
-#: catalog/models/item.py:141
+#: catalog/models/item.py:137
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:142
+#: catalog/models/item.py:138
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:139
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:144 catalog/models/performance.py:231
+#: catalog/models/item.py:140 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr ""
 
-#: catalog/models/item.py:147
+#: catalog/models/item.py:143
 msgid "voice actor"
 msgstr ""
 
-#: catalog/models/item.py:148 catalog/templates/edition.html:30
+#: catalog/models/item.py:144 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr ""
 
-#: catalog/models/item.py:173 catalog/models/people.py:476
+#: catalog/models/item.py:169 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr ""
 
-#: catalog/models/item.py:174 catalog/models/people.py:155
+#: catalog/models/item.py:170 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr ""
 
-#: catalog/models/item.py:176 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:288 catalog/models/item.py:320
-#: journal/models/collection.py:96
+#: catalog/models/item.py:304 catalog/models/item.py:336
+#: journal/models/collection.py:100
 msgid "title"
 msgstr ""
 
-#: catalog/models/item.py:289 catalog/models/item.py:328
-#: journal/models/collection.py:97
+#: catalog/models/item.py:305 catalog/models/item.py:344
+#: journal/models/collection.py:101
 msgid "description"
 msgstr ""
 
-#: catalog/models/item.py:300 catalog/models/people.py:484
+#: catalog/models/item.py:316 catalog/models/people.py:484
 msgid "metadata"
 msgstr ""
 
-#: catalog/models/item.py:302 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
 msgid "cover"
 msgstr ""
 
-#: catalog/models/item.py:1485
+#: catalog/models/item.py:1526
 msgid "source site"
 msgstr ""
 
-#: catalog/models/item.py:1487
+#: catalog/models/item.py:1528
 msgid "ID on source site"
 msgstr ""
 
-#: catalog/models/item.py:1489
+#: catalog/models/item.py:1530
 msgid "source url"
 msgstr ""
 
-#: catalog/models/item.py:1505
+#: catalog/models/item.py:1546
 msgid "IdType of the source site"
 msgstr ""
 
-#: catalog/models/item.py:1511
+#: catalog/models/item.py:1552
 msgid "Primary Id on the source site"
 msgstr ""
 
-#: catalog/models/item.py:1514
+#: catalog/models/item.py:1555
 msgid "url to the resource"
 msgstr ""
 
 #: catalog/models/movie.py:152 catalog/models/music.py:124
-#: catalog/models/tv.py:243 catalog/models/tv.py:469
+#: catalog/models/tv.py:245 catalog/models/tv.py:471
 #: catalog/templates/_item_card_metadata_album.html:16
 #: catalog/templates/album.html:17 catalog/templates/game.html:22
 #: catalog/templates/movie.html:36 catalog/templates/tvseason.html:53
@@ -874,7 +882,7 @@ msgid "length"
 msgstr ""
 
 #: catalog/models/movie.py:162 catalog/models/music.py:131
-#: catalog/models/tv.py:259 catalog/models/tv.py:486
+#: catalog/models/tv.py:261 catalog/models/tv.py:488
 msgid "seconds"
 msgstr ""
 
@@ -1036,32 +1044,83 @@ msgstr ""
 msgid "closing date"
 msgstr ""
 
-#: catalog/models/tv.py:186 catalog/templates/tvseason.html:38
+#: catalog/models/tv.py:188 catalog/templates/tvseason.html:38
 #: catalog/templates/tvshow.html:33
 msgid "number of seasons"
 msgstr ""
 
-#: catalog/models/tv.py:189 catalog/models/tv.py:415
+#: catalog/models/tv.py:191 catalog/models/tv.py:417
 #: catalog/templates/tvseason.html:43 catalog/templates/tvshow.html:38
 msgid "number of episodes"
 msgstr ""
 
-#: catalog/models/tv.py:256 catalog/models/tv.py:483
+#: catalog/models/tv.py:258 catalog/models/tv.py:485
 msgid "episode length"
 msgstr ""
 
-#: catalog/models/tv.py:412 catalog/templates/tvseason.html:33
+#: catalog/models/tv.py:414 catalog/templates/tvseason.html:33
 msgid "season number"
 msgstr ""
 
-#: catalog/models/tv.py:530
+#: catalog/models/tv.py:532
 #, python-brace-format
 msgid "{show_title} Season {season_number}"
 msgstr ""
 
-#: catalog/models/tv.py:684
+#: catalog/models/tv.py:686
 #, python-brace-format
 msgid "{season_title} E{episode_number}"
+msgstr ""
+
+#: catalog/templates/_catalog_confirm_item.html:7
+#: catalog/templates/catalog_edit.html:62
+msgid "Item has been deleted."
+msgstr ""
+
+#: catalog/templates/_catalog_confirm_item.html:12
+#: catalog/templates/catalog_edit.html:65
+msgid "Item contains sub-items."
+msgstr ""
+
+#: catalog/templates/_catalog_confirm_item.html:17
+msgid "Item has been merged to another item."
+msgstr ""
+
+#: catalog/templates/_catalog_confirm_item.html:22
+msgid "Item has been marked by users."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:11
+msgid "Confirm changes"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:16
+msgid "Please correct the errors below."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:24
+msgid "Field"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:25
+msgid "From"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:26
+msgid "To"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:45
+msgid "No changes detected."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:54
+#: users/templates/users/register.html:104
+msgid "Confirm and save"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:57
+msgid "Back to editing"
 msgstr ""
 
 #: catalog/templates/_country_list.html:5
@@ -1069,9 +1128,7 @@ msgid "region"
 msgstr ""
 
 #: catalog/templates/_fetch_failed.html:4
-msgid ""
-"Unable to fetch from the link, please check again. Some sites may require "
-"login for certain links, please manually create them here."
+msgid "Unable to fetch from the link, please check again. Some sites may require login for certain links, please manually create them here."
 msgstr ""
 
 #: catalog/templates/_item_card_metadata_album.html:7
@@ -1127,7 +1184,7 @@ msgstr ""
 #: journal/templates/profile_posts.html:21
 #: journal/templates/user_follow_list_items.html:63
 #: journal/templates/user_post_list_items.html:24
-#: social/templates/events.html:43 social/templates/feed_events.html:28
+#: social/templates/events.html:43 social/templates/feed_events.html:27
 msgid "nothing more."
 msgstr ""
 
@@ -1214,7 +1271,7 @@ msgid "Add note"
 msgstr ""
 
 #: catalog/templates/_item_user_pieces.html:83
-#: common/templates/_sidebar.html:196 journal/templates/profile_items.html:46
+#: common/templates/_sidebar.html:195 journal/templates/profile_items.html:46
 msgid "Set progress"
 msgstr ""
 
@@ -1240,6 +1297,10 @@ msgstr ""
 
 #: catalog/templates/_item_user_pieces.html:214
 msgid "mark history"
+msgstr ""
+
+#: catalog/templates/_search_suggest.html:2
+msgid "Suggestions"
 msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:8
@@ -1269,15 +1330,15 @@ msgid "Edit Options"
 msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
-#: catalog/views/edit.py:82 catalog/views/edit.py:143 catalog/views/edit.py:197
-#: catalog/views/edit.py:218 catalog/views/edit.py:259
-#: catalog/views/edit.py:328 catalog/views/edit.py:332
-#: catalog/views/edit.py:351 catalog/views/edit.py:400
-#: catalog/views/edit.py:425 catalog/views/edit.py:440
-#: catalog/views/edit.py:480 catalog/views/edit.py:490
-#: catalog/views/edit.py:517 catalog/views/edit.py:582
-#: catalog/views/edit.py:637 catalog/views/edit.py:659
-#: catalog/views/search.py:367
+#: catalog/views/edit.py:160 catalog/views/edit.py:221
+#: catalog/views/edit.py:288 catalog/views/edit.py:309
+#: catalog/views/edit.py:364 catalog/views/edit.py:471
+#: catalog/views/edit.py:475 catalog/views/edit.py:509
+#: catalog/views/edit.py:576 catalog/views/edit.py:601
+#: catalog/views/edit.py:624 catalog/views/edit.py:664
+#: catalog/views/edit.py:674 catalog/views/edit.py:703
+#: catalog/views/edit.py:782 catalog/views/edit.py:837
+#: catalog/views/edit.py:859 catalog/views/search.py:418
 msgid "Editing this item is restricted."
 msgstr ""
 
@@ -1305,7 +1366,7 @@ msgstr ""
 msgid "The following items are merged into this item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:70
+#: catalog/templates/_sidebar_edit.html:70 catalog/views/edit.py:456
 msgid "External website"
 msgstr ""
 
@@ -1325,35 +1386,31 @@ msgstr ""
 msgid "Fetch again"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:97
-msgid "You may not be able to undo this operation, sure to remove?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:102
+#: catalog/templates/_sidebar_edit.html:100
 msgid "Remove link to site"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:110
+#: catalog/templates/_sidebar_edit.html:108
 msgid "Choose cover"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:119
+#: catalog/templates/_sidebar_edit.html:117
+#: catalog/templates/_sidebar_edit.html:118
 #: catalog/templates/_sidebar_edit.html:120
-#: catalog/templates/_sidebar_edit.html:122
 msgid "Current cover"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:139
+#: catalog/templates/_sidebar_edit.html:137
 msgid "Select an image to use as the cover of this item."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:140
-#: catalog/templates/catalog_edit.html:65
-#: common/templates/manage/settings.html:136
+#: catalog/templates/_sidebar_edit.html:138
+#: catalog/templates/catalog_edit.html:78
+#: common/templates/manage/settings.html:19
 #: journal/templates/add_to_collection.html:43
 #: journal/templates/article_edit.html:60
 #: journal/templates/collection_edit.html:39 journal/templates/comment.html:41
-#: journal/templates/mark.html:134 journal/templates/note.html:65
+#: journal/templates/mark.html:138 journal/templates/note.html:65
 #: journal/templates/post_compose.html:103
 #: journal/templates/review_edit.html:46 journal/templates/tag_edit.html:51
 #: users/templates/users/_pref_device.html:37
@@ -1362,181 +1419,157 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:147
+#: catalog/templates/_sidebar_edit.html:145
 msgid "Edit sub-items"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:160
+#: catalog/templates/_sidebar_edit.html:158
 msgid "create"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:166
+#: catalog/templates/_sidebar_edit.html:164
 msgid "Fetch all episodes"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:171
+#: catalog/templates/_sidebar_edit.html:169
 msgid "Fetch all"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:172
-msgid ""
-"Due to differences in how Douban, IMDB, and TMDB handle season data, a small "
-"number of TV shows and animations may not return correct results. Please "
-"manually verify and clean up after updating."
+#: catalog/templates/_sidebar_edit.html:170
+msgid "Due to differences in how Douban, IMDB, and TMDB handle season data, a small number of TV shows and animations may not return correct results. Please manually verify and clean up after updating."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:173
+#: catalog/templates/_sidebar_edit.html:171
 msgid "Up to 250 episodes will be fetched for a season."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:176
-msgid ""
-"To fetch all episodes, season numbers and IMDB information are required. If "
-"filling this out is inconvenient, you can also manually create sub-entries."
+#: catalog/templates/_sidebar_edit.html:174
+msgid "To fetch all episodes, season numbers and IMDB information are required. If filling this out is inconvenient, you can also manually create sub-entries."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:182
-#: catalog/templates/_sidebar_edit.html:194
-#: catalog/templates/_sidebar_edit.html:213
+#: catalog/templates/_sidebar_edit.html:180
+#: catalog/templates/_sidebar_edit.html:191
+#: catalog/templates/_sidebar_edit.html:208
 msgid "switch category"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:185
-msgid "Switching may remove some metadata. Sure to proceed?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:188
+#: catalog/templates/_sidebar_edit.html:185 catalog/views/edit.py:383
 msgid "TV Show"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:227
+#: catalog/templates/_sidebar_edit.html:221
 msgid "Link to parent item"
 msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:230
-msgid "Sure to link?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:237
 msgid "Update link"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:243
+#: catalog/templates/_sidebar_edit.html:236
 msgid "Cleanup seasons"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:246
-#: catalog/templates/catalog_delete.html:45
-msgid "This operation cannot be undone. Sure to delete?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:250
+#: catalog/templates/_sidebar_edit.html:242
 msgid "remove seasons not marked"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:256
-#: catalog/templates/catalog_merge.html:12
+#: catalog/templates/_sidebar_edit.html:248
 msgid "Merge"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:262
+#: catalog/templates/_sidebar_edit.html:254
 msgid "URL of target item, or empty if undo merge"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:268
-#: catalog/templates/_sidebar_edit.html:348
+#: catalog/templates/_sidebar_edit.html:260
+#: catalog/templates/_sidebar_edit.html:350
 msgid "merge to another item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:273
-#: catalog/templates/_sidebar_edit.html:277
-#: catalog/templates/catalog_delete.html:12
+#: catalog/templates/_sidebar_edit.html:265
+#: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
 #: journal/templates/article.html:199 journal/templates/collection.html:188
-#: journal/templates/mark.html:149 journal/templates/note.html:82
+#: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
 #: users/templates/users/account.html:254
 msgid "Delete"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:287
+#: catalog/templates/_sidebar_edit.html:275
+#: catalog/templates/_sidebar_edit.html:279
+msgid "Undo delete"
+msgstr ""
+
+#: catalog/templates/_sidebar_edit.html:280
+msgid "Links to external sites and parent item were removed on delete and will not be restored."
+msgstr ""
+
+#: catalog/templates/_sidebar_edit.html:290
 msgid "This edition belongs to the following work"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:292
-msgid "Sure to unlink?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:298
+#: catalog/templates/_sidebar_edit.html:300
 msgid "Unlink from work"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:304
+#: catalog/templates/_sidebar_edit.html:306
 msgid "Link"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:315
+#: catalog/templates/_sidebar_edit.html:317
 msgid "Link to another edition from same work"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:324
+#: catalog/templates/_sidebar_edit.html:326
 msgid "Restriction"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:337
+#: catalog/templates/_sidebar_edit.html:339
 #: journal/templates/collection_update_item_note.html:4
 msgid "Update"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:342
+#: catalog/templates/_sidebar_edit.html:344
 msgid "Suggest Edits"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:347
+#: catalog/templates/_sidebar_edit.html:349
 msgid "proposed action"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:349
+#: catalog/templates/_sidebar_edit.html:351
 msgid "link to another item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:350
+#: catalog/templates/_sidebar_edit.html:352
 msgid "change item category"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:351
+#: catalog/templates/_sidebar_edit.html:353
 msgid "change item metadata"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:352
+#: catalog/templates/_sidebar_edit.html:354
 msgid "remove item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:353
+#: catalog/templates/_sidebar_edit.html:355
 msgid "other"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:357
-msgid ""
-"To suggest merging or association, please include the URL of the target item"
+#: catalog/templates/_sidebar_edit.html:359
+msgid "To suggest merging or association, please include the URL of the target item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:358
+#: catalog/templates/_sidebar_edit.html:360
 #: catalog/templates/catalog_verify.html:116
 msgid "submit"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:359
-msgid ""
-"As a user of this community, you may edit some metadata of items on this "
-"site. If you are unsure whether your edits are appropriate or are unable to "
-"make a certain change, you can make suggestions here. Moderators will "
-"consider each suggestion, although there is no guarantee that they will "
-"always be fully adopted; suggestions may also be viewed or discussed by "
-"other community users. If you have suggestions that are not related to a "
-"specific item, please contact us. Thank you for your support and "
-"contribution."
+#: catalog/templates/_sidebar_edit.html:361
+msgid "As a user of this community, you may edit some metadata of items on this site. If you are unsure whether your edits are appropriate or are unable to make a certain change, you can make suggestions here. Moderators will consider each suggestion, although there is no guarantee that they will always be fully adopted; suggestions may also be viewed or discussed by other community users. If you have suggestions that are not related to a specific item, please contact us. Thank you for your support and contribution."
 msgstr ""
 
 #: catalog/templates/_sidebar_search.html:5
@@ -1634,16 +1667,14 @@ msgid "matched"
 msgstr ""
 
 #: catalog/templates/_verify_status.html:21
-msgid ""
-"Sure to remove your creator verification? Anyone will be able to edit this "
-"item again."
+msgid "Sure to remove your creator verification? Anyone will be able to edit this item again."
 msgstr ""
 
 #: catalog/templates/_verify_status.html:26
 msgid "Remove my verification"
 msgstr ""
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:309
+#: catalog/templates/_verify_status.html:31 users/views/account.py:311
 msgid "Verification failed"
 msgstr ""
 
@@ -1680,43 +1711,11 @@ msgstr ""
 msgid "album media"
 msgstr ""
 
-#: catalog/templates/catalog_delete.html:19
-msgid "Are you sure to delete?"
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:24
-#: catalog/templates/catalog_edit.html:52
-#: catalog/templates/catalog_merge.html:36
-#: catalog/templates/catalog_merge.html:64
-msgid "Item has been deleted."
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:29
-#: catalog/templates/catalog_edit.html:55
-#: catalog/templates/catalog_merge.html:41
-#: catalog/templates/catalog_merge.html:69
-msgid "Item contains sub-items."
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:34
-#: catalog/templates/catalog_merge.html:46
-#: catalog/templates/catalog_merge.html:74
-msgid "Item has been merged to another item."
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:39
-#: catalog/templates/catalog_merge.html:51
-#: catalog/templates/catalog_merge.html:79
-msgid "Item has been marked by users."
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:48
-#: catalog/templates/catalog_merge.html:92 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:55 common/views_manage.py:139
 msgid "Yes"
 msgstr ""
 
-#: catalog/templates/catalog_delete.html:49
-#: catalog/templates/catalog_merge.html:93 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:56 common/views_manage.py:139
 msgid "No"
 msgstr ""
 
@@ -1725,36 +1724,18 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: catalog/templates/catalog_edit.html:68
+#: catalog/templates/catalog_edit.html:81
 #: journal/templates/collection_update_item_note.html:8
 #: journal/templates/piece_delete.html:38
 msgid "Cancel"
 msgstr ""
 
-#: catalog/templates/catalog_edit.html:104
+#: catalog/templates/catalog_edit.html:118
 msgid "open linked people page"
 msgstr ""
 
-#: catalog/templates/catalog_merge.html:22
-msgid "Are you sure to merge?"
-msgstr ""
-
-#: catalog/templates/catalog_merge.html:24
-msgid "Are you sure to cancel merge?"
-msgstr ""
-
-#: catalog/templates/catalog_merge.html:27
-msgid "Are you sure to link?"
-msgstr ""
-
-#: catalog/templates/catalog_merge.html:86
-msgid "This operation cannot be undone. Sure to merge?"
-msgstr ""
-
 #: catalog/templates/catalog_verify.html:21
-msgid ""
-"If you are a creator of this podcast, you may verify the ownership, so that "
-"only you (and other verified creators) can edit its metadata on this site."
+msgid "If you are a creator of this podcast, you may verify the ownership, so that only you (and other verified creators) can edit its metadata on this site."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:22
@@ -1762,9 +1743,7 @@ msgid "Your recent episodes may also occasionally be featured in discovery."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:24
-msgid ""
-"To verify, prove you control one of the following identifiers of your "
-"account (click to copy):"
+msgid "To verify, prove you control one of the following identifiers of your account (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:30
@@ -1775,18 +1754,11 @@ msgid "copied"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:35
-msgid ""
-"You can prove this in a few ways, then start verification: add one of the "
-"identifiers above to the podcast feed's description; add a <code>rel=\"me\"</"
-"code> link back to one of them on the web page your feed links to (the link "
-"verification Mastodon uses); or point your feed's website at your Bluesky "
-"handle's own domain."
+msgid "You can prove this in a few ways, then start verification: add one of the identifiers above to the podcast feed's description; add a <code>rel=\"me\"</code> link back to one of them on the web page your feed links to (the link verification Mastodon uses); or point your feed's website at your Bluesky handle's own domain."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:44
-msgid ""
-"For example, add this rel=me link to the web page your feed links to (click "
-"to copy):"
+msgid "For example, add this rel=me link to the web page your feed links to (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:50
@@ -1794,9 +1766,7 @@ msgid "or, in the page's head:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:57
-msgid ""
-"Can't edit the website? Just add a line like this to your feed's description "
-"instead (click to copy):"
+msgid "Can't edit the website? Just add a line like this to your feed's description instead (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:62
@@ -1804,10 +1774,7 @@ msgid "Welcome to follow me on the Fediverse:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:66
-msgid ""
-"NeoDB does not re-check this periodically at the moment, but we recommend "
-"you keep it so that your audience can discover and connect with you in "
-"distributed social media."
+msgid "NeoDB does not re-check this periodically at the moment, but we recommend you keep it so that your audience can discover and connect with you in distributed social media."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:72
@@ -1835,12 +1802,11 @@ msgid "Send feedback"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:115
-msgid ""
-"Questions or issues with creator verification? Let the site moderators know."
+msgid "Questions or issues with creator verification? Let the site moderators know."
 msgstr ""
 
-#: catalog/templates/discover.html:28 common/views_manage.py:145
-#: common/views_manage.py:353 users/templates/users/preferences.html:34
+#: catalog/templates/discover.html:28 common/views_manage.py:35
+#: common/views_manage.py:431 users/templates/users/preferences.html:34
 msgid "Discover"
 msgstr ""
 
@@ -1878,17 +1844,17 @@ msgstr ""
 msgid "hide"
 msgstr ""
 
-#: catalog/templates/discover.html:206 common/templates/_sidebar.html:14
+#: catalog/templates/discover.html:206 common/templates/_sidebar.html:13
 msgid "Unread Announcements"
 msgstr ""
 
-#: catalog/templates/discover.html:212 common/templates/_sidebar.html:20
+#: catalog/templates/discover.html:212 common/templates/_sidebar.html:19
 #: social/templates/notification.html:67
 msgid "mark all as read"
 msgstr ""
 
 #: catalog/templates/discover.html:222
-#: common/templates/_sidebar_anonymous.html:55
+#: common/templates/_sidebar_anonymous.html:54
 msgid "Popular Tags"
 msgstr ""
 
@@ -1899,9 +1865,9 @@ msgstr ""
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
 #: catalog/templates/user_verified_works.html:23
-#: common/templates/_sidebar.html:127
-#: common/templates/_sidebar_anonymous.html:46
-#: common/templates/_sidebar_anonymous.html:62 journal/templates/posts.html:8
+#: common/templates/_sidebar.html:126
+#: common/templates/_sidebar_anonymous.html:45
+#: common/templates/_sidebar_anonymous.html:61 journal/templates/posts.html:7
 #: journal/templates/profile_articles.html:24
 #: journal/templates/profile_articles.html:26
 #: journal/templates/profile_items.html:65
@@ -1917,7 +1883,7 @@ msgstr ""
 msgid "nothing so far."
 msgstr ""
 
-#: catalog/templates/discover.html:239 common/templates/_sidebar.html:269
+#: catalog/templates/discover.html:239 common/templates/_sidebar.html:268
 msgid "Recent Posts"
 msgstr ""
 
@@ -1943,9 +1909,7 @@ msgid "Borrow or Buy"
 msgstr ""
 
 #: catalog/templates/external_search_results.html:10
-msgid ""
-"Some items were found from other websites and instances, click their title "
-"to save them locally."
+msgid "Some items were found from other websites and instances, click their title to save them locally."
 msgstr ""
 
 #: catalog/templates/fetch_pending.html:13
@@ -2045,12 +2009,12 @@ msgstr ""
 msgid "number of Episodes"
 msgstr ""
 
-#: catalog/templates/people.html:13 common/templates/_sidebar.html:77
-#: common/templates/_sidebar.html:84 journal/models/shelf.py:326
+#: catalog/templates/people.html:13 common/templates/_sidebar.html:76
+#: common/templates/_sidebar.html:83 journal/models/shelf.py:328
 msgid "following"
 msgstr ""
 
-#: catalog/templates/people.html:15 journal/models/shelf.py:324
+#: catalog/templates/people.html:15 journal/models/shelf.py:326
 #: social/templates/notification.html:60
 msgid "follow"
 msgstr ""
@@ -2069,7 +2033,6 @@ msgstr ""
 #: journal/templates/_sidebar_collection_filter.html:14
 #: journal/templates/_sidebar_collection_filter.html:28
 #: journal/templates/_sidebar_user_mark_list.html:56
-#: social/templates/feed.html:42 social/templates/feed.html:44
 #: social/templates/notification.html:56
 msgid "all"
 msgstr ""
@@ -2093,7 +2056,7 @@ msgstr ""
 msgid "production"
 msgstr ""
 
-#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:54
+#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:53
 msgid "verified creator"
 msgstr ""
 
@@ -2174,10 +2137,7 @@ msgid "No items matching your search query."
 msgstr ""
 
 #: catalog/templates/search_results.html:34
-msgid ""
-"If you have URL from one of these sites, please put the full URL (e.g. "
-"<code>https://www.imdb.com/title/tt2513074/</code>) to the search box and "
-"press Enter."
+msgid "If you have URL from one of these sites, please put the full URL (e.g. <code>https://www.imdb.com/title/tt2513074/</code>) to the search box and press Enter."
 msgstr ""
 
 #: catalog/templates/search_results.html:48
@@ -2214,97 +2174,170 @@ msgstr ""
 msgid "Editions"
 msgstr ""
 
-#: catalog/views/edit.py:202 catalog/views/edit.py:205
-#: catalog/views/edit.py:306 catalog/views/edit.py:309
-#: catalog/views/verify.py:197 journal/views/collection.py:77
-#: journal/views/collection.py:102 journal/views/collection.py:556
-#: journal/views/collection.py:651 journal/views/common.py:221
-#: journal/views/mark.py:196 journal/views/post.py:117
-#: journal/views/post.py:119 journal/views/post.py:166
-#: journal/views/post.py:185 journal/views/post.py:187
-#: journal/views/post.py:228 journal/views/post.py:241
+#: catalog/views/edit.py:293 catalog/views/edit.py:296
+#: catalog/views/edit.py:440 catalog/views/edit.py:443
+#: catalog/views/verify.py:197 journal/views/collection.py:75
+#: journal/views/collection.py:100 journal/views/collection.py:538
+#: journal/views/collection.py:634 journal/views/common.py:231
+#: journal/views/mark.py:244 journal/views/post.py:119
+#: journal/views/post.py:121 journal/views/post.py:168
+#: journal/views/post.py:187 journal/views/post.py:189
+#: journal/views/post.py:230 journal/views/post.py:243
 #: journal/views/review.py:154 journal/views/review.py:158
-#: users/views/actions.py:179
+#: users/views/actions.py:178
 msgid "Invalid parameter"
 msgstr ""
 
-#: catalog/views/edit.py:220
+#: catalog/views/edit.py:313
 msgid "Item in use."
 msgstr ""
 
-#: catalog/views/edit.py:222
+#: catalog/views/edit.py:315
 msgid "Item cannot be deleted."
 msgstr ""
 
-#: catalog/views/edit.py:247 catalog/views/edit.py:303
-#: catalog/views/edit.py:427 catalog/views/edit.py:519
-#: catalog/views/edit.py:552 catalog/views/verify.py:158
+#: catalog/views/edit.py:319 catalog/views/edit.py:515
+msgid "Are you sure to delete?"
+msgstr ""
+
+#: catalog/views/edit.py:323 catalog/views/edit.py:518
+#: catalog/views/edit.py:617
+msgid "This operation cannot be undone."
+msgstr ""
+
+#: catalog/views/edit.py:344 catalog/views/edit.py:437
+#: catalog/views/edit.py:603 catalog/views/edit.py:705
+#: catalog/views/edit.py:752 catalog/views/verify.py:158
 #: catalog/views/verify.py:206 journal/views/article.py:44
 #: journal/views/article.py:133 journal/views/article.py:153
 #: journal/views/collection.py:248 journal/views/collection.py:341
-#: journal/views/collection.py:360 journal/views/collection.py:384
-#: journal/views/collection.py:457 journal/views/collection.py:500
-#: journal/views/collection.py:539 journal/views/collection.py:551
-#: journal/views/collection.py:576 journal/views/collection.py:613
-#: journal/views/common.py:300 journal/views/mark.py:281
-#: journal/views/post.py:58 journal/views/post.py:78 journal/views/post.py:100
-#: journal/views/post.py:170 journal/views/post.py:199
-#: journal/views/post.py:272 journal/views/post.py:287
-#: journal/views/post.py:394 journal/views/post.py:549
+#: journal/views/collection.py:354 journal/views/collection.py:372
+#: journal/views/collection.py:439 journal/views/collection.py:482
+#: journal/views/collection.py:521 journal/views/collection.py:533
+#: journal/views/collection.py:558 journal/views/collection.py:595
+#: journal/views/common.py:304 journal/views/mark.py:317
+#: journal/views/post.py:60 journal/views/post.py:80 journal/views/post.py:102
+#: journal/views/post.py:172 journal/views/post.py:201
+#: journal/views/post.py:274 journal/views/post.py:289
+#: journal/views/post.py:390 journal/views/post.py:539
 #: journal/views/review.py:64 journal/views/review.py:81
 #: journal/views/review.py:106
 msgid "Insufficient permission"
 msgstr ""
 
-#: catalog/views/edit.py:374
+#: catalog/views/edit.py:346
+msgid "Item is not deleted"
+msgstr ""
+
+#: catalog/views/edit.py:389
+msgid "Switching may remove some metadata."
+msgstr ""
+
+#: catalog/views/edit.py:395
+msgid "The following seasons will be detached from this show"
+msgstr ""
+
+#: catalog/views/edit.py:400
+msgid "Links to IMDB and TMDB will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:403
+msgid "Are you sure to switch category?"
+msgstr ""
+
+#: catalog/views/edit.py:451
+msgid "Are you sure to remove the link to this site?"
+msgstr ""
+
+#: catalog/views/edit.py:457
+msgid "You may not be able to undo this operation."
+msgstr ""
+
+#: catalog/views/edit.py:483
+msgid "Current parent item"
+msgstr ""
+
+#: catalog/views/edit.py:487
+msgid "The link to the parent item will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:490 catalog/views/edit.py:680
+msgid "Are you sure to link?"
+msgstr ""
+
+#: catalog/views/edit.py:521
+msgid "The following seasons will be deleted"
+msgstr ""
+
+#: catalog/views/edit.py:525
+msgid "The following seasons will be kept"
+msgstr ""
+
+#: catalog/views/edit.py:550
 msgid "TV Season with IMDB id and season number required."
 msgstr ""
 
-#: catalog/views/edit.py:380
+#: catalog/views/edit.py:556
 msgid "Updating episodes"
 msgstr ""
 
-#: catalog/views/edit.py:405
+#: catalog/views/edit.py:581
 msgid "This person has no supported source to fetch works from."
 msgstr ""
 
-#: catalog/views/edit.py:412
+#: catalog/views/edit.py:588
 msgid "Already pulling works for this person, try again later."
 msgstr ""
 
-#: catalog/views/edit.py:416
+#: catalog/views/edit.py:592
 msgid "Pulling works in background."
 msgstr ""
 
-#: catalog/views/edit.py:438
+#: catalog/views/edit.py:609
+msgid "Are you sure to merge?"
+msgstr ""
+
+#: catalog/views/edit.py:611
+msgid "Are you sure to cancel merge?"
+msgstr ""
+
+#: catalog/views/edit.py:622
 msgid "Cannot be merged to an item already deleted or merged"
 msgstr ""
 
-#: catalog/views/edit.py:443
+#: catalog/views/edit.py:627
 msgid "Cannot merge items in different categories"
 msgstr ""
 
-#: catalog/views/edit.py:447
+#: catalog/views/edit.py:631
 msgid "Cannot merge an item to itself"
 msgstr ""
 
-#: catalog/views/edit.py:488
+#: catalog/views/edit.py:672
 msgid "Cannot be linked to an item already deleted or merged"
 msgstr ""
 
-#: catalog/views/edit.py:492
+#: catalog/views/edit.py:676
 msgid "Cannot link items other than editions"
 msgstr ""
 
-#: catalog/views/search.py:96
+#: catalog/views/edit.py:710
+msgid "Are you sure to unlink?"
+msgstr ""
+
+#: catalog/views/edit.py:715
+msgid "This edition will be unlinked from the following work"
+msgstr ""
+
+#: catalog/views/search.py:113
 msgid "the internet"
 msgstr ""
 
-#: catalog/views/search.py:359
+#: catalog/views/search.py:410
 msgid "Invalid URL"
 msgstr ""
 
-#: catalog/views/search.py:362
+#: catalog/views/search.py:413
 msgid "Unsupported URL"
 msgstr ""
 
@@ -2328,9 +2361,9 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:122 common/utils.py:163
+#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
 #: journal/views/article.py:186 journal/views/review.py:182
-#: users/views/actions.py:45 users/views/actions.py:131
+#: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
 msgstr ""
 
@@ -2342,15 +2375,15 @@ msgstr ""
 msgid "Creator verification removed."
 msgstr ""
 
-#: catalog/views/view.py:74 catalog/views/view.py:99
+#: catalog/views/view.py:77 catalog/views/view.py:102
 msgid "Item not found"
 msgstr ""
 
-#: catalog/views/view.py:78 catalog/views/view.py:107 catalog/views/view.py:190
+#: catalog/views/view.py:81 catalog/views/view.py:110 catalog/views/view.py:193
 msgid "Item no longer exists"
 msgstr ""
 
-#: catalog/views/view.py:187
+#: catalog/views/view.py:190
 msgid "Invalid role"
 msgstr ""
 
@@ -2834,759 +2867,759 @@ msgctxt "genre"
 msgid "Health"
 msgstr ""
 
-#: common/models/lang.py:54
+#: common/models/lang.py:56
 msgid "Afar"
 msgstr ""
 
-#: common/models/lang.py:55
+#: common/models/lang.py:57
 msgid "Afrikaans"
 msgstr ""
 
-#: common/models/lang.py:56
+#: common/models/lang.py:58
 msgid "Akan"
 msgstr ""
 
-#: common/models/lang.py:57
+#: common/models/lang.py:59
 msgid "Aragonese"
 msgstr ""
 
-#: common/models/lang.py:58
+#: common/models/lang.py:60
 msgid "Assamese"
 msgstr ""
 
-#: common/models/lang.py:59
+#: common/models/lang.py:61
 msgid "Avaric"
 msgstr ""
 
-#: common/models/lang.py:60
+#: common/models/lang.py:62
 msgid "Avestan"
 msgstr ""
 
-#: common/models/lang.py:61
+#: common/models/lang.py:63
 msgid "Aymara"
 msgstr ""
 
-#: common/models/lang.py:62
+#: common/models/lang.py:64
 msgid "Azerbaijani"
 msgstr ""
 
-#: common/models/lang.py:63
+#: common/models/lang.py:65
 msgid "Bashkir"
 msgstr ""
 
-#: common/models/lang.py:64
+#: common/models/lang.py:66
 msgid "Bambara"
 msgstr ""
 
-#: common/models/lang.py:65
+#: common/models/lang.py:67
 msgid "Bislama"
 msgstr ""
 
-#: common/models/lang.py:66
+#: common/models/lang.py:68
 msgid "Tibetan"
 msgstr ""
 
-#: common/models/lang.py:67
+#: common/models/lang.py:69
 msgid "Breton"
 msgstr ""
 
-#: common/models/lang.py:68
+#: common/models/lang.py:70
 msgid "Catalan"
 msgstr ""
 
-#: common/models/lang.py:69
+#: common/models/lang.py:71
 msgid "Czech"
 msgstr ""
 
-#: common/models/lang.py:70
+#: common/models/lang.py:72
 msgid "Chechen"
 msgstr ""
 
-#: common/models/lang.py:71
+#: common/models/lang.py:73
 msgid "Slavic"
 msgstr ""
 
-#: common/models/lang.py:72
+#: common/models/lang.py:74
 msgid "Chuvash"
 msgstr ""
 
-#: common/models/lang.py:73
+#: common/models/lang.py:75
 msgid "Cornish"
 msgstr ""
 
-#: common/models/lang.py:74
+#: common/models/lang.py:76
 msgid "Corsican"
 msgstr ""
 
-#: common/models/lang.py:75
+#: common/models/lang.py:77
 msgid "Cree"
 msgstr ""
 
-#: common/models/lang.py:76
+#: common/models/lang.py:78
 msgid "Welsh"
 msgstr ""
 
-#: common/models/lang.py:79
+#: common/models/lang.py:81
 msgid "Divehi"
 msgstr ""
 
-#: common/models/lang.py:80
+#: common/models/lang.py:82
 msgid "Dzongkha"
 msgstr ""
 
-#: common/models/lang.py:81
+#: common/models/lang.py:83
 msgid "Esperanto"
 msgstr ""
 
-#: common/models/lang.py:82
+#: common/models/lang.py:84
 msgid "Estonian"
 msgstr ""
 
-#: common/models/lang.py:83
+#: common/models/lang.py:85
 msgid "Basque"
 msgstr ""
 
-#: common/models/lang.py:84
+#: common/models/lang.py:86
 msgid "Faroese"
 msgstr ""
 
-#: common/models/lang.py:85
+#: common/models/lang.py:87
 msgid "Fijian"
 msgstr ""
 
-#: common/models/lang.py:86
+#: common/models/lang.py:88
 msgid "Finnish"
 msgstr ""
 
-#: common/models/lang.py:88
+#: common/models/lang.py:90
 msgid "Frisian"
 msgstr ""
 
-#: common/models/lang.py:89
+#: common/models/lang.py:91
 msgid "Fulah"
 msgstr ""
 
-#: common/models/lang.py:90
+#: common/models/lang.py:92
 msgid "Gaelic"
 msgstr ""
 
-#: common/models/lang.py:91
+#: common/models/lang.py:93
 msgid "Irish"
 msgstr ""
 
-#: common/models/lang.py:92
+#: common/models/lang.py:94
 msgid "Galician"
 msgstr ""
 
-#: common/models/lang.py:93
+#: common/models/lang.py:95
 msgid "Manx"
 msgstr ""
 
-#: common/models/lang.py:94
+#: common/models/lang.py:96
 msgid "Guarani"
 msgstr ""
 
-#: common/models/lang.py:95
+#: common/models/lang.py:97
 msgid "Gujarati"
 msgstr ""
 
-#: common/models/lang.py:96
+#: common/models/lang.py:98
 msgid "Haitian; Haitian Creole"
 msgstr ""
 
-#: common/models/lang.py:97
+#: common/models/lang.py:99
 msgid "Hausa"
 msgstr ""
 
-#: common/models/lang.py:98
+#: common/models/lang.py:100
 msgid "Serbo-Croatian"
 msgstr ""
 
-#: common/models/lang.py:99
+#: common/models/lang.py:101
 msgid "Herero"
 msgstr ""
 
-#: common/models/lang.py:100
+#: common/models/lang.py:102
 msgid "Hiri Motu"
 msgstr ""
 
-#: common/models/lang.py:101
+#: common/models/lang.py:103
 msgid "Croatian"
 msgstr ""
 
-#: common/models/lang.py:102
+#: common/models/lang.py:104
 msgid "Hungarian"
 msgstr ""
 
-#: common/models/lang.py:103
+#: common/models/lang.py:105
 msgid "Igbo"
 msgstr ""
 
-#: common/models/lang.py:104
+#: common/models/lang.py:106
 msgid "Ido"
 msgstr ""
 
-#: common/models/lang.py:105
+#: common/models/lang.py:107
 msgid "Yi"
 msgstr ""
 
-#: common/models/lang.py:106
+#: common/models/lang.py:108
 msgid "Inuktitut"
 msgstr ""
 
-#: common/models/lang.py:107
+#: common/models/lang.py:109
 msgid "Interlingue"
 msgstr ""
 
-#: common/models/lang.py:108
+#: common/models/lang.py:110
 msgid "Interlingua"
 msgstr ""
 
-#: common/models/lang.py:109
+#: common/models/lang.py:111
 msgid "Indonesian"
 msgstr ""
 
-#: common/models/lang.py:110
+#: common/models/lang.py:112
 msgid "Inupiaq"
 msgstr ""
 
-#: common/models/lang.py:111
+#: common/models/lang.py:113
 msgid "Icelandic"
 msgstr ""
 
-#: common/models/lang.py:113
+#: common/models/lang.py:115
 msgid "Javanese"
 msgstr ""
 
-#: common/models/lang.py:114
+#: common/models/lang.py:116
 msgid "Japanese"
 msgstr ""
 
-#: common/models/lang.py:115
+#: common/models/lang.py:117
 msgid "Kalaallisut"
 msgstr ""
 
-#: common/models/lang.py:116
+#: common/models/lang.py:118
 msgid "Kannada"
 msgstr ""
 
-#: common/models/lang.py:117
+#: common/models/lang.py:119
 msgid "Kashmiri"
 msgstr ""
 
-#: common/models/lang.py:118
+#: common/models/lang.py:120
 msgid "Kanuri"
 msgstr ""
 
-#: common/models/lang.py:119
+#: common/models/lang.py:121
 msgid "Kazakh"
 msgstr ""
 
-#: common/models/lang.py:120
+#: common/models/lang.py:122
 msgid "Khmer"
 msgstr ""
 
-#: common/models/lang.py:121
+#: common/models/lang.py:123
 msgid "Kikuyu"
 msgstr ""
 
-#: common/models/lang.py:122
+#: common/models/lang.py:124
 msgid "Kinyarwanda"
 msgstr ""
 
-#: common/models/lang.py:123
+#: common/models/lang.py:125
 msgid "Kirghiz"
 msgstr ""
 
-#: common/models/lang.py:124
+#: common/models/lang.py:126
 msgid "Komi"
 msgstr ""
 
-#: common/models/lang.py:125
+#: common/models/lang.py:127
 msgid "Kongo"
 msgstr ""
 
-#: common/models/lang.py:126
+#: common/models/lang.py:128
 msgid "Korean"
 msgstr ""
 
-#: common/models/lang.py:127
+#: common/models/lang.py:129
 msgid "Kuanyama"
 msgstr ""
 
-#: common/models/lang.py:128
+#: common/models/lang.py:130
 msgid "Kurdish"
 msgstr ""
 
-#: common/models/lang.py:129
+#: common/models/lang.py:131
 msgid "Lao"
 msgstr ""
 
-#: common/models/lang.py:130
+#: common/models/lang.py:132
 msgid "Latin"
 msgstr ""
 
-#: common/models/lang.py:131
+#: common/models/lang.py:133
 msgid "Latvian"
 msgstr ""
 
-#: common/models/lang.py:132
+#: common/models/lang.py:134
 msgid "Limburgish"
 msgstr ""
 
-#: common/models/lang.py:133
+#: common/models/lang.py:135
 msgid "Lingala"
 msgstr ""
 
-#: common/models/lang.py:134
+#: common/models/lang.py:136
 msgid "Lithuanian"
 msgstr ""
 
-#: common/models/lang.py:135
+#: common/models/lang.py:137
 msgid "Letzeburgesch"
 msgstr ""
 
-#: common/models/lang.py:136
+#: common/models/lang.py:138
 msgid "Luba-Katanga"
 msgstr ""
 
-#: common/models/lang.py:137
+#: common/models/lang.py:139
 msgid "Ganda"
 msgstr ""
 
-#: common/models/lang.py:138
+#: common/models/lang.py:140
 msgid "Marshall"
 msgstr ""
 
-#: common/models/lang.py:139
+#: common/models/lang.py:141
 msgid "Malayalam"
 msgstr ""
 
-#: common/models/lang.py:140
+#: common/models/lang.py:142
 msgid "Marathi"
 msgstr ""
 
-#: common/models/lang.py:141
+#: common/models/lang.py:143
 msgid "Malagasy"
 msgstr ""
 
-#: common/models/lang.py:142
+#: common/models/lang.py:144
 msgid "Maltese"
 msgstr ""
 
-#: common/models/lang.py:143
+#: common/models/lang.py:145
 msgid "Moldavian"
 msgstr ""
 
-#: common/models/lang.py:144
+#: common/models/lang.py:146
 msgid "Mongolian"
 msgstr ""
 
-#: common/models/lang.py:145
+#: common/models/lang.py:147
 msgid "Maori"
 msgstr ""
 
-#: common/models/lang.py:146
+#: common/models/lang.py:148
 msgid "Malay"
 msgstr ""
 
-#: common/models/lang.py:147
+#: common/models/lang.py:149
 msgid "Burmese"
 msgstr ""
 
-#: common/models/lang.py:148
+#: common/models/lang.py:150
 msgid "Nauru"
 msgstr ""
 
-#: common/models/lang.py:149
+#: common/models/lang.py:151
 msgid "Navajo"
 msgstr ""
 
-#: common/models/lang.py:150 common/models/lang.py:151
+#: common/models/lang.py:152 common/models/lang.py:153
 msgid "Ndebele"
 msgstr ""
 
-#: common/models/lang.py:152
+#: common/models/lang.py:154
 msgid "Ndonga"
 msgstr ""
 
-#: common/models/lang.py:153
+#: common/models/lang.py:155
 msgid "Nepali"
 msgstr ""
 
-#: common/models/lang.py:154
+#: common/models/lang.py:156
 msgid "Dutch"
 msgstr ""
 
-#: common/models/lang.py:155
+#: common/models/lang.py:157
 msgid "Norwegian Nynorsk"
 msgstr ""
 
-#: common/models/lang.py:156
+#: common/models/lang.py:158
 msgid "Norwegian Bokmål"
 msgstr ""
 
-#: common/models/lang.py:157
+#: common/models/lang.py:159
 msgid "Norwegian"
 msgstr ""
 
-#: common/models/lang.py:158
+#: common/models/lang.py:160
 msgid "Chichewa; Nyanja"
 msgstr ""
 
-#: common/models/lang.py:159
+#: common/models/lang.py:161
 msgid "Occitan"
 msgstr ""
 
-#: common/models/lang.py:160
+#: common/models/lang.py:162
 msgid "Ojibwa"
 msgstr ""
 
-#: common/models/lang.py:161
+#: common/models/lang.py:163
 msgid "Oriya"
 msgstr ""
 
-#: common/models/lang.py:162
+#: common/models/lang.py:164
 msgid "Oromo"
 msgstr ""
 
-#: common/models/lang.py:163
+#: common/models/lang.py:165
 msgid "Ossetian; Ossetic"
 msgstr ""
 
-#: common/models/lang.py:164
+#: common/models/lang.py:166
 msgid "Pali"
 msgstr ""
 
-#: common/models/lang.py:165
+#: common/models/lang.py:167
 msgid "Polish"
 msgstr ""
 
-#: common/models/lang.py:167
+#: common/models/lang.py:169
 msgid "Quechua"
 msgstr ""
 
-#: common/models/lang.py:168
+#: common/models/lang.py:170
 msgid "Raeto-Romance"
 msgstr ""
 
-#: common/models/lang.py:169
+#: common/models/lang.py:171
 msgid "Romanian"
 msgstr ""
 
-#: common/models/lang.py:170
+#: common/models/lang.py:172
 msgid "Rundi"
 msgstr ""
 
-#: common/models/lang.py:171
+#: common/models/lang.py:173
 msgid "Russian"
 msgstr ""
 
-#: common/models/lang.py:172
+#: common/models/lang.py:174
 msgid "Sango"
 msgstr ""
 
-#: common/models/lang.py:173
+#: common/models/lang.py:175
 msgid "Sanskrit"
 msgstr ""
 
-#: common/models/lang.py:174
+#: common/models/lang.py:176
 msgid "Sinhalese"
 msgstr ""
 
-#: common/models/lang.py:175
+#: common/models/lang.py:177
 msgid "Slovak"
 msgstr ""
 
-#: common/models/lang.py:176
+#: common/models/lang.py:178
 msgid "Slovenian"
 msgstr ""
 
-#: common/models/lang.py:177
+#: common/models/lang.py:179
 msgid "Northern Sami"
 msgstr ""
 
-#: common/models/lang.py:178
+#: common/models/lang.py:180
 msgid "Samoan"
 msgstr ""
 
-#: common/models/lang.py:179
+#: common/models/lang.py:181
 msgid "Shona"
 msgstr ""
 
-#: common/models/lang.py:180
+#: common/models/lang.py:182
 msgid "Sindhi"
 msgstr ""
 
-#: common/models/lang.py:181
+#: common/models/lang.py:183
 msgid "Somali"
 msgstr ""
 
-#: common/models/lang.py:182
+#: common/models/lang.py:184
 msgid "Sotho"
 msgstr ""
 
-#: common/models/lang.py:184
+#: common/models/lang.py:186
 msgid "Albanian"
 msgstr ""
 
-#: common/models/lang.py:185
+#: common/models/lang.py:187
 msgid "Sardinian"
 msgstr ""
 
-#: common/models/lang.py:186
+#: common/models/lang.py:188
 msgid "Serbian"
 msgstr ""
 
-#: common/models/lang.py:187
+#: common/models/lang.py:189
 msgid "Swati"
 msgstr ""
 
-#: common/models/lang.py:188
+#: common/models/lang.py:190
 msgid "Sundanese"
 msgstr ""
 
-#: common/models/lang.py:189
+#: common/models/lang.py:191
 msgid "Swahili"
 msgstr ""
 
-#: common/models/lang.py:190
+#: common/models/lang.py:192
 msgid "Swedish"
 msgstr ""
 
-#: common/models/lang.py:191
+#: common/models/lang.py:193
 msgid "Tahitian"
 msgstr ""
 
-#: common/models/lang.py:192
+#: common/models/lang.py:194
 msgid "Tamil"
 msgstr ""
 
-#: common/models/lang.py:193
+#: common/models/lang.py:195
 msgid "Tatar"
 msgstr ""
 
-#: common/models/lang.py:194
+#: common/models/lang.py:196
 msgid "Telugu"
 msgstr ""
 
-#: common/models/lang.py:195
+#: common/models/lang.py:197
 msgid "Tajik"
 msgstr ""
 
-#: common/models/lang.py:196
+#: common/models/lang.py:198
 msgid "Tagalog"
 msgstr ""
 
-#: common/models/lang.py:197
+#: common/models/lang.py:199
 msgid "Thai"
 msgstr ""
 
-#: common/models/lang.py:198
+#: common/models/lang.py:200
 msgid "Tigrinya"
 msgstr ""
 
-#: common/models/lang.py:199
+#: common/models/lang.py:201
 msgid "Tonga"
 msgstr ""
 
-#: common/models/lang.py:200
+#: common/models/lang.py:202
 msgid "Tswana"
 msgstr ""
 
-#: common/models/lang.py:201
+#: common/models/lang.py:203
 msgid "Tsonga"
 msgstr ""
 
-#: common/models/lang.py:202
+#: common/models/lang.py:204
 msgid "Turkmen"
 msgstr ""
 
-#: common/models/lang.py:203
+#: common/models/lang.py:205
 msgid "Turkish"
 msgstr ""
 
-#: common/models/lang.py:204
+#: common/models/lang.py:206
 msgid "Twi"
 msgstr ""
 
-#: common/models/lang.py:205
+#: common/models/lang.py:207
 msgid "Uighur"
 msgstr ""
 
-#: common/models/lang.py:206
+#: common/models/lang.py:208
 msgid "Ukrainian"
 msgstr ""
 
-#: common/models/lang.py:207
+#: common/models/lang.py:209
 msgid "Urdu"
 msgstr ""
 
-#: common/models/lang.py:208
+#: common/models/lang.py:210
 msgid "Uzbek"
 msgstr ""
 
-#: common/models/lang.py:209
+#: common/models/lang.py:211
 msgid "Venda"
 msgstr ""
 
-#: common/models/lang.py:210
+#: common/models/lang.py:212
 msgid "Vietnamese"
 msgstr ""
 
-#: common/models/lang.py:211
+#: common/models/lang.py:213
 msgid "Volapük"
 msgstr ""
 
-#: common/models/lang.py:212
+#: common/models/lang.py:214
 msgid "Walloon"
 msgstr ""
 
-#: common/models/lang.py:213
+#: common/models/lang.py:215
 msgid "Wolof"
 msgstr ""
 
-#: common/models/lang.py:214
+#: common/models/lang.py:216
 msgid "Xhosa"
 msgstr ""
 
-#: common/models/lang.py:215
+#: common/models/lang.py:217
 msgid "Yiddish"
 msgstr ""
 
-#: common/models/lang.py:216
+#: common/models/lang.py:218
 msgid "Zhuang"
 msgstr ""
 
-#: common/models/lang.py:217
+#: common/models/lang.py:219
 msgid "Zulu"
 msgstr ""
 
-#: common/models/lang.py:218
+#: common/models/lang.py:220
 msgid "Abkhazian"
 msgstr ""
 
-#: common/models/lang.py:219
+#: common/models/lang.py:221
 msgid "Chinese"
 msgstr ""
 
-#: common/models/lang.py:220
+#: common/models/lang.py:222
 msgid "Pushto"
 msgstr ""
 
-#: common/models/lang.py:221
+#: common/models/lang.py:223
 msgid "Amharic"
 msgstr ""
 
-#: common/models/lang.py:222
+#: common/models/lang.py:224
 msgid "Arabic"
 msgstr ""
 
-#: common/models/lang.py:223
+#: common/models/lang.py:225
 msgid "Bulgarian"
 msgstr ""
 
-#: common/models/lang.py:224
+#: common/models/lang.py:226
 msgid "Macedonian"
 msgstr ""
 
-#: common/models/lang.py:225
+#: common/models/lang.py:227
 msgid "Greek"
 msgstr ""
 
-#: common/models/lang.py:226
+#: common/models/lang.py:228
 msgid "Persian"
 msgstr ""
 
-#: common/models/lang.py:227
+#: common/models/lang.py:229
 msgid "Hebrew"
 msgstr ""
 
-#: common/models/lang.py:228
+#: common/models/lang.py:230
 msgid "Hindi"
 msgstr ""
 
-#: common/models/lang.py:229
+#: common/models/lang.py:231
 msgid "Armenian"
 msgstr ""
 
-#: common/models/lang.py:231
+#: common/models/lang.py:233
 msgid "Ewe"
 msgstr ""
 
-#: common/models/lang.py:232
+#: common/models/lang.py:234
 msgid "Georgian"
 msgstr ""
 
-#: common/models/lang.py:233
+#: common/models/lang.py:235
 msgid "Punjabi"
 msgstr ""
 
-#: common/models/lang.py:234
+#: common/models/lang.py:236
 msgid "Bengali"
 msgstr ""
 
-#: common/models/lang.py:235
+#: common/models/lang.py:237
 msgid "Bosnian"
 msgstr ""
 
-#: common/models/lang.py:236
+#: common/models/lang.py:238
 msgid "Chamorro"
 msgstr ""
 
-#: common/models/lang.py:237
+#: common/models/lang.py:239
 msgid "Belarusian"
 msgstr ""
 
-#: common/models/lang.py:238
+#: common/models/lang.py:240
 msgid "Yoruba"
 msgstr ""
 
-#: common/models/lang.py:300
+#: common/models/lang.py:302
 msgid "Simplified Chinese (Mainland)"
 msgstr ""
 
-#: common/models/lang.py:301
+#: common/models/lang.py:303
 msgid "Traditional Chinese (Taiwan)"
 msgstr ""
 
-#: common/models/lang.py:302
+#: common/models/lang.py:304
 msgid "Traditional Chinese (Hongkong)"
 msgstr ""
 
-#: common/models/lang.py:310
+#: common/models/lang.py:312
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: common/models/lang.py:313
+#: common/models/lang.py:315
 msgid "Simplified Chinese (Singapore)"
 msgstr ""
 
-#: common/models/lang.py:314
+#: common/models/lang.py:316
 msgid "Simplified Chinese (Malaysia)"
 msgstr ""
 
-#: common/models/lang.py:315
+#: common/models/lang.py:317
 msgid "Traditional Chinese (Macau)"
 msgstr ""
 
-#: common/models/lang.py:323
+#: common/models/lang.py:325
 msgid "Mandarin Chinese"
 msgstr ""
 
-#: common/models/lang.py:324
+#: common/models/lang.py:326
 msgid "Yue Chinese"
 msgstr ""
 
-#: common/models/lang.py:328
+#: common/models/lang.py:330
 msgid "Min Nan Chinese"
 msgstr ""
 
-#: common/models/lang.py:329
+#: common/models/lang.py:331
 msgid "Wu Chinese"
 msgstr ""
 
-#: common/models/lang.py:330
+#: common/models/lang.py:332
 msgid "Hakka Chinese"
 msgstr ""
 
@@ -3716,22 +3749,16 @@ msgid "VCD"
 msgstr ""
 
 #: common/templates/400.html:23
-msgid ""
-"You may have submitted invalid data, or the content may have been deleted by "
-"the author."
+msgid "You may have submitted invalid data, or the content may have been deleted by the author."
 msgstr ""
 
 #: common/templates/400.html:25 common/templates/403.html:24
 #: common/templates/404.html:24
-msgid ""
-"If you believe this is our mistake, please contact us through the link at "
-"the bottom of the page."
+msgid "If you believe this is our mistake, please contact us through the link at the bottom of the page."
 msgstr ""
 
 #: common/templates/403.html:22
-msgid ""
-"Author may require you to log in before accessing this content, or you do "
-"not have permission to view it."
+msgid "Author may require you to log in before accessing this content, or you do not have permission to view it."
 msgstr ""
 
 #: common/templates/404.html:20
@@ -3739,9 +3766,7 @@ msgid "Something is missing"
 msgstr ""
 
 #: common/templates/404.html:22
-msgid ""
-"You may have visited an incorrect URL, or the content you are looking for "
-"has been deleted by the author."
+msgid "You may have visited an incorrect URL, or the content you are looking for has been deleted by the author."
 msgstr ""
 
 #: common/templates/404.html:26
@@ -3749,15 +3774,11 @@ msgid "Go to Home"
 msgstr ""
 
 #: common/templates/500.html:22
-msgid ""
-"An internal error occurred. If this error occurs repeatedly, it will be "
-"recorded and handled by a human."
+msgid "An internal error occurred. If this error occurs repeatedly, it will be recorded and handled by a human."
 msgstr ""
 
 #: common/templates/500.html:24
-msgid ""
-"If you have an urgent situation or any questions, please contact us through "
-"the link at the bottom of the page."
+msgid "If you have an urgent situation or any questions, please contact us through the link at the bottom of the page."
 msgstr ""
 
 #: common/templates/_footer.html:6
@@ -3772,207 +3793,184 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: common/templates/_footer.html:12 users/templates/users/login.html:265
+#: common/templates/_footer.html:12 users/templates/users/login.html:259
 #, python-format
-msgid ""
-"You are visiting an alternative domain for %(site_name)s, please always use "
-"<a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if "
-"possible."
+msgid "You are visiting an alternative domain for %(site_name)s, please always use <a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if possible."
 msgstr ""
 
-#: common/templates/_header.html:19 common/templates/_header.html:164
+#: common/templates/_header.html:19 common/templates/_header.html:177
 msgid "title, creator, ISBN, item url, @user, @user@instance"
 msgstr ""
 
-#: common/templates/_header.html:24
+#: common/templates/_header.html:34
 msgid "All Items"
 msgstr ""
 
-#: common/templates/_header.html:31
+#: common/templates/_header.html:41
 msgid "Movie & TV"
 msgstr ""
 
-#: common/templates/_header.html:50
+#: common/templates/_header.html:60
 msgid "People & Organizations"
 msgstr ""
 
-#: common/templates/_header.html:52
+#: common/templates/_header.html:62
 msgid "Journal"
 msgstr ""
 
-#: common/templates/_header.html:54 journal/templates/user_post_list.html:10
+#: common/templates/_header.html:64 journal/templates/user_post_list.html:10
 #: journal/templates/user_post_list.html:23
 msgid "Posts"
 msgstr ""
 
-#: common/templates/_header.html:89
+#: common/templates/_header.html:102
 msgid "Explore"
 msgstr ""
 
-#: common/templates/_header.html:93
+#: common/templates/_header.html:106 common/views_manage.py:36
 msgid "Feed"
 msgstr ""
 
-#: common/templates/_header.html:98 journal/templates/profile.html:13
+#: common/templates/_header.html:111 journal/templates/profile.html:13
 #: users/templates/users/preferences.html:46
 msgid "Home"
 msgstr ""
 
-#: common/templates/_header.html:114 common/templates/common/scan.html:9
+#: common/templates/_header.html:127 common/templates/common/scan.html:9
 #: common/templates/common/scan.html:42
 msgid "Scan Barcode"
 msgstr ""
 
-#: common/templates/_header.html:118 social/templates/notification.html:12
+#: common/templates/_header.html:131 social/templates/notification.html:12
 #: social/templates/notification.html:53
 msgid "Notification"
 msgstr ""
 
-#: common/templates/_header.html:122 users/models/task.py:21
+#: common/templates/_header.html:135 users/models/task.py:23
 #: users/templates/users/account.html:219
 #: users/templates/users/crossposts.html:9
 msgid "Pending"
 msgstr ""
 
-#: common/templates/_header.html:125
+#: common/templates/_header.html:138
 msgid "Data"
 msgstr ""
 
-#: common/templates/_header.html:128 common/templates/_header.html:146
+#: common/templates/_header.html:141 common/templates/_header.html:159
 #: users/templates/users/preferences.html:12
 #: users/templates/users/preferences.html:23
 #: users/templates/users/preferences_anonymous.html:13
 msgid "Preferences"
 msgstr ""
 
-#: common/templates/_header.html:131
+#: common/templates/_header.html:144
 msgid "Account"
 msgstr ""
 
-#: common/templates/_header.html:135
+#: common/templates/_header.html:148
 msgid "Manage"
 msgstr ""
 
-#: common/templates/_header.html:139
+#: common/templates/_header.html:152
 msgid "Logout"
 msgstr ""
 
-#: common/templates/_header.html:143
+#: common/templates/_header.html:156
 msgid "Sign up or Login"
 msgstr ""
 
-#: common/templates/_header.html:160
-msgid ""
-"title or content  category:tv  status:complete  rating:8..10  "
-"date:2021-09-11..2022-02"
+#: common/templates/_header.html:173
+msgid "title or content  category:tv  status:complete  rating:8..10  date:2021-09-11..2022-02"
 msgstr ""
 
-#: common/templates/_header.html:162
+#: common/templates/_header.html:175
 msgid "name of a person or company"
 msgstr ""
 
-#: common/templates/_header.html:179
+#: common/templates/_header.html:192
 msgid "Open"
 msgstr ""
 
-#: common/templates/_sidebar.html:62
+#: common/templates/_sidebar.html:61
 #: users/templates/users/profile_actions.html:36
 msgid "approving followers manually"
 msgstr ""
 
-#: common/templates/_sidebar.html:81 common/templates/_sidebar.html:86
+#: common/templates/_sidebar.html:80 common/templates/_sidebar.html:85
 msgid "followers"
 msgstr ""
 
-#: common/templates/_sidebar.html:112
+#: common/templates/_sidebar.html:111
 msgid "Current Targets"
 msgstr ""
 
-#: common/templates/_sidebar.html:125
+#: common/templates/_sidebar.html:124
 msgid "Set a collection as target, its progress will show up here."
 msgstr ""
 
-#: common/templates/_sidebar.html:138
+#: common/templates/_sidebar.html:137
 msgid "Recent podcast episodes"
 msgstr ""
 
-#: common/templates/_sidebar.html:173
+#: common/templates/_sidebar.html:172
 msgid "Currently reading"
 msgstr ""
 
-#: common/templates/_sidebar.html:215
+#: common/templates/_sidebar.html:214
 msgid "Currently watching"
 msgstr ""
 
-#: common/templates/_sidebar.html:238 journal/forms.py:217
+#: common/templates/_sidebar.html:237 journal/forms.py:217
 #: journal/templates/user_tag_list.html:13
 #: journal/templates/user_tagmember_list.html:4
 msgid "Tags"
 msgstr ""
 
-#: common/templates/_sidebar.html:244 journal/templates/user_tag_list.html:28
+#: common/templates/_sidebar.html:243 journal/templates/user_tag_list.html:28
 #: journal/templates/user_tagmember_list.html:10
 msgid "featured tag"
 msgstr ""
 
-#: common/templates/_sidebar.html:247 journal/templates/user_tag_list.html:31
+#: common/templates/_sidebar.html:246 journal/templates/user_tag_list.html:31
 #: journal/templates/user_tagmember_list.html:15
 msgid "personal tag"
 msgstr ""
 
-#: common/templates/_sidebar.html:254 journal/templates/user_tag_list.html:39
+#: common/templates/_sidebar.html:253 journal/templates/user_tag_list.html:39
 msgid "no tags so far."
 msgstr ""
 
-#: common/templates/_sidebar.html:258 common/templates/_sidebar.html:271
+#: common/templates/_sidebar.html:257 common/templates/_sidebar.html:270
 msgid "show all"
 msgstr ""
 
-#: common/templates/_sidebar_anonymous.html:16
+#: common/templates/_sidebar_anonymous.html:15
 #, python-format
 msgid ""
 "\n"
 "        <h3>Welcome 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is "
-"committed to creating a free, open, and interconnected space for collecting "
-"and reviewing books, movies, music, games, and podcasts. Here, you can "
-"manage your collections, share your thoughts, discover new content, and "
-"connect with others.\n"
+"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is committed to creating a free, open, and interconnected space for collecting and reviewing books, movies, music, games, and podcasts. Here, you can manage your collections, share your thoughts, discover new content, and connect with others.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in "
-"to %(site_name)s is through a Fediverse (a distributed social network, "
-"including Mastodon/Pleroma/etc) instance account. If you haven’t registered "
-"yet, you can <a href=\"https://joinmastodon.org/en/servers\" "
-"target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
+"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in to %(site_name)s is through a Fediverse (a distributed social network, including Mastodon/Pleroma/etc) instance account. If you haven’t registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log "
-"in is through a Bluesky (another distributed social network, also called "
-"ATProto) account. If you haven’t registered yet, you may <a href=\"https://"
-"bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
+"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log in is through a Bluesky (another distributed social network, also called ATProto) account. If you haven’t registered yet, you may <a href=\"https://bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready "
-"to join either Fediverse or Bluesky, that’s perfectly fine. You can create "
-"an account here using your email address, and link it to the Fediverse and "
-"Bluesky in settings whenever you’re ready.\n"
+"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready to join either Fediverse or Bluesky, that’s perfectly fine. You can create an account here using your email address, and link it to the Fediverse and Bluesky in settings whenever you’re ready.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have "
-"any questions or suggestions, please feel free to contact us via <a "
-"href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://"
-"discord.gg/uprvcH8gqD\">Discord</a>.\n"
+"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have any questions or suggestions, please feel free to contact us via <a href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-"href=\"%(login_url)s\">Click here</a> to register or log in.\n"
+"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Click here</a> to register or log in.\n"
 "        </p>\n"
 "        "
 msgstr ""
 
-#: common/templates/_sidebar_anonymous.html:43
+#: common/templates/_sidebar_anonymous.html:42
 #: users/templates/users/announcements.html:12
 #: users/templates/users/announcements.html:39
 msgid "Announcements"
@@ -3994,7 +3992,7 @@ msgstr ""
 msgid "Registration"
 msgstr ""
 
-#: common/templates/common/about.html:35 common/views_manage.py:493
+#: common/templates/common/about.html:35 common/views_manage.py:594
 msgid "Invite Only"
 msgstr ""
 
@@ -4002,7 +4000,7 @@ msgstr ""
 msgid "Open Registration"
 msgstr ""
 
-#: common/templates/common/about.html:40 common/views_manage.py:556
+#: common/templates/common/about.html:40 common/views_manage.py:657
 msgid "Preferred Languages"
 msgstr ""
 
@@ -4047,9 +4045,7 @@ msgid "Error"
 msgstr ""
 
 #: common/templates/common/scan.html:45
-msgid ""
-"Point the camera at a book ISBN or product barcode (EAN / UPC). You will be "
-"redirected to the search once a code is detected."
+msgid "Point the camera at a book ISBN or product barcode (EAN / UPC). You will be redirected to the search once a code is detected."
 msgstr ""
 
 #: common/templates/common/scan.html:50
@@ -4060,7 +4056,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:628
+#: common/templates/common/scan.html:60 common/views_manage.py:738
 msgid "Search"
 msgstr ""
 
@@ -4092,16 +4088,28 @@ msgstr ""
 msgid "Camera unavailable. Use manual entry below."
 msgstr ""
 
-#: common/templates/manage/settings.html:9
+#: common/templates/manage/base.html:9
 msgid "Site Settings"
 msgstr ""
 
-#: common/templates/manage/settings.html:109
+#: common/templates/manage/base.html:127
 msgid "Takahe Admin"
 msgstr ""
 
-#: common/templates/manage/settings.html:112
+#: common/templates/manage/base.html:130
 msgid "Database Admin"
+msgstr ""
+
+#: common/templates/manage/environment.html:6
+msgid "These settings come from environment variables and cannot be changed here. Edit .env and restart the server to change them. Passwords and keys are hidden."
+msgstr ""
+
+#: common/templates/manage/environment.html:23
+msgid "(empty)"
+msgstr ""
+
+#: common/templates/manage/environment.html:26
+msgid "default"
 msgstr ""
 
 #: common/templatetags/duration.py:59
@@ -4120,7 +4128,7 @@ msgstr ""
 msgid "following you"
 msgstr ""
 
-#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:95
+#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:90
 msgid "you"
 msgstr ""
 
@@ -4128,799 +4136,806 @@ msgstr ""
 msgid "unavailable"
 msgstr ""
 
-#: common/utils.py:126 common/utils.py:167 users/views/actions.py:134
+#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr ""
 
-#: common/utils.py:133 common/utils.py:135 common/utils.py:138
-#: common/utils.py:174 common/utils.py:178 journal/views/profile.py:499
+#: common/utils.py:135 common/utils.py:137 common/utils.py:140
+#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
 msgid "Access denied"
 msgstr ""
 
-#: common/utils.py:141 common/utils.py:143 journal/views/article.py:204
+#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr ""
 
-#: common/views_manage.py:144 common/views_manage.py:295
+#: common/views_manage.py:34 common/views_manage.py:373
 msgid "Branding"
 msgstr ""
 
-#: common/views_manage.py:146
+#: common/views_manage.py:37
 msgid "Recommendations"
 msgstr ""
 
-#: common/views_manage.py:147
+#: common/views_manage.py:38
 msgid "Access"
 msgstr ""
 
-#: common/views_manage.py:148 common/views_manage.py:623
+#: common/views_manage.py:39 common/views_manage.py:733
 msgid "Federation"
 msgstr ""
 
-#: common/views_manage.py:149
+#: common/views_manage.py:40
 msgid "Catalog"
 msgstr ""
 
-#: common/views_manage.py:150
+#: common/views_manage.py:41
 msgid "API Keys"
 msgstr ""
 
-#: common/views_manage.py:151
+#: common/views_manage.py:42
 msgid "Downloader"
 msgstr ""
 
-#: common/views_manage.py:152 common/views_manage.py:303
+#: common/views_manage.py:43 common/views_manage.py:381
 #: users/templates/users/steam_import.html:113
 msgid "Advanced"
 msgstr ""
 
-#: common/views_manage.py:202
-msgid "Invalid value."
-msgstr ""
-
-#: common/views_manage.py:206
-msgid "Invalid configuration. Please check your input."
-msgstr ""
-
-#: common/views_manage.py:211
-msgid "Settings have been saved."
-msgstr ""
-
-#: common/views_manage.py:231
-msgid "Site Name"
-msgstr ""
-
-#: common/views_manage.py:234
-msgid "Site Description"
-msgstr ""
-
-#: common/views_manage.py:235
-msgid "Short description shown in metadata and about page."
-msgstr ""
-
-#: common/views_manage.py:238
-msgid "Site Logo URL"
-msgstr ""
-
-#: common/views_manage.py:239
-msgid "URL path to the site logo image."
-msgstr ""
-
-#: common/views_manage.py:242
-msgid "Site Icon URL"
-msgstr ""
-
-#: common/views_manage.py:243
-msgid "URL path to the site icon/favicon."
-msgstr ""
-
-#: common/views_manage.py:246
-msgid "Default User Avatar URL"
-msgstr ""
-
-#: common/views_manage.py:247
-msgid "URL path to the default user avatar."
-msgstr ""
-
-#: common/views_manage.py:250
-msgid "Site Color Theme"
-msgstr ""
-
-#: common/views_manage.py:251
-msgid "PicoCSS color theme."
-msgstr ""
-
-#: common/views_manage.py:276
-msgid "Site Introduction"
-msgstr ""
-
-#: common/views_manage.py:277
-msgid "URL path for the intro/welcome sidebar page."
+#: common/views_manage.py:44
+msgid "Environment"
 msgstr ""
 
 #: common/views_manage.py:280
-msgid "Custom HTML Head"
+msgid "Invalid value."
 msgstr ""
 
-#: common/views_manage.py:281
-msgid "Extra HTML injected into the <head> of all pages."
+#: common/views_manage.py:284
+msgid "Invalid configuration. Please check your input."
 msgstr ""
 
-#: common/views_manage.py:285
-msgid "Footer Links"
+#: common/views_manage.py:289
+msgid "Settings have been saved."
 msgstr ""
 
-#: common/views_manage.py:286
-msgid "Link title mapped to URL."
+#: common/views_manage.py:309
+msgid "Site Name"
 msgstr ""
 
-#: common/views_manage.py:315
-msgid "Minimum Marks for Discover"
+#: common/views_manage.py:312
+msgid "Site Description"
+msgstr ""
+
+#: common/views_manage.py:313
+msgid "Short description shown in metadata and about page."
+msgstr ""
+
+#: common/views_manage.py:316
+msgid "Site Logo URL"
 msgstr ""
 
 #: common/views_manage.py:317
-msgid "Number of marks required for an item to appear in discover."
+msgid "URL path to the site logo image."
 msgstr ""
 
-#: common/views_manage.py:322
-msgid "Update Interval (minutes)"
+#: common/views_manage.py:320
+msgid "Site Icon URL"
 msgstr ""
 
-#: common/views_manage.py:323
-msgid "How often to refresh the popular items list."
+#: common/views_manage.py:321
+msgid "URL path to the site icon/favicon."
 msgstr ""
 
-#: common/views_manage.py:327
-msgid "Filter by Preferred Languages"
+#: common/views_manage.py:324
+msgid "Default User Avatar URL"
+msgstr ""
+
+#: common/views_manage.py:325
+msgid "URL path to the default user avatar."
 msgstr ""
 
 #: common/views_manage.py:328
-msgid "Only show items with titles in the preferred languages."
+msgid "Site Color Theme"
 msgstr ""
 
-#: common/views_manage.py:331
-msgid "Show Local Only"
+#: common/views_manage.py:329
+msgid "PicoCSS color theme."
 msgstr ""
 
-#: common/views_manage.py:333
-msgid "Only show items marked by local users, not the entire network."
+#: common/views_manage.py:354
+msgid "Site Introduction"
 msgstr ""
 
-#: common/views_manage.py:337
-msgid "Show Popular Posts"
+#: common/views_manage.py:355
+msgid "URL path for the intro/welcome sidebar page."
 msgstr ""
 
-#: common/views_manage.py:338
-msgid "Show popular public posts instead of recent ones."
+#: common/views_manage.py:358
+msgid "Custom HTML Head"
 msgstr ""
 
-#: common/views_manage.py:341
-msgid "Show Popular Tags"
+#: common/views_manage.py:359
+msgid "Extra HTML injected into the <head> of all pages."
 msgstr ""
 
-#: common/views_manage.py:342
-msgid "Show popular public tags on the discover page."
+#: common/views_manage.py:363
+msgid "Footer Links"
 msgstr ""
 
-#: common/views_manage.py:345
-msgid "Show Verified Podcasts"
-msgstr ""
-
-#: common/views_manage.py:347
-msgid ""
-"Show a shelf of recent episodes from podcasts with a verified creator on the "
-"discover page."
-msgstr ""
-
-#: common/views_manage.py:386
-msgid "Enable Recommendations"
-msgstr ""
-
-#: common/views_manage.py:388
-msgid ""
-"Master switch. When off, all recommendation surfaces are hidden and the cron "
-"jobs are not scheduled."
+#: common/views_manage.py:364
+msgid "Link title mapped to URL."
 msgstr ""
 
 #: common/views_manage.py:393
-msgid "Source Item Mark Threshold"
+msgid "Minimum Marks for Discover"
 msgstr ""
 
 #: common/views_manage.py:395
-msgid ""
-"Minimum public marks an item needs before similarity rows are built for it."
+msgid "Number of marks required for an item to appear in discover."
+msgstr ""
+
+#: common/views_manage.py:400
+msgid "Update Interval (minutes)"
 msgstr ""
 
 #: common/views_manage.py:401
-msgid "Target Item Mark Threshold"
+msgid "How often to refresh the popular items list."
 msgstr ""
 
-#: common/views_manage.py:403
-msgid ""
-"Minimum public marks an item needs to be eligible as a recommendation target."
+#: common/views_manage.py:405
+msgid "Filter by Preferred Languages"
+msgstr ""
+
+#: common/views_manage.py:406
+msgid "Only show items with titles in the preferred languages."
 msgstr ""
 
 #: common/views_manage.py:409
-msgid "Top-K Similar Items per Source"
+msgid "Show Local Only"
 msgstr ""
 
-#: common/views_manage.py:410
-msgid "Number of similar items stored per source item."
-msgstr ""
-
-#: common/views_manage.py:414
-msgid "Top-N Recommendations per User"
+#: common/views_manage.py:411
+msgid "Only show items marked by local users, not the entire network."
 msgstr ""
 
 #: common/views_manage.py:415
-msgid "Number of personalised rows stored per user."
+msgid "Show Popular Posts"
+msgstr ""
+
+#: common/views_manage.py:416
+msgid "Show popular public posts instead of recent ones."
 msgstr ""
 
 #: common/views_manage.py:419
-msgid "Dampen Heavy Shelvers"
+msgid "Show Popular Tags"
 msgstr ""
 
-#: common/views_manage.py:421
-msgid ""
-"Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-"
-"shelvers in similarity scoring."
+#: common/views_manage.py:420
+msgid "Show popular public tags on the discover page."
 msgstr ""
 
-#: common/views_manage.py:426
-msgid "Per-User Mark Cap (training)"
+#: common/views_manage.py:423
+msgid "Show Verified Podcasts"
 msgstr ""
 
-#: common/views_manage.py:428
-msgid ""
-"Truncate each user's contribution to their N most recent marks when building "
-"the similarity matrix."
+#: common/views_manage.py:425
+msgid "Show a shelf of recent episodes from podcasts with a verified creator on the discover page."
 msgstr ""
 
-#: common/views_manage.py:434
-msgid "Active-User Window (days)"
+#: common/views_manage.py:447
+msgid "Show World Timeline"
 msgstr ""
 
-#: common/views_manage.py:436
-msgid ""
-"Refresh personalised recommendations for users with at least one public mark "
-"in the last N days."
+#: common/views_manage.py:449
+msgid "Offer a tab with public posts from this site and every server it federates with."
 msgstr ""
 
-#: common/views_manage.py:442
-msgid "Per-User Seed Cap (serving)"
+#: common/views_manage.py:454
+msgid "Show Local Timeline"
 msgstr ""
 
-#: common/views_manage.py:444
-msgid ""
-"Number of recent marks used as seeds when scoring personalised "
-"recommendations for one user."
+#: common/views_manage.py:455
+msgid "Offer a tab with public posts from this site only."
 msgstr ""
 
-#: common/views_manage.py:450
-msgid "Lazy Refresh TTL (days)"
+#: common/views_manage.py:459
+msgid "Timelines"
 msgstr ""
 
-#: common/views_manage.py:452
-msgid ""
-"How long cached on-demand recommendations are valid before the next request "
-"triggers a refresh."
+#: common/views_manage.py:487
+msgid "Enable Recommendations"
 msgstr ""
 
-#: common/views_manage.py:458
-msgid "Circles Window (days)"
+#: common/views_manage.py:489
+msgid "Master switch. When off, all recommendation surfaces are hidden and the cron jobs are not scheduled."
 msgstr ""
 
-#: common/views_manage.py:460
-msgid ""
-"Look back N days when finding items recently marked by people the viewer "
-"follows."
+#: common/views_manage.py:494
+msgid "Source Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:467
-msgid "Master Switch"
+#: common/views_manage.py:496
+msgid "Minimum public marks an item needs before similarity rows are built for it."
 msgstr ""
 
-#: common/views_manage.py:470
-msgid "Similarity Builder"
-msgstr ""
-
-#: common/views_manage.py:477
-msgid "Personalisation"
-msgstr ""
-
-#: common/views_manage.py:495
-msgid ""
-"Require an invite token to register. Invite tokens can be generated with "
-"neodb-manage invite --create."
-msgstr ""
-
-#: common/views_manage.py:500
-msgid "Enable Local-Only Posting"
-msgstr ""
-
-#: common/views_manage.py:501
-msgid "Allow users to create posts visible only to local users."
+#: common/views_manage.py:502
+msgid "Target Item Mark Threshold"
 msgstr ""
 
 #: common/views_manage.py:504
-msgid "Mastodon Login Whitelist"
+msgid "Minimum public marks an item needs to be eligible as a recommendation target."
 msgstr ""
 
-#: common/views_manage.py:505
-msgid "One domain per line. Leave empty to allow any instance."
+#: common/views_manage.py:510
+msgid "Top-K Similar Items per Source"
 msgstr ""
 
-#: common/views_manage.py:508
-msgid "Registration Captcha Items"
+#: common/views_manage.py:511
+msgid "Number of similar items stored per source item."
 msgstr ""
 
-#: common/views_manage.py:512
-msgid ""
-"Number of item covers a new user must sort into two category rows before "
-"choosing a username. 0 disables the captcha; 5-6 is recommended. The covers "
-"carry no title text, so this cannot be solved with a screen reader: if you "
-"enable it, keep another way in, such as an invite link."
+#: common/views_manage.py:515
+msgid "Top-N Recommendations per User"
+msgstr ""
+
+#: common/views_manage.py:516
+msgid "Number of personalised rows stored per user."
 msgstr ""
 
 #: common/views_manage.py:520
-msgid "Registration Captcha Minimum Marks"
+msgid "Dampen Heavy Shelvers"
 msgstr ""
 
-#: common/views_manage.py:523
-msgid ""
-"Marks an item needs before the captcha treats it as well known enough to be "
-"recognizable. Categories with too few such items fall back to any item."
+#: common/views_manage.py:522
+msgid "Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-shelvers in similarity scoring."
+msgstr ""
+
+#: common/views_manage.py:527
+msgid "Per-User Mark Cap (training)"
 msgstr ""
 
 #: common/views_manage.py:529
-msgid "Enable Mastodon Login"
-msgstr ""
-
-#: common/views_manage.py:532
-msgid "Enable Bluesky Login"
+msgid "Truncate each user's contribution to their N most recent marks when building the similarity matrix."
 msgstr ""
 
 #: common/views_manage.py:535
-msgid "Enable Threads Login"
+msgid "Active-User Window (days)"
 msgstr ""
 
-#: common/views_manage.py:538
-msgid "Email URL"
+#: common/views_manage.py:537
+msgid "Refresh personalised recommendations for users with at least one public mark in the last N days."
 msgstr ""
 
-#: common/views_manage.py:540
-msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
-msgstr ""
-
-#: common/views_manage.py:544
-msgid "Email From"
+#: common/views_manage.py:543
+msgid "Per-User Seed Cap (serving)"
 msgstr ""
 
 #: common/views_manage.py:545
-msgid "Sender name and address for outgoing email."
-msgstr ""
-
-#: common/views_manage.py:548
-msgid "Default Language"
+msgid "Number of recent marks used as seeds when scoring personalised recommendations for one user."
 msgstr ""
 
 #: common/views_manage.py:551
-msgid ""
-"Interface language for visitors and for users who have not chosen one "
-"themselves."
+msgid "Lazy Refresh TTL (days)"
 msgstr ""
 
-#: common/views_manage.py:558
-msgid ""
-"Language codes, one per line (e.g. en, zh, ja). First language is the "
-"default."
+#: common/views_manage.py:553
+msgid "How long cached on-demand recommendations are valid before the next request triggers a refresh."
 msgstr ""
 
-#: common/views_manage.py:564
-msgid "Access Control"
+#: common/views_manage.py:559
+msgid "Circles Window (days)"
+msgstr ""
+
+#: common/views_manage.py:561
+msgid "Look back N days when finding items recently marked by people the viewer follows."
+msgstr ""
+
+#: common/views_manage.py:568
+msgid "Master Switch"
 msgstr ""
 
 #: common/views_manage.py:571
+msgid "Similarity Builder"
+msgstr ""
+
+#: common/views_manage.py:578
+msgid "Personalisation"
+msgstr ""
+
+#: common/views_manage.py:596
+msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
+msgstr ""
+
+#: common/views_manage.py:601
+msgid "Enable Local-Only Posting"
+msgstr ""
+
+#: common/views_manage.py:602
+msgid "Allow users to create posts visible only to local users."
+msgstr ""
+
+#: common/views_manage.py:605
+msgid "Mastodon Login Whitelist"
+msgstr ""
+
+#: common/views_manage.py:606
+msgid "One domain per line. Leave empty to allow any instance."
+msgstr ""
+
+#: common/views_manage.py:609
+msgid "Registration Captcha Items"
+msgstr ""
+
+#: common/views_manage.py:613
+msgid "Number of item covers a new user must sort into two category rows before choosing a username. 0 disables the captcha; 5-6 is recommended. The covers carry no title text, so this cannot be solved with a screen reader: if you enable it, keep another way in, such as an invite link."
+msgstr ""
+
+#: common/views_manage.py:621
+msgid "Registration Captcha Minimum Marks"
+msgstr ""
+
+#: common/views_manage.py:624
+msgid "Marks an item needs before the captcha treats it as well known enough to be recognizable. Categories with too few such items fall back to any item."
+msgstr ""
+
+#: common/views_manage.py:630
+msgid "Enable Mastodon Login"
+msgstr ""
+
+#: common/views_manage.py:633
+msgid "Enable Bluesky Login"
+msgstr ""
+
+#: common/views_manage.py:636
+msgid "Enable Threads Login"
+msgstr ""
+
+#: common/views_manage.py:639
+msgid "Email URL"
+msgstr ""
+
+#: common/views_manage.py:641
+msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
+msgstr ""
+
+#: common/views_manage.py:645
+msgid "Email From"
+msgstr ""
+
+#: common/views_manage.py:646
+msgid "Sender name and address for outgoing email."
+msgstr ""
+
+#: common/views_manage.py:649
+msgid "Default Language"
+msgstr ""
+
+#: common/views_manage.py:652
+msgid "Interface language for visitors and for users who have not chosen one themselves."
+msgstr ""
+
+#: common/views_manage.py:659
+msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
+msgstr ""
+
+#: common/views_manage.py:665
+msgid "Access Control"
+msgstr ""
+
+#: common/views_manage.py:672
 msgid "Login Methods"
 msgstr ""
 
-#: common/views_manage.py:576 mastodon/models/common.py:28
+#: common/views_manage.py:677 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr ""
 
-#: common/views_manage.py:580
+#: common/views_manage.py:681
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:591
+#: common/views_manage.py:692
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:593
-msgid ""
-"Disable relay.neodb.net federation for sharing public ratings across "
-"instances."
+#: common/views_manage.py:694
+msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:598
+#: common/views_manage.py:699
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:599
+#: common/views_manage.py:700
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:603
+#: common/views_manage.py:704
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:605
+#: common/views_manage.py:706
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:610
+#: common/views_manage.py:711
 msgid "Search Sites"
 msgstr ""
 
-#: common/views_manage.py:611
+#: common/views_manage.py:712
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:614
+#: common/views_manage.py:715
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:615
+#: common/views_manage.py:716
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:618
+#: common/views_manage.py:719
 msgid "Hidden Categories"
 msgstr ""
 
-#: common/views_manage.py:619
+#: common/views_manage.py:720
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:640
-msgid "Spotify API Key"
-msgstr ""
-
-#: common/views_manage.py:641
-msgid "https://developer.spotify.com/"
-msgstr ""
-
-#: common/views_manage.py:644
-msgid "TMDB API Key"
-msgstr ""
-
-#: common/views_manage.py:645
-msgid "https://developer.themoviedb.org/"
-msgstr ""
-
-#: common/views_manage.py:648
-msgid "Google Books API Key"
-msgstr ""
-
-#: common/views_manage.py:649
-msgid "https://developers.google.com/books/"
-msgstr ""
-
-#: common/views_manage.py:652
-msgid "Discogs API Key"
-msgstr ""
-
-#: common/views_manage.py:654
-msgid "Personal access token from https://www.discogs.com/settings/developers"
-msgstr ""
-
-#: common/views_manage.py:658
-msgid "IGDB Client ID"
-msgstr ""
-
-#: common/views_manage.py:659
-msgid "https://api-docs.igdb.com/"
-msgstr ""
-
-#: common/views_manage.py:662
-msgid "IGDB Client Secret"
-msgstr ""
-
-#: common/views_manage.py:665
-msgid "BoardGameGeek API Token"
-msgstr ""
-
-#: common/views_manage.py:667
-msgid ""
-"Bearer token from https://boardgamegeek.com/applications (see https://"
-"boardgamegeek.com/using_the_xml_api#toc9)."
-msgstr ""
-
-#: common/views_manage.py:672 users/templates/users/steam_import.html:26
-msgid "Steam API Key"
-msgstr ""
-
-#: common/views_manage.py:674
-msgid ""
-"https://steamcommunity.com/dev - fallback key for Steam importer. Users can "
-"provide their own key when importing."
-msgstr ""
-
-#: common/views_manage.py:679
-msgid "DeepL API Key"
-msgstr ""
-
-#: common/views_manage.py:680
-msgid "For translation features."
-msgstr ""
-
-#: common/views_manage.py:683
-msgid "LibreTranslate API URL"
-msgstr ""
-
-#: common/views_manage.py:686
-msgid "LibreTranslate API Key"
-msgstr ""
-
-#: common/views_manage.py:689
-msgid "Threads App ID"
-msgstr ""
-
-#: common/views_manage.py:690
-msgid "OAuth app ID for Threads login."
-msgstr ""
-
-#: common/views_manage.py:693
-msgid "Threads App Secret"
-msgstr ""
-
-#: common/views_manage.py:696
-msgid "Discord Webhooks"
-msgstr ""
-
-#: common/views_manage.py:698
-msgid ""
-"Webhook URLs keyed by channel (default, report, audit, suggest, system). All "
-"channels must be Discord forum or media channels (thread mode) because "
-"notifications are posted as threads."
-msgstr ""
-
-#: common/views_manage.py:715
-msgid "Catalog APIs"
+#: common/views_manage.py:723
+msgid "Guest Search Page Limit"
 msgstr ""
 
 #: common/views_manage.py:725
+msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
+msgstr ""
+
+#: common/views_manage.py:751
+msgid "Spotify API Key"
+msgstr ""
+
+#: common/views_manage.py:752
+msgid "https://developer.spotify.com/"
+msgstr ""
+
+#: common/views_manage.py:755
+msgid "TMDB API Key"
+msgstr ""
+
+#: common/views_manage.py:756
+msgid "https://developer.themoviedb.org/"
+msgstr ""
+
+#: common/views_manage.py:759
+msgid "Google Books API Key"
+msgstr ""
+
+#: common/views_manage.py:760
+msgid "https://developers.google.com/books/"
+msgstr ""
+
+#: common/views_manage.py:763
+msgid "Discogs API Key"
+msgstr ""
+
+#: common/views_manage.py:765
+msgid "Personal access token from https://www.discogs.com/settings/developers"
+msgstr ""
+
+#: common/views_manage.py:769
+msgid "IGDB Client ID"
+msgstr ""
+
+#: common/views_manage.py:770
+msgid "https://api-docs.igdb.com/"
+msgstr ""
+
+#: common/views_manage.py:773
+msgid "IGDB Client Secret"
+msgstr ""
+
+#: common/views_manage.py:776
+msgid "BoardGameGeek API Token"
+msgstr ""
+
+#: common/views_manage.py:778
+msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
+msgstr ""
+
+#: common/views_manage.py:783
+msgid "MyAnimeList Client ID"
+msgstr ""
+
+#: common/views_manage.py:785
+msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
+msgstr ""
+
+#: common/views_manage.py:790 users/templates/users/steam_import.html:26
+msgid "Steam API Key"
+msgstr ""
+
+#: common/views_manage.py:792
+msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
+msgstr ""
+
+#: common/views_manage.py:797
+msgid "DeepL API Key"
+msgstr ""
+
+#: common/views_manage.py:798
+msgid "For translation features."
+msgstr ""
+
+#: common/views_manage.py:801
+msgid "LibreTranslate API URL"
+msgstr ""
+
+#: common/views_manage.py:804
+msgid "LibreTranslate API Key"
+msgstr ""
+
+#: common/views_manage.py:807
+msgid "Threads App ID"
+msgstr ""
+
+#: common/views_manage.py:808
+msgid "OAuth app ID for Threads login."
+msgstr ""
+
+#: common/views_manage.py:811
+msgid "Threads App Secret"
+msgstr ""
+
+#: common/views_manage.py:814
+msgid "Discord Webhooks"
+msgstr ""
+
+#: common/views_manage.py:816
+msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
+msgstr ""
+
+#: common/views_manage.py:833
+msgid "Catalog APIs"
+msgstr ""
+
+#: common/views_manage.py:844
 msgid "Translation"
 msgstr ""
 
-#: common/views_manage.py:730
+#: common/views_manage.py:849
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:734 social/templates/feed.html:27
+#: common/views_manage.py:853 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr ""
 
-#: common/views_manage.py:744
+#: common/views_manage.py:863
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:745
+#: common/views_manage.py:864
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:748
+#: common/views_manage.py:867
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:749
+#: common/views_manage.py:868
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:752
+#: common/views_manage.py:871
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:874
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:758
+#: common/views_manage.py:877
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:761
+#: common/views_manage.py:880
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:764
+#: common/views_manage.py:883
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:767
+#: common/views_manage.py:886
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:768
+#: common/views_manage.py:887
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:771
+#: common/views_manage.py:890
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:775
+#: common/views_manage.py:894
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:779
+#: common/views_manage.py:898
 msgid "Retries"
 msgstr ""
 
-#: common/views_manage.py:784
+#: common/views_manage.py:903
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:789
+#: common/views_manage.py:908
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:796
+#: common/views_manage.py:915
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:808
+#: common/views_manage.py:927
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:809
+#: common/views_manage.py:928
 msgid "One domain per line."
 msgstr ""
 
-#: common/views_manage.py:812
+#: common/views_manage.py:931
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:813
+#: common/views_manage.py:932
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:935
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:818
-msgid ""
-"Timeout for requests to Mastodon instances and remote fediverse servers."
+#: common/views_manage.py:937
+msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:824
+#: common/views_manage.py:943
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:825
+#: common/views_manage.py:944
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:828
+#: common/views_manage.py:947
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:829
+#: common/views_manage.py:948
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:839
+#: common/views_manage.py:958
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:841
-msgid ""
-"Delete import/export tasks and their files after this many days. Set to 0 to "
-"disable cleanup."
+#: common/views_manage.py:960
+msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:847
+#: common/views_manage.py:966
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:849
-msgid ""
-"Post-migration job keys to skip, one per line (e.g. normalize_genre). "
-"Checked by the worker at dequeue time; skipped jobs log a warning and notify "
-"the Discord system channel."
+#: common/views_manage.py:968
+msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:855
+#: common/views_manage.py:974
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:857
-msgid ""
-"Private key (JWK) identifying this site to ATProto authorization servers. "
-"Auto-generated on first Bluesky login; clear to regenerate."
+#: common/views_manage.py:976
+msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:983
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:986
 msgid "Operational"
 msgstr ""
 
-#: common/views_manage.py:883
+#: common/views_manage.py:1002
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:885
-msgid ""
-"Genre codes offered in the Movie edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1004
+msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:1009
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:892
-msgid ""
-"Genre codes offered in the TV edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1011
+msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:897
+#: common/views_manage.py:1016
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:899
-msgid ""
-"Genre codes offered in the Music edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1018
+msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:904
+#: common/views_manage.py:1023
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:906
-msgid ""
-"Genre codes offered in the Game edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1025
+msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:911
+#: common/views_manage.py:1030
 msgid "Podcast Genres"
 msgstr ""
 
-#: common/views_manage.py:913
-msgid ""
-"Genre codes offered in the Podcast edit dropdown, one per line. Leave empty "
-"to use the built-in default."
+#: common/views_manage.py:1032
+msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:918
+#: common/views_manage.py:1037
 msgid "Performance Genres"
 msgstr ""
 
-#: common/views_manage.py:920
-msgid ""
-"Genre codes offered in the Performance edit dropdown, one per line. Leave "
-"empty to use the built-in default."
+#: common/views_manage.py:1039
+msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:926
+#: common/views_manage.py:1045
 msgid "Genres by Category"
 msgstr ""
 
+#: common/views_manage.py:1069
+msgid "Site"
+msgstr ""
+
+#: common/views_manage.py:1079
+msgid "Database and Services"
+msgstr ""
+
+#: common/views_manage.py:1089
+msgid "Media and Files"
+msgstr ""
+
+#: common/views_manage.py:1098
+msgid "Monitoring"
+msgstr ""
+
+#: common/views_manage.py:1102
+msgid "Security"
+msgstr ""
+
+#: common/views_manage.py:1111
+msgid "Other Environment Variables"
+msgstr ""
+
+#: common/views_manage.py:1113
+msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
+msgstr ""
+
 #: journal/forms.py:12
-msgid ""
-"Tips: use >!text!< for spoilers; some instances may not be able to show "
-"posts longer than 360 charactors."
+msgid "Tips: use >!text!< for spoilers; some instances may not be able to show posts longer than 360 charactors."
 msgstr ""
 
 #: journal/forms.py:29 journal/forms.py:31 journal/forms.py:80
@@ -4935,12 +4950,12 @@ msgid "Content (Markdown)"
 msgstr ""
 
 #: journal/forms.py:46 journal/forms.py:124 journal/forms.py:226
-#: journal/forms.py:288 journal/views/note.py:38
+#: journal/forms.py:288 journal/views/note.py:37
 msgid "Crosspost"
 msgstr ""
 
 #: journal/forms.py:47 journal/forms.py:125 journal/forms.py:227
-#: journal/forms.py:289 journal/views/note.py:39
+#: journal/forms.py:289 journal/views/note.py:38
 msgid "Crosspost to your connected social networks"
 msgstr ""
 
@@ -4955,10 +4970,10 @@ msgstr ""
 #: journal/forms.py:59 journal/forms.py:137 journal/forms.py:162
 #: journal/forms.py:219 journal/forms.py:281
 #: journal/templates/collection_share.html:24
-#: journal/templates/wrapped_share.html:36 journal/views/note.py:31
-#: users/templates/users/data.html:45 users/templates/users/data.html:98
-#: users/templates/users/data.html:155 users/templates/users/data.html:206
-#: users/templates/users/data.html:269 users/templates/users/data.html:328
+#: journal/templates/wrapped_share.html:36 journal/views/note.py:30
+#: users/templates/users/data.html:60 users/templates/users/data.html:113
+#: users/templates/users/data.html:170 users/templates/users/data.html:221
+#: users/templates/users/data.html:284 users/templates/users/data.html:346
 #: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
@@ -4995,7 +5010,6 @@ msgid "Collaborative editing"
 msgstr ""
 
 #: journal/forms.py:204 users/templates/users/crossposts.html:51
-#: users/templates/users/data.html:483
 msgid "Status"
 msgstr ""
 
@@ -5007,48 +5021,46 @@ msgstr ""
 msgid "Rating"
 msgstr ""
 
-#: journal/importers/goodreads.py:196 journal/importers/letterboxd.py:144
-#: journal/importers/rym.py:442 journal/importers/storygraph.py:500
+#: journal/importers/goodreads.py:198 journal/importers/letterboxd.py:147
+#: journal/importers/rym.py:444 journal/importers/storygraph.py:504
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr ""
 
-#: journal/importers/opml.py:45
+#: journal/importers/opml.py:49
 #, python-brace-format
 msgid "{username}'s podcast subscriptions"
 msgstr ""
 
-#: journal/importers/rym.py:168 journal/importers/storygraph.py:128
+#: journal/importers/rym.py:170 journal/importers/storygraph.py:132
 #, python-brace-format
-msgid ""
-"Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
+msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:178 journal/importers/storygraph.py:138
+#: journal/importers/rym.py:180 journal/importers/storygraph.py:142
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/importers/rym.py:233 journal/importers/storygraph.py:184
+#: journal/importers/rym.py:235 journal/importers/storygraph.py:188
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:348 journal/importers/storygraph.py:389
+#: journal/importers/rym.py:350 journal/importers/storygraph.py:393
 msgid "Matched file missing; cannot import."
 msgstr ""
 
-#: journal/importers/rym.py:376 journal/importers/storygraph.py:412
+#: journal/importers/rym.py:378 journal/importers/storygraph.py:416
 #, python-brace-format
-msgid ""
-"Import complete: {imported} imported, {skipped} skipped, {failed} failed"
+msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:212 journal/views/article.py:218
+#: journal/models/article.py:215 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
-#: journal/models/collection.py:44 journal/templates/add_to_collection.html:39
+#: journal/models/collection.py:48 journal/templates/add_to_collection.html:39
 #: journal/templates/collection_edit.html:64
 #: journal/templates/collection_share.html:63
 #: journal/templates/collection_update_item_note.html:3
@@ -5056,73 +5068,73 @@ msgstr ""
 msgid "note"
 msgstr ""
 
-#: journal/models/collection.py:111
+#: journal/models/collection.py:115
 msgid "search query for dynamic collection"
 msgstr ""
 
-#: journal/models/collection.py:524 journal/templatetags/collection.py:35
+#: journal/models/collection.py:566 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:529 journal/templatetags/collection.py:43
+#: journal/models/collection.py:571 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:534 journal/templatetags/collection.py:51
+#: journal/models/collection.py:576 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:539 journal/templatetags/collection.py:59
+#: journal/models/collection.py:581 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:544 journal/templatetags/collection.py:67
+#: journal/models/collection.py:586 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:549 journal/templatetags/collection.py:75
+#: journal/models/collection.py:591 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:555 journal/templatetags/collection.py:83
+#: journal/models/collection.py:597 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:563 journal/templatetags/collection.py:91
+#: journal/models/collection.py:605 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/common.py:50 journal/templates/action_open_post.html:15
-#: journal/templates/collection_share.html:35 journal/templates/mark.html:84
+#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
-#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:54
-#: users/templates/users/data.html:107 users/templates/users/data.html:164
-#: users/templates/users/data.html:215 users/templates/users/data.html:277
-#: users/templates/users/data.html:337 users/templates/users/data.html:534
+#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
+#: users/templates/users/data.html:122 users/templates/users/data.html:179
+#: users/templates/users/data.html:230 users/templates/users/data.html:292
+#: users/templates/users/data.html:355 users/templates/users/data.html:534
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5130,13 +5142,13 @@ msgstr[1] ""
 msgid "Public"
 msgstr ""
 
-#: journal/models/common.py:51 journal/templates/action_open_post.html:9
-#: journal/templates/collection_share.html:46 journal/templates/mark.html:91
+#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
-#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
-#: users/templates/users/data.html:115 users/templates/users/data.html:172
-#: users/templates/users/data.html:223 users/templates/users/data.html:285
-#: users/templates/users/data.html:345 users/templates/users/data.html:542
+#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
+#: users/templates/users/data.html:130 users/templates/users/data.html:187
+#: users/templates/users/data.html:238 users/templates/users/data.html:300
+#: users/templates/users/data.html:363 users/templates/users/data.html:542
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5144,12 +5156,12 @@ msgstr ""
 msgid "Followers Only"
 msgstr ""
 
-#: journal/models/common.py:52 journal/templates/collection_share.html:57
-#: journal/templates/mark.html:98 journal/templates/post_compose.html:72
-#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
-#: users/templates/users/data.html:123 users/templates/users/data.html:180
-#: users/templates/users/data.html:231 users/templates/users/data.html:293
-#: users/templates/users/data.html:353 users/templates/users/data.html:550
+#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/templates/mark.html:102 journal/templates/post_compose.html:72
+#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
+#: users/templates/users/data.html:138 users/templates/users/data.html:195
+#: users/templates/users/data.html:246 users/templates/users/data.html:308
+#: users/templates/users/data.html:371 users/templates/users/data.html:550
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5157,29 +5169,27 @@ msgstr ""
 msgid "Mentioned Only"
 msgstr ""
 
-#: journal/models/common.py:790
-msgid ""
-"A recent post was not posted to Bluesky, please login NeoDB using ATProto "
-"again to re-authorize."
+#: journal/models/common.py:806
+msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr ""
 
-#: journal/models/common.py:987
+#: journal/models/common.py:1003
 msgid "A recent post was not posted to Threads."
 msgstr ""
 
-#: journal/models/common.py:1020
+#: journal/models/common.py:1036
 msgid "A recent post was not boosted on Mastodon."
 msgstr ""
 
-#: journal/models/common.py:1030
+#: journal/models/common.py:1046
 msgid "Original post no longer exists."
 msgstr ""
 
-#: journal/models/common.py:1044
+#: journal/models/common.py:1060
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr ""
 
-#: journal/models/common.py:1053
+#: journal/models/common.py:1069
 msgid "A recent post was not posted to Mastodon."
 msgstr ""
 
@@ -5187,7 +5197,7 @@ msgstr ""
 msgid "Authorization expired"
 msgstr ""
 
-#: journal/models/crosspost.py:17 users/models/task.py:24
+#: journal/models/crosspost.py:17 users/models/task.py:26
 msgid "Failed"
 msgstr ""
 
@@ -5195,81 +5205,81 @@ msgstr ""
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:469
+#: journal/models/mark.py:475
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:473
+#: journal/models/mark.py:479
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:480
+#: journal/models/mark.py:486
 msgid "Invalid progress type."
 msgstr ""
 
-#: journal/models/mark.py:482
+#: journal/models/mark.py:488
 msgid "Invalid progress type for this item."
 msgstr ""
 
-#: journal/models/note.py:34 users/templates/users/rym_import.html:73
+#: journal/models/note.py:47 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr ""
 
-#: journal/models/note.py:35
+#: journal/models/note.py:48
 msgid "Chapter"
 msgstr ""
 
-#: journal/models/note.py:38
+#: journal/models/note.py:51
 msgid "Part"
 msgstr ""
 
-#: journal/models/note.py:39
+#: journal/models/note.py:52
 msgid "Episode"
 msgstr ""
 
-#: journal/models/note.py:40
+#: journal/models/note.py:53
 msgid "Track"
 msgstr ""
 
-#: journal/models/note.py:41
+#: journal/models/note.py:54
 msgid "Cycle"
 msgstr ""
 
-#: journal/models/note.py:42
+#: journal/models/note.py:55
 msgid "Timestamp"
 msgstr ""
 
-#: journal/models/note.py:43
+#: journal/models/note.py:56
 msgid "Percentage"
 msgstr ""
 
-#: journal/models/note.py:60
+#: journal/models/note.py:77
 #, python-brace-format
 msgid "Page {value}"
 msgstr ""
 
-#: journal/models/note.py:61
+#: journal/models/note.py:78
 #, python-brace-format
 msgid "Chapter {value}"
 msgstr ""
 
-#: journal/models/note.py:64
+#: journal/models/note.py:81
 #, python-brace-format
 msgid "Part {value}"
 msgstr ""
 
-#: journal/models/note.py:65
+#: journal/models/note.py:82
 #, python-brace-format
 msgid "Episode {value}"
 msgstr ""
 
-#: journal/models/note.py:66
+#: journal/models/note.py:83
 #, python-brace-format
 msgid "Track {value}"
 msgstr ""
 
-#: journal/models/note.py:67
+#: journal/models/note.py:84
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr ""
@@ -5279,439 +5289,439 @@ msgstr ""
 msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr ""
 
-#: journal/models/review.py:78
+#: journal/models/review.py:79
 #, python-brace-format
 msgid "a review of {title}"
 msgstr ""
 
-#: journal/models/review.py:80
+#: journal/models/review.py:81
 msgid "(may contain spoilers)"
 msgstr ""
 
-#: journal/models/shelf.py:37
+#: journal/models/shelf.py:39
 msgid "WISHLIST"
 msgstr ""
 
-#: journal/models/shelf.py:38
+#: journal/models/shelf.py:40
 msgid "PROGRESS"
 msgstr ""
 
-#: journal/models/shelf.py:39
+#: journal/models/shelf.py:41
 msgid "COMPLETE"
 msgstr ""
 
-#: journal/models/shelf.py:40
+#: journal/models/shelf.py:42
 msgid "DROPPED"
 msgstr ""
 
-#: journal/models/shelf.py:49
+#: journal/models/shelf.py:51
 msgid "books to read"
 msgstr ""
 
-#: journal/models/shelf.py:50
+#: journal/models/shelf.py:52
 msgid "want to read"
 msgstr ""
 
-#: journal/models/shelf.py:51
+#: journal/models/shelf.py:53
 #, python-brace-format
 msgid "wants to read {item}"
 msgstr ""
 
-#: journal/models/shelf.py:52
+#: journal/models/shelf.py:54
 msgid "to read"
 msgstr ""
 
-#: journal/models/shelf.py:57
+#: journal/models/shelf.py:59
 msgid "books reading"
 msgstr ""
 
-#: journal/models/shelf.py:58
+#: journal/models/shelf.py:60
 msgid "start reading"
 msgstr ""
 
-#: journal/models/shelf.py:59
+#: journal/models/shelf.py:61
 #, python-brace-format
 msgid "started reading {item}"
 msgstr ""
 
-#: journal/models/shelf.py:60
+#: journal/models/shelf.py:62
 msgid "reading"
 msgstr ""
 
-#: journal/models/shelf.py:65
+#: journal/models/shelf.py:67
 msgid "books completed"
 msgstr ""
 
-#: journal/models/shelf.py:66
+#: journal/models/shelf.py:68
 msgid "finish reading"
 msgstr ""
 
-#: journal/models/shelf.py:67
+#: journal/models/shelf.py:69
 #, python-brace-format
 msgid "finished reading {item}"
 msgstr ""
 
-#: journal/models/shelf.py:68
+#: journal/models/shelf.py:70
 msgid "read"
 msgstr ""
 
-#: journal/models/shelf.py:73
+#: journal/models/shelf.py:75
 msgid "books dropped"
 msgstr ""
 
-#: journal/models/shelf.py:74
+#: journal/models/shelf.py:76
 msgid "stop reading"
 msgstr ""
 
-#: journal/models/shelf.py:75
+#: journal/models/shelf.py:77
 #, python-brace-format
 msgid "stopped reading {item}"
 msgstr ""
 
-#: journal/models/shelf.py:76
+#: journal/models/shelf.py:78
 msgid "stopped reading"
 msgstr ""
 
-#: journal/models/shelf.py:81
+#: journal/models/shelf.py:83
 msgid "books reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:82 journal/models/shelf.py:122
-#: journal/models/shelf.py:162 journal/models/shelf.py:202
-#: journal/models/shelf.py:242 journal/models/shelf.py:282
-#: journal/models/shelf.py:316
+#: journal/models/shelf.py:84 journal/models/shelf.py:124
+#: journal/models/shelf.py:164 journal/models/shelf.py:204
+#: journal/models/shelf.py:244 journal/models/shelf.py:284
+#: journal/models/shelf.py:318
 msgid "review"
 msgstr ""
 
-#: journal/models/shelf.py:83 journal/models/shelf.py:123
-#: journal/models/shelf.py:163 journal/models/shelf.py:203
-#: journal/models/shelf.py:243 journal/models/shelf.py:283
-#: journal/models/shelf.py:317
+#: journal/models/shelf.py:85 journal/models/shelf.py:125
+#: journal/models/shelf.py:165 journal/models/shelf.py:205
+#: journal/models/shelf.py:245 journal/models/shelf.py:285
+#: journal/models/shelf.py:319
 #, python-brace-format
 msgid "wrote a review of {item}"
 msgstr ""
 
-#: journal/models/shelf.py:89
+#: journal/models/shelf.py:91
 msgid "movies to watch"
 msgstr ""
 
-#: journal/models/shelf.py:90 journal/models/shelf.py:130
+#: journal/models/shelf.py:92 journal/models/shelf.py:132
 msgid "want to watch"
 msgstr ""
 
-#: journal/models/shelf.py:91 journal/models/shelf.py:131
+#: journal/models/shelf.py:93 journal/models/shelf.py:133
 #, python-brace-format
 msgid "wants to watch {item}"
 msgstr ""
 
-#: journal/models/shelf.py:92 journal/models/shelf.py:132
+#: journal/models/shelf.py:94 journal/models/shelf.py:134
 msgid "to watch"
 msgstr ""
 
-#: journal/models/shelf.py:97
+#: journal/models/shelf.py:99
 msgid "movies watching"
 msgstr ""
 
-#: journal/models/shelf.py:98 journal/models/shelf.py:138
+#: journal/models/shelf.py:100 journal/models/shelf.py:140
 msgid "start watching"
 msgstr ""
 
-#: journal/models/shelf.py:99 journal/models/shelf.py:139
+#: journal/models/shelf.py:101 journal/models/shelf.py:141
 #, python-brace-format
 msgid "started watching {item}"
 msgstr ""
 
-#: journal/models/shelf.py:100 journal/models/shelf.py:140
+#: journal/models/shelf.py:102 journal/models/shelf.py:142
 msgid "watching"
 msgstr ""
 
-#: journal/models/shelf.py:105
+#: journal/models/shelf.py:107
 msgid "movies watched"
 msgstr ""
 
-#: journal/models/shelf.py:106 journal/models/shelf.py:146
+#: journal/models/shelf.py:108 journal/models/shelf.py:148
 msgid "finish watching"
 msgstr ""
 
-#: journal/models/shelf.py:107 journal/models/shelf.py:147
+#: journal/models/shelf.py:109 journal/models/shelf.py:149
 #, python-brace-format
 msgid "finished watching {item}"
 msgstr ""
 
-#: journal/models/shelf.py:108 journal/models/shelf.py:148
+#: journal/models/shelf.py:110 journal/models/shelf.py:150
 msgid "watched"
 msgstr ""
 
-#: journal/models/shelf.py:113
+#: journal/models/shelf.py:115
 msgid "movies dropped"
 msgstr ""
 
-#: journal/models/shelf.py:114 journal/models/shelf.py:154
+#: journal/models/shelf.py:116 journal/models/shelf.py:156
 msgid "stop watching"
 msgstr ""
 
-#: journal/models/shelf.py:115 journal/models/shelf.py:155
+#: journal/models/shelf.py:117 journal/models/shelf.py:157
 #, python-brace-format
 msgid "stopped watching {item}"
 msgstr ""
 
-#: journal/models/shelf.py:116 journal/models/shelf.py:156
+#: journal/models/shelf.py:118 journal/models/shelf.py:158
 msgid "stopped watching"
 msgstr ""
 
-#: journal/models/shelf.py:121
+#: journal/models/shelf.py:123
 msgid "movies reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:129
+#: journal/models/shelf.py:131
 msgid "TV shows to watch"
 msgstr ""
 
-#: journal/models/shelf.py:137
+#: journal/models/shelf.py:139
 msgid "TV shows watching"
 msgstr ""
 
-#: journal/models/shelf.py:145
+#: journal/models/shelf.py:147
 msgid "TV shows watched"
 msgstr ""
 
-#: journal/models/shelf.py:153
+#: journal/models/shelf.py:155
 msgid "TV shows dropped"
 msgstr ""
 
-#: journal/models/shelf.py:161
+#: journal/models/shelf.py:163
 msgid "TV shows reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:169
+#: journal/models/shelf.py:171
 msgid "albums to listen"
 msgstr ""
 
-#: journal/models/shelf.py:170 journal/models/shelf.py:250
+#: journal/models/shelf.py:172 journal/models/shelf.py:252
 msgid "want to listen"
 msgstr ""
 
-#: journal/models/shelf.py:171 journal/models/shelf.py:251
+#: journal/models/shelf.py:173 journal/models/shelf.py:253
 #, python-brace-format
 msgid "wants to listen {item}"
 msgstr ""
 
-#: journal/models/shelf.py:172 journal/models/shelf.py:252
+#: journal/models/shelf.py:174 journal/models/shelf.py:254
 msgid "to listen"
 msgstr ""
 
-#: journal/models/shelf.py:177
+#: journal/models/shelf.py:179
 msgid "albums listening"
 msgstr ""
 
-#: journal/models/shelf.py:178 journal/models/shelf.py:258
+#: journal/models/shelf.py:180 journal/models/shelf.py:260
 msgid "start listening"
 msgstr ""
 
-#: journal/models/shelf.py:179 journal/models/shelf.py:259
+#: journal/models/shelf.py:181 journal/models/shelf.py:261
 #, python-brace-format
 msgid "started listening {item}"
 msgstr ""
 
-#: journal/models/shelf.py:180 journal/models/shelf.py:260
+#: journal/models/shelf.py:182 journal/models/shelf.py:262
 msgid "listening"
 msgstr ""
 
-#: journal/models/shelf.py:185
+#: journal/models/shelf.py:187
 msgid "albums listened"
 msgstr ""
 
-#: journal/models/shelf.py:186 journal/models/shelf.py:266
+#: journal/models/shelf.py:188 journal/models/shelf.py:268
 msgid "finish listening"
 msgstr ""
 
-#: journal/models/shelf.py:187 journal/models/shelf.py:267
+#: journal/models/shelf.py:189 journal/models/shelf.py:269
 #, python-brace-format
 msgid "finished listening {item}"
 msgstr ""
 
-#: journal/models/shelf.py:188 journal/models/shelf.py:268
+#: journal/models/shelf.py:190 journal/models/shelf.py:270
 msgid "listened"
 msgstr ""
 
-#: journal/models/shelf.py:193
+#: journal/models/shelf.py:195
 msgid "albums dropped"
 msgstr ""
 
-#: journal/models/shelf.py:194 journal/models/shelf.py:274
+#: journal/models/shelf.py:196 journal/models/shelf.py:276
 msgid "stop listening"
 msgstr ""
 
-#: journal/models/shelf.py:195 journal/models/shelf.py:275
+#: journal/models/shelf.py:197 journal/models/shelf.py:277
 #, python-brace-format
 msgid "stopped listening {item}"
 msgstr ""
 
-#: journal/models/shelf.py:196 journal/models/shelf.py:276
+#: journal/models/shelf.py:198 journal/models/shelf.py:278
 msgid "stopped listening"
 msgstr ""
 
-#: journal/models/shelf.py:201
+#: journal/models/shelf.py:203
 msgid "albums reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:209
+#: journal/models/shelf.py:211
 msgid "games to play"
 msgstr ""
 
-#: journal/models/shelf.py:210
+#: journal/models/shelf.py:212
 msgid "want to play"
 msgstr ""
 
-#: journal/models/shelf.py:211
+#: journal/models/shelf.py:213
 #, python-brace-format
 msgid "wants to play {item}"
 msgstr ""
 
-#: journal/models/shelf.py:212
+#: journal/models/shelf.py:214
 msgid "to play"
 msgstr ""
 
-#: journal/models/shelf.py:217
+#: journal/models/shelf.py:219
 msgid "games playing"
 msgstr ""
 
-#: journal/models/shelf.py:218
+#: journal/models/shelf.py:220
 msgid "start playing"
 msgstr ""
 
-#: journal/models/shelf.py:219
+#: journal/models/shelf.py:221
 #, python-brace-format
 msgid "started playing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:220
+#: journal/models/shelf.py:222
 msgid "playing"
 msgstr ""
 
-#: journal/models/shelf.py:225
+#: journal/models/shelf.py:227
 msgid "games played"
 msgstr ""
 
-#: journal/models/shelf.py:226
+#: journal/models/shelf.py:228
 msgid "finish playing"
 msgstr ""
 
-#: journal/models/shelf.py:227
+#: journal/models/shelf.py:229
 #, python-brace-format
 msgid "finished playing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:228
+#: journal/models/shelf.py:230
 msgid "played"
 msgstr ""
 
-#: journal/models/shelf.py:233
+#: journal/models/shelf.py:235
 msgid "games dropped"
 msgstr ""
 
-#: journal/models/shelf.py:234
+#: journal/models/shelf.py:236
 msgid "stop playing"
 msgstr ""
 
-#: journal/models/shelf.py:235
+#: journal/models/shelf.py:237
 #, python-brace-format
 msgid "stopped playing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:236
+#: journal/models/shelf.py:238
 msgid "stopped playing"
 msgstr ""
 
-#: journal/models/shelf.py:241
+#: journal/models/shelf.py:243
 msgid "games reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:249
+#: journal/models/shelf.py:251
 msgid "podcasts to listen"
 msgstr ""
 
-#: journal/models/shelf.py:257
+#: journal/models/shelf.py:259
 msgid "podcasts listening"
 msgstr ""
 
-#: journal/models/shelf.py:265
+#: journal/models/shelf.py:267
 msgid "podcasts listened"
 msgstr ""
 
-#: journal/models/shelf.py:273
+#: journal/models/shelf.py:275
 msgid "podcasts dropped"
 msgstr ""
 
-#: journal/models/shelf.py:281
+#: journal/models/shelf.py:283
 msgid "podcasts reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:289
+#: journal/models/shelf.py:291
 msgid "performances to see"
 msgstr ""
 
-#: journal/models/shelf.py:290
+#: journal/models/shelf.py:292
 msgid "want to see"
 msgstr ""
 
-#: journal/models/shelf.py:291
+#: journal/models/shelf.py:293
 #, python-brace-format
 msgid "wants to see {item}"
 msgstr ""
 
-#: journal/models/shelf.py:292
+#: journal/models/shelf.py:294
 msgid "to see"
 msgstr ""
 
-#: journal/models/shelf.py:299
+#: journal/models/shelf.py:301
 msgid "performances saw"
 msgstr ""
 
-#: journal/models/shelf.py:300
+#: journal/models/shelf.py:302
 msgid "finish seeing"
 msgstr ""
 
-#: journal/models/shelf.py:301
+#: journal/models/shelf.py:303
 #, python-brace-format
 msgid "finished seeing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:302
+#: journal/models/shelf.py:304
 msgid "seen"
 msgstr ""
 
-#: journal/models/shelf.py:307
+#: journal/models/shelf.py:309
 msgid "performances dropped"
 msgstr ""
 
-#: journal/models/shelf.py:308
+#: journal/models/shelf.py:310
 msgid "stop seeing"
 msgstr ""
 
-#: journal/models/shelf.py:309
+#: journal/models/shelf.py:311
 #, python-brace-format
 msgid "stopped seeing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:310
+#: journal/models/shelf.py:312
 msgid "stopped seeing"
 msgstr ""
 
-#: journal/models/shelf.py:315
+#: journal/models/shelf.py:317
 msgid "performances reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:323
+#: journal/models/shelf.py:325
 msgid "people following"
 msgstr ""
 
-#: journal/models/shelf.py:325
+#: journal/models/shelf.py:327
 #, python-brace-format
 msgid "started following {item}"
 msgstr ""
 
-#: journal/models/shelf.py:921
+#: journal/models/shelf.py:923
 msgid "removed mark"
 msgstr ""
 
@@ -5739,30 +5749,20 @@ msgstr ""
 msgid "Remove from collection"
 msgstr ""
 
-#: journal/templates/_list_item.html:34
-msgid "add mark"
-msgstr ""
-
-#: journal/templates/_list_item.html:42
-msgid "update mark"
-msgstr ""
-
-#: journal/templates/_list_item.html:60
+#: journal/templates/_list_item.html:43
 #: journal/templates/collection_update_item_note_ok.html:3
 msgid "Update note"
 msgstr ""
 
-#: journal/templates/_list_item.html:100 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:123
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
 msgstr ""
 
-#: journal/templates/_list_item.html:133
+#: journal/templates/_list_item.html:91
 #, python-format
-msgid ""
-"%(dups)s item(s) are from the same work or have the same identifier, click "
-"here to display:"
+msgid "%(dups)s item(s) are from the same work or have the same identifier, click here to display:"
 msgstr ""
 
 #: journal/templates/_sidebar_collection_filter.html:32
@@ -5870,6 +5870,14 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
+#: journal/templates/action_mark_item.html:10
+msgid "add mark"
+msgstr ""
+
+#: journal/templates/action_mark_item.html:18
+msgid "update mark"
+msgstr ""
+
 #: journal/templates/action_open_post.html:7
 msgid "Quiet Public"
 msgstr ""
@@ -5922,11 +5930,11 @@ msgstr ""
 msgid "Create a new collection"
 msgstr ""
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:81
+#: journal/templates/article.html:104 social/templates/_event_post.html:76
 msgid "wrote a review"
 msgstr ""
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:83
+#: journal/templates/article.html:106 social/templates/_event_post.html:78
 msgid "wrote an article"
 msgstr ""
 
@@ -6038,19 +6046,19 @@ msgstr ""
 msgid "Mark"
 msgstr ""
 
-#: journal/templates/mark.html:50
+#: journal/templates/mark.html:54
 msgid "not rated"
 msgstr ""
 
-#: journal/templates/mark.html:70
+#: journal/templates/mark.html:74
 msgid "add a tag and press Enter"
 msgstr ""
 
-#: journal/templates/mark.html:122
+#: journal/templates/mark.html:126
 msgid "change mark date"
 msgstr ""
 
-#: journal/templates/mark.html:148
+#: journal/templates/mark.html:156
 msgid "Sure to delete mark, comment and tags for this item?"
 msgstr ""
 
@@ -6093,12 +6101,11 @@ msgid ""
 "Content Cell  | Content Cell\n"
 "Content Cell  | Content Cell\n"
 "\n"
-"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/"
-"Wikipedia-logo-v2.svg)\n"
+"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 "\n"
 msgstr ""
 
-#: journal/templates/note.html:19 journal/views/note.py:23
+#: journal/templates/note.html:19 journal/views/note.py:22
 msgid "Note"
 msgstr ""
 
@@ -6123,9 +6130,7 @@ msgid "Are you sure to delete this entire content?"
 msgstr ""
 
 #: journal/templates/piece_delete.html:24
-msgid ""
-"By deleting it, you will also lose track of others' comments and feedbacks "
-"to your content."
+msgid "By deleting it, you will also lose track of others' comments and feedbacks to your content."
 msgstr ""
 
 #: journal/templates/piece_delete.html:25
@@ -6205,7 +6210,7 @@ msgstr ""
 msgid "Articles"
 msgstr ""
 
-#: journal/templates/profile.html:166 journal/views/collection.py:427
+#: journal/templates/profile.html:166 journal/views/collection.py:409
 #: journal/views/profile.py:401
 msgid "collection"
 msgstr ""
@@ -6239,9 +6244,7 @@ msgid "Personal"
 msgstr ""
 
 #: journal/templates/tag_edit.html:52
-msgid ""
-"Personal tags are not included in public index. However, if you use this tag "
-"when marking an item publicly, it might still be visible to others."
+msgid "Personal tags are not included in public index. However, if you use this tag when marking an item publicly, it might still be visible to others."
 msgstr ""
 
 #: journal/templates/tag_edit.html:55
@@ -6310,113 +6313,114 @@ msgstr ""
 msgid "Link invalid"
 msgstr ""
 
-#: journal/views/collection.py:58 journal/views/collection.py:96
+#: journal/views/collection.py:62 journal/views/collection.py:94
 #, python-brace-format
 msgid "Collection by {0}"
 msgstr ""
 
-#: journal/views/collection.py:432
+#: journal/views/collection.py:414
 msgid "shared my collection"
 msgstr ""
 
-#: journal/views/collection.py:435
+#: journal/views/collection.py:417
 #, python-brace-format
 msgid "shared {username}'s collection"
 msgstr ""
 
-#: journal/views/collection.py:502 journal/views/collection.py:541
-#: journal/views/collection.py:553 journal/views/collection.py:579
+#: journal/views/collection.py:484 journal/views/collection.py:523
+#: journal/views/collection.py:535 journal/views/collection.py:561
 msgid "Dynamic collection is not editable"
 msgstr ""
 
-#: journal/views/collection.py:518
+#: journal/views/collection.py:500
 msgid "The item is already in the collection."
 msgstr ""
 
-#: journal/views/collection.py:520
+#: journal/views/collection.py:502
 msgid "Unable to find the item, please use item url from this site."
 msgstr ""
 
-#: journal/views/collection.py:566
+#: journal/views/collection.py:548
 msgid "Saved."
 msgstr ""
 
-#: journal/views/common.py:119 journal/views/mark.py:225
-#: journal/views/mark.py:279 journal/views/note.py:175
+#: journal/views/common.py:126 journal/views/mark.py:273
+#: journal/views/mark.py:315 journal/views/note.py:167
 #: journal/views/profile.py:42 journal/views/review.py:59
 #: journal/views/review.py:79
 msgid "Content not found"
 msgstr ""
 
-#: journal/views/common.py:174 journal/views/mark.py:159
+#: journal/views/common.py:184 journal/views/mark.py:210
 msgid "Data saved but unable to crosspost to Fediverse instance."
 msgstr ""
 
-#: journal/views/common.py:176
+#: journal/views/common.py:186
 msgid "Redirecting to your Fediverse instance now to re-authenticate."
 msgstr ""
 
-#: journal/views/common.py:183
+#: journal/views/common.py:193
 msgid "List not found."
 msgstr ""
 
-#: journal/views/mark.py:150
+#: journal/views/mark.py:206
 msgid "Content too long for your Fediverse instance."
 msgstr ""
 
-#: journal/views/mark.py:178 journal/views/mark.py:238
+#: journal/views/mark.py:224 journal/views/mark.py:226
+#: journal/views/mark.py:280
 msgid "Invalid input"
 msgstr ""
 
-#: journal/views/note.py:23
+#: journal/views/note.py:22
 msgid "Progress"
 msgstr ""
 
-#: journal/views/note.py:28
+#: journal/views/note.py:27
 msgid "Update progress"
 msgstr ""
 
-#: journal/views/note.py:59
+#: journal/views/note.py:58
 msgid "Progress (optional)"
 msgstr ""
 
-#: journal/views/note.py:61
+#: journal/views/note.py:60
 msgid "Note Content"
 msgstr ""
 
-#: journal/views/note.py:63
+#: journal/views/note.py:62
 msgid "Content Warning (optional)"
 msgstr ""
 
-#: journal/views/note.py:85
+#: journal/views/note.py:84
 msgid "Progress Type (optional)"
 msgstr ""
 
-#: journal/views/note.py:123 journal/views/note.py:183
+#: journal/views/note.py:115 journal/views/note.py:175
 msgid "Only in-progress items can have progress."
 msgstr ""
 
-#: journal/views/post.py:98 journal/views/post.py:392
+#: journal/views/post.py:100 journal/views/post.py:388
 msgid "Post not found"
 msgstr ""
 
-#: journal/views/post.py:189
+#: journal/views/post.py:191
 msgid "Visibility too high for quoting this post"
 msgstr ""
 
-#: journal/views/post.py:337 journal/views/post.py:418
+#: journal/views/post.py:339 journal/views/post.py:414
 msgid "Content cannot be empty."
 msgstr ""
 
-#: journal/views/post.py:396
+#: journal/views/post.py:392
 msgid "This post cannot be edited here"
 msgstr ""
 
-#: journal/views/post.py:541
+#: journal/views/post.py:531
 msgid "Invalid choices"
 msgstr ""
 
-#: journal/views/post.py:544
+#: journal/views/post.py:534
 msgid "Invalid post"
 msgstr ""
 
@@ -6434,56 +6438,54 @@ msgstr ""
 msgid "may contain spoiler or triggering content"
 msgstr ""
 
-#: journal/views/tag.py:47 journal/views/tag.py:61
+#: journal/views/tag.py:46 journal/views/tag.py:60
 msgid "Invalid tag"
 msgstr ""
 
-#: journal/views/tag.py:50
+#: journal/views/tag.py:49
 msgid "Tag not found"
 msgstr ""
 
-#: journal/views/tag.py:72
+#: journal/views/tag.py:65
 msgid "Tag deleted."
 msgstr ""
 
-#: journal/views/tag.py:82
+#: journal/views/tag.py:75
 msgid "Duplicated tag."
 msgstr ""
 
-#: journal/views/tag.py:96
+#: journal/views/tag.py:83
 msgid "Tag updated."
 msgstr ""
 
-#: journal/views/wrapped.py:160
+#: journal/views/wrapped.py:161
 msgid "Summary posted to timeline."
 msgstr ""
 
-#: mastodon/models/common.py:29
+#: mastodon/models/common.py:31
 msgid "Mastodon"
 msgstr ""
 
-#: mastodon/models/common.py:30 users/templates/users/login.html:120
+#: mastodon/models/common.py:32 users/templates/users/login.html:114
 msgid "Threads"
 msgstr ""
 
-#: mastodon/models/common.py:31
+#: mastodon/models/common.py:33
 msgid "Bluesky"
 msgstr ""
 
-#: mastodon/models/email.py:59
+#: mastodon/models/email.py:63
 msgid ""
 "\n"
 "\n"
-"If you did not mean to register or login, please ignore this email. If you "
-"are concerned with your account security, please change the email linked "
-"with your account, or contact us."
+"If you did not mean to register or login, please ignore this email. If you are concerned with your account security, please change the email linked with your account, or contact us."
 msgstr ""
 
-#: mastodon/models/email.py:64 mastodon/models/email.py:69
+#: mastodon/models/email.py:68 mastodon/models/email.py:73
 msgid "Verification Code"
 msgstr ""
 
-#: mastodon/models/email.py:66
+#: mastodon/models/email.py:70
 #, python-brace-format
 msgid ""
 "Use this code to verify your email address {email}\n"
@@ -6491,7 +6493,7 @@ msgid ""
 "{code}"
 msgstr ""
 
-#: mastodon/models/email.py:70
+#: mastodon/models/email.py:74
 #, python-brace-format
 msgid ""
 "Use this code to login as {email}\n"
@@ -6499,23 +6501,21 @@ msgid ""
 "{code}"
 msgstr ""
 
-#: mastodon/models/email.py:74 users/templates/users/captcha.html:13
+#: mastodon/models/email.py:78 users/templates/users/captcha.html:13
 #: users/templates/users/captcha_solved.html:9
 #: users/templates/users/login.html:20 users/templates/users/register.html:9
 #: users/templates/users/welcome.html:10
 msgid "Register"
 msgstr ""
 
-#: mastodon/models/email.py:76
+#: mastodon/models/email.py:80
 #, python-brace-format
 msgid ""
 "There is no account registered with this email address yet: {email}\n"
 "\n"
-"If you already have an account with us, just login and add this email to you "
-"account.\n"
+"If you already have an account with us, just login and add this email to you account.\n"
 "\n"
-"If you prefer to register a new account with this email, please use this "
-"verification code: {code}"
+"If you prefer to register a new account with this email, please use this verification code: {code}"
 msgstr ""
 
 #: mastodon/models/mastodon.py:570
@@ -6558,44 +6558,49 @@ msgstr ""
 msgid "New Post"
 msgstr ""
 
-#: mastodon/views/bluesky.py:26 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:32 mastodon/views/bluesky.py:93
 msgid "Bluesky login is disabled."
 msgstr ""
 
-#: mastodon/views/bluesky.py:28 mastodon/views/email.py:35
-#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:29
-#: users/templates/users/login.html:6 users/views/webauthn.py:133
-msgid "Security check failed. Please try again."
-msgstr ""
-
-#: mastodon/views/bluesky.py:34 mastodon/views/bluesky.py:40
-#: mastodon/views/bluesky.py:64 mastodon/views/bluesky.py:72
-#: mastodon/views/bluesky.py:78 mastodon/views/common.py:36
-#: mastodon/views/mastodon.py:62 mastodon/views/mastodon.py:70
-#: mastodon/views/mastodon.py:77 mastodon/views/mastodon.py:87
-#: mastodon/views/mastodon.py:94 mastodon/views/threads.py:55
-#: mastodon/views/threads.py:63 mastodon/views/threads.py:69
-#: users/views/account.py:254 users/views/account.py:373
+#: mastodon/views/bluesky.py:47 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:65 mastodon/views/bluesky.py:98
+#: mastodon/views/bluesky.py:106 mastodon/views/bluesky.py:112
+#: mastodon/views/common.py:36 mastodon/views/mastodon.py:62
+#: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
+#: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
+#: mastodon/views/threads.py:57 mastodon/views/threads.py:65
+#: mastodon/views/threads.py:71 users/views/account.py:256
+#: users/views/account.py:375
 msgid "Authentication failed"
 msgstr ""
 
-#: mastodon/views/bluesky.py:35 mastodon/views/email.py:66
+#: mastodon/views/bluesky.py:47 mastodon/views/common.py:103
+msgid "Identity not found."
+msgstr ""
+
+#: mastodon/views/bluesky.py:53 mastodon/views/email.py:35
+#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:31
+#: users/templates/users/login.html:6 users/views/webauthn.py:136
+msgid "Security check failed. Please try again."
+msgstr ""
+
+#: mastodon/views/bluesky.py:60 mastodon/views/email.py:66
 msgid "Too many attempts, please try again later."
 msgstr ""
 
-#: mastodon/views/bluesky.py:40
+#: mastodon/views/bluesky.py:65
 msgid "ATProto handle is required."
 msgstr ""
 
-#: mastodon/views/bluesky.py:50
+#: mastodon/views/bluesky.py:84
 msgid "Error connecting to your ATProto server"
 msgstr ""
 
-#: mastodon/views/bluesky.py:73
+#: mastodon/views/bluesky.py:107
 msgid "Invalid response from ATProto authorization server."
 msgstr ""
 
-#: mastodon/views/bluesky.py:78
+#: mastodon/views/bluesky.py:112
 msgid "Invalid account data from Bluesky."
 msgstr ""
 
@@ -6603,7 +6608,7 @@ msgstr ""
 msgid "Invalid user."
 msgstr ""
 
-#: mastodon/views/common.py:52 users/views/account.py:414
+#: mastodon/views/common.py:52 users/views/account.py:416
 msgid "Registration failed"
 msgstr ""
 
@@ -6633,10 +6638,6 @@ msgstr ""
 #: mastodon/views/common.py:103 mastodon/views/common.py:107
 #: mastodon/views/common.py:116
 msgid "Disconnect identity failed"
-msgstr ""
-
-#: mastodon/views/common.py:103
-msgid "Identity not found."
 msgstr ""
 
 #: mastodon/views/common.py:117
@@ -6680,7 +6681,7 @@ msgstr ""
 msgid "Invalid response from Fediverse instance."
 msgstr ""
 
-#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:64
+#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:66
 msgid "Invalid OAuth state. Please try again."
 msgstr ""
 
@@ -6700,19 +6701,17 @@ msgstr ""
 msgid "Invalid account data from Fediverse instance."
 msgstr ""
 
-#: mastodon/views/threads.py:69
+#: mastodon/views/threads.py:71
 msgid "Invalid account data from Threads."
 msgstr ""
 
-#: mastodon/views/threads.py:147
+#: mastodon/views/threads.py:149
 msgid "Data deletion completed"
 msgstr ""
 
-#: mastodon/views/threads.py:149
+#: mastodon/views/threads.py:151
 #, python-brace-format
-msgid ""
-"Data linked to your Threads account has been deleted. Confirmation code: "
-"{code}"
+msgid "Data linked to your Threads account has been deleted. Confirmation code: {code}"
 msgstr ""
 
 #: social/templates/_article_teaser.html:10
@@ -6745,15 +6744,11 @@ msgstr ""
 msgid "play"
 msgstr ""
 
-#: social/templates/_event_post.html:50
-msgid "mark"
-msgstr ""
-
-#: social/templates/_event_post.html:79
+#: social/templates/_event_post.html:74
 msgid "wrote a note"
 msgstr ""
 
-#: social/templates/_event_post.html:88
+#: social/templates/_event_post.html:83
 msgid "replying to"
 msgstr ""
 
@@ -6766,7 +6761,7 @@ msgstr ""
 msgid "Untitled article"
 msgstr ""
 
-#: social/templates/event/boosted.html:3
+#: social/templates/event/boosted.html:2
 msgid "boosted your post"
 msgstr ""
 
@@ -6809,8 +6804,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
 #: social/templates/event/boosted_shelfmember.html:3
@@ -6828,7 +6822,7 @@ msgstr ""
 msgid "followed you"
 msgstr ""
 
-#: social/templates/event/liked.html:3
+#: social/templates/event/liked.html:2
 msgid "liked your post"
 msgstr ""
 
@@ -6871,8 +6865,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
 #: social/templates/event/liked_shelfmember.html:3
@@ -6882,7 +6875,7 @@ msgid ""
 "liked your mark on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
-#: social/templates/event/mentioned.html:3
+#: social/templates/event/mentioned.html:2
 msgid "mentioned you"
 msgstr ""
 
@@ -6925,8 +6918,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
 #: social/templates/event/mentioned_shelfmember.html:3
@@ -6936,26 +6928,37 @@ msgid ""
 "replied to your mark on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
-#: social/templates/feed.html:12 social/templates/feed.html:39
-#: social/templates/search_feed.html:12
-msgid "Activities from those you follow"
+#: social/templates/feed.html:39 users/templates/users/preferences.html:40
+msgid "Activities"
 msgstr ""
 
-#: social/templates/feed.html:42 social/templates/feed.html:44
+#: social/templates/feed.html:43 social/templates/feed.html:45
+msgid "world"
+msgstr ""
+
+#: social/templates/feed.html:51 social/templates/feed.html:53
+msgid "local"
+msgstr ""
+
+#: social/templates/feed.html:58 social/templates/feed.html:60
+msgid "those you follow"
+msgstr ""
+
+#: social/templates/feed.html:64 social/templates/feed.html:66
 msgid "what they read/watch/..."
 msgstr ""
 
-#: social/templates/feed_events.html:30
+#: social/templates/feed_events.html:29
 msgid "no matching activities."
 msgstr ""
 
-#: social/templates/feed_events.html:33
+#: social/templates/feed_events.html:31
+msgid "no public activities yet."
+msgstr ""
+
+#: social/templates/feed_events.html:34
 #, python-format
-msgid ""
-"Find and mark some books/movies/podcasts/games, <a "
-"href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/"
-"Douban, follow some fellow %(site_name)s users on the fediverse, so their "
-"recent activities and yours will show up here."
+msgid "Find and mark some books/movies/podcasts/games, <a href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/Douban, follow some fellow %(site_name)s users on the fediverse, so their recent activities and yours will show up here."
 msgstr ""
 
 #: social/templates/notification.html:58
@@ -6988,6 +6991,10 @@ msgstr ""
 msgid "Poll ending at %(end_time)s"
 msgstr ""
 
+#: social/templates/search_feed.html:12 social/views.py:57 social/views.py:58
+msgid "Activities from those you follow"
+msgstr ""
+
 #: social/templates/single_post.html:13 social/templates/single_post.html:32
 msgid "Post"
 msgstr ""
@@ -7000,57 +7007,63 @@ msgstr ""
 msgid "Poll"
 msgstr ""
 
-#: takahe/models.py:453
+#: social/views.py:59
+msgid "Activities on this site"
+msgstr ""
+
+#: social/views.py:60
+msgid "Activities from the fediverse"
+msgstr ""
+
+#: takahe/models.py:445
 msgid "Display Name"
 msgstr ""
 
-#: takahe/models.py:455
+#: takahe/models.py:447
 msgid "Bio"
 msgstr ""
 
-#: takahe/models.py:457
+#: takahe/models.py:449
 msgid "Manually approve new followers"
 msgstr ""
 
-#: takahe/models.py:461
+#: takahe/models.py:453
 msgid "Include profile, marks and posts in discovery"
 msgstr ""
 
-#: takahe/models.py:464
+#: takahe/models.py:456
 msgid "Include posts in search results"
 msgstr ""
 
-#: takahe/models.py:482
+#: takahe/models.py:474
 msgid "Profile picture"
 msgstr ""
 
-#: takahe/models.py:489
+#: takahe/models.py:481
 msgid "Header picture"
 msgstr ""
 
-#: users/models/task.py:22
+#: users/models/task.py:24
 msgid "Started"
 msgstr ""
 
-#: users/models/task.py:23
+#: users/models/task.py:25
 msgid "Complete"
 msgstr ""
 
-#: users/models/user.py:69
-msgid ""
-"Enter a valid username. This value may contain only unaccented lowercase a-z "
-"and uppercase A-Z letters, numbers, and _ characters."
+#: users/models/user.py:71
+msgid "Enter a valid username. This value may contain only unaccented lowercase a-z and uppercase A-Z letters, numbers, and _ characters."
 msgstr ""
 
-#: users/models/user.py:130
+#: users/models/user.py:132
 msgid "username"
 msgstr ""
 
-#: users/models/user.py:135
+#: users/models/user.py:137
 msgid "Required. 50 characters or fewer. Letters, digits and _ only."
 msgstr ""
 
-#: users/models/user.py:138
+#: users/models/user.py:140
 msgid "A user with that username already exists."
 msgstr ""
 
@@ -7181,9 +7194,7 @@ msgid "Cancel import"
 msgstr ""
 
 #: users/templates/users/_rym_section.html:29
-msgid ""
-"On RateYourMusic, go to your profile and use the <b>Export your music "
-"catalog</b> option to download your library as a CSV file."
+msgid "On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:31
@@ -7192,18 +7203,12 @@ msgid "Upload the downloaded CSV file below."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:33
-msgid ""
-"Albums are matched by title + artist (and year if present) — first against "
-"the local catalog, then MusicBrainz, then Spotify. After auto-matching, "
-"you'll preview the matches in a table, edit any link or shelf status, and "
-"confirm the import."
+msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:36
 #: users/templates/users/_storygraph_section.html:38
-msgid ""
-"You can also re-upload a previously-downloaded matched CSV — the existing "
-"<code>link</code> column will be honoured as the default match."
+msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:40
@@ -7230,18 +7235,11 @@ msgid "Cancel the StoryGraph import? Progress will be discarded."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:31
-msgid ""
-"On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to "
-"download your library as a CSV file."
+msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:35
-msgid ""
-"Books are matched by ISBN — first against the local catalog, then Google "
-"Books and OpenLibrary — with a title + author search as fallback. After auto-"
-"matching, you'll preview the matches in a table, edit any link or shelf "
-"status, and confirm the import."
+msgid "Books are matched by ISBN — first against the local catalog, then Google Books and OpenLibrary — with a title + author search as fallback. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/account.html:11
@@ -7253,9 +7251,7 @@ msgid "Display name, avatar and other information"
 msgstr ""
 
 #: users/templates/users/account.html:23
-msgid ""
-"Updating profile information here will turn off automatic sync of display "
-"name, bio and avatar from your Mastodon instance. Sure to continue?"
+msgid "Updating profile information here will turn off automatic sync of display name, bio and avatar from your Mastodon instance. Sure to continue?"
 msgstr ""
 
 #: users/templates/users/account.html:26
@@ -7268,16 +7264,11 @@ msgstr ""
 
 #: users/templates/users/account.html:59 users/templates/users/register.html:47
 #, python-format
-msgid ""
-"Please click the confirmation link in the email sent to %(pending_email)s; "
-"if you haven't received it for more than a few minutes, please input and "
-"save again."
+msgid "Please click the confirmation link in the email sent to %(pending_email)s; if you haven't received it for more than a few minutes, please input and save again."
 msgstr ""
 
 #: users/templates/users/account.html:61 users/templates/users/register.html:50
-msgid ""
-"Email is recommended as a backup login method, if you log in via a Fediverse "
-"instance"
+msgid "Email is recommended as a backup login method, if you log in via a Fediverse instance"
 msgstr ""
 
 #: users/templates/users/account.html:73 users/templates/users/login.html:84
@@ -7295,22 +7286,15 @@ msgid "Last updated"
 msgstr ""
 
 #: users/templates/users/account.html:92
-msgid ""
-"If you have not yet registered with any Federated instance, you may <a "
-"href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an "
-"instance</a> and register."
+msgid "If you have not yet registered with any Federated instance, you may <a href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an instance</a> and register."
 msgstr ""
 
 #: users/templates/users/account.html:97
-msgid ""
-"To associate with another federated identity, please enter the domain name "
-"of the instance where the new identity is located."
+msgid "To associate with another federated identity, please enter the domain name of the instance where the new identity is located."
 msgstr ""
 
 #: users/templates/users/account.html:99
-msgid ""
-"If you have registered with a Federated instance, please enter the instance "
-"domain name."
+msgid "If you have registered with a Federated instance, please enter the instance domain name."
 msgstr ""
 
 #: users/templates/users/account.html:104
@@ -7322,24 +7306,17 @@ msgid "Go to target instance and authorize with the identity"
 msgstr ""
 
 #: users/templates/users/account.html:113
-msgid ""
-"After replacing the association, you may use the new Fediverse identity to "
-"log in and control data visibility. Existing data such as tags, comments, "
-"and collections will not be affected."
+msgid "After replacing the association, you may use the new Fediverse identity to log in and control data visibility. Existing data such as tags, comments, and collections will not be affected."
 msgstr ""
 
 #: users/templates/users/account.html:115
-msgid ""
-"Once associated with Fediverse identity, you can discover more users and use "
-"the full features of this site."
+msgid "Once associated with Fediverse identity, you can discover more users and use the full features of this site."
 msgstr ""
 
 #: users/templates/users/account.html:123
 #: users/templates/users/account.html:160
 #: users/templates/users/account.html:206
-msgid ""
-"Once disconnected, you will no longer be able login with this identity. Are "
-"you sure to continue?"
+msgid "Once disconnected, you will no longer be able login with this identity. Are you sure to continue?"
 msgstr ""
 
 #: users/templates/users/account.html:126
@@ -7366,7 +7343,7 @@ msgstr ""
 msgid "Disconnect with Threads"
 msgstr ""
 
-#: users/templates/users/account.html:173 users/templates/users/login.html:112
+#: users/templates/users/account.html:173 users/templates/users/login.html:106
 msgid "Bluesky (ATProto)"
 msgstr ""
 
@@ -7374,7 +7351,7 @@ msgstr ""
 msgid "Verified ATProto identity"
 msgstr ""
 
-#: users/templates/users/account.html:194 users/templates/users/login.html:216
+#: users/templates/users/account.html:194 users/templates/users/login.html:210
 msgid "ATProto handle"
 msgstr ""
 
@@ -7399,7 +7376,7 @@ msgid "Name this passkey:"
 msgstr ""
 
 #: users/templates/users/account.html:227 users/templates/users/login.html:69
-#: users/templates/users/welcome.html:33 users/views/webauthn.py:106
+#: users/templates/users/welcome.html:33 users/views/webauthn.py:109
 msgid "Passkey"
 msgstr ""
 
@@ -7442,9 +7419,7 @@ msgid "Save sync settings"
 msgstr ""
 
 #: users/templates/users/account.html:297
-msgid ""
-"New follow, mute and blocks in the associated identity may be automatically "
-"imported; removal has to be done manually."
+msgid "New follow, mute and blocks in the associated identity may be automatically imported; removal has to be done manually."
 msgstr ""
 
 #: users/templates/users/account.html:304
@@ -7481,15 +7456,11 @@ msgid "Log out everywhere"
 msgstr ""
 
 #: users/templates/users/account.html:365
-msgid ""
-"This will log you out of all browsers and devices (including the current "
-"one), and revoke all API tokens. Continue?"
+msgid "This will log you out of all browsers and devices (including the current one), and revoke all API tokens. Continue?"
 msgstr ""
 
 #: users/templates/users/account.html:368
-msgid ""
-"If you notice any suspicious activity or have logged in on a shared "
-"computer, you can log out of all sessions and revoke all API tokens."
+msgid "If you notice any suspicious activity or have logged in on a shared computer, you can log out of all sessions and revoke all API tokens."
 msgstr ""
 
 #: users/templates/users/account.html:378
@@ -7550,10 +7521,10 @@ msgstr ""
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:74
-#: users/templates/users/data.html:126 users/templates/users/data.html:183
-#: users/templates/users/data.html:234 users/templates/users/data.html:298
-#: users/templates/users/data.html:358 users/templates/users/data.html:553
+#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/data.html:141 users/templates/users/data.html:198
+#: users/templates/users/data.html:249 users/templates/users/data.html:313
+#: users/templates/users/data.html:376 users/templates/users/data.html:553
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr ""
@@ -7578,9 +7549,7 @@ msgid "Migrate Account"
 msgstr ""
 
 #: users/templates/users/account.html:488
-msgid ""
-"Linking an email to your account is highly recommended before migrating from "
-"another Fediverse instance."
+msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
 msgstr ""
 
 #: users/templates/users/account.html:491
@@ -7600,9 +7569,7 @@ msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
 msgstr ""
 
 #: users/templates/users/account.html:507
-msgid ""
-"Enter full <code>username@instance.social</code> or <code>email@domain.com</"
-"code> to confirm deletion."
+msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
 msgstr ""
 
 #: users/templates/users/account.html:517
@@ -7654,9 +7621,7 @@ msgid "Token Created"
 msgstr ""
 
 #: users/templates/users/authorized_app_created.html:22
-msgid ""
-"Your new personal access token has been created. Copy it now -- you will not "
-"be able to see it again."
+msgid "Your new personal access token has been created. Copy it now -- you will not be able to see it again."
 msgstr ""
 
 #: users/templates/users/authorized_app_created.html:25
@@ -7684,9 +7649,7 @@ msgid "One quick check"
 msgstr ""
 
 #: users/templates/users/captcha.html:28
-msgid ""
-"Put every cover into the row it belongs to. Drag it, or select a cover and "
-"then select a row."
+msgid "Put every cover into the row it belongs to. Drag it, or select a cover and then select a row."
 msgstr ""
 
 #: users/templates/users/captcha.html:41 users/templates/users/captcha.html:43
@@ -7717,7 +7680,7 @@ msgstr ""
 msgid "That is all we needed. Let's get you a username."
 msgstr ""
 
-#: users/templates/users/captcha_solved.html:34
+#: users/templates/users/captcha_solved.html:32
 #: users/templates/users/login.html:63
 #: users/templates/users/verify_email.html:25
 #: users/templates/users/welcome.html:51
@@ -7737,10 +7700,7 @@ msgid "Failed Crossposts"
 msgstr ""
 
 #: users/templates/users/crossposts.html:42
-msgid ""
-"These posts could not be crossposted to your linked social accounts. Re-"
-"authorize the account if needed, then retry. In rare cases retrying may "
-"create a duplicate post."
+msgid "These posts could not be crossposted to your linked social accounts. Re-authorize the account if needed, then retry. In rare cases retrying may create a duplicate post."
 msgstr ""
 
 #: users/templates/users/crossposts.html:48
@@ -7759,209 +7719,162 @@ msgstr ""
 msgid "Data Management"
 msgstr ""
 
-#: users/templates/users/data.html:27
+#: users/templates/users/data.html:39
 msgid "Import Marks and Reviews from Douban"
 msgstr ""
 
-#: users/templates/users/data.html:31
-msgid ""
-"Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
-"target=\"_blank\" rel=\"noopener\">Doufen</a>"
+#: users/templates/users/data.html:43
+msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr ""
 
 #: users/templates/users/data.html:45
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
-"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
-"NeoDB Archive</a> below."
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON format instead; upload it under <a href=\"#import-neodb-archive\">Import NeoDB Archive</a> below."
 msgstr ""
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:256
+#: users/templates/users/data.html:49 users/templates/users/data.html:271
 msgid "Import Method"
 msgstr ""
 
-#: users/templates/users/data.html:37
-msgid ""
-"Merge: only update when status changes from wishlist to in-progress, or from "
-"in-progress to complete."
+#: users/templates/users/data.html:52
+msgid "Merge: only update when status changes from wishlist to in-progress, or from in-progress to complete."
 msgstr ""
 
-#: users/templates/users/data.html:41
+#: users/templates/users/data.html:56
 msgid "Overwrite: update all imported status."
 msgstr ""
 
-#: users/templates/users/data.html:74
-msgid ""
-"Another import is in progress, starting a new import may cause issues, sure "
-"to import?"
+#: users/templates/users/data.html:89
+msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
 msgstr ""
 
-#: users/templates/users/data.html:74
+#: users/templates/users/data.html:89 users/views/data.py:1130
 msgid "Import in progress, please wait"
 msgstr ""
 
-#: users/templates/users/data.html:81
+#: users/templates/users/data.html:96
 #, fuzzy
 msgid "Import from Goodreads"
 msgstr "Goodreads"
 
-#: users/templates/users/data.html:87
-msgid ""
-"On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download "
-"your library as a CSV file."
+#: users/templates/users/data.html:102
+msgid "On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download your library as a CSV file."
 msgstr ""
 
-#: users/templates/users/data.html:90
-msgid ""
-"Upload the downloaded <code>goodreads_library_export.csv</code> file below."
+#: users/templates/users/data.html:105
+msgid "Upload the downloaded <code>goodreads_library_export.csv</code> file below."
 msgstr ""
 
-#: users/templates/users/data.html:93
-msgid ""
-"want-to-read / currently-reading / read / did-not-finish books and their "
-"reviews will be imported."
-msgstr ""
-
-#: users/templates/users/data.html:134
-msgid "Import from Letterboxd"
-msgstr ""
-
-#: users/templates/users/data.html:140
-msgid ""
-"on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" "
-"target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap "
-"Advanced Settings in Settings, tap EXPORT YOUR DATA"
-msgstr ""
-
-#: users/templates/users/data.html:143
-msgid ""
-"download file with name like <code>letterboxd-username-2018-03-11-07-52-"
-"utc.zip</code>, do not unzip"
-msgstr ""
-
-#: users/templates/users/data.html:146
-msgid ""
-"the following files in the zip file will be processed: <code>reviews.csv</"
-"code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</"
-"code> <code>lists/*.csv</code>"
+#: users/templates/users/data.html:108
+msgid "want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported."
 msgstr ""
 
 #: users/templates/users/data.html:149
-msgid ""
-"exported file does not indicate whether a list is private, unlisted or "
-"public, so all imported marks, reviews and collections will be created with "
-"the visibility selected below"
+msgid "Import from Letterboxd"
 msgstr ""
 
-#: users/templates/users/data.html:184 users/templates/users/data.html:235
+#: users/templates/users/data.html:155
+msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
+msgstr ""
+
+#: users/templates/users/data.html:158
+msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
+msgstr ""
+
+#: users/templates/users/data.html:161
+msgid "the following files in the zip file will be processed: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
+msgstr ""
+
+#: users/templates/users/data.html:164
+msgid "exported file does not indicate whether a list is private, unlisted or public, so all imported marks, reviews and collections will be created with the visibility selected below"
+msgstr ""
+
+#: users/templates/users/data.html:199 users/templates/users/data.html:250
 msgid "Only forward changes(none->to-watch->watched) will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:191
+#: users/templates/users/data.html:206
 msgid "Import from Trakt"
 msgstr ""
 
-#: users/templates/users/data.html:197
-msgid ""
-"On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" "
-"rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait "
-"for the download link to appear."
+#: users/templates/users/data.html:212
+msgid "On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait for the download link to appear."
 msgstr ""
 
-#: users/templates/users/data.html:200
+#: users/templates/users/data.html:215
 msgid "Upload the downloaded <code>.zip</code> file below, do not unzip."
 msgstr ""
 
-#: users/templates/users/data.html:202
+#: users/templates/users/data.html:217
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:243
+#: users/templates/users/data.html:258
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr ""
 
-#: users/templates/users/data.html:246
+#: users/templates/users/data.html:261
 msgid "Login with Steam"
 msgstr ""
 
-#: users/templates/users/data.html:252
+#: users/templates/users/data.html:267
 msgid "Import Podcast Subscriptions"
 msgstr ""
 
-#: users/templates/users/data.html:263
+#: users/templates/users/data.html:278
 msgid "Mark as listening"
 msgstr ""
 
-#: users/templates/users/data.html:267
+#: users/templates/users/data.html:282
 msgid "Import as a new collection"
 msgstr ""
 
-#: users/templates/users/data.html:296
+#: users/templates/users/data.html:311
 msgid "Select OPML file"
 msgstr ""
 
-#: users/templates/users/data.html:306
+#: users/templates/users/data.html:321
 msgid "Import NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:312
-msgid ""
-"Upload a <code>.zip</code> file containing <code>.csv</code> or "
-"<code>.ndjson</code> files exported from NeoDB."
+#: users/templates/users/data.html:327
+msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr ""
 
 #: users/templates/users/data.html:330
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
-"imported here."
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is imported here."
 msgstr ""
 
-#: users/templates/users/data.html:314
+#: users/templates/users/data.html:332
 msgid "Existing data may be overwritten."
 msgstr ""
 
-#: users/templates/users/data.html:324
+#: users/templates/users/data.html:342
 msgid "Detected format"
 msgstr ""
 
-#: users/templates/users/data.html:385
+#: users/templates/users/data.html:403
 msgid "Detecting format..."
 msgstr ""
 
-#: users/templates/users/data.html:411
+#: users/templates/users/data.html:429
 msgid "Unknown format"
 msgstr ""
 
-#: users/templates/users/data.html:436
+#: users/templates/users/data.html:454
 msgid "Error detecting format"
 msgstr ""
 
-#: users/templates/users/data.html:460
+#: users/templates/users/data.html:478
 msgid "Export NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:464
+#: users/templates/users/data.html:482
 msgid "Export marks, reviews and notes in CSV"
 msgstr ""
 
-#: users/templates/users/data.html:471
+#: users/templates/users/data.html:489
 msgid "Export everything in NDJSON"
-msgstr ""
-
-#: users/templates/users/data.html:479
-msgid "Export marks and reviews in XLSX (Doufen format)"
-msgstr ""
-
-#: users/templates/users/data.html:482
-msgid "Last export"
-msgstr ""
-
-#: users/templates/users/data.html:487
-msgid "Download"
 msgstr ""
 
 #: users/templates/users/data.html:496
@@ -7969,22 +7882,15 @@ msgid "Import and Export Articles (WordPress)"
 msgstr ""
 
 #: users/templates/users/data.html:499
-msgid ""
-"Your articles are exchanged as WordPress posts in the WXR format, which "
-"WordPress and most blogging tools can read and write. Marks, reviews and "
-"notes are not included: use the NeoDB archive above for those."
+msgid "Your articles are exchanged as WordPress posts in the WXR format, which WordPress and most blogging tools can read and write. Marks, reviews and notes are not included: use the NeoDB archive above for those."
 msgstr ""
 
 #: users/templates/users/data.html:502
-msgid ""
-"Article title, body, excerpt, tags, dates and featured image are exchanged. "
-"Comments and custom fields are ignored."
+msgid "Article title, body, excerpt, tags, dates and featured image are exchanged. Comments and custom fields are ignored."
 msgstr ""
 
 #: users/templates/users/data.html:505
-msgid ""
-"The body is converted between Markdown and HTML, so formatting is kept but "
-"the text is not character-for-character identical."
+msgid "The body is converted between Markdown and HTML, so formatting is kept but the text is not character-for-character identical."
 msgstr ""
 
 #: users/templates/users/data.html:512
@@ -7992,16 +7898,11 @@ msgid "Export articles in WordPress format"
 msgstr ""
 
 #: users/templates/users/data.html:519
-msgid ""
-"In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download "
-"an <code>.xml</code> file, then upload it below."
+msgid "In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download an <code>.xml</code> file, then upload it below."
 msgstr ""
 
 #: users/templates/users/data.html:522
-msgid ""
-"Only published posts use the visibility below. Drafts, pending, private and "
-"password-protected posts are always imported as mentioned-only, so nothing "
-"unpublished becomes public."
+msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
 #: users/templates/users/data.html:560
@@ -8009,9 +7910,7 @@ msgid "View Annual Summary"
 msgstr ""
 
 #: users/templates/users/fetch_identity_failed.html:4
-msgid ""
-"Unable to find the user, please check your spelling; or the server may be "
-"busy, please try again later."
+msgid "Unable to find the user, please check your spelling; or the server may be busy, please try again later."
 msgstr ""
 
 #: users/templates/users/fetch_identity_pending.html:13
@@ -8031,94 +7930,76 @@ msgstr ""
 msgid "logo"
 msgstr ""
 
-#: users/templates/users/login.html:127
-msgid ""
-"Sign in with a passkey saved on this device or in your password manager."
+#: users/templates/users/login.html:121
+msgid "Sign in with a passkey saved on this device or in your password manager."
 msgstr ""
 
-#: users/templates/users/login.html:132
+#: users/templates/users/login.html:126
 msgid "Sign in with Passkey"
 msgstr ""
 
-#: users/templates/users/login.html:148
+#: users/templates/users/login.html:142
 msgid "Enter your email address"
 msgstr ""
 
-#: users/templates/users/login.html:152
+#: users/templates/users/login.html:146
 msgid "Send verification code"
 msgstr ""
 
-#: users/templates/users/login.html:171
+#: users/templates/users/login.html:165
 msgid "Domain of your instance, e.g. mastodon.social"
 msgstr ""
 
-#: users/templates/users/login.html:177
-msgid ""
-"Please enter domain of your instance; e.g. if your id is "
-"<i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
+#: users/templates/users/login.html:171
+msgid "Please enter domain of your instance; e.g. if your id is <i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
 msgstr ""
 
-#: users/templates/users/login.html:182 users/templates/users/login.html:246
+#: users/templates/users/login.html:176 users/templates/users/login.html:240
 msgid "Authorize via Fediverse instance"
 msgstr ""
 
-#: users/templates/users/login.html:187
-msgid ""
-"If you don't have a <a href=\"https://joinmastodon.org/servers\" "
-"target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or "
-"login with Email first, and link it with Fediverse (Mastodon) later in "
-"account settings."
+#: users/templates/users/login.html:181
+msgid "If you don't have a <a href=\"https://joinmastodon.org/servers\" target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or login with Email first, and link it with Fediverse (Mastodon) later in account settings."
 msgstr ""
 
-#: users/templates/users/login.html:200
+#: users/templates/users/login.html:194
 msgid "Authorize via Threads"
 msgstr ""
 
-#: users/templates/users/login.html:221
-msgid ""
-"Please input your ATProto handle (e.g. neodb.bsky.social, without the "
-"leading @), do not use email. If you changed handle recently, just use the "
-"latest one."
+#: users/templates/users/login.html:215
+msgid "Please input your ATProto handle (e.g. neodb.bsky.social, without the leading @), do not use email. If you changed handle recently, just use the latest one."
 msgstr ""
 
-#: users/templates/users/login.html:224
+#: users/templates/users/login.html:218
 msgid "Authorize via ATProto server"
 msgstr ""
 
-#: users/templates/users/login.html:231
+#: users/templates/users/login.html:225
 #, python-format
-msgid ""
-"Please choose one to register or login %(site_name)s. Have more than one of "
-"these identities? Don't worry, you may link them in account settings once "
-"logged in."
+msgid "Please choose one to register or login %(site_name)s. Have more than one of these identities? Don't worry, you may link them in account settings once logged in."
 msgstr ""
 
-#: users/templates/users/login.html:255
+#: users/templates/users/login.html:249
 msgid "Valid invitation code, please login or register."
 msgstr ""
 
-#: users/templates/users/login.html:257
-msgid ""
-"Please use invitation link to register a new account; existing user may "
-"login."
+#: users/templates/users/login.html:251
+msgid "Please use invitation link to register a new account; existing user may login."
 msgstr ""
 
-#: users/templates/users/login.html:259
+#: users/templates/users/login.html:253
 msgid "Invitation code invalid or expired."
 msgstr ""
 
-#: users/templates/users/login.html:267
+#: users/templates/users/login.html:261
 msgid "Loading timed out, please check your network (VPN) settings."
 msgstr ""
 
-#: users/templates/users/login.html:273
-msgid ""
-"Continue using this site implies consent to our <a href=\"/pages/rules/"
-"\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using "
-"cookies to provide necessary functionality."
+#: users/templates/users/login.html:267
+msgid "Continue using this site implies consent to our <a href=\"/pages/rules/\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using cookies to provide necessary functionality."
 msgstr ""
 
-#: users/templates/users/login.html:287
+#: users/templates/users/login.html:281
 msgid "Domain of your instance (excl. @)"
 msgstr ""
 
@@ -8128,9 +8009,7 @@ msgid "Migrate Here"
 msgstr ""
 
 #: users/templates/users/migrate_in.html:22
-msgid ""
-"To move another account to this one, first add it as an alias here, and then "
-"go to the server where it is hosted and initiate the move."
+msgid "To move another account to this one, first add it as an alias here, and then go to the server where it is hosted and initiate the move."
 msgstr ""
 
 #: users/templates/users/migrate_in.html:27
@@ -8172,16 +8051,11 @@ msgstr ""
 
 #: users/templates/users/migrate_out.html:46
 #, python-format
-msgid ""
-"To migrate to another account, first add <code>@%(handle)s</code> as an "
-"alias on the target server, and then type the target account below to start "
-"the migration."
+msgid "To migrate to another account, first add <code>@%(handle)s</code> as an alias on the target server, and then type the target account below to start the migration."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:50
-msgid ""
-"Are you sure you want to migrate your account? Your followers will be moved "
-"to the target account."
+msgid "Are you sure you want to migrate your account? Your followers will be moved to the target account."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:53
@@ -8194,10 +8068,6 @@ msgstr ""
 
 #: users/templates/users/preferences.html:28
 msgid "Default view once logged in"
-msgstr ""
-
-#: users/templates/users/preferences.html:40
-msgid "Activities"
 msgstr ""
 
 #: users/templates/users/preferences.html:49
@@ -8227,9 +8097,7 @@ msgstr ""
 
 #: users/templates/users/preferences.html:111
 #: users/templates/users/register.html:88
-msgid ""
-"If a Mastodon account is linked with this identity, boosting a post will "
-"also make the same post boosted with that Mastodon account."
+msgid "If a Mastodon account is linked with this identity, boosting a post will also make the same post boosted with that Mastodon account."
 msgstr ""
 
 #: users/templates/users/preferences.html:115
@@ -8245,16 +8113,12 @@ msgid "Create a new post"
 msgstr ""
 
 #: users/templates/users/preferences.html:130
-msgid ""
-"this method is less optimal, may generate duplicated posts and miss "
-"reactions."
+msgid "this method is less optimal, may generate duplicated posts and miss reactions."
 msgstr ""
 
 #: users/templates/users/preferences.html:140
 #: users/templates/users/register.html:97
-msgid ""
-"Always publish my public marks, reviews and articles as data records to my "
-"PDS."
+msgid "Always publish my public marks, reviews and articles as data records to my PDS."
 msgstr ""
 
 #: users/templates/users/preferences.html:145
@@ -8274,12 +8138,7 @@ msgid "Automatic bookmark for these categories"
 msgstr ""
 
 #: users/templates/users/preferences.html:175
-msgid ""
-"When start to read/watch/play/... an item in these categories, a bookmark "
-"will be created automatically. Bookmarks can be viewed and managed in most "
-"<a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon "
-"compatible apps</a>; your replies to these posts will automatically become "
-"notes for the item."
+msgid "When start to read/watch/play/... an item in these categories, a bookmark will be created automatically. Bookmarks can be viewed and managed in most <a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon compatible apps</a>; your replies to these posts will automatically become notes for the item."
 msgstr ""
 
 #: users/templates/users/preferences.html:183
@@ -8299,9 +8158,7 @@ msgid "Profile visible to anonymous web visitors and search engines"
 msgstr ""
 
 #: users/templates/users/preferences.html:217
-msgid ""
-"this option limits web visits only; to limit fediverse visibility, choose "
-"followers only or mentioned only when posting"
+msgid "this option limits web visits only; to limit fediverse visibility, choose followers only or mentioned only when posting"
 msgstr ""
 
 #: users/templates/users/preferences.html:225
@@ -8313,17 +8170,7 @@ msgid "Do not show me item recommendations"
 msgstr ""
 
 #: users/templates/users/preferences.html:237
-msgid ""
-"Recommendations are generated only from public marks, processed in batch on "
-"this server. Your private and follower-only marks are never used as a signal "
-"for anyone, and we never share your data with third parties for this "
-"feature. When you share marks publicly and keep your profile discoverable, "
-"your marks help others here and across the Fediverse find things they might "
-"enjoy -- that voluntary contribution is what makes the feature work for "
-"everyone. If you'd rather not contribute, uncheck \"Include profile, marks "
-"and posts in discovery\" on your account page; this setting is published "
-"over ActivityPub, so other servers will also stop including you in their "
-"discovery features."
+msgid "Recommendations are generated only from public marks, processed in batch on this server. Your private and follower-only marks are never used as a signal for anyone, and we never share your data with third parties for this feature. When you share marks publicly and keep your profile discoverable, your marks help others here and across the Fediverse find things they might enjoy -- that voluntary contribution is what makes the feature work for everyone. If you'd rather not contribute, uncheck \"Include profile, marks and posts in discovery\" on your account page; this setting is published over ActivityPub, so other servers will also stop including you in their discovery features."
 msgstr ""
 
 #: users/templates/users/profile_actions.html:12
@@ -8424,19 +8271,11 @@ msgid "2-30 alphabets, numbers or underscore, can't be changed once saved"
 msgstr ""
 
 #: users/templates/users/register.html:72
-msgid ""
-"Use display name, bio and avatar from the social network you authenticated "
-"with"
+msgid "Use display name, bio and avatar from the social network you authenticated with"
 msgstr ""
 
 #: users/templates/users/register.html:80
-msgid ""
-"Add follow, mute and block list from the social network you authenticated "
-"with"
-msgstr ""
-
-#: users/templates/users/register.html:104
-msgid "Confirm and save"
+msgid "Add follow, mute and block list from the social network you authenticated with"
 msgstr ""
 
 #: users/templates/users/register.html:106
@@ -8465,8 +8304,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"              Matched %(local)s locally, %(external)s externally, "
-"%(unmatched)s unmatched out of %(total)s rows.\n"
+"              Matched %(local)s locally, %(external)s externally, %(unmatched)s unmatched out of %(total)s rows.\n"
 "            "
 msgstr ""
 
@@ -8583,9 +8421,7 @@ msgid "Played"
 msgstr ""
 
 #: users/templates/users/steam_import.html:90
-msgid ""
-"Games in wishlist; or purchased in library but never played, mark date will "
-"be set as today"
+msgid "Games in wishlist; or purchased in library but never played, mark date will be set as today"
 msgstr ""
 
 #: users/templates/users/steam_import.html:91
@@ -8625,15 +8461,11 @@ msgid "Comma-separated Steam AppIDs"
 msgstr ""
 
 #: users/templates/users/steam_import.html:121
-msgid ""
-"Allow reverse override of status (e.g. playing -> want to, or played -> "
-"playing)"
+msgid "Allow reverse override of status (e.g. playing -> want to, or played -> playing)"
 msgstr ""
 
 #: users/templates/users/steam_import.html:139
-msgid ""
-"To import from Steam, your game details must be visible to public in Steam "
-"privacy settings."
+msgid "To import from Steam, your game details must be visible to public in Steam privacy settings."
 msgstr ""
 
 #: users/templates/users/storygraph_import.html:9
@@ -8678,23 +8510,16 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"              %(site_name)s is flourishing because of collaborations and "
-"contributions from users like you. Please read our <a href=\"/pages/"
-"rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</"
-"a> if you have any question or feedback.\n"
+"              %(site_name)s is flourishing because of collaborations and contributions from users like you. Please read our <a href=\"/pages/rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</a> if you have any question or feedback.\n"
 "        "
 msgstr ""
 
 #: users/templates/users/welcome.html:37
-msgid ""
-"Set up a passkey to sign in quickly next time using your fingerprint, face, "
-"or screen lock."
+msgid "Set up a passkey to sign in quickly next time using your fingerprint, face, or screen lock."
 msgstr ""
 
 #: users/templates/users/welcome.html:39
-msgid ""
-"Creating a passkey is highly recommended, as the website or email you use to "
-"create this account may not be always available."
+msgid "Creating a passkey is highly recommended, as the website or email you use to create this account may not be always available."
 msgstr ""
 
 #: users/templates/users/welcome.html:43
@@ -8709,220 +8534,219 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:124
+#: users/views/account.py:126
 msgid "This username is already in use."
 msgstr ""
 
-#: users/views/account.py:135
+#: users/views/account.py:137
 msgid "This email address is already in use."
 msgstr ""
 
-#: users/views/account.py:255 users/views/account.py:374
+#: users/views/account.py:257 users/views/account.py:376
 msgid "Registration is for invitation only"
 msgstr ""
 
-#: users/views/account.py:266 users/views/account.py:338
+#: users/views/account.py:268 users/views/account.py:340
 msgid "Time is up"
 msgstr ""
 
-#: users/views/account.py:267 users/views/account.py:310
-#: users/views/account.py:339
+#: users/views/account.py:269 users/views/account.py:312
+#: users/views/account.py:341
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:313
+#: users/views/account.py:315
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:325
+#: users/views/account.py:327
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:326
+#: users/views/account.py:328
 msgid "Please try again later."
 msgstr ""
 
-#: users/views/account.py:415
+#: users/views/account.py:417
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:445
+#: users/views/account.py:447
 msgid "Valid username required"
 msgstr ""
 
-#: users/views/account.py:526
+#: users/views/account.py:518
 msgid "Account is being deleted."
 msgstr ""
 
-#: users/views/account.py:529
+#: users/views/account.py:521
 msgid "Account mismatch."
 msgstr ""
 
-#: users/views/data.py:262 users/views/data.py:294
+#: users/views/data.py:264 users/views/data.py:296
 msgid "Export file not available."
 msgstr ""
 
-#: users/views/data.py:288
+#: users/views/data.py:290
 msgid "Generating exports."
 msgstr ""
 
-#: users/views/data.py:306
+#: users/views/data.py:308
 msgid "Export file expired. Please export again."
 msgstr ""
 
-#: users/views/data.py:321 users/views/data.py:342 users/views/data.py:363
+#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
 msgid "Recent export still in progress."
 msgstr ""
 
-#: users/views/data.py:379 users/views/data.py:513 users/views/data.py:547
-#: users/views/data.py:772 users/views/data.py:989 users/views/data.py:1015
-#: users/views/data.py:1040 users/views/data.py:1065
+#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
+#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
+#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
 msgid "Invalid file."
 msgstr ""
 
-#: users/views/data.py:403
+#: users/views/data.py:405
 msgid "Sync in progress."
 msgstr ""
 
-#: users/views/data.py:417
+#: users/views/data.py:419
 msgid "Settings saved."
 msgstr ""
 
-#: users/views/data.py:472
+#: users/views/data.py:474
 msgid "Account no longer linked."
 msgstr ""
 
-#: users/views/data.py:475
+#: users/views/data.py:477
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:503
+#: users/views/data.py:505
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:583 users/views/data.py:808
+#: users/views/data.py:585 users/views/data.py:810
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:608 users/views/data.py:837
+#: users/views/data.py:610 users/views/data.py:839
 msgid "Cancelled."
 msgstr ""
 
-#: users/views/data.py:628
+#: users/views/data.py:630
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:636 users/views/data.py:746 users/views/data.py:867
-#: users/views/data.py:972
+#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
+#: users/views/data.py:974
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:732 users/views/data.py:958
+#: users/views/data.py:734 users/views/data.py:960
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:742 users/views/data.py:968
+#: users/views/data.py:744 users/views/data.py:970
 msgid "No matched file available."
 msgstr ""
 
-#: users/views/data.py:859
+#: users/views/data.py:861
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1188
+#: users/views/data.py:1226
 msgid "Name is required."
 msgstr ""
 
-#: users/views/data.py:1210
+#: users/views/data.py:1248
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1264
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1231
+#: users/views/data.py:1269
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1241 users/views/data.py:1292
+#: users/views/data.py:1279 users/views/data.py:1330
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:1248
+#: users/views/data.py:1286
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:1253
+#: users/views/data.py:1291
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:1279
+#: users/views/data.py:1317
 msgid "Migration cancelled."
 msgstr ""
 
-#: users/views/data.py:1284
+#: users/views/data.py:1322
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:1297
+#: users/views/data.py:1335
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:1308
+#: users/views/data.py:1346
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:1314
+#: users/views/data.py:1352
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr ""
 
-#: users/views/data.py:1372
+#: users/views/data.py:1410
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1388
+#: users/views/data.py:1426
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1392
+#: users/views/data.py:1430
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1402
+#: users/views/data.py:1440
 #, python-brace-format
-msgid ""
-"Import of {count} entries received. They will be processed in the background."
+msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""
 
-#: users/views/webauthn.py:103
+#: users/views/webauthn.py:106
 msgid "Passkey registration failed"
 msgstr ""
 
-#: users/views/webauthn.py:123
+#: users/views/webauthn.py:126
 msgid "Credential already registered"
 msgstr ""
 
-#: users/views/webauthn.py:165 users/views/webauthn.py:172
-#: users/views/webauthn.py:181
+#: users/views/webauthn.py:168 users/views/webauthn.py:175
+#: users/views/webauthn.py:184
 msgid "Passkey not recognized"
 msgstr ""
 
-#: users/views/webauthn.py:186
+#: users/views/webauthn.py:189
 msgid "Account is inactive"
 msgstr ""
 
-#: users/views/webauthn.py:202
+#: users/views/webauthn.py:205
 msgid "Passkey verification failed"
 msgstr ""
 
-#: users/views/webauthn.py:228 users/views/webauthn.py:250
+#: users/views/webauthn.py:231 users/views/webauthn.py:253
 msgid "Passkey not found"
 msgstr ""
 
-#: users/views/webauthn.py:244
+#: users/views/webauthn.py:247
 msgid "Name is required"
 msgstr ""

--- a/neodb/locale/lzh/LC_MESSAGES/django.po
+++ b/neodb/locale/lzh/LC_MESSAGES/django.po
@@ -7,11 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-23 15:40-0400\n"
+"POT-Creation-Date: 2026-09-06 20:04-0400\n"
 "PO-Revision-Date: 2026-08-08 21:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Literary Chinese <https://hosted.weblate.org/projects/neodb/"
-"neodb/lzh/>\n"
+"Language-Team: Literary Chinese <https://hosted.weblate.org/projects/neodb/neodb/lzh/>\n"
 "Language: lzh\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,159 +18,159 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: boofilsic/settings.py:472 common/models/lang.py:230
+#: boofilsic/settings.py:501 common/models/lang.py:232
 msgid "English"
 msgstr ""
 
-#: boofilsic/settings.py:473 common/models/lang.py:77
+#: boofilsic/settings.py:502 common/models/lang.py:79
 msgid "Danish"
 msgstr ""
 
-#: boofilsic/settings.py:474 common/models/lang.py:78
+#: boofilsic/settings.py:503 common/models/lang.py:80
 msgid "German"
 msgstr ""
 
-#: boofilsic/settings.py:475 common/models/lang.py:183
+#: boofilsic/settings.py:504 common/models/lang.py:185
 msgid "Spanish"
 msgstr ""
 
-#: boofilsic/settings.py:476 common/models/lang.py:87
+#: boofilsic/settings.py:505 common/models/lang.py:89
 msgid "French"
 msgstr ""
 
-#: boofilsic/settings.py:477 common/models/lang.py:112
+#: boofilsic/settings.py:506 common/models/lang.py:114
 msgid "Italian"
 msgstr ""
 
-#: boofilsic/settings.py:478 common/models/lang.py:166
-#: common/models/lang.py:305
+#: boofilsic/settings.py:507 common/models/lang.py:168
+#: common/models/lang.py:307
 msgid "Portuguese"
 msgstr ""
 
-#: boofilsic/settings.py:479
+#: boofilsic/settings.py:508
 msgid "Brazilian Portuguese"
 msgstr ""
 
-#: boofilsic/settings.py:480 common/models/lang.py:316
+#: boofilsic/settings.py:509 common/models/lang.py:318
 msgid "Simplified Chinese"
 msgstr ""
 
-#: boofilsic/settings.py:481 common/models/lang.py:317
+#: boofilsic/settings.py:510 common/models/lang.py:319
 msgid "Traditional Chinese"
 msgstr ""
 
-#: catalog/forms.py:35 catalog/models/item.py:291
+#: catalog/forms.py:35 catalog/models/item.py:307
 msgid "Primary ID Type"
 msgstr ""
 
-#: catalog/forms.py:40 catalog/models/item.py:294
+#: catalog/forms.py:40 catalog/models/item.py:310
 msgid "Primary ID Value"
 msgstr ""
 
-#: catalog/forms.py:181
+#: catalog/forms.py:176
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
-#: catalog/models/book.py:139 catalog/models/book.py:158
-#: catalog/models/common.py:280 catalog/models/common.py:298
+#: catalog/models/book.py:141 catalog/models/book.py:160
+#: catalog/models/common.py:279 catalog/models/common.py:297
 msgid "locale"
 msgstr ""
 
-#: catalog/models/book.py:142 catalog/models/book.py:161
-#: catalog/models/common.py:283 catalog/models/common.py:303
+#: catalog/models/book.py:144 catalog/models/book.py:163
+#: catalog/models/common.py:282 catalog/models/common.py:302
 msgid "text content"
 msgstr ""
 
-#: catalog/models/book.py:177
+#: catalog/models/book.py:179
 msgid "Paperback"
 msgstr ""
 
-#: catalog/models/book.py:178
+#: catalog/models/book.py:180
 msgid "Hardcover"
 msgstr ""
 
-#: catalog/models/book.py:179
+#: catalog/models/book.py:181
 msgid "eBook"
 msgstr ""
 
-#: catalog/models/book.py:180
+#: catalog/models/book.py:182
 msgid "Audiobook"
 msgstr ""
 
-#: catalog/models/book.py:182
+#: catalog/models/book.py:184
 msgid "Web Fiction"
 msgstr ""
 
-#: catalog/models/book.py:183 catalog/models/game.py:38
+#: catalog/models/book.py:185 catalog/models/game.py:38
 msgid "Other"
 msgstr ""
 
-#: catalog/models/book.py:260
+#: catalog/models/book.py:262
 msgid "subtitle"
 msgstr ""
 
-#: catalog/models/book.py:270 catalog/models/movie.py:120
-#: catalog/models/performance.py:385 catalog/models/tv.py:211
-#: catalog/models/tv.py:437
+#: catalog/models/book.py:272 catalog/models/movie.py:120
+#: catalog/models/performance.py:385 catalog/models/tv.py:213
+#: catalog/models/tv.py:439
 msgid "original title"
 msgstr ""
 
-#: catalog/models/book.py:274
+#: catalog/models/book.py:276
 msgid "other title"
 msgstr ""
 
-#: catalog/models/book.py:280 catalog/models/book.py:564
-#: catalog/models/item.py:123
+#: catalog/models/book.py:282 catalog/models/book.py:566
+#: catalog/models/item.py:119
 msgid "author"
 msgstr ""
 
-#: catalog/models/book.py:287 catalog/models/item.py:124
+#: catalog/models/book.py:289 catalog/models/item.py:120
 msgid "translator"
 msgstr ""
 
-#: catalog/models/book.py:294 catalog/templates/edition.html:26
+#: catalog/models/book.py:296 catalog/templates/edition.html:26
 msgid "book format"
 msgstr ""
 
-#: catalog/models/book.py:301 catalog/models/game.py:135
-#: catalog/models/item.py:138 catalog/models/music.py:142
+#: catalog/models/book.py:303 catalog/models/game.py:135
+#: catalog/models/item.py:134 catalog/models/music.py:142
 msgid "publisher"
 msgstr ""
 
-#: catalog/models/book.py:308
+#: catalog/models/book.py:310
 msgid "publication year"
 msgstr ""
 
-#: catalog/models/book.py:314
+#: catalog/models/book.py:316
 msgid "publication month"
 msgstr ""
 
-#: catalog/models/book.py:319
+#: catalog/models/book.py:321
 msgid "binding"
 msgstr ""
 
-#: catalog/models/book.py:320
+#: catalog/models/book.py:322
 msgid "pages"
 msgstr ""
 
-#: catalog/models/book.py:321 catalog/templates/edition.html:45
+#: catalog/models/book.py:323 catalog/templates/edition.html:45
 msgid "series"
 msgstr ""
 
-#: catalog/models/book.py:322 catalog/templates/edition.html:65
+#: catalog/models/book.py:324 catalog/templates/edition.html:65
 msgid "contents"
 msgstr ""
 
-#: catalog/models/book.py:323 catalog/templates/edition.html:51
+#: catalog/models/book.py:325 catalog/templates/edition.html:51
 msgid "price"
 msgstr ""
 
-#: catalog/models/book.py:324 catalog/models/item.py:149
+#: catalog/models/book.py:326 catalog/models/item.py:145
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr ""
 
-#: catalog/models/common.py:26 common/models/lang.py:256
+#: catalog/models/common.py:26 common/models/lang.py:258
 msgid "Unknown"
 msgstr ""
 
@@ -179,11 +178,11 @@ msgstr ""
 msgid "Douban"
 msgstr ""
 
-#: catalog/models/common.py:28 catalog/models/common.py:79
+#: catalog/models/common.py:28 catalog/models/common.py:81
 msgid "Goodreads"
 msgstr ""
 
-#: catalog/models/common.py:29 catalog/models/common.py:81
+#: catalog/models/common.py:29 catalog/models/common.py:83
 msgid "Google Books"
 msgstr ""
 
@@ -191,16 +190,16 @@ msgstr ""
 msgid "BooksTW"
 msgstr ""
 
-#: catalog/models/common.py:31 catalog/models/common.py:91
-#: catalog/models/common.py:93
+#: catalog/models/common.py:31 catalog/models/common.py:93
+#: catalog/models/common.py:95
 msgid "Bibliotek.dk"
 msgstr ""
 
-#: catalog/models/common.py:32 catalog/models/common.py:92
+#: catalog/models/common.py:32 catalog/models/common.py:94
 msgid "eReolen.dk"
 msgstr ""
 
-#: catalog/models/common.py:33 catalog/models/common.py:74
+#: catalog/models/common.py:33 catalog/models/common.py:76
 #: catalog/templates/movie.html:41 catalog/templates/people.html:37
 #: catalog/templates/tvseason.html:58 catalog/templates/tvshow.html:53
 msgid "IMDb"
@@ -210,7 +209,7 @@ msgstr ""
 msgid "TMDB"
 msgstr ""
 
-#: catalog/models/common.py:35 catalog/models/common.py:94
+#: catalog/models/common.py:35 catalog/models/common.py:96
 msgid "Bandcamp"
 msgstr ""
 
@@ -226,11 +225,11 @@ msgstr ""
 msgid "Steam"
 msgstr ""
 
-#: catalog/models/common.py:39 catalog/models/common.py:114
+#: catalog/models/common.py:39 catalog/models/common.py:116
 msgid "itch.io"
 msgstr ""
 
-#: catalog/models/common.py:40 catalog/models/common.py:115
+#: catalog/models/common.py:40 catalog/models/common.py:117
 msgid "Bangumi"
 msgstr ""
 
@@ -238,7 +237,7 @@ msgstr ""
 msgid "BGG"
 msgstr ""
 
-#: catalog/models/common.py:42 catalog/models/common.py:116
+#: catalog/models/common.py:42 catalog/models/common.py:118
 msgid "Apple Podcast"
 msgstr ""
 
@@ -250,35 +249,35 @@ msgstr ""
 msgid "Discogs"
 msgstr ""
 
-#: catalog/models/common.py:45 catalog/models/common.py:117
+#: catalog/models/common.py:45 catalog/models/common.py:119
 msgid "Apple Music"
 msgstr ""
 
-#: catalog/models/common.py:46 catalog/models/common.py:119
+#: catalog/models/common.py:46 catalog/models/common.py:121
 msgid "Fediverse"
 msgstr ""
 
-#: catalog/models/common.py:47 catalog/models/common.py:120
+#: catalog/models/common.py:47 catalog/models/common.py:122
 msgid "Qidian"
 msgstr ""
 
-#: catalog/models/common.py:48 catalog/models/common.py:121
+#: catalog/models/common.py:48 catalog/models/common.py:123
 msgid "Ypshuo"
 msgstr ""
 
-#: catalog/models/common.py:49 catalog/models/common.py:122
+#: catalog/models/common.py:49 catalog/models/common.py:124
 msgid "Archive of Our Own"
 msgstr ""
 
-#: catalog/models/common.py:50 catalog/models/common.py:123
+#: catalog/models/common.py:50 catalog/models/common.py:125
 msgid "JinJiang"
 msgstr ""
 
-#: catalog/models/common.py:51 catalog/models/common.py:64
+#: catalog/models/common.py:51 catalog/models/common.py:66
 msgid "WikiData"
 msgstr ""
 
-#: catalog/models/common.py:52 catalog/models/common.py:124
+#: catalog/models/common.py:52 catalog/models/common.py:126
 msgid "Open Library"
 msgstr ""
 
@@ -290,15 +289,15 @@ msgstr ""
 msgid "WorldCat"
 msgstr ""
 
-#: catalog/models/common.py:55 catalog/models/common.py:126
+#: catalog/models/common.py:55 catalog/models/common.py:128
 msgid "MobyGames"
 msgstr ""
 
-#: catalog/models/common.py:56 catalog/models/common.py:127
+#: catalog/models/common.py:56 catalog/models/common.py:129
 msgid "StoryGraph"
 msgstr ""
 
-#: catalog/models/common.py:57 catalog/models/common.py:118
+#: catalog/models/common.py:57 catalog/models/common.py:120
 msgid "YouTube Music"
 msgstr ""
 
@@ -314,335 +313,344 @@ msgstr ""
 msgid "Readmoo"
 msgstr ""
 
-#: catalog/models/common.py:65
-msgid "ISBN10"
+#: catalog/models/common.py:61
+msgid "MyAnimeList"
 msgstr ""
 
-#: catalog/models/common.py:66 catalog/templates/edition.html:19
-msgid "ISBN"
+#: catalog/models/common.py:62 catalog/models/common.py:140
+msgid "MangaUpdates"
 msgstr ""
 
 #: catalog/models/common.py:67
-msgid "ASIN"
+msgid "ISBN10"
 msgstr ""
 
-#: catalog/models/common.py:68
-msgid "ISSN"
+#: catalog/models/common.py:68 catalog/templates/edition.html:19
+msgid "ISBN"
 msgstr ""
 
 #: catalog/models/common.py:69
-msgid "CUBN"
+msgid "ASIN"
 msgstr ""
 
 #: catalog/models/common.py:70
-msgid "ISRC"
+msgid "ISSN"
 msgstr ""
 
 #: catalog/models/common.py:71
-msgid "GTIN UPC EAN"
+msgid "CUBN"
 msgstr ""
 
 #: catalog/models/common.py:72
-msgid "OCLC Number"
+msgid "ISRC"
 msgstr ""
 
 #: catalog/models/common.py:73
-msgid "RSS Feed URL"
+msgid "GTIN UPC EAN"
+msgstr ""
+
+#: catalog/models/common.py:74
+msgid "OCLC Number"
 msgstr ""
 
 #: catalog/models/common.py:75
-msgid "TMDB TV Series"
-msgstr ""
-
-#: catalog/models/common.py:76
-msgid "TMDB TV Season"
+msgid "RSS Feed URL"
 msgstr ""
 
 #: catalog/models/common.py:77
-msgid "TMDB TV Episode"
+msgid "TMDB TV Series"
 msgstr ""
 
 #: catalog/models/common.py:78
-msgid "TMDB Movie"
+msgid "TMDB TV Season"
+msgstr ""
+
+#: catalog/models/common.py:79
+msgid "TMDB TV Episode"
 msgstr ""
 
 #: catalog/models/common.py:80
-msgid "Goodreads Work"
+msgid "TMDB Movie"
 msgstr ""
 
 #: catalog/models/common.py:82
-msgid "Douban Book"
-msgstr ""
-
-#: catalog/models/common.py:83
-msgid "Douban Book Work"
+msgid "Goodreads Work"
 msgstr ""
 
 #: catalog/models/common.py:84
-msgid "Douban Movie"
+msgid "Douban Book"
 msgstr ""
 
 #: catalog/models/common.py:85
-msgid "Douban Music"
+msgid "Douban Book Work"
 msgstr ""
 
 #: catalog/models/common.py:86
-msgid "Douban Game"
+msgid "Douban Movie"
 msgstr ""
 
 #: catalog/models/common.py:87
-msgid "Douban Drama"
+msgid "Douban Music"
 msgstr ""
 
 #: catalog/models/common.py:88
-msgid "Douban Drama Version"
+msgid "Douban Game"
 msgstr ""
 
 #: catalog/models/common.py:89
-msgid "BooksTW Book"
+msgid "Douban Drama"
 msgstr ""
 
 #: catalog/models/common.py:90
+msgid "Douban Drama Version"
+msgstr ""
+
+#: catalog/models/common.py:91
+msgid "BooksTW Book"
+msgstr ""
+
+#: catalog/models/common.py:92
 msgid "Readmoo Book"
 msgstr ""
 
-#: catalog/models/common.py:95
+#: catalog/models/common.py:97
 msgid "Spotify Album"
 msgstr ""
 
-#: catalog/models/common.py:96
+#: catalog/models/common.py:98
 msgid "Spotify Podcast"
 msgstr ""
 
-#: catalog/models/common.py:97
+#: catalog/models/common.py:99
 msgid "Discogs Release"
 msgstr ""
 
-#: catalog/models/common.py:98
+#: catalog/models/common.py:100
 msgid "Discogs Master"
 msgstr ""
 
-#: catalog/models/common.py:101
+#: catalog/models/common.py:103
 msgid "MusicBrainz Release Group"
 msgstr ""
 
-#: catalog/models/common.py:103
+#: catalog/models/common.py:105
 msgid "MusicBrainz Release"
 msgstr ""
 
-#: catalog/models/common.py:104
+#: catalog/models/common.py:106
 msgid "MusicBrainz Artist"
 msgstr ""
 
-#: catalog/models/common.py:105
+#: catalog/models/common.py:107
 msgid "Douban Personage"
 msgstr ""
 
-#: catalog/models/common.py:106
+#: catalog/models/common.py:108
 msgid "Goodreads Author"
 msgstr ""
 
-#: catalog/models/common.py:107
+#: catalog/models/common.py:109
 msgid "Spotify Artist"
 msgstr ""
 
-#: catalog/models/common.py:108
+#: catalog/models/common.py:110
 msgid "TMDB Person"
 msgstr ""
 
-#: catalog/models/common.py:109
+#: catalog/models/common.py:111
 msgid "Open Library Author"
 msgstr ""
 
-#: catalog/models/common.py:110
+#: catalog/models/common.py:112
 msgid "IGDB Company"
 msgstr ""
 
-#: catalog/models/common.py:111
+#: catalog/models/common.py:113
 msgid "IGDB Game"
 msgstr ""
 
-#: catalog/models/common.py:112
+#: catalog/models/common.py:114
 msgid "BGG Boardgame"
 msgstr ""
 
-#: catalog/models/common.py:113
+#: catalog/models/common.py:115
 msgid "Steam Game"
 msgstr ""
 
-#: catalog/models/common.py:125
+#: catalog/models/common.py:127
 msgid "Open Library Work"
 msgstr ""
 
-#: catalog/models/common.py:128
+#: catalog/models/common.py:130
 msgid "RateYourMusic Release"
 msgstr ""
 
-#: catalog/models/common.py:132
+#: catalog/models/common.py:134
 msgid "AniList Anime"
 msgstr ""
 
-#: catalog/models/common.py:133
+#: catalog/models/common.py:135
 msgid "AniList Manga"
 msgstr ""
 
-#: catalog/models/common.py:134
+#: catalog/models/common.py:136
 msgid "MyAnimeList Anime"
 msgstr ""
 
-#: catalog/models/common.py:135
+#: catalog/models/common.py:137
 msgid "MyAnimeList Manga"
 msgstr ""
 
-#: catalog/models/common.py:156
+#: catalog/models/common.py:161
 msgid "Edition"
 msgstr ""
 
-#: catalog/models/common.py:157 catalog/templates/_sidebar_edit.html:286
+#: catalog/models/common.py:162 catalog/templates/_sidebar_edit.html:289
 msgid "Work"
 msgstr ""
 
-#: catalog/models/common.py:158
+#: catalog/models/common.py:163
 msgid "TV Series"
 msgstr ""
 
-#: catalog/models/common.py:159 catalog/templates/_sidebar_edit.html:207
+#: catalog/models/common.py:164 catalog/templates/_sidebar_edit.html:202
+#: catalog/views/edit.py:385
 msgid "TV Season"
 msgstr ""
 
-#: catalog/models/common.py:160
+#: catalog/models/common.py:165
 msgid "TV Episode"
 msgstr ""
 
-#: catalog/models/common.py:161 catalog/models/common.py:177
-#: catalog/models/common.py:191 catalog/templates/_sidebar_edit.html:200
-#: journal/templates/_sidebar_user_mark_list.html:35
+#: catalog/models/common.py:166 catalog/models/common.py:182
+#: catalog/models/common.py:196 catalog/templates/_sidebar_edit.html:196
+#: catalog/views/edit.py:384 journal/templates/_sidebar_user_mark_list.html:35
 #: journal/templates/_sidebar_user_tag_filter.html:27
 msgid "Movie"
 msgstr ""
 
-#: catalog/models/common.py:162
+#: catalog/models/common.py:167
 msgid "Album"
 msgstr ""
 
-#: catalog/models/common.py:163 catalog/models/common.py:180
-#: catalog/models/common.py:194 common/templates/_header.html:43
+#: catalog/models/common.py:168 catalog/models/common.py:185
+#: catalog/models/common.py:199 common/templates/_header.html:53
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
 msgstr ""
 
-#: catalog/models/common.py:164
+#: catalog/models/common.py:169
 msgid "Podcast Program"
 msgstr ""
 
-#: catalog/models/common.py:165
+#: catalog/models/common.py:170
 msgid "Podcast Episode"
 msgstr ""
 
-#: catalog/models/common.py:166 catalog/models/common.py:182
-#: catalog/models/common.py:196 common/templates/_header.html:47
+#: catalog/models/common.py:171 catalog/models/common.py:187
+#: catalog/models/common.py:201 common/templates/_header.html:57
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
 msgstr ""
 
-#: catalog/models/common.py:167
+#: catalog/models/common.py:172
 msgid "Production"
 msgstr ""
 
-#: catalog/models/common.py:168
+#: catalog/models/common.py:173
 msgid "Exhibition"
 msgstr ""
 
-#: catalog/models/common.py:169 catalog/models/common.py:186
+#: catalog/models/common.py:174 catalog/models/common.py:191
 #: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr ""
 
-#: catalog/models/common.py:172 catalog/models/common.py:185
+#: catalog/models/common.py:177 catalog/models/common.py:190
 msgid "Person / Organization"
 msgstr ""
 
-#: catalog/models/common.py:176 catalog/models/common.py:190
-#: common/templates/_header.html:27
+#: catalog/models/common.py:181 catalog/models/common.py:195
+#: common/templates/_header.html:37
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
 msgstr ""
 
-#: catalog/models/common.py:178 catalog/models/common.py:192
+#: catalog/models/common.py:183 catalog/models/common.py:197
 #: journal/templates/_sidebar_user_mark_list.html:38
 #: journal/templates/_sidebar_user_tag_filter.html:30
 msgid "TV"
 msgstr ""
 
-#: catalog/models/common.py:179 catalog/models/common.py:193
-#: common/templates/_header.html:39
+#: catalog/models/common.py:184 catalog/models/common.py:198
+#: common/templates/_header.html:49
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr ""
 
-#: catalog/models/common.py:181 catalog/models/common.py:195
-#: catalog/templates/_sidebar_edit.html:219 common/templates/_header.html:35
+#: catalog/models/common.py:186 catalog/models/common.py:200
+#: catalog/templates/_sidebar_edit.html:213 common/templates/_header.html:45
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
 msgstr ""
 
-#: catalog/models/common.py:346 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:345 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr ""
 
-#: catalog/models/common.py:384
+#: catalog/models/common.py:383
 msgid "origin country"
 msgstr ""
 
-#: catalog/models/common.py:413 catalog/templates/album.html:33
+#: catalog/models/common.py:412 catalog/templates/album.html:33
 msgid "album type"
 msgstr ""
 
-#: catalog/models/common.py:417 catalog/templates/_platform_list.html:5
+#: catalog/models/common.py:416 catalog/templates/_platform_list.html:5
 msgid "platform"
 msgstr ""
 
-#: catalog/models/common.py:421
+#: catalog/models/common.py:420
 msgid "media format"
 msgstr ""
 
-#: catalog/models/common.py:426 catalog/templates/_language_list.html:5
-#: users/models/user.py:142
+#: catalog/models/common.py:425 catalog/templates/_language_list.html:5
+#: users/models/user.py:144
 msgid "language"
 msgstr ""
 
-#: catalog/models/creator.py:24
+#: catalog/models/creator.py:26
 msgid "pending"
 msgstr ""
 
-#: catalog/models/creator.py:25
+#: catalog/models/creator.py:27
 msgid "verified"
 msgstr ""
 
-#: catalog/models/creator.py:26
+#: catalog/models/creator.py:28
 msgid "failed"
 msgstr ""
 
-#: catalog/models/creator.py:29
+#: catalog/models/creator.py:31
 msgid "no feed url available for this item"
 msgstr ""
 
-#: catalog/models/creator.py:30
+#: catalog/models/creator.py:32
 msgid "unable to fetch or parse the feed"
 msgstr ""
 
-#: catalog/models/creator.py:31
+#: catalog/models/creator.py:33
 msgid "no audio episode found in the feed"
 msgstr ""
 
-#: catalog/models/creator.py:34
+#: catalog/models/creator.py:36
 msgid "no matching identity found in the feed or its linked website"
 msgstr ""
 
@@ -678,16 +686,16 @@ msgstr ""
 msgid "Special Edition"
 msgstr ""
 
-#: catalog/models/game.py:111 catalog/models/item.py:130
+#: catalog/models/game.py:111 catalog/models/item.py:126
 msgid "designer"
 msgstr ""
 
-#: catalog/models/game.py:119 catalog/models/item.py:129
+#: catalog/models/game.py:119 catalog/models/item.py:125
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr ""
 
-#: catalog/models/game.py:127 catalog/models/item.py:139
+#: catalog/models/game.py:127 catalog/models/item.py:135
 msgid "developer"
 msgstr ""
 
@@ -696,8 +704,8 @@ msgid "date of publication"
 msgstr ""
 
 #: catalog/models/game.py:147 catalog/models/movie.py:156
-#: catalog/models/music.py:128 catalog/models/tv.py:247
-#: catalog/models/tv.py:473
+#: catalog/models/music.py:128 catalog/models/tv.py:249
+#: catalog/models/tv.py:475
 msgid "YYYY, YYYY-MM or YYYY-MM-DD"
 msgstr ""
 
@@ -708,7 +716,7 @@ msgstr ""
 #: catalog/models/game.py:180 catalog/models/movie.py:158
 #: catalog/models/people.py:178 catalog/models/performance.py:258
 #: catalog/models/performance.py:465 catalog/models/podcast.py:89
-#: catalog/models/tv.py:249 catalog/models/tv.py:476
+#: catalog/models/tv.py:251 catalog/models/tv.py:478
 #: catalog/templates/game.html:33 catalog/templates/movie.html:48
 #: catalog/templates/people.html:44 catalog/templates/performance.html:35
 #: catalog/templates/performanceproduction.html:35
@@ -717,146 +725,146 @@ msgstr ""
 msgid "website"
 msgstr ""
 
-#: catalog/models/item.py:125 catalog/models/movie.py:123
+#: catalog/models/item.py:121 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
-#: catalog/models/tv.py:214 catalog/models/tv.py:440
+#: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr ""
 
-#: catalog/models/item.py:126 catalog/models/movie.py:130
+#: catalog/models/item.py:122 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
-#: catalog/models/tv.py:221 catalog/models/tv.py:447
+#: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr ""
 
-#: catalog/models/item.py:127 catalog/models/movie.py:137
+#: catalog/models/item.py:123 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
-#: catalog/models/tv.py:228 catalog/models/tv.py:454
+#: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr ""
 
-#: catalog/models/item.py:128 catalog/models/movie.py:144
-#: catalog/models/tv.py:235 catalog/models/tv.py:461
+#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/tv.py:237 catalog/models/tv.py:463
 msgid "producer"
 msgstr ""
 
-#: catalog/models/item.py:131 catalog/models/performance.py:203
+#: catalog/models/item.py:127 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr ""
 
-#: catalog/models/item.py:132 catalog/models/performance.py:210
+#: catalog/models/item.py:128 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr ""
 
-#: catalog/models/item.py:133 catalog/models/performance.py:224
+#: catalog/models/item.py:129 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr ""
 
-#: catalog/models/item.py:134 catalog/models/podcast.py:80
+#: catalog/models/item.py:130 catalog/models/podcast.py:80
 msgid "host"
 msgstr ""
 
-#: catalog/models/item.py:135 catalog/models/performance.py:196
+#: catalog/models/item.py:131 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr ""
 
-#: catalog/models/item.py:136 catalog/models/performance.py:238
+#: catalog/models/item.py:132 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr ""
 
-#: catalog/models/item.py:140
+#: catalog/models/item.py:136
 msgid "production company"
 msgstr ""
 
-#: catalog/models/item.py:141
+#: catalog/models/item.py:137
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:142
+#: catalog/models/item.py:138
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:139
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:144 catalog/models/performance.py:231
+#: catalog/models/item.py:140 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr ""
 
-#: catalog/models/item.py:147
+#: catalog/models/item.py:143
 msgid "voice actor"
 msgstr ""
 
-#: catalog/models/item.py:148 catalog/templates/edition.html:30
+#: catalog/models/item.py:144 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr ""
 
-#: catalog/models/item.py:173 catalog/models/people.py:476
+#: catalog/models/item.py:169 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr ""
 
-#: catalog/models/item.py:174 catalog/models/people.py:155
+#: catalog/models/item.py:170 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr ""
 
-#: catalog/models/item.py:176 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:288 catalog/models/item.py:320
-#: journal/models/collection.py:96
+#: catalog/models/item.py:304 catalog/models/item.py:336
+#: journal/models/collection.py:100
 msgid "title"
 msgstr ""
 
-#: catalog/models/item.py:289 catalog/models/item.py:328
-#: journal/models/collection.py:97
+#: catalog/models/item.py:305 catalog/models/item.py:344
+#: journal/models/collection.py:101
 msgid "description"
 msgstr ""
 
-#: catalog/models/item.py:300 catalog/models/people.py:484
+#: catalog/models/item.py:316 catalog/models/people.py:484
 msgid "metadata"
 msgstr ""
 
-#: catalog/models/item.py:302 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
 msgid "cover"
 msgstr ""
 
-#: catalog/models/item.py:1485
+#: catalog/models/item.py:1526
 msgid "source site"
 msgstr ""
 
-#: catalog/models/item.py:1487
+#: catalog/models/item.py:1528
 msgid "ID on source site"
 msgstr ""
 
-#: catalog/models/item.py:1489
+#: catalog/models/item.py:1530
 msgid "source url"
 msgstr ""
 
-#: catalog/models/item.py:1505
+#: catalog/models/item.py:1546
 msgid "IdType of the source site"
 msgstr ""
 
-#: catalog/models/item.py:1511
+#: catalog/models/item.py:1552
 msgid "Primary Id on the source site"
 msgstr ""
 
-#: catalog/models/item.py:1514
+#: catalog/models/item.py:1555
 msgid "url to the resource"
 msgstr ""
 
 #: catalog/models/movie.py:152 catalog/models/music.py:124
-#: catalog/models/tv.py:243 catalog/models/tv.py:469
+#: catalog/models/tv.py:245 catalog/models/tv.py:471
 #: catalog/templates/_item_card_metadata_album.html:16
 #: catalog/templates/album.html:17 catalog/templates/game.html:22
 #: catalog/templates/movie.html:36 catalog/templates/tvseason.html:53
@@ -871,7 +879,7 @@ msgid "length"
 msgstr ""
 
 #: catalog/models/movie.py:162 catalog/models/music.py:131
-#: catalog/models/tv.py:259 catalog/models/tv.py:486
+#: catalog/models/tv.py:261 catalog/models/tv.py:488
 msgid "seconds"
 msgstr ""
 
@@ -1033,32 +1041,83 @@ msgstr ""
 msgid "closing date"
 msgstr ""
 
-#: catalog/models/tv.py:186 catalog/templates/tvseason.html:38
+#: catalog/models/tv.py:188 catalog/templates/tvseason.html:38
 #: catalog/templates/tvshow.html:33
 msgid "number of seasons"
 msgstr ""
 
-#: catalog/models/tv.py:189 catalog/models/tv.py:415
+#: catalog/models/tv.py:191 catalog/models/tv.py:417
 #: catalog/templates/tvseason.html:43 catalog/templates/tvshow.html:38
 msgid "number of episodes"
 msgstr ""
 
-#: catalog/models/tv.py:256 catalog/models/tv.py:483
+#: catalog/models/tv.py:258 catalog/models/tv.py:485
 msgid "episode length"
 msgstr ""
 
-#: catalog/models/tv.py:412 catalog/templates/tvseason.html:33
+#: catalog/models/tv.py:414 catalog/templates/tvseason.html:33
 msgid "season number"
 msgstr ""
 
-#: catalog/models/tv.py:530
+#: catalog/models/tv.py:532
 #, python-brace-format
 msgid "{show_title} Season {season_number}"
 msgstr ""
 
-#: catalog/models/tv.py:684
+#: catalog/models/tv.py:686
 #, python-brace-format
 msgid "{season_title} E{episode_number}"
+msgstr ""
+
+#: catalog/templates/_catalog_confirm_item.html:7
+#: catalog/templates/catalog_edit.html:62
+msgid "Item has been deleted."
+msgstr ""
+
+#: catalog/templates/_catalog_confirm_item.html:12
+#: catalog/templates/catalog_edit.html:65
+msgid "Item contains sub-items."
+msgstr ""
+
+#: catalog/templates/_catalog_confirm_item.html:17
+msgid "Item has been merged to another item."
+msgstr ""
+
+#: catalog/templates/_catalog_confirm_item.html:22
+msgid "Item has been marked by users."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:11
+msgid "Confirm changes"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:16
+msgid "Please correct the errors below."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:24
+msgid "Field"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:25
+msgid "From"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:26
+msgid "To"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:45
+msgid "No changes detected."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:54
+#: users/templates/users/register.html:104
+msgid "Confirm and save"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:57
+msgid "Back to editing"
 msgstr ""
 
 #: catalog/templates/_country_list.html:5
@@ -1066,9 +1125,7 @@ msgid "region"
 msgstr ""
 
 #: catalog/templates/_fetch_failed.html:4
-msgid ""
-"Unable to fetch from the link, please check again. Some sites may require "
-"login for certain links, please manually create them here."
+msgid "Unable to fetch from the link, please check again. Some sites may require login for certain links, please manually create them here."
 msgstr ""
 
 #: catalog/templates/_item_card_metadata_album.html:7
@@ -1124,7 +1181,7 @@ msgstr ""
 #: journal/templates/profile_posts.html:21
 #: journal/templates/user_follow_list_items.html:63
 #: journal/templates/user_post_list_items.html:24
-#: social/templates/events.html:43 social/templates/feed_events.html:28
+#: social/templates/events.html:43 social/templates/feed_events.html:27
 msgid "nothing more."
 msgstr ""
 
@@ -1211,7 +1268,7 @@ msgid "Add note"
 msgstr ""
 
 #: catalog/templates/_item_user_pieces.html:83
-#: common/templates/_sidebar.html:196 journal/templates/profile_items.html:46
+#: common/templates/_sidebar.html:195 journal/templates/profile_items.html:46
 msgid "Set progress"
 msgstr ""
 
@@ -1237,6 +1294,10 @@ msgstr ""
 
 #: catalog/templates/_item_user_pieces.html:214
 msgid "mark history"
+msgstr ""
+
+#: catalog/templates/_search_suggest.html:2
+msgid "Suggestions"
 msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:8
@@ -1266,15 +1327,15 @@ msgid "Edit Options"
 msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
-#: catalog/views/edit.py:82 catalog/views/edit.py:143 catalog/views/edit.py:197
-#: catalog/views/edit.py:218 catalog/views/edit.py:259
-#: catalog/views/edit.py:328 catalog/views/edit.py:332
-#: catalog/views/edit.py:351 catalog/views/edit.py:400
-#: catalog/views/edit.py:425 catalog/views/edit.py:440
-#: catalog/views/edit.py:480 catalog/views/edit.py:490
-#: catalog/views/edit.py:517 catalog/views/edit.py:582
-#: catalog/views/edit.py:637 catalog/views/edit.py:659
-#: catalog/views/search.py:367
+#: catalog/views/edit.py:160 catalog/views/edit.py:221
+#: catalog/views/edit.py:288 catalog/views/edit.py:309
+#: catalog/views/edit.py:364 catalog/views/edit.py:471
+#: catalog/views/edit.py:475 catalog/views/edit.py:509
+#: catalog/views/edit.py:576 catalog/views/edit.py:601
+#: catalog/views/edit.py:624 catalog/views/edit.py:664
+#: catalog/views/edit.py:674 catalog/views/edit.py:703
+#: catalog/views/edit.py:782 catalog/views/edit.py:837
+#: catalog/views/edit.py:859 catalog/views/search.py:418
 msgid "Editing this item is restricted."
 msgstr ""
 
@@ -1302,7 +1363,7 @@ msgstr ""
 msgid "The following items are merged into this item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:70
+#: catalog/templates/_sidebar_edit.html:70 catalog/views/edit.py:456
 msgid "External website"
 msgstr ""
 
@@ -1322,35 +1383,31 @@ msgstr ""
 msgid "Fetch again"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:97
-msgid "You may not be able to undo this operation, sure to remove?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:102
+#: catalog/templates/_sidebar_edit.html:100
 msgid "Remove link to site"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:110
+#: catalog/templates/_sidebar_edit.html:108
 msgid "Choose cover"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:119
+#: catalog/templates/_sidebar_edit.html:117
+#: catalog/templates/_sidebar_edit.html:118
 #: catalog/templates/_sidebar_edit.html:120
-#: catalog/templates/_sidebar_edit.html:122
 msgid "Current cover"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:139
+#: catalog/templates/_sidebar_edit.html:137
 msgid "Select an image to use as the cover of this item."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:140
-#: catalog/templates/catalog_edit.html:65
-#: common/templates/manage/settings.html:136
+#: catalog/templates/_sidebar_edit.html:138
+#: catalog/templates/catalog_edit.html:78
+#: common/templates/manage/settings.html:19
 #: journal/templates/add_to_collection.html:43
 #: journal/templates/article_edit.html:60
 #: journal/templates/collection_edit.html:39 journal/templates/comment.html:41
-#: journal/templates/mark.html:134 journal/templates/note.html:65
+#: journal/templates/mark.html:138 journal/templates/note.html:65
 #: journal/templates/post_compose.html:103
 #: journal/templates/review_edit.html:46 journal/templates/tag_edit.html:51
 #: users/templates/users/_pref_device.html:37
@@ -1359,185 +1416,158 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:147
+#: catalog/templates/_sidebar_edit.html:145
 msgid "Edit sub-items"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:160
+#: catalog/templates/_sidebar_edit.html:158
 msgid "create"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:166
+#: catalog/templates/_sidebar_edit.html:164
 msgid "Fetch all episodes"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:171
+#: catalog/templates/_sidebar_edit.html:169
 msgid "Fetch all"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:172
-msgid ""
-"Due to differences in how Douban, IMDB, and TMDB handle season data, a small "
-"number of TV shows and animations may not return correct results. Please "
-"manually verify and clean up after updating."
+#: catalog/templates/_sidebar_edit.html:170
+msgid "Due to differences in how Douban, IMDB, and TMDB handle season data, a small number of TV shows and animations may not return correct results. Please manually verify and clean up after updating."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:173
+#: catalog/templates/_sidebar_edit.html:171
 msgid "Up to 250 episodes will be fetched for a season."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:176
-msgid ""
-"To fetch all episodes, season numbers and IMDB information are required. If "
-"filling this out is inconvenient, you can also manually create sub-entries."
+#: catalog/templates/_sidebar_edit.html:174
+msgid "To fetch all episodes, season numbers and IMDB information are required. If filling this out is inconvenient, you can also manually create sub-entries."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:182
-#: catalog/templates/_sidebar_edit.html:194
-#: catalog/templates/_sidebar_edit.html:213
+#: catalog/templates/_sidebar_edit.html:180
+#: catalog/templates/_sidebar_edit.html:191
+#: catalog/templates/_sidebar_edit.html:208
 msgid "switch category"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:185
-msgid "Switching may remove some metadata. Sure to proceed?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:188
+#: catalog/templates/_sidebar_edit.html:185 catalog/views/edit.py:383
 msgid "TV Show"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:227
+#: catalog/templates/_sidebar_edit.html:221
 msgid "Link to parent item"
 msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:230
-msgid "Sure to link?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:237
 msgid "Update link"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:243
+#: catalog/templates/_sidebar_edit.html:236
 msgid "Cleanup seasons"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:246
-#: catalog/templates/catalog_delete.html:45
-msgid "This operation cannot be undone. Sure to delete?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:250
+#: catalog/templates/_sidebar_edit.html:242
 msgid "remove seasons not marked"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:256
-#: catalog/templates/catalog_merge.html:12
+#: catalog/templates/_sidebar_edit.html:248
 msgid "Merge"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:262
+#: catalog/templates/_sidebar_edit.html:254
 msgid "URL of target item, or empty if undo merge"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:268
-#: catalog/templates/_sidebar_edit.html:348
+#: catalog/templates/_sidebar_edit.html:260
+#: catalog/templates/_sidebar_edit.html:350
 msgid "merge to another item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:273
-#: catalog/templates/_sidebar_edit.html:277
-#: catalog/templates/catalog_delete.html:12
+#: catalog/templates/_sidebar_edit.html:265
+#: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
 #: journal/templates/article.html:199 journal/templates/collection.html:188
-#: journal/templates/mark.html:149 journal/templates/note.html:82
+#: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
 #: users/templates/users/account.html:254
 msgid "Delete"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:287
+#: catalog/templates/_sidebar_edit.html:275
+#: catalog/templates/_sidebar_edit.html:279
+msgid "Undo delete"
+msgstr ""
+
+#: catalog/templates/_sidebar_edit.html:280
+msgid "Links to external sites and parent item were removed on delete and will not be restored."
+msgstr ""
+
+#: catalog/templates/_sidebar_edit.html:290
 msgid "This edition belongs to the following work"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:292
-msgid "Sure to unlink?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:298
+#: catalog/templates/_sidebar_edit.html:300
 msgid "Unlink from work"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:304
+#: catalog/templates/_sidebar_edit.html:306
 msgid "Link"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:315
+#: catalog/templates/_sidebar_edit.html:317
 msgid "Link to another edition from same work"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:324
+#: catalog/templates/_sidebar_edit.html:326
 msgid "Restriction"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:337
+#: catalog/templates/_sidebar_edit.html:339
 #: journal/templates/collection_update_item_note.html:4
 msgid "Update"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:342
+#: catalog/templates/_sidebar_edit.html:344
 msgid "Suggest Edits"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:347
+#: catalog/templates/_sidebar_edit.html:349
 msgid "proposed action"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:349
+#: catalog/templates/_sidebar_edit.html:351
 msgid "link to another item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:350
+#: catalog/templates/_sidebar_edit.html:352
 msgid "change item category"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:351
+#: catalog/templates/_sidebar_edit.html:353
 msgid "change item metadata"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:352
+#: catalog/templates/_sidebar_edit.html:354
 msgid "remove item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:353
+#: catalog/templates/_sidebar_edit.html:355
 msgid "other"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:357
-msgid ""
-"To suggest merging or association, please include the URL of the target item"
+#: catalog/templates/_sidebar_edit.html:359
+msgid "To suggest merging or association, please include the URL of the target item"
 msgstr "欲倡合併或關聯之事，請附以条目之網址"
 
-#: catalog/templates/_sidebar_edit.html:358
+#: catalog/templates/_sidebar_edit.html:360
 #: catalog/templates/catalog_verify.html:116
 msgid "submit"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:359
-msgid ""
-"As a user of this community, you may edit some metadata of items on this "
-"site. If you are unsure whether your edits are appropriate or are unable to "
-"make a certain change, you can make suggestions here. Moderators will "
-"consider each suggestion, although there is no guarantee that they will "
-"always be fully adopted; suggestions may also be viewed or discussed by "
-"other community users. If you have suggestions that are not related to a "
-"specific item, please contact us. Thank you for your support and "
-"contribution."
-msgstr ""
-"閣下既為社群之使用者，可編修元數據。若有疑所纂是否允當，或有所不能，则可於此"
-"建言。主事者將審議各項，然未必盡納；建言亦或為眾所覽議。若有建言非關乎特定之"
-"項者，敬請聯繫主事者。謹此致謝諸君之襄助與貢獻。"
+#: catalog/templates/_sidebar_edit.html:361
+msgid "As a user of this community, you may edit some metadata of items on this site. If you are unsure whether your edits are appropriate or are unable to make a certain change, you can make suggestions here. Moderators will consider each suggestion, although there is no guarantee that they will always be fully adopted; suggestions may also be viewed or discussed by other community users. If you have suggestions that are not related to a specific item, please contact us. Thank you for your support and contribution."
+msgstr "閣下既為社群之使用者，可編修元數據。若有疑所纂是否允當，或有所不能，则可於此建言。主事者將審議各項，然未必盡納；建言亦或為眾所覽議。若有建言非關乎特定之項者，敬請聯繫主事者。謹此致謝諸君之襄助與貢獻。"
 
 #: catalog/templates/_sidebar_search.html:5
 #: journal/templates/_sidebar_search_journal.html:4
@@ -1634,16 +1664,14 @@ msgid "matched"
 msgstr ""
 
 #: catalog/templates/_verify_status.html:21
-msgid ""
-"Sure to remove your creator verification? Anyone will be able to edit this "
-"item again."
+msgid "Sure to remove your creator verification? Anyone will be able to edit this item again."
 msgstr ""
 
 #: catalog/templates/_verify_status.html:26
 msgid "Remove my verification"
 msgstr ""
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:309
+#: catalog/templates/_verify_status.html:31 users/views/account.py:311
 msgid "Verification failed"
 msgstr ""
 
@@ -1680,43 +1708,11 @@ msgstr ""
 msgid "album media"
 msgstr ""
 
-#: catalog/templates/catalog_delete.html:19
-msgid "Are you sure to delete?"
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:24
-#: catalog/templates/catalog_edit.html:52
-#: catalog/templates/catalog_merge.html:36
-#: catalog/templates/catalog_merge.html:64
-msgid "Item has been deleted."
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:29
-#: catalog/templates/catalog_edit.html:55
-#: catalog/templates/catalog_merge.html:41
-#: catalog/templates/catalog_merge.html:69
-msgid "Item contains sub-items."
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:34
-#: catalog/templates/catalog_merge.html:46
-#: catalog/templates/catalog_merge.html:74
-msgid "Item has been merged to another item."
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:39
-#: catalog/templates/catalog_merge.html:51
-#: catalog/templates/catalog_merge.html:79
-msgid "Item has been marked by users."
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:48
-#: catalog/templates/catalog_merge.html:92 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:55 common/views_manage.py:139
 msgid "Yes"
 msgstr "善"
 
-#: catalog/templates/catalog_delete.html:49
-#: catalog/templates/catalog_merge.html:93 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:56 common/views_manage.py:139
 msgid "No"
 msgstr ""
 
@@ -1725,36 +1721,18 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: catalog/templates/catalog_edit.html:68
+#: catalog/templates/catalog_edit.html:81
 #: journal/templates/collection_update_item_note.html:8
 #: journal/templates/piece_delete.html:38
 msgid "Cancel"
 msgstr ""
 
-#: catalog/templates/catalog_edit.html:104
+#: catalog/templates/catalog_edit.html:118
 msgid "open linked people page"
 msgstr ""
 
-#: catalog/templates/catalog_merge.html:22
-msgid "Are you sure to merge?"
-msgstr ""
-
-#: catalog/templates/catalog_merge.html:24
-msgid "Are you sure to cancel merge?"
-msgstr ""
-
-#: catalog/templates/catalog_merge.html:27
-msgid "Are you sure to link?"
-msgstr ""
-
-#: catalog/templates/catalog_merge.html:86
-msgid "This operation cannot be undone. Sure to merge?"
-msgstr ""
-
 #: catalog/templates/catalog_verify.html:21
-msgid ""
-"If you are a creator of this podcast, you may verify the ownership, so that "
-"only you (and other verified creators) can edit its metadata on this site."
+msgid "If you are a creator of this podcast, you may verify the ownership, so that only you (and other verified creators) can edit its metadata on this site."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:22
@@ -1762,9 +1740,7 @@ msgid "Your recent episodes may also occasionally be featured in discovery."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:24
-msgid ""
-"To verify, prove you control one of the following identifiers of your "
-"account (click to copy):"
+msgid "To verify, prove you control one of the following identifiers of your account (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:30
@@ -1775,18 +1751,11 @@ msgid "copied"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:35
-msgid ""
-"You can prove this in a few ways, then start verification: add one of the "
-"identifiers above to the podcast feed's description; add a <code>rel=\"me\"</"
-"code> link back to one of them on the web page your feed links to (the link "
-"verification Mastodon uses); or point your feed's website at your Bluesky "
-"handle's own domain."
+msgid "You can prove this in a few ways, then start verification: add one of the identifiers above to the podcast feed's description; add a <code>rel=\"me\"</code> link back to one of them on the web page your feed links to (the link verification Mastodon uses); or point your feed's website at your Bluesky handle's own domain."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:44
-msgid ""
-"For example, add this rel=me link to the web page your feed links to (click "
-"to copy):"
+msgid "For example, add this rel=me link to the web page your feed links to (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:50
@@ -1794,9 +1763,7 @@ msgid "or, in the page's head:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:57
-msgid ""
-"Can't edit the website? Just add a line like this to your feed's description "
-"instead (click to copy):"
+msgid "Can't edit the website? Just add a line like this to your feed's description instead (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:62
@@ -1804,10 +1771,7 @@ msgid "Welcome to follow me on the Fediverse:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:66
-msgid ""
-"NeoDB does not re-check this periodically at the moment, but we recommend "
-"you keep it so that your audience can discover and connect with you in "
-"distributed social media."
+msgid "NeoDB does not re-check this periodically at the moment, but we recommend you keep it so that your audience can discover and connect with you in distributed social media."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:72
@@ -1835,12 +1799,11 @@ msgid "Send feedback"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:115
-msgid ""
-"Questions or issues with creator verification? Let the site moderators know."
+msgid "Questions or issues with creator verification? Let the site moderators know."
 msgstr ""
 
-#: catalog/templates/discover.html:28 common/views_manage.py:145
-#: common/views_manage.py:353 users/templates/users/preferences.html:34
+#: catalog/templates/discover.html:28 common/views_manage.py:35
+#: common/views_manage.py:431 users/templates/users/preferences.html:34
 msgid "Discover"
 msgstr ""
 
@@ -1878,17 +1841,17 @@ msgstr ""
 msgid "hide"
 msgstr ""
 
-#: catalog/templates/discover.html:206 common/templates/_sidebar.html:14
+#: catalog/templates/discover.html:206 common/templates/_sidebar.html:13
 msgid "Unread Announcements"
 msgstr ""
 
-#: catalog/templates/discover.html:212 common/templates/_sidebar.html:20
+#: catalog/templates/discover.html:212 common/templates/_sidebar.html:19
 #: social/templates/notification.html:67
 msgid "mark all as read"
 msgstr ""
 
 #: catalog/templates/discover.html:222
-#: common/templates/_sidebar_anonymous.html:55
+#: common/templates/_sidebar_anonymous.html:54
 msgid "Popular Tags"
 msgstr ""
 
@@ -1899,9 +1862,9 @@ msgstr ""
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
 #: catalog/templates/user_verified_works.html:23
-#: common/templates/_sidebar.html:127
-#: common/templates/_sidebar_anonymous.html:46
-#: common/templates/_sidebar_anonymous.html:62 journal/templates/posts.html:8
+#: common/templates/_sidebar.html:126
+#: common/templates/_sidebar_anonymous.html:45
+#: common/templates/_sidebar_anonymous.html:61 journal/templates/posts.html:7
 #: journal/templates/profile_articles.html:24
 #: journal/templates/profile_articles.html:26
 #: journal/templates/profile_items.html:65
@@ -1917,7 +1880,7 @@ msgstr ""
 msgid "nothing so far."
 msgstr ""
 
-#: catalog/templates/discover.html:239 common/templates/_sidebar.html:269
+#: catalog/templates/discover.html:239 common/templates/_sidebar.html:268
 msgid "Recent Posts"
 msgstr ""
 
@@ -1943,9 +1906,7 @@ msgid "Borrow or Buy"
 msgstr ""
 
 #: catalog/templates/external_search_results.html:10
-msgid ""
-"Some items were found from other websites and instances, click their title "
-"to save them locally."
+msgid "Some items were found from other websites and instances, click their title to save them locally."
 msgstr ""
 
 #: catalog/templates/fetch_pending.html:13
@@ -2045,12 +2006,12 @@ msgstr ""
 msgid "number of Episodes"
 msgstr ""
 
-#: catalog/templates/people.html:13 common/templates/_sidebar.html:77
-#: common/templates/_sidebar.html:84 journal/models/shelf.py:326
+#: catalog/templates/people.html:13 common/templates/_sidebar.html:76
+#: common/templates/_sidebar.html:83 journal/models/shelf.py:328
 msgid "following"
 msgstr ""
 
-#: catalog/templates/people.html:15 journal/models/shelf.py:324
+#: catalog/templates/people.html:15 journal/models/shelf.py:326
 #: social/templates/notification.html:60
 msgid "follow"
 msgstr ""
@@ -2069,7 +2030,6 @@ msgstr ""
 #: journal/templates/_sidebar_collection_filter.html:14
 #: journal/templates/_sidebar_collection_filter.html:28
 #: journal/templates/_sidebar_user_mark_list.html:56
-#: social/templates/feed.html:42 social/templates/feed.html:44
 #: social/templates/notification.html:56
 msgid "all"
 msgstr ""
@@ -2093,7 +2053,7 @@ msgstr ""
 msgid "production"
 msgstr ""
 
-#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:54
+#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:53
 msgid "verified creator"
 msgstr ""
 
@@ -2174,10 +2134,7 @@ msgid "No items matching your search query."
 msgstr ""
 
 #: catalog/templates/search_results.html:34
-msgid ""
-"If you have URL from one of these sites, please put the full URL (e.g. "
-"<code>https://www.imdb.com/title/tt2513074/</code>) to the search box and "
-"press Enter."
+msgid "If you have URL from one of these sites, please put the full URL (e.g. <code>https://www.imdb.com/title/tt2513074/</code>) to the search box and press Enter."
 msgstr ""
 
 #: catalog/templates/search_results.html:48
@@ -2214,97 +2171,170 @@ msgstr ""
 msgid "Editions"
 msgstr ""
 
-#: catalog/views/edit.py:202 catalog/views/edit.py:205
-#: catalog/views/edit.py:306 catalog/views/edit.py:309
-#: catalog/views/verify.py:197 journal/views/collection.py:77
-#: journal/views/collection.py:102 journal/views/collection.py:556
-#: journal/views/collection.py:651 journal/views/common.py:221
-#: journal/views/mark.py:196 journal/views/post.py:117
-#: journal/views/post.py:119 journal/views/post.py:166
-#: journal/views/post.py:185 journal/views/post.py:187
-#: journal/views/post.py:228 journal/views/post.py:241
+#: catalog/views/edit.py:293 catalog/views/edit.py:296
+#: catalog/views/edit.py:440 catalog/views/edit.py:443
+#: catalog/views/verify.py:197 journal/views/collection.py:75
+#: journal/views/collection.py:100 journal/views/collection.py:538
+#: journal/views/collection.py:634 journal/views/common.py:231
+#: journal/views/mark.py:244 journal/views/post.py:119
+#: journal/views/post.py:121 journal/views/post.py:168
+#: journal/views/post.py:187 journal/views/post.py:189
+#: journal/views/post.py:230 journal/views/post.py:243
 #: journal/views/review.py:154 journal/views/review.py:158
-#: users/views/actions.py:179
+#: users/views/actions.py:178
 msgid "Invalid parameter"
 msgstr ""
 
-#: catalog/views/edit.py:220
+#: catalog/views/edit.py:313
 msgid "Item in use."
 msgstr ""
 
-#: catalog/views/edit.py:222
+#: catalog/views/edit.py:315
 msgid "Item cannot be deleted."
 msgstr ""
 
-#: catalog/views/edit.py:247 catalog/views/edit.py:303
-#: catalog/views/edit.py:427 catalog/views/edit.py:519
-#: catalog/views/edit.py:552 catalog/views/verify.py:158
+#: catalog/views/edit.py:319 catalog/views/edit.py:515
+msgid "Are you sure to delete?"
+msgstr ""
+
+#: catalog/views/edit.py:323 catalog/views/edit.py:518
+#: catalog/views/edit.py:617
+msgid "This operation cannot be undone."
+msgstr ""
+
+#: catalog/views/edit.py:344 catalog/views/edit.py:437
+#: catalog/views/edit.py:603 catalog/views/edit.py:705
+#: catalog/views/edit.py:752 catalog/views/verify.py:158
 #: catalog/views/verify.py:206 journal/views/article.py:44
 #: journal/views/article.py:133 journal/views/article.py:153
 #: journal/views/collection.py:248 journal/views/collection.py:341
-#: journal/views/collection.py:360 journal/views/collection.py:384
-#: journal/views/collection.py:457 journal/views/collection.py:500
-#: journal/views/collection.py:539 journal/views/collection.py:551
-#: journal/views/collection.py:576 journal/views/collection.py:613
-#: journal/views/common.py:300 journal/views/mark.py:281
-#: journal/views/post.py:58 journal/views/post.py:78 journal/views/post.py:100
-#: journal/views/post.py:170 journal/views/post.py:199
-#: journal/views/post.py:272 journal/views/post.py:287
-#: journal/views/post.py:394 journal/views/post.py:549
+#: journal/views/collection.py:354 journal/views/collection.py:372
+#: journal/views/collection.py:439 journal/views/collection.py:482
+#: journal/views/collection.py:521 journal/views/collection.py:533
+#: journal/views/collection.py:558 journal/views/collection.py:595
+#: journal/views/common.py:304 journal/views/mark.py:317
+#: journal/views/post.py:60 journal/views/post.py:80 journal/views/post.py:102
+#: journal/views/post.py:172 journal/views/post.py:201
+#: journal/views/post.py:274 journal/views/post.py:289
+#: journal/views/post.py:390 journal/views/post.py:539
 #: journal/views/review.py:64 journal/views/review.py:81
 #: journal/views/review.py:106
 msgid "Insufficient permission"
 msgstr ""
 
-#: catalog/views/edit.py:374
+#: catalog/views/edit.py:346
+msgid "Item is not deleted"
+msgstr ""
+
+#: catalog/views/edit.py:389
+msgid "Switching may remove some metadata."
+msgstr ""
+
+#: catalog/views/edit.py:395
+msgid "The following seasons will be detached from this show"
+msgstr ""
+
+#: catalog/views/edit.py:400
+msgid "Links to IMDB and TMDB will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:403
+msgid "Are you sure to switch category?"
+msgstr ""
+
+#: catalog/views/edit.py:451
+msgid "Are you sure to remove the link to this site?"
+msgstr ""
+
+#: catalog/views/edit.py:457
+msgid "You may not be able to undo this operation."
+msgstr ""
+
+#: catalog/views/edit.py:483
+msgid "Current parent item"
+msgstr ""
+
+#: catalog/views/edit.py:487
+msgid "The link to the parent item will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:490 catalog/views/edit.py:680
+msgid "Are you sure to link?"
+msgstr ""
+
+#: catalog/views/edit.py:521
+msgid "The following seasons will be deleted"
+msgstr ""
+
+#: catalog/views/edit.py:525
+msgid "The following seasons will be kept"
+msgstr ""
+
+#: catalog/views/edit.py:550
 msgid "TV Season with IMDB id and season number required."
 msgstr ""
 
-#: catalog/views/edit.py:380
+#: catalog/views/edit.py:556
 msgid "Updating episodes"
 msgstr ""
 
-#: catalog/views/edit.py:405
+#: catalog/views/edit.py:581
 msgid "This person has no supported source to fetch works from."
 msgstr ""
 
-#: catalog/views/edit.py:412
+#: catalog/views/edit.py:588
 msgid "Already pulling works for this person, try again later."
 msgstr ""
 
-#: catalog/views/edit.py:416
+#: catalog/views/edit.py:592
 msgid "Pulling works in background."
 msgstr ""
 
-#: catalog/views/edit.py:438
+#: catalog/views/edit.py:609
+msgid "Are you sure to merge?"
+msgstr ""
+
+#: catalog/views/edit.py:611
+msgid "Are you sure to cancel merge?"
+msgstr ""
+
+#: catalog/views/edit.py:622
 msgid "Cannot be merged to an item already deleted or merged"
 msgstr ""
 
-#: catalog/views/edit.py:443
+#: catalog/views/edit.py:627
 msgid "Cannot merge items in different categories"
 msgstr ""
 
-#: catalog/views/edit.py:447
+#: catalog/views/edit.py:631
 msgid "Cannot merge an item to itself"
 msgstr ""
 
-#: catalog/views/edit.py:488
+#: catalog/views/edit.py:672
 msgid "Cannot be linked to an item already deleted or merged"
 msgstr ""
 
-#: catalog/views/edit.py:492
+#: catalog/views/edit.py:676
 msgid "Cannot link items other than editions"
 msgstr ""
 
-#: catalog/views/search.py:96
+#: catalog/views/edit.py:710
+msgid "Are you sure to unlink?"
+msgstr ""
+
+#: catalog/views/edit.py:715
+msgid "This edition will be unlinked from the following work"
+msgstr ""
+
+#: catalog/views/search.py:113
 msgid "the internet"
 msgstr ""
 
-#: catalog/views/search.py:359
+#: catalog/views/search.py:410
 msgid "Invalid URL"
 msgstr ""
 
-#: catalog/views/search.py:362
+#: catalog/views/search.py:413
 msgid "Unsupported URL"
 msgstr ""
 
@@ -2328,9 +2358,9 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:122 common/utils.py:163
+#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
 #: journal/views/article.py:186 journal/views/review.py:182
-#: users/views/actions.py:45 users/views/actions.py:131
+#: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
 msgstr ""
 
@@ -2342,15 +2372,15 @@ msgstr ""
 msgid "Creator verification removed."
 msgstr ""
 
-#: catalog/views/view.py:74 catalog/views/view.py:99
+#: catalog/views/view.py:77 catalog/views/view.py:102
 msgid "Item not found"
 msgstr ""
 
-#: catalog/views/view.py:78 catalog/views/view.py:107 catalog/views/view.py:190
+#: catalog/views/view.py:81 catalog/views/view.py:110 catalog/views/view.py:193
 msgid "Item no longer exists"
 msgstr ""
 
-#: catalog/views/view.py:187
+#: catalog/views/view.py:190
 msgid "Invalid role"
 msgstr ""
 
@@ -2834,759 +2864,759 @@ msgctxt "genre"
 msgid "Health"
 msgstr ""
 
-#: common/models/lang.py:54
+#: common/models/lang.py:56
 msgid "Afar"
 msgstr ""
 
-#: common/models/lang.py:55
+#: common/models/lang.py:57
 msgid "Afrikaans"
 msgstr ""
 
-#: common/models/lang.py:56
+#: common/models/lang.py:58
 msgid "Akan"
 msgstr ""
 
-#: common/models/lang.py:57
+#: common/models/lang.py:59
 msgid "Aragonese"
 msgstr ""
 
-#: common/models/lang.py:58
+#: common/models/lang.py:60
 msgid "Assamese"
 msgstr ""
 
-#: common/models/lang.py:59
+#: common/models/lang.py:61
 msgid "Avaric"
 msgstr ""
 
-#: common/models/lang.py:60
+#: common/models/lang.py:62
 msgid "Avestan"
 msgstr ""
 
-#: common/models/lang.py:61
+#: common/models/lang.py:63
 msgid "Aymara"
 msgstr ""
 
-#: common/models/lang.py:62
+#: common/models/lang.py:64
 msgid "Azerbaijani"
 msgstr ""
 
-#: common/models/lang.py:63
+#: common/models/lang.py:65
 msgid "Bashkir"
 msgstr ""
 
-#: common/models/lang.py:64
+#: common/models/lang.py:66
 msgid "Bambara"
 msgstr ""
 
-#: common/models/lang.py:65
+#: common/models/lang.py:67
 msgid "Bislama"
 msgstr ""
 
-#: common/models/lang.py:66
+#: common/models/lang.py:68
 msgid "Tibetan"
 msgstr ""
 
-#: common/models/lang.py:67
+#: common/models/lang.py:69
 msgid "Breton"
 msgstr ""
 
-#: common/models/lang.py:68
+#: common/models/lang.py:70
 msgid "Catalan"
 msgstr ""
 
-#: common/models/lang.py:69
+#: common/models/lang.py:71
 msgid "Czech"
 msgstr ""
 
-#: common/models/lang.py:70
+#: common/models/lang.py:72
 msgid "Chechen"
 msgstr ""
 
-#: common/models/lang.py:71
+#: common/models/lang.py:73
 msgid "Slavic"
 msgstr ""
 
-#: common/models/lang.py:72
+#: common/models/lang.py:74
 msgid "Chuvash"
 msgstr ""
 
-#: common/models/lang.py:73
+#: common/models/lang.py:75
 msgid "Cornish"
 msgstr ""
 
-#: common/models/lang.py:74
+#: common/models/lang.py:76
 msgid "Corsican"
 msgstr ""
 
-#: common/models/lang.py:75
+#: common/models/lang.py:77
 msgid "Cree"
 msgstr ""
 
-#: common/models/lang.py:76
+#: common/models/lang.py:78
 msgid "Welsh"
 msgstr ""
 
-#: common/models/lang.py:79
+#: common/models/lang.py:81
 msgid "Divehi"
 msgstr ""
 
-#: common/models/lang.py:80
+#: common/models/lang.py:82
 msgid "Dzongkha"
 msgstr ""
 
-#: common/models/lang.py:81
+#: common/models/lang.py:83
 msgid "Esperanto"
 msgstr ""
 
-#: common/models/lang.py:82
+#: common/models/lang.py:84
 msgid "Estonian"
 msgstr ""
 
-#: common/models/lang.py:83
+#: common/models/lang.py:85
 msgid "Basque"
 msgstr ""
 
-#: common/models/lang.py:84
+#: common/models/lang.py:86
 msgid "Faroese"
 msgstr ""
 
-#: common/models/lang.py:85
+#: common/models/lang.py:87
 msgid "Fijian"
 msgstr ""
 
-#: common/models/lang.py:86
+#: common/models/lang.py:88
 msgid "Finnish"
 msgstr ""
 
-#: common/models/lang.py:88
+#: common/models/lang.py:90
 msgid "Frisian"
 msgstr ""
 
-#: common/models/lang.py:89
+#: common/models/lang.py:91
 msgid "Fulah"
 msgstr ""
 
-#: common/models/lang.py:90
+#: common/models/lang.py:92
 msgid "Gaelic"
 msgstr ""
 
-#: common/models/lang.py:91
+#: common/models/lang.py:93
 msgid "Irish"
 msgstr ""
 
-#: common/models/lang.py:92
+#: common/models/lang.py:94
 msgid "Galician"
 msgstr ""
 
-#: common/models/lang.py:93
+#: common/models/lang.py:95
 msgid "Manx"
 msgstr ""
 
-#: common/models/lang.py:94
+#: common/models/lang.py:96
 msgid "Guarani"
 msgstr ""
 
-#: common/models/lang.py:95
+#: common/models/lang.py:97
 msgid "Gujarati"
 msgstr ""
 
-#: common/models/lang.py:96
+#: common/models/lang.py:98
 msgid "Haitian; Haitian Creole"
 msgstr ""
 
-#: common/models/lang.py:97
+#: common/models/lang.py:99
 msgid "Hausa"
 msgstr ""
 
-#: common/models/lang.py:98
+#: common/models/lang.py:100
 msgid "Serbo-Croatian"
 msgstr ""
 
-#: common/models/lang.py:99
+#: common/models/lang.py:101
 msgid "Herero"
 msgstr ""
 
-#: common/models/lang.py:100
+#: common/models/lang.py:102
 msgid "Hiri Motu"
 msgstr ""
 
-#: common/models/lang.py:101
+#: common/models/lang.py:103
 msgid "Croatian"
 msgstr ""
 
-#: common/models/lang.py:102
+#: common/models/lang.py:104
 msgid "Hungarian"
 msgstr ""
 
-#: common/models/lang.py:103
+#: common/models/lang.py:105
 msgid "Igbo"
 msgstr ""
 
-#: common/models/lang.py:104
+#: common/models/lang.py:106
 msgid "Ido"
 msgstr ""
 
-#: common/models/lang.py:105
+#: common/models/lang.py:107
 msgid "Yi"
 msgstr ""
 
-#: common/models/lang.py:106
+#: common/models/lang.py:108
 msgid "Inuktitut"
 msgstr ""
 
-#: common/models/lang.py:107
+#: common/models/lang.py:109
 msgid "Interlingue"
 msgstr ""
 
-#: common/models/lang.py:108
+#: common/models/lang.py:110
 msgid "Interlingua"
 msgstr ""
 
-#: common/models/lang.py:109
+#: common/models/lang.py:111
 msgid "Indonesian"
 msgstr ""
 
-#: common/models/lang.py:110
+#: common/models/lang.py:112
 msgid "Inupiaq"
 msgstr ""
 
-#: common/models/lang.py:111
+#: common/models/lang.py:113
 msgid "Icelandic"
 msgstr ""
 
-#: common/models/lang.py:113
+#: common/models/lang.py:115
 msgid "Javanese"
 msgstr ""
 
-#: common/models/lang.py:114
+#: common/models/lang.py:116
 msgid "Japanese"
 msgstr ""
 
-#: common/models/lang.py:115
+#: common/models/lang.py:117
 msgid "Kalaallisut"
 msgstr ""
 
-#: common/models/lang.py:116
+#: common/models/lang.py:118
 msgid "Kannada"
 msgstr ""
 
-#: common/models/lang.py:117
+#: common/models/lang.py:119
 msgid "Kashmiri"
 msgstr ""
 
-#: common/models/lang.py:118
+#: common/models/lang.py:120
 msgid "Kanuri"
 msgstr ""
 
-#: common/models/lang.py:119
+#: common/models/lang.py:121
 msgid "Kazakh"
 msgstr ""
 
-#: common/models/lang.py:120
+#: common/models/lang.py:122
 msgid "Khmer"
 msgstr ""
 
-#: common/models/lang.py:121
+#: common/models/lang.py:123
 msgid "Kikuyu"
 msgstr ""
 
-#: common/models/lang.py:122
+#: common/models/lang.py:124
 msgid "Kinyarwanda"
 msgstr ""
 
-#: common/models/lang.py:123
+#: common/models/lang.py:125
 msgid "Kirghiz"
 msgstr ""
 
-#: common/models/lang.py:124
+#: common/models/lang.py:126
 msgid "Komi"
 msgstr ""
 
-#: common/models/lang.py:125
+#: common/models/lang.py:127
 msgid "Kongo"
 msgstr ""
 
-#: common/models/lang.py:126
+#: common/models/lang.py:128
 msgid "Korean"
 msgstr ""
 
-#: common/models/lang.py:127
+#: common/models/lang.py:129
 msgid "Kuanyama"
 msgstr ""
 
-#: common/models/lang.py:128
+#: common/models/lang.py:130
 msgid "Kurdish"
 msgstr ""
 
-#: common/models/lang.py:129
+#: common/models/lang.py:131
 msgid "Lao"
 msgstr ""
 
-#: common/models/lang.py:130
+#: common/models/lang.py:132
 msgid "Latin"
 msgstr ""
 
-#: common/models/lang.py:131
+#: common/models/lang.py:133
 msgid "Latvian"
 msgstr ""
 
-#: common/models/lang.py:132
+#: common/models/lang.py:134
 msgid "Limburgish"
 msgstr ""
 
-#: common/models/lang.py:133
+#: common/models/lang.py:135
 msgid "Lingala"
 msgstr ""
 
-#: common/models/lang.py:134
+#: common/models/lang.py:136
 msgid "Lithuanian"
 msgstr ""
 
-#: common/models/lang.py:135
+#: common/models/lang.py:137
 msgid "Letzeburgesch"
 msgstr ""
 
-#: common/models/lang.py:136
+#: common/models/lang.py:138
 msgid "Luba-Katanga"
 msgstr ""
 
-#: common/models/lang.py:137
+#: common/models/lang.py:139
 msgid "Ganda"
 msgstr ""
 
-#: common/models/lang.py:138
+#: common/models/lang.py:140
 msgid "Marshall"
 msgstr ""
 
-#: common/models/lang.py:139
+#: common/models/lang.py:141
 msgid "Malayalam"
 msgstr ""
 
-#: common/models/lang.py:140
+#: common/models/lang.py:142
 msgid "Marathi"
 msgstr ""
 
-#: common/models/lang.py:141
+#: common/models/lang.py:143
 msgid "Malagasy"
 msgstr ""
 
-#: common/models/lang.py:142
+#: common/models/lang.py:144
 msgid "Maltese"
 msgstr ""
 
-#: common/models/lang.py:143
+#: common/models/lang.py:145
 msgid "Moldavian"
 msgstr ""
 
-#: common/models/lang.py:144
+#: common/models/lang.py:146
 msgid "Mongolian"
 msgstr ""
 
-#: common/models/lang.py:145
+#: common/models/lang.py:147
 msgid "Maori"
 msgstr ""
 
-#: common/models/lang.py:146
+#: common/models/lang.py:148
 msgid "Malay"
 msgstr ""
 
-#: common/models/lang.py:147
+#: common/models/lang.py:149
 msgid "Burmese"
 msgstr ""
 
-#: common/models/lang.py:148
+#: common/models/lang.py:150
 msgid "Nauru"
 msgstr ""
 
-#: common/models/lang.py:149
+#: common/models/lang.py:151
 msgid "Navajo"
 msgstr ""
 
-#: common/models/lang.py:150 common/models/lang.py:151
+#: common/models/lang.py:152 common/models/lang.py:153
 msgid "Ndebele"
 msgstr ""
 
-#: common/models/lang.py:152
+#: common/models/lang.py:154
 msgid "Ndonga"
 msgstr ""
 
-#: common/models/lang.py:153
+#: common/models/lang.py:155
 msgid "Nepali"
 msgstr ""
 
-#: common/models/lang.py:154
+#: common/models/lang.py:156
 msgid "Dutch"
 msgstr ""
 
-#: common/models/lang.py:155
+#: common/models/lang.py:157
 msgid "Norwegian Nynorsk"
 msgstr ""
 
-#: common/models/lang.py:156
+#: common/models/lang.py:158
 msgid "Norwegian Bokmål"
 msgstr ""
 
-#: common/models/lang.py:157
+#: common/models/lang.py:159
 msgid "Norwegian"
 msgstr ""
 
-#: common/models/lang.py:158
+#: common/models/lang.py:160
 msgid "Chichewa; Nyanja"
 msgstr ""
 
-#: common/models/lang.py:159
+#: common/models/lang.py:161
 msgid "Occitan"
 msgstr ""
 
-#: common/models/lang.py:160
+#: common/models/lang.py:162
 msgid "Ojibwa"
 msgstr ""
 
-#: common/models/lang.py:161
+#: common/models/lang.py:163
 msgid "Oriya"
 msgstr ""
 
-#: common/models/lang.py:162
+#: common/models/lang.py:164
 msgid "Oromo"
 msgstr ""
 
-#: common/models/lang.py:163
+#: common/models/lang.py:165
 msgid "Ossetian; Ossetic"
 msgstr ""
 
-#: common/models/lang.py:164
+#: common/models/lang.py:166
 msgid "Pali"
 msgstr ""
 
-#: common/models/lang.py:165
+#: common/models/lang.py:167
 msgid "Polish"
 msgstr ""
 
-#: common/models/lang.py:167
+#: common/models/lang.py:169
 msgid "Quechua"
 msgstr ""
 
-#: common/models/lang.py:168
+#: common/models/lang.py:170
 msgid "Raeto-Romance"
 msgstr ""
 
-#: common/models/lang.py:169
+#: common/models/lang.py:171
 msgid "Romanian"
 msgstr ""
 
-#: common/models/lang.py:170
+#: common/models/lang.py:172
 msgid "Rundi"
 msgstr ""
 
-#: common/models/lang.py:171
+#: common/models/lang.py:173
 msgid "Russian"
 msgstr ""
 
-#: common/models/lang.py:172
+#: common/models/lang.py:174
 msgid "Sango"
 msgstr ""
 
-#: common/models/lang.py:173
+#: common/models/lang.py:175
 msgid "Sanskrit"
 msgstr ""
 
-#: common/models/lang.py:174
+#: common/models/lang.py:176
 msgid "Sinhalese"
 msgstr ""
 
-#: common/models/lang.py:175
+#: common/models/lang.py:177
 msgid "Slovak"
 msgstr ""
 
-#: common/models/lang.py:176
+#: common/models/lang.py:178
 msgid "Slovenian"
 msgstr ""
 
-#: common/models/lang.py:177
+#: common/models/lang.py:179
 msgid "Northern Sami"
 msgstr ""
 
-#: common/models/lang.py:178
+#: common/models/lang.py:180
 msgid "Samoan"
 msgstr ""
 
-#: common/models/lang.py:179
+#: common/models/lang.py:181
 msgid "Shona"
 msgstr ""
 
-#: common/models/lang.py:180
+#: common/models/lang.py:182
 msgid "Sindhi"
 msgstr ""
 
-#: common/models/lang.py:181
+#: common/models/lang.py:183
 msgid "Somali"
 msgstr ""
 
-#: common/models/lang.py:182
+#: common/models/lang.py:184
 msgid "Sotho"
 msgstr ""
 
-#: common/models/lang.py:184
+#: common/models/lang.py:186
 msgid "Albanian"
 msgstr ""
 
-#: common/models/lang.py:185
+#: common/models/lang.py:187
 msgid "Sardinian"
 msgstr ""
 
-#: common/models/lang.py:186
+#: common/models/lang.py:188
 msgid "Serbian"
 msgstr ""
 
-#: common/models/lang.py:187
+#: common/models/lang.py:189
 msgid "Swati"
 msgstr ""
 
-#: common/models/lang.py:188
+#: common/models/lang.py:190
 msgid "Sundanese"
 msgstr ""
 
-#: common/models/lang.py:189
+#: common/models/lang.py:191
 msgid "Swahili"
 msgstr ""
 
-#: common/models/lang.py:190
+#: common/models/lang.py:192
 msgid "Swedish"
 msgstr ""
 
-#: common/models/lang.py:191
+#: common/models/lang.py:193
 msgid "Tahitian"
 msgstr ""
 
-#: common/models/lang.py:192
+#: common/models/lang.py:194
 msgid "Tamil"
 msgstr ""
 
-#: common/models/lang.py:193
+#: common/models/lang.py:195
 msgid "Tatar"
 msgstr ""
 
-#: common/models/lang.py:194
+#: common/models/lang.py:196
 msgid "Telugu"
 msgstr ""
 
-#: common/models/lang.py:195
+#: common/models/lang.py:197
 msgid "Tajik"
 msgstr ""
 
-#: common/models/lang.py:196
+#: common/models/lang.py:198
 msgid "Tagalog"
 msgstr ""
 
-#: common/models/lang.py:197
+#: common/models/lang.py:199
 msgid "Thai"
 msgstr ""
 
-#: common/models/lang.py:198
+#: common/models/lang.py:200
 msgid "Tigrinya"
 msgstr ""
 
-#: common/models/lang.py:199
+#: common/models/lang.py:201
 msgid "Tonga"
 msgstr ""
 
-#: common/models/lang.py:200
+#: common/models/lang.py:202
 msgid "Tswana"
 msgstr ""
 
-#: common/models/lang.py:201
+#: common/models/lang.py:203
 msgid "Tsonga"
 msgstr ""
 
-#: common/models/lang.py:202
+#: common/models/lang.py:204
 msgid "Turkmen"
 msgstr ""
 
-#: common/models/lang.py:203
+#: common/models/lang.py:205
 msgid "Turkish"
 msgstr ""
 
-#: common/models/lang.py:204
+#: common/models/lang.py:206
 msgid "Twi"
 msgstr ""
 
-#: common/models/lang.py:205
+#: common/models/lang.py:207
 msgid "Uighur"
 msgstr ""
 
-#: common/models/lang.py:206
+#: common/models/lang.py:208
 msgid "Ukrainian"
 msgstr ""
 
-#: common/models/lang.py:207
+#: common/models/lang.py:209
 msgid "Urdu"
 msgstr ""
 
-#: common/models/lang.py:208
+#: common/models/lang.py:210
 msgid "Uzbek"
 msgstr ""
 
-#: common/models/lang.py:209
+#: common/models/lang.py:211
 msgid "Venda"
 msgstr ""
 
-#: common/models/lang.py:210
+#: common/models/lang.py:212
 msgid "Vietnamese"
 msgstr ""
 
-#: common/models/lang.py:211
+#: common/models/lang.py:213
 msgid "Volapük"
 msgstr ""
 
-#: common/models/lang.py:212
+#: common/models/lang.py:214
 msgid "Walloon"
 msgstr ""
 
-#: common/models/lang.py:213
+#: common/models/lang.py:215
 msgid "Wolof"
 msgstr ""
 
-#: common/models/lang.py:214
+#: common/models/lang.py:216
 msgid "Xhosa"
 msgstr ""
 
-#: common/models/lang.py:215
+#: common/models/lang.py:217
 msgid "Yiddish"
 msgstr ""
 
-#: common/models/lang.py:216
+#: common/models/lang.py:218
 msgid "Zhuang"
 msgstr ""
 
-#: common/models/lang.py:217
+#: common/models/lang.py:219
 msgid "Zulu"
 msgstr ""
 
-#: common/models/lang.py:218
+#: common/models/lang.py:220
 msgid "Abkhazian"
 msgstr ""
 
-#: common/models/lang.py:219
+#: common/models/lang.py:221
 msgid "Chinese"
 msgstr ""
 
-#: common/models/lang.py:220
+#: common/models/lang.py:222
 msgid "Pushto"
 msgstr ""
 
-#: common/models/lang.py:221
+#: common/models/lang.py:223
 msgid "Amharic"
 msgstr ""
 
-#: common/models/lang.py:222
+#: common/models/lang.py:224
 msgid "Arabic"
 msgstr ""
 
-#: common/models/lang.py:223
+#: common/models/lang.py:225
 msgid "Bulgarian"
 msgstr ""
 
-#: common/models/lang.py:224
+#: common/models/lang.py:226
 msgid "Macedonian"
 msgstr ""
 
-#: common/models/lang.py:225
+#: common/models/lang.py:227
 msgid "Greek"
 msgstr ""
 
-#: common/models/lang.py:226
+#: common/models/lang.py:228
 msgid "Persian"
 msgstr ""
 
-#: common/models/lang.py:227
+#: common/models/lang.py:229
 msgid "Hebrew"
 msgstr ""
 
-#: common/models/lang.py:228
+#: common/models/lang.py:230
 msgid "Hindi"
 msgstr ""
 
-#: common/models/lang.py:229
+#: common/models/lang.py:231
 msgid "Armenian"
 msgstr ""
 
-#: common/models/lang.py:231
+#: common/models/lang.py:233
 msgid "Ewe"
 msgstr ""
 
-#: common/models/lang.py:232
+#: common/models/lang.py:234
 msgid "Georgian"
 msgstr ""
 
-#: common/models/lang.py:233
+#: common/models/lang.py:235
 msgid "Punjabi"
 msgstr ""
 
-#: common/models/lang.py:234
+#: common/models/lang.py:236
 msgid "Bengali"
 msgstr ""
 
-#: common/models/lang.py:235
+#: common/models/lang.py:237
 msgid "Bosnian"
 msgstr ""
 
-#: common/models/lang.py:236
+#: common/models/lang.py:238
 msgid "Chamorro"
 msgstr ""
 
-#: common/models/lang.py:237
+#: common/models/lang.py:239
 msgid "Belarusian"
 msgstr ""
 
-#: common/models/lang.py:238
+#: common/models/lang.py:240
 msgid "Yoruba"
 msgstr ""
 
-#: common/models/lang.py:300
+#: common/models/lang.py:302
 msgid "Simplified Chinese (Mainland)"
 msgstr ""
 
-#: common/models/lang.py:301
+#: common/models/lang.py:303
 msgid "Traditional Chinese (Taiwan)"
 msgstr ""
 
-#: common/models/lang.py:302
+#: common/models/lang.py:304
 msgid "Traditional Chinese (Hongkong)"
 msgstr ""
 
-#: common/models/lang.py:310
+#: common/models/lang.py:312
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: common/models/lang.py:313
+#: common/models/lang.py:315
 msgid "Simplified Chinese (Singapore)"
 msgstr ""
 
-#: common/models/lang.py:314
+#: common/models/lang.py:316
 msgid "Simplified Chinese (Malaysia)"
 msgstr ""
 
-#: common/models/lang.py:315
+#: common/models/lang.py:317
 msgid "Traditional Chinese (Macau)"
 msgstr ""
 
-#: common/models/lang.py:323
+#: common/models/lang.py:325
 msgid "Mandarin Chinese"
 msgstr ""
 
-#: common/models/lang.py:324
+#: common/models/lang.py:326
 msgid "Yue Chinese"
 msgstr ""
 
-#: common/models/lang.py:328
+#: common/models/lang.py:330
 msgid "Min Nan Chinese"
 msgstr ""
 
-#: common/models/lang.py:329
+#: common/models/lang.py:331
 msgid "Wu Chinese"
 msgstr ""
 
-#: common/models/lang.py:330
+#: common/models/lang.py:332
 msgid "Hakka Chinese"
 msgstr ""
 
@@ -3716,22 +3746,16 @@ msgid "VCD"
 msgstr ""
 
 #: common/templates/400.html:23
-msgid ""
-"You may have submitted invalid data, or the content may have been deleted by "
-"the author."
+msgid "You may have submitted invalid data, or the content may have been deleted by the author."
 msgstr ""
 
 #: common/templates/400.html:25 common/templates/403.html:24
 #: common/templates/404.html:24
-msgid ""
-"If you believe this is our mistake, please contact us through the link at "
-"the bottom of the page."
+msgid "If you believe this is our mistake, please contact us through the link at the bottom of the page."
 msgstr ""
 
 #: common/templates/403.html:22
-msgid ""
-"Author may require you to log in before accessing this content, or you do "
-"not have permission to view it."
+msgid "Author may require you to log in before accessing this content, or you do not have permission to view it."
 msgstr ""
 
 #: common/templates/404.html:20
@@ -3739,9 +3763,7 @@ msgid "Something is missing"
 msgstr ""
 
 #: common/templates/404.html:22
-msgid ""
-"You may have visited an incorrect URL, or the content you are looking for "
-"has been deleted by the author."
+msgid "You may have visited an incorrect URL, or the content you are looking for has been deleted by the author."
 msgstr ""
 
 #: common/templates/404.html:26
@@ -3749,15 +3771,11 @@ msgid "Go to Home"
 msgstr ""
 
 #: common/templates/500.html:22
-msgid ""
-"An internal error occurred. If this error occurs repeatedly, it will be "
-"recorded and handled by a human."
+msgid "An internal error occurred. If this error occurs repeatedly, it will be recorded and handled by a human."
 msgstr ""
 
 #: common/templates/500.html:24
-msgid ""
-"If you have an urgent situation or any questions, please contact us through "
-"the link at the bottom of the page."
+msgid "If you have an urgent situation or any questions, please contact us through the link at the bottom of the page."
 msgstr ""
 
 #: common/templates/_footer.html:6
@@ -3772,207 +3790,184 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: common/templates/_footer.html:12 users/templates/users/login.html:265
+#: common/templates/_footer.html:12 users/templates/users/login.html:259
 #, python-format
-msgid ""
-"You are visiting an alternative domain for %(site_name)s, please always use "
-"<a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if "
-"possible."
+msgid "You are visiting an alternative domain for %(site_name)s, please always use <a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if possible."
 msgstr ""
 
-#: common/templates/_header.html:19 common/templates/_header.html:164
+#: common/templates/_header.html:19 common/templates/_header.html:177
 msgid "title, creator, ISBN, item url, @user, @user@instance"
 msgstr ""
 
-#: common/templates/_header.html:24
+#: common/templates/_header.html:34
 msgid "All Items"
 msgstr ""
 
-#: common/templates/_header.html:31
+#: common/templates/_header.html:41
 msgid "Movie & TV"
 msgstr ""
 
-#: common/templates/_header.html:50
+#: common/templates/_header.html:60
 msgid "People & Organizations"
 msgstr ""
 
-#: common/templates/_header.html:52
+#: common/templates/_header.html:62
 msgid "Journal"
 msgstr ""
 
-#: common/templates/_header.html:54 journal/templates/user_post_list.html:10
+#: common/templates/_header.html:64 journal/templates/user_post_list.html:10
 #: journal/templates/user_post_list.html:23
 msgid "Posts"
 msgstr ""
 
-#: common/templates/_header.html:89
+#: common/templates/_header.html:102
 msgid "Explore"
 msgstr ""
 
-#: common/templates/_header.html:93
+#: common/templates/_header.html:106 common/views_manage.py:36
 msgid "Feed"
 msgstr ""
 
-#: common/templates/_header.html:98 journal/templates/profile.html:13
+#: common/templates/_header.html:111 journal/templates/profile.html:13
 #: users/templates/users/preferences.html:46
 msgid "Home"
 msgstr "卷首"
 
-#: common/templates/_header.html:114 common/templates/common/scan.html:9
+#: common/templates/_header.html:127 common/templates/common/scan.html:9
 #: common/templates/common/scan.html:42
 msgid "Scan Barcode"
 msgstr ""
 
-#: common/templates/_header.html:118 social/templates/notification.html:12
+#: common/templates/_header.html:131 social/templates/notification.html:12
 #: social/templates/notification.html:53
 msgid "Notification"
 msgstr ""
 
-#: common/templates/_header.html:122 users/models/task.py:21
+#: common/templates/_header.html:135 users/models/task.py:23
 #: users/templates/users/account.html:219
 #: users/templates/users/crossposts.html:9
 msgid "Pending"
 msgstr ""
 
-#: common/templates/_header.html:125
+#: common/templates/_header.html:138
 msgid "Data"
 msgstr ""
 
-#: common/templates/_header.html:128 common/templates/_header.html:146
+#: common/templates/_header.html:141 common/templates/_header.html:159
 #: users/templates/users/preferences.html:12
 #: users/templates/users/preferences.html:23
 #: users/templates/users/preferences_anonymous.html:13
 msgid "Preferences"
 msgstr ""
 
-#: common/templates/_header.html:131
+#: common/templates/_header.html:144
 msgid "Account"
 msgstr ""
 
-#: common/templates/_header.html:135
+#: common/templates/_header.html:148
 msgid "Manage"
 msgstr ""
 
-#: common/templates/_header.html:139
+#: common/templates/_header.html:152
 msgid "Logout"
 msgstr "出籍"
 
-#: common/templates/_header.html:143
+#: common/templates/_header.html:156
 msgid "Sign up or Login"
 msgstr ""
 
-#: common/templates/_header.html:160
-msgid ""
-"title or content  category:tv  status:complete  rating:8..10  "
-"date:2021-09-11..2022-02"
+#: common/templates/_header.html:173
+msgid "title or content  category:tv  status:complete  rating:8..10  date:2021-09-11..2022-02"
 msgstr ""
 
-#: common/templates/_header.html:162
+#: common/templates/_header.html:175
 msgid "name of a person or company"
 msgstr ""
 
-#: common/templates/_header.html:179
+#: common/templates/_header.html:192
 msgid "Open"
 msgstr ""
 
-#: common/templates/_sidebar.html:62
+#: common/templates/_sidebar.html:61
 #: users/templates/users/profile_actions.html:36
 msgid "approving followers manually"
 msgstr ""
 
-#: common/templates/_sidebar.html:81 common/templates/_sidebar.html:86
+#: common/templates/_sidebar.html:80 common/templates/_sidebar.html:85
 msgid "followers"
 msgstr ""
 
-#: common/templates/_sidebar.html:112
+#: common/templates/_sidebar.html:111
 msgid "Current Targets"
 msgstr ""
 
-#: common/templates/_sidebar.html:125
+#: common/templates/_sidebar.html:124
 msgid "Set a collection as target, its progress will show up here."
 msgstr ""
 
-#: common/templates/_sidebar.html:138
+#: common/templates/_sidebar.html:137
 msgid "Recent podcast episodes"
 msgstr ""
 
-#: common/templates/_sidebar.html:173
+#: common/templates/_sidebar.html:172
 msgid "Currently reading"
 msgstr ""
 
-#: common/templates/_sidebar.html:215
+#: common/templates/_sidebar.html:214
 msgid "Currently watching"
 msgstr ""
 
-#: common/templates/_sidebar.html:238 journal/forms.py:217
+#: common/templates/_sidebar.html:237 journal/forms.py:217
 #: journal/templates/user_tag_list.html:13
 #: journal/templates/user_tagmember_list.html:4
 msgid "Tags"
 msgstr ""
 
-#: common/templates/_sidebar.html:244 journal/templates/user_tag_list.html:28
+#: common/templates/_sidebar.html:243 journal/templates/user_tag_list.html:28
 #: journal/templates/user_tagmember_list.html:10
 msgid "featured tag"
 msgstr ""
 
-#: common/templates/_sidebar.html:247 journal/templates/user_tag_list.html:31
+#: common/templates/_sidebar.html:246 journal/templates/user_tag_list.html:31
 #: journal/templates/user_tagmember_list.html:15
 msgid "personal tag"
 msgstr ""
 
-#: common/templates/_sidebar.html:254 journal/templates/user_tag_list.html:39
+#: common/templates/_sidebar.html:253 journal/templates/user_tag_list.html:39
 msgid "no tags so far."
 msgstr ""
 
-#: common/templates/_sidebar.html:258 common/templates/_sidebar.html:271
+#: common/templates/_sidebar.html:257 common/templates/_sidebar.html:270
 msgid "show all"
 msgstr ""
 
-#: common/templates/_sidebar_anonymous.html:16
+#: common/templates/_sidebar_anonymous.html:15
 #, python-format
 msgid ""
 "\n"
 "        <h3>Welcome 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is "
-"committed to creating a free, open, and interconnected space for collecting "
-"and reviewing books, movies, music, games, and podcasts. Here, you can "
-"manage your collections, share your thoughts, discover new content, and "
-"connect with others.\n"
+"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is committed to creating a free, open, and interconnected space for collecting and reviewing books, movies, music, games, and podcasts. Here, you can manage your collections, share your thoughts, discover new content, and connect with others.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in "
-"to %(site_name)s is through a Fediverse (a distributed social network, "
-"including Mastodon/Pleroma/etc) instance account. If you haven’t registered "
-"yet, you can <a href=\"https://joinmastodon.org/en/servers\" "
-"target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
+"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in to %(site_name)s is through a Fediverse (a distributed social network, including Mastodon/Pleroma/etc) instance account. If you haven’t registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log "
-"in is through a Bluesky (another distributed social network, also called "
-"ATProto) account. If you haven’t registered yet, you may <a href=\"https://"
-"bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
+"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log in is through a Bluesky (another distributed social network, also called ATProto) account. If you haven’t registered yet, you may <a href=\"https://bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready "
-"to join either Fediverse or Bluesky, that’s perfectly fine. You can create "
-"an account here using your email address, and link it to the Fediverse and "
-"Bluesky in settings whenever you’re ready.\n"
+"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready to join either Fediverse or Bluesky, that’s perfectly fine. You can create an account here using your email address, and link it to the Fediverse and Bluesky in settings whenever you’re ready.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have "
-"any questions or suggestions, please feel free to contact us via <a "
-"href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://"
-"discord.gg/uprvcH8gqD\">Discord</a>.\n"
+"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have any questions or suggestions, please feel free to contact us via <a href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-"href=\"%(login_url)s\">Click here</a> to register or log in.\n"
+"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Click here</a> to register or log in.\n"
 "        </p>\n"
 "        "
 msgstr ""
 
-#: common/templates/_sidebar_anonymous.html:43
+#: common/templates/_sidebar_anonymous.html:42
 #: users/templates/users/announcements.html:12
 #: users/templates/users/announcements.html:39
 msgid "Announcements"
@@ -3994,7 +3989,7 @@ msgstr ""
 msgid "Registration"
 msgstr ""
 
-#: common/templates/common/about.html:35 common/views_manage.py:493
+#: common/templates/common/about.html:35 common/views_manage.py:594
 msgid "Invite Only"
 msgstr ""
 
@@ -4002,7 +3997,7 @@ msgstr ""
 msgid "Open Registration"
 msgstr ""
 
-#: common/templates/common/about.html:40 common/views_manage.py:556
+#: common/templates/common/about.html:40 common/views_manage.py:657
 msgid "Preferred Languages"
 msgstr ""
 
@@ -4047,9 +4042,7 @@ msgid "Error"
 msgstr ""
 
 #: common/templates/common/scan.html:45
-msgid ""
-"Point the camera at a book ISBN or product barcode (EAN / UPC). You will be "
-"redirected to the search once a code is detected."
+msgid "Point the camera at a book ISBN or product barcode (EAN / UPC). You will be redirected to the search once a code is detected."
 msgstr ""
 
 #: common/templates/common/scan.html:50
@@ -4060,7 +4053,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:628
+#: common/templates/common/scan.html:60 common/views_manage.py:738
 msgid "Search"
 msgstr ""
 
@@ -4092,16 +4085,28 @@ msgstr ""
 msgid "Camera unavailable. Use manual entry below."
 msgstr ""
 
-#: common/templates/manage/settings.html:9
+#: common/templates/manage/base.html:9
 msgid "Site Settings"
 msgstr ""
 
-#: common/templates/manage/settings.html:109
+#: common/templates/manage/base.html:127
 msgid "Takahe Admin"
 msgstr ""
 
-#: common/templates/manage/settings.html:112
+#: common/templates/manage/base.html:130
 msgid "Database Admin"
+msgstr ""
+
+#: common/templates/manage/environment.html:6
+msgid "These settings come from environment variables and cannot be changed here. Edit .env and restart the server to change them. Passwords and keys are hidden."
+msgstr ""
+
+#: common/templates/manage/environment.html:23
+msgid "(empty)"
+msgstr ""
+
+#: common/templates/manage/environment.html:26
+msgid "default"
 msgstr ""
 
 #: common/templatetags/duration.py:59
@@ -4120,7 +4125,7 @@ msgstr ""
 msgid "following you"
 msgstr ""
 
-#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:95
+#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:90
 msgid "you"
 msgstr ""
 
@@ -4128,801 +4133,808 @@ msgstr ""
 msgid "unavailable"
 msgstr ""
 
-#: common/utils.py:126 common/utils.py:167 users/views/actions.py:134
+#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr ""
 
-#: common/utils.py:133 common/utils.py:135 common/utils.py:138
-#: common/utils.py:174 common/utils.py:178 journal/views/profile.py:499
+#: common/utils.py:135 common/utils.py:137 common/utils.py:140
+#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
 msgid "Access denied"
 msgstr ""
 
-#: common/utils.py:141 common/utils.py:143 journal/views/article.py:204
+#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr ""
 
-#: common/views_manage.py:144 common/views_manage.py:295
+#: common/views_manage.py:34 common/views_manage.py:373
 msgid "Branding"
 msgstr ""
 
-#: common/views_manage.py:146
+#: common/views_manage.py:37
 msgid "Recommendations"
 msgstr ""
 
-#: common/views_manage.py:147
+#: common/views_manage.py:38
 msgid "Access"
 msgstr ""
 
-#: common/views_manage.py:148 common/views_manage.py:623
+#: common/views_manage.py:39 common/views_manage.py:733
 msgid "Federation"
 msgstr ""
 
-#: common/views_manage.py:149
+#: common/views_manage.py:40
 msgid "Catalog"
 msgstr ""
 
-#: common/views_manage.py:150
+#: common/views_manage.py:41
 msgid "API Keys"
 msgstr ""
 
-#: common/views_manage.py:151
+#: common/views_manage.py:42
 msgid "Downloader"
 msgstr ""
 
-#: common/views_manage.py:152 common/views_manage.py:303
+#: common/views_manage.py:43 common/views_manage.py:381
 #: users/templates/users/steam_import.html:113
 msgid "Advanced"
 msgstr ""
 
-#: common/views_manage.py:202
-msgid "Invalid value."
-msgstr ""
-
-#: common/views_manage.py:206
-msgid "Invalid configuration. Please check your input."
-msgstr ""
-
-#: common/views_manage.py:211
-msgid "Settings have been saved."
-msgstr ""
-
-#: common/views_manage.py:231
-msgid "Site Name"
-msgstr ""
-
-#: common/views_manage.py:234
-msgid "Site Description"
-msgstr ""
-
-#: common/views_manage.py:235
-msgid "Short description shown in metadata and about page."
-msgstr ""
-
-#: common/views_manage.py:238
-msgid "Site Logo URL"
-msgstr ""
-
-#: common/views_manage.py:239
-msgid "URL path to the site logo image."
-msgstr ""
-
-#: common/views_manage.py:242
-msgid "Site Icon URL"
-msgstr ""
-
-#: common/views_manage.py:243
-msgid "URL path to the site icon/favicon."
-msgstr ""
-
-#: common/views_manage.py:246
-msgid "Default User Avatar URL"
-msgstr ""
-
-#: common/views_manage.py:247
-msgid "URL path to the default user avatar."
-msgstr ""
-
-#: common/views_manage.py:250
-msgid "Site Color Theme"
-msgstr ""
-
-#: common/views_manage.py:251
-msgid "PicoCSS color theme."
-msgstr ""
-
-#: common/views_manage.py:276
-msgid "Site Introduction"
-msgstr ""
-
-#: common/views_manage.py:277
-msgid "URL path for the intro/welcome sidebar page."
+#: common/views_manage.py:44
+msgid "Environment"
 msgstr ""
 
 #: common/views_manage.py:280
-msgid "Custom HTML Head"
+msgid "Invalid value."
 msgstr ""
 
-#: common/views_manage.py:281
-msgid "Extra HTML injected into the <head> of all pages."
+#: common/views_manage.py:284
+msgid "Invalid configuration. Please check your input."
 msgstr ""
 
-#: common/views_manage.py:285
-msgid "Footer Links"
+#: common/views_manage.py:289
+msgid "Settings have been saved."
 msgstr ""
 
-#: common/views_manage.py:286
-msgid "Link title mapped to URL."
+#: common/views_manage.py:309
+msgid "Site Name"
 msgstr ""
 
-#: common/views_manage.py:315
-msgid "Minimum Marks for Discover"
+#: common/views_manage.py:312
+msgid "Site Description"
+msgstr ""
+
+#: common/views_manage.py:313
+msgid "Short description shown in metadata and about page."
+msgstr ""
+
+#: common/views_manage.py:316
+msgid "Site Logo URL"
 msgstr ""
 
 #: common/views_manage.py:317
-msgid "Number of marks required for an item to appear in discover."
+msgid "URL path to the site logo image."
 msgstr ""
 
-#: common/views_manage.py:322
-msgid "Update Interval (minutes)"
+#: common/views_manage.py:320
+msgid "Site Icon URL"
 msgstr ""
 
-#: common/views_manage.py:323
-msgid "How often to refresh the popular items list."
+#: common/views_manage.py:321
+msgid "URL path to the site icon/favicon."
 msgstr ""
 
-#: common/views_manage.py:327
-msgid "Filter by Preferred Languages"
+#: common/views_manage.py:324
+msgid "Default User Avatar URL"
+msgstr ""
+
+#: common/views_manage.py:325
+msgid "URL path to the default user avatar."
 msgstr ""
 
 #: common/views_manage.py:328
-msgid "Only show items with titles in the preferred languages."
+msgid "Site Color Theme"
 msgstr ""
 
-#: common/views_manage.py:331
-msgid "Show Local Only"
+#: common/views_manage.py:329
+msgid "PicoCSS color theme."
 msgstr ""
 
-#: common/views_manage.py:333
-msgid "Only show items marked by local users, not the entire network."
+#: common/views_manage.py:354
+msgid "Site Introduction"
 msgstr ""
 
-#: common/views_manage.py:337
-msgid "Show Popular Posts"
+#: common/views_manage.py:355
+msgid "URL path for the intro/welcome sidebar page."
 msgstr ""
 
-#: common/views_manage.py:338
-msgid "Show popular public posts instead of recent ones."
+#: common/views_manage.py:358
+msgid "Custom HTML Head"
 msgstr ""
 
-#: common/views_manage.py:341
-msgid "Show Popular Tags"
+#: common/views_manage.py:359
+msgid "Extra HTML injected into the <head> of all pages."
 msgstr ""
 
-#: common/views_manage.py:342
-msgid "Show popular public tags on the discover page."
+#: common/views_manage.py:363
+msgid "Footer Links"
 msgstr ""
 
-#: common/views_manage.py:345
-msgid "Show Verified Podcasts"
-msgstr ""
-
-#: common/views_manage.py:347
-msgid ""
-"Show a shelf of recent episodes from podcasts with a verified creator on the "
-"discover page."
-msgstr ""
-
-#: common/views_manage.py:386
-msgid "Enable Recommendations"
-msgstr ""
-
-#: common/views_manage.py:388
-msgid ""
-"Master switch. When off, all recommendation surfaces are hidden and the cron "
-"jobs are not scheduled."
+#: common/views_manage.py:364
+msgid "Link title mapped to URL."
 msgstr ""
 
 #: common/views_manage.py:393
-msgid "Source Item Mark Threshold"
+msgid "Minimum Marks for Discover"
 msgstr ""
 
 #: common/views_manage.py:395
-msgid ""
-"Minimum public marks an item needs before similarity rows are built for it."
+msgid "Number of marks required for an item to appear in discover."
+msgstr ""
+
+#: common/views_manage.py:400
+msgid "Update Interval (minutes)"
 msgstr ""
 
 #: common/views_manage.py:401
-msgid "Target Item Mark Threshold"
+msgid "How often to refresh the popular items list."
 msgstr ""
 
-#: common/views_manage.py:403
-msgid ""
-"Minimum public marks an item needs to be eligible as a recommendation target."
+#: common/views_manage.py:405
+msgid "Filter by Preferred Languages"
+msgstr ""
+
+#: common/views_manage.py:406
+msgid "Only show items with titles in the preferred languages."
 msgstr ""
 
 #: common/views_manage.py:409
-msgid "Top-K Similar Items per Source"
+msgid "Show Local Only"
 msgstr ""
 
-#: common/views_manage.py:410
-msgid "Number of similar items stored per source item."
-msgstr ""
-
-#: common/views_manage.py:414
-msgid "Top-N Recommendations per User"
+#: common/views_manage.py:411
+msgid "Only show items marked by local users, not the entire network."
 msgstr ""
 
 #: common/views_manage.py:415
-msgid "Number of personalised rows stored per user."
+msgid "Show Popular Posts"
+msgstr ""
+
+#: common/views_manage.py:416
+msgid "Show popular public posts instead of recent ones."
 msgstr ""
 
 #: common/views_manage.py:419
-msgid "Dampen Heavy Shelvers"
+msgid "Show Popular Tags"
 msgstr ""
 
-#: common/views_manage.py:421
-msgid ""
-"Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-"
-"shelvers in similarity scoring."
+#: common/views_manage.py:420
+msgid "Show popular public tags on the discover page."
 msgstr ""
 
-#: common/views_manage.py:426
-msgid "Per-User Mark Cap (training)"
+#: common/views_manage.py:423
+msgid "Show Verified Podcasts"
 msgstr ""
 
-#: common/views_manage.py:428
-msgid ""
-"Truncate each user's contribution to their N most recent marks when building "
-"the similarity matrix."
+#: common/views_manage.py:425
+msgid "Show a shelf of recent episodes from podcasts with a verified creator on the discover page."
 msgstr ""
 
-#: common/views_manage.py:434
-msgid "Active-User Window (days)"
+#: common/views_manage.py:447
+msgid "Show World Timeline"
 msgstr ""
 
-#: common/views_manage.py:436
-msgid ""
-"Refresh personalised recommendations for users with at least one public mark "
-"in the last N days."
+#: common/views_manage.py:449
+msgid "Offer a tab with public posts from this site and every server it federates with."
 msgstr ""
 
-#: common/views_manage.py:442
-msgid "Per-User Seed Cap (serving)"
+#: common/views_manage.py:454
+msgid "Show Local Timeline"
 msgstr ""
 
-#: common/views_manage.py:444
-msgid ""
-"Number of recent marks used as seeds when scoring personalised "
-"recommendations for one user."
+#: common/views_manage.py:455
+msgid "Offer a tab with public posts from this site only."
 msgstr ""
 
-#: common/views_manage.py:450
-msgid "Lazy Refresh TTL (days)"
+#: common/views_manage.py:459
+msgid "Timelines"
 msgstr ""
 
-#: common/views_manage.py:452
-msgid ""
-"How long cached on-demand recommendations are valid before the next request "
-"triggers a refresh."
+#: common/views_manage.py:487
+msgid "Enable Recommendations"
 msgstr ""
 
-#: common/views_manage.py:458
-msgid "Circles Window (days)"
+#: common/views_manage.py:489
+msgid "Master switch. When off, all recommendation surfaces are hidden and the cron jobs are not scheduled."
 msgstr ""
 
-#: common/views_manage.py:460
-msgid ""
-"Look back N days when finding items recently marked by people the viewer "
-"follows."
+#: common/views_manage.py:494
+msgid "Source Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:467
-msgid "Master Switch"
+#: common/views_manage.py:496
+msgid "Minimum public marks an item needs before similarity rows are built for it."
 msgstr ""
 
-#: common/views_manage.py:470
-msgid "Similarity Builder"
-msgstr ""
-
-#: common/views_manage.py:477
-msgid "Personalisation"
-msgstr ""
-
-#: common/views_manage.py:495
-msgid ""
-"Require an invite token to register. Invite tokens can be generated with "
-"neodb-manage invite --create."
-msgstr ""
-
-#: common/views_manage.py:500
-msgid "Enable Local-Only Posting"
-msgstr ""
-
-#: common/views_manage.py:501
-msgid "Allow users to create posts visible only to local users."
+#: common/views_manage.py:502
+msgid "Target Item Mark Threshold"
 msgstr ""
 
 #: common/views_manage.py:504
-msgid "Mastodon Login Whitelist"
+msgid "Minimum public marks an item needs to be eligible as a recommendation target."
 msgstr ""
 
-#: common/views_manage.py:505
-msgid "One domain per line. Leave empty to allow any instance."
+#: common/views_manage.py:510
+msgid "Top-K Similar Items per Source"
 msgstr ""
 
-#: common/views_manage.py:508
-msgid "Registration Captcha Items"
+#: common/views_manage.py:511
+msgid "Number of similar items stored per source item."
 msgstr ""
 
-#: common/views_manage.py:512
-msgid ""
-"Number of item covers a new user must sort into two category rows before "
-"choosing a username. 0 disables the captcha; 5-6 is recommended. The covers "
-"carry no title text, so this cannot be solved with a screen reader: if you "
-"enable it, keep another way in, such as an invite link."
+#: common/views_manage.py:515
+msgid "Top-N Recommendations per User"
+msgstr ""
+
+#: common/views_manage.py:516
+msgid "Number of personalised rows stored per user."
 msgstr ""
 
 #: common/views_manage.py:520
-msgid "Registration Captcha Minimum Marks"
+msgid "Dampen Heavy Shelvers"
 msgstr ""
 
-#: common/views_manage.py:523
-msgid ""
-"Marks an item needs before the captcha treats it as well known enough to be "
-"recognizable. Categories with too few such items fall back to any item."
+#: common/views_manage.py:522
+msgid "Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-shelvers in similarity scoring."
+msgstr ""
+
+#: common/views_manage.py:527
+msgid "Per-User Mark Cap (training)"
 msgstr ""
 
 #: common/views_manage.py:529
-msgid "Enable Mastodon Login"
-msgstr ""
-
-#: common/views_manage.py:532
-msgid "Enable Bluesky Login"
+msgid "Truncate each user's contribution to their N most recent marks when building the similarity matrix."
 msgstr ""
 
 #: common/views_manage.py:535
-msgid "Enable Threads Login"
+msgid "Active-User Window (days)"
 msgstr ""
 
-#: common/views_manage.py:538
-msgid "Email URL"
+#: common/views_manage.py:537
+msgid "Refresh personalised recommendations for users with at least one public mark in the last N days."
 msgstr ""
 
-#: common/views_manage.py:540
-msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
-msgstr ""
-
-#: common/views_manage.py:544
-msgid "Email From"
+#: common/views_manage.py:543
+msgid "Per-User Seed Cap (serving)"
 msgstr ""
 
 #: common/views_manage.py:545
+msgid "Number of recent marks used as seeds when scoring personalised recommendations for one user."
+msgstr ""
+
+#: common/views_manage.py:551
+msgid "Lazy Refresh TTL (days)"
+msgstr ""
+
+#: common/views_manage.py:553
+msgid "How long cached on-demand recommendations are valid before the next request triggers a refresh."
+msgstr ""
+
+#: common/views_manage.py:559
+msgid "Circles Window (days)"
+msgstr ""
+
+#: common/views_manage.py:561
+msgid "Look back N days when finding items recently marked by people the viewer follows."
+msgstr ""
+
+#: common/views_manage.py:568
+msgid "Master Switch"
+msgstr ""
+
+#: common/views_manage.py:571
+msgid "Similarity Builder"
+msgstr ""
+
+#: common/views_manage.py:578
+msgid "Personalisation"
+msgstr ""
+
+#: common/views_manage.py:596
+msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
+msgstr ""
+
+#: common/views_manage.py:601
+msgid "Enable Local-Only Posting"
+msgstr ""
+
+#: common/views_manage.py:602
+msgid "Allow users to create posts visible only to local users."
+msgstr ""
+
+#: common/views_manage.py:605
+msgid "Mastodon Login Whitelist"
+msgstr ""
+
+#: common/views_manage.py:606
+msgid "One domain per line. Leave empty to allow any instance."
+msgstr ""
+
+#: common/views_manage.py:609
+msgid "Registration Captcha Items"
+msgstr ""
+
+#: common/views_manage.py:613
+msgid "Number of item covers a new user must sort into two category rows before choosing a username. 0 disables the captcha; 5-6 is recommended. The covers carry no title text, so this cannot be solved with a screen reader: if you enable it, keep another way in, such as an invite link."
+msgstr ""
+
+#: common/views_manage.py:621
+msgid "Registration Captcha Minimum Marks"
+msgstr ""
+
+#: common/views_manage.py:624
+msgid "Marks an item needs before the captcha treats it as well known enough to be recognizable. Categories with too few such items fall back to any item."
+msgstr ""
+
+#: common/views_manage.py:630
+msgid "Enable Mastodon Login"
+msgstr ""
+
+#: common/views_manage.py:633
+msgid "Enable Bluesky Login"
+msgstr ""
+
+#: common/views_manage.py:636
+msgid "Enable Threads Login"
+msgstr ""
+
+#: common/views_manage.py:639
+msgid "Email URL"
+msgstr ""
+
+#: common/views_manage.py:641
+msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
+msgstr ""
+
+#: common/views_manage.py:645
+msgid "Email From"
+msgstr ""
+
+#: common/views_manage.py:646
 msgid "Sender name and address for outgoing email."
 msgstr ""
 
-#: common/views_manage.py:548
+#: common/views_manage.py:649
 #, fuzzy
 #| msgid "Language"
 msgid "Default Language"
 msgstr "語言"
 
-#: common/views_manage.py:551
-msgid ""
-"Interface language for visitors and for users who have not chosen one "
-"themselves."
+#: common/views_manage.py:652
+msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:558
-msgid ""
-"Language codes, one per line (e.g. en, zh, ja). First language is the "
-"default."
+#: common/views_manage.py:659
+msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:564
+#: common/views_manage.py:665
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:571
+#: common/views_manage.py:672
 msgid "Login Methods"
 msgstr ""
 
-#: common/views_manage.py:576 mastodon/models/common.py:28
+#: common/views_manage.py:677 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr ""
 
-#: common/views_manage.py:580
+#: common/views_manage.py:681
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:591
+#: common/views_manage.py:692
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:593
-msgid ""
-"Disable relay.neodb.net federation for sharing public ratings across "
-"instances."
+#: common/views_manage.py:694
+msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:598
+#: common/views_manage.py:699
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:599
+#: common/views_manage.py:700
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:603
+#: common/views_manage.py:704
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:605
+#: common/views_manage.py:706
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:610
+#: common/views_manage.py:711
 msgid "Search Sites"
 msgstr ""
 
-#: common/views_manage.py:611
+#: common/views_manage.py:712
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:614
+#: common/views_manage.py:715
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:615
+#: common/views_manage.py:716
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:618
+#: common/views_manage.py:719
 msgid "Hidden Categories"
 msgstr ""
 
-#: common/views_manage.py:619
+#: common/views_manage.py:720
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:640
-msgid "Spotify API Key"
-msgstr ""
-
-#: common/views_manage.py:641
-msgid "https://developer.spotify.com/"
-msgstr ""
-
-#: common/views_manage.py:644
-msgid "TMDB API Key"
-msgstr ""
-
-#: common/views_manage.py:645
-msgid "https://developer.themoviedb.org/"
-msgstr ""
-
-#: common/views_manage.py:648
-msgid "Google Books API Key"
-msgstr ""
-
-#: common/views_manage.py:649
-msgid "https://developers.google.com/books/"
-msgstr ""
-
-#: common/views_manage.py:652
-msgid "Discogs API Key"
-msgstr ""
-
-#: common/views_manage.py:654
-msgid "Personal access token from https://www.discogs.com/settings/developers"
-msgstr ""
-
-#: common/views_manage.py:658
-msgid "IGDB Client ID"
-msgstr ""
-
-#: common/views_manage.py:659
-msgid "https://api-docs.igdb.com/"
-msgstr ""
-
-#: common/views_manage.py:662
-msgid "IGDB Client Secret"
-msgstr ""
-
-#: common/views_manage.py:665
-msgid "BoardGameGeek API Token"
-msgstr ""
-
-#: common/views_manage.py:667
-msgid ""
-"Bearer token from https://boardgamegeek.com/applications (see https://"
-"boardgamegeek.com/using_the_xml_api#toc9)."
-msgstr ""
-
-#: common/views_manage.py:672 users/templates/users/steam_import.html:26
-msgid "Steam API Key"
-msgstr ""
-
-#: common/views_manage.py:674
-msgid ""
-"https://steamcommunity.com/dev - fallback key for Steam importer. Users can "
-"provide their own key when importing."
-msgstr ""
-
-#: common/views_manage.py:679
-msgid "DeepL API Key"
-msgstr ""
-
-#: common/views_manage.py:680
-msgid "For translation features."
-msgstr ""
-
-#: common/views_manage.py:683
-msgid "LibreTranslate API URL"
-msgstr ""
-
-#: common/views_manage.py:686
-msgid "LibreTranslate API Key"
-msgstr ""
-
-#: common/views_manage.py:689
-msgid "Threads App ID"
-msgstr ""
-
-#: common/views_manage.py:690
-msgid "OAuth app ID for Threads login."
-msgstr ""
-
-#: common/views_manage.py:693
-msgid "Threads App Secret"
-msgstr ""
-
-#: common/views_manage.py:696
-msgid "Discord Webhooks"
-msgstr ""
-
-#: common/views_manage.py:698
-msgid ""
-"Webhook URLs keyed by channel (default, report, audit, suggest, system). All "
-"channels must be Discord forum or media channels (thread mode) because "
-"notifications are posted as threads."
-msgstr ""
-
-#: common/views_manage.py:715
-msgid "Catalog APIs"
+#: common/views_manage.py:723
+msgid "Guest Search Page Limit"
 msgstr ""
 
 #: common/views_manage.py:725
+msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
+msgstr ""
+
+#: common/views_manage.py:751
+msgid "Spotify API Key"
+msgstr ""
+
+#: common/views_manage.py:752
+msgid "https://developer.spotify.com/"
+msgstr ""
+
+#: common/views_manage.py:755
+msgid "TMDB API Key"
+msgstr ""
+
+#: common/views_manage.py:756
+msgid "https://developer.themoviedb.org/"
+msgstr ""
+
+#: common/views_manage.py:759
+msgid "Google Books API Key"
+msgstr ""
+
+#: common/views_manage.py:760
+msgid "https://developers.google.com/books/"
+msgstr ""
+
+#: common/views_manage.py:763
+msgid "Discogs API Key"
+msgstr ""
+
+#: common/views_manage.py:765
+msgid "Personal access token from https://www.discogs.com/settings/developers"
+msgstr ""
+
+#: common/views_manage.py:769
+msgid "IGDB Client ID"
+msgstr ""
+
+#: common/views_manage.py:770
+msgid "https://api-docs.igdb.com/"
+msgstr ""
+
+#: common/views_manage.py:773
+msgid "IGDB Client Secret"
+msgstr ""
+
+#: common/views_manage.py:776
+msgid "BoardGameGeek API Token"
+msgstr ""
+
+#: common/views_manage.py:778
+msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
+msgstr ""
+
+#: common/views_manage.py:783
+msgid "MyAnimeList Client ID"
+msgstr ""
+
+#: common/views_manage.py:785
+msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
+msgstr ""
+
+#: common/views_manage.py:790 users/templates/users/steam_import.html:26
+msgid "Steam API Key"
+msgstr ""
+
+#: common/views_manage.py:792
+msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
+msgstr ""
+
+#: common/views_manage.py:797
+msgid "DeepL API Key"
+msgstr ""
+
+#: common/views_manage.py:798
+msgid "For translation features."
+msgstr ""
+
+#: common/views_manage.py:801
+msgid "LibreTranslate API URL"
+msgstr ""
+
+#: common/views_manage.py:804
+msgid "LibreTranslate API Key"
+msgstr ""
+
+#: common/views_manage.py:807
+msgid "Threads App ID"
+msgstr ""
+
+#: common/views_manage.py:808
+msgid "OAuth app ID for Threads login."
+msgstr ""
+
+#: common/views_manage.py:811
+msgid "Threads App Secret"
+msgstr ""
+
+#: common/views_manage.py:814
+msgid "Discord Webhooks"
+msgstr ""
+
+#: common/views_manage.py:816
+msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
+msgstr ""
+
+#: common/views_manage.py:833
+msgid "Catalog APIs"
+msgstr ""
+
+#: common/views_manage.py:844
 msgid "Translation"
 msgstr ""
 
-#: common/views_manage.py:730
+#: common/views_manage.py:849
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:734 social/templates/feed.html:27
+#: common/views_manage.py:853 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr ""
 
-#: common/views_manage.py:744
+#: common/views_manage.py:863
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:745
+#: common/views_manage.py:864
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:748
+#: common/views_manage.py:867
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:749
+#: common/views_manage.py:868
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:752
+#: common/views_manage.py:871
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:874
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:758
+#: common/views_manage.py:877
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:761
+#: common/views_manage.py:880
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:764
+#: common/views_manage.py:883
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:767
+#: common/views_manage.py:886
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:768
+#: common/views_manage.py:887
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:771
+#: common/views_manage.py:890
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:775
+#: common/views_manage.py:894
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:779
+#: common/views_manage.py:898
 msgid "Retries"
 msgstr ""
 
-#: common/views_manage.py:784
+#: common/views_manage.py:903
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:789
+#: common/views_manage.py:908
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:796
+#: common/views_manage.py:915
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:808
+#: common/views_manage.py:927
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:809
+#: common/views_manage.py:928
 msgid "One domain per line."
 msgstr ""
 
-#: common/views_manage.py:812
+#: common/views_manage.py:931
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:813
+#: common/views_manage.py:932
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:935
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:818
-msgid ""
-"Timeout for requests to Mastodon instances and remote fediverse servers."
+#: common/views_manage.py:937
+msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:824
+#: common/views_manage.py:943
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:825
+#: common/views_manage.py:944
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:828
+#: common/views_manage.py:947
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:829
+#: common/views_manage.py:948
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:839
+#: common/views_manage.py:958
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:841
-msgid ""
-"Delete import/export tasks and their files after this many days. Set to 0 to "
-"disable cleanup."
+#: common/views_manage.py:960
+msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:847
+#: common/views_manage.py:966
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:849
-msgid ""
-"Post-migration job keys to skip, one per line (e.g. normalize_genre). "
-"Checked by the worker at dequeue time; skipped jobs log a warning and notify "
-"the Discord system channel."
+#: common/views_manage.py:968
+msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:855
+#: common/views_manage.py:974
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:857
-msgid ""
-"Private key (JWK) identifying this site to ATProto authorization servers. "
-"Auto-generated on first Bluesky login; clear to regenerate."
+#: common/views_manage.py:976
+msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:983
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:986
 msgid "Operational"
 msgstr ""
 
-#: common/views_manage.py:883
+#: common/views_manage.py:1002
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:885
-msgid ""
-"Genre codes offered in the Movie edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1004
+msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:1009
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:892
-msgid ""
-"Genre codes offered in the TV edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1011
+msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:897
+#: common/views_manage.py:1016
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:899
-msgid ""
-"Genre codes offered in the Music edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1018
+msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:904
+#: common/views_manage.py:1023
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:906
-msgid ""
-"Genre codes offered in the Game edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1025
+msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:911
+#: common/views_manage.py:1030
 msgid "Podcast Genres"
 msgstr ""
 
-#: common/views_manage.py:913
-msgid ""
-"Genre codes offered in the Podcast edit dropdown, one per line. Leave empty "
-"to use the built-in default."
+#: common/views_manage.py:1032
+msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:918
+#: common/views_manage.py:1037
 msgid "Performance Genres"
 msgstr ""
 
-#: common/views_manage.py:920
-msgid ""
-"Genre codes offered in the Performance edit dropdown, one per line. Leave "
-"empty to use the built-in default."
+#: common/views_manage.py:1039
+msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:926
+#: common/views_manage.py:1045
 msgid "Genres by Category"
 msgstr ""
 
+#: common/views_manage.py:1069
+msgid "Site"
+msgstr ""
+
+#: common/views_manage.py:1079
+msgid "Database and Services"
+msgstr ""
+
+#: common/views_manage.py:1089
+msgid "Media and Files"
+msgstr ""
+
+#: common/views_manage.py:1098
+msgid "Monitoring"
+msgstr ""
+
+#: common/views_manage.py:1102
+msgid "Security"
+msgstr ""
+
+#: common/views_manage.py:1111
+msgid "Other Environment Variables"
+msgstr ""
+
+#: common/views_manage.py:1113
+msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
+msgstr ""
+
 #: journal/forms.py:12
-msgid ""
-"Tips: use >!text!< for spoilers; some instances may not be able to show "
-"posts longer than 360 charactors."
+msgid "Tips: use >!text!< for spoilers; some instances may not be able to show posts longer than 360 charactors."
 msgstr ""
 
 #: journal/forms.py:29 journal/forms.py:31 journal/forms.py:80
@@ -4937,12 +4949,12 @@ msgid "Content (Markdown)"
 msgstr ""
 
 #: journal/forms.py:46 journal/forms.py:124 journal/forms.py:226
-#: journal/forms.py:288 journal/views/note.py:38
+#: journal/forms.py:288 journal/views/note.py:37
 msgid "Crosspost"
 msgstr ""
 
 #: journal/forms.py:47 journal/forms.py:125 journal/forms.py:227
-#: journal/forms.py:289 journal/views/note.py:39
+#: journal/forms.py:289 journal/views/note.py:38
 msgid "Crosspost to your connected social networks"
 msgstr ""
 
@@ -4957,10 +4969,10 @@ msgstr ""
 #: journal/forms.py:59 journal/forms.py:137 journal/forms.py:162
 #: journal/forms.py:219 journal/forms.py:281
 #: journal/templates/collection_share.html:24
-#: journal/templates/wrapped_share.html:36 journal/views/note.py:31
-#: users/templates/users/data.html:45 users/templates/users/data.html:98
-#: users/templates/users/data.html:155 users/templates/users/data.html:206
-#: users/templates/users/data.html:269 users/templates/users/data.html:328
+#: journal/templates/wrapped_share.html:36 journal/views/note.py:30
+#: users/templates/users/data.html:60 users/templates/users/data.html:113
+#: users/templates/users/data.html:170 users/templates/users/data.html:221
+#: users/templates/users/data.html:284 users/templates/users/data.html:346
 #: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
@@ -4997,7 +5009,6 @@ msgid "Collaborative editing"
 msgstr ""
 
 #: journal/forms.py:204 users/templates/users/crossposts.html:51
-#: users/templates/users/data.html:483
 msgid "Status"
 msgstr ""
 
@@ -5009,48 +5020,46 @@ msgstr ""
 msgid "Rating"
 msgstr ""
 
-#: journal/importers/goodreads.py:196 journal/importers/letterboxd.py:144
-#: journal/importers/rym.py:442 journal/importers/storygraph.py:500
+#: journal/importers/goodreads.py:198 journal/importers/letterboxd.py:147
+#: journal/importers/rym.py:444 journal/importers/storygraph.py:504
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr ""
 
-#: journal/importers/opml.py:45
+#: journal/importers/opml.py:49
 #, python-brace-format
 msgid "{username}'s podcast subscriptions"
 msgstr ""
 
-#: journal/importers/rym.py:168 journal/importers/storygraph.py:128
+#: journal/importers/rym.py:170 journal/importers/storygraph.py:132
 #, python-brace-format
-msgid ""
-"Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
+msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:178 journal/importers/storygraph.py:138
+#: journal/importers/rym.py:180 journal/importers/storygraph.py:142
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/importers/rym.py:233 journal/importers/storygraph.py:184
+#: journal/importers/rym.py:235 journal/importers/storygraph.py:188
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:348 journal/importers/storygraph.py:389
+#: journal/importers/rym.py:350 journal/importers/storygraph.py:393
 msgid "Matched file missing; cannot import."
 msgstr ""
 
-#: journal/importers/rym.py:376 journal/importers/storygraph.py:412
+#: journal/importers/rym.py:378 journal/importers/storygraph.py:416
 #, python-brace-format
-msgid ""
-"Import complete: {imported} imported, {skipped} skipped, {failed} failed"
+msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:212 journal/views/article.py:218
+#: journal/models/article.py:215 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
-#: journal/models/collection.py:44 journal/templates/add_to_collection.html:39
+#: journal/models/collection.py:48 journal/templates/add_to_collection.html:39
 #: journal/templates/collection_edit.html:64
 #: journal/templates/collection_share.html:63
 #: journal/templates/collection_update_item_note.html:3
@@ -5058,65 +5067,65 @@ msgstr ""
 msgid "note"
 msgstr ""
 
-#: journal/models/collection.py:111
+#: journal/models/collection.py:115
 msgid "search query for dynamic collection"
 msgstr ""
 
-#: journal/models/collection.py:524 journal/templatetags/collection.py:35
+#: journal/models/collection.py:566 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] ""
 
-#: journal/models/collection.py:529 journal/templatetags/collection.py:43
+#: journal/models/collection.py:571 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] ""
 
-#: journal/models/collection.py:534 journal/templatetags/collection.py:51
+#: journal/models/collection.py:576 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] ""
 
-#: journal/models/collection.py:539 journal/templatetags/collection.py:59
+#: journal/models/collection.py:581 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] ""
 
-#: journal/models/collection.py:544 journal/templatetags/collection.py:67
+#: journal/models/collection.py:586 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] ""
 
-#: journal/models/collection.py:549 journal/templatetags/collection.py:75
+#: journal/models/collection.py:591 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] ""
 
-#: journal/models/collection.py:555 journal/templatetags/collection.py:83
+#: journal/models/collection.py:597 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] ""
 
-#: journal/models/collection.py:563 journal/templatetags/collection.py:91
+#: journal/models/collection.py:605 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] ""
 
-#: journal/models/common.py:50 journal/templates/action_open_post.html:15
-#: journal/templates/collection_share.html:35 journal/templates/mark.html:84
+#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
-#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:54
-#: users/templates/users/data.html:107 users/templates/users/data.html:164
-#: users/templates/users/data.html:215 users/templates/users/data.html:277
-#: users/templates/users/data.html:337 users/templates/users/data.html:534
+#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
+#: users/templates/users/data.html:122 users/templates/users/data.html:179
+#: users/templates/users/data.html:230 users/templates/users/data.html:292
+#: users/templates/users/data.html:355 users/templates/users/data.html:534
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5124,13 +5133,13 @@ msgstr[0] ""
 msgid "Public"
 msgstr ""
 
-#: journal/models/common.py:51 journal/templates/action_open_post.html:9
-#: journal/templates/collection_share.html:46 journal/templates/mark.html:91
+#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
-#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
-#: users/templates/users/data.html:115 users/templates/users/data.html:172
-#: users/templates/users/data.html:223 users/templates/users/data.html:285
-#: users/templates/users/data.html:345 users/templates/users/data.html:542
+#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
+#: users/templates/users/data.html:130 users/templates/users/data.html:187
+#: users/templates/users/data.html:238 users/templates/users/data.html:300
+#: users/templates/users/data.html:363 users/templates/users/data.html:542
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5138,12 +5147,12 @@ msgstr ""
 msgid "Followers Only"
 msgstr ""
 
-#: journal/models/common.py:52 journal/templates/collection_share.html:57
-#: journal/templates/mark.html:98 journal/templates/post_compose.html:72
-#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
-#: users/templates/users/data.html:123 users/templates/users/data.html:180
-#: users/templates/users/data.html:231 users/templates/users/data.html:293
-#: users/templates/users/data.html:353 users/templates/users/data.html:550
+#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/templates/mark.html:102 journal/templates/post_compose.html:72
+#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
+#: users/templates/users/data.html:138 users/templates/users/data.html:195
+#: users/templates/users/data.html:246 users/templates/users/data.html:308
+#: users/templates/users/data.html:371 users/templates/users/data.html:550
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5151,29 +5160,27 @@ msgstr ""
 msgid "Mentioned Only"
 msgstr ""
 
-#: journal/models/common.py:790
-msgid ""
-"A recent post was not posted to Bluesky, please login NeoDB using ATProto "
-"again to re-authorize."
+#: journal/models/common.py:806
+msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr ""
 
-#: journal/models/common.py:987
+#: journal/models/common.py:1003
 msgid "A recent post was not posted to Threads."
 msgstr ""
 
-#: journal/models/common.py:1020
+#: journal/models/common.py:1036
 msgid "A recent post was not boosted on Mastodon."
 msgstr ""
 
-#: journal/models/common.py:1030
+#: journal/models/common.py:1046
 msgid "Original post no longer exists."
 msgstr ""
 
-#: journal/models/common.py:1044
+#: journal/models/common.py:1060
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr ""
 
-#: journal/models/common.py:1053
+#: journal/models/common.py:1069
 msgid "A recent post was not posted to Mastodon."
 msgstr ""
 
@@ -5181,7 +5188,7 @@ msgstr ""
 msgid "Authorization expired"
 msgstr ""
 
-#: journal/models/crosspost.py:17 users/models/task.py:24
+#: journal/models/crosspost.py:17 users/models/task.py:26
 msgid "Failed"
 msgstr ""
 
@@ -5189,81 +5196,81 @@ msgstr ""
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:469
+#: journal/models/mark.py:475
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:473
+#: journal/models/mark.py:479
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:480
+#: journal/models/mark.py:486
 msgid "Invalid progress type."
 msgstr ""
 
-#: journal/models/mark.py:482
+#: journal/models/mark.py:488
 msgid "Invalid progress type for this item."
 msgstr ""
 
-#: journal/models/note.py:34 users/templates/users/rym_import.html:73
+#: journal/models/note.py:47 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr ""
 
-#: journal/models/note.py:35
+#: journal/models/note.py:48
 msgid "Chapter"
 msgstr ""
 
-#: journal/models/note.py:38
+#: journal/models/note.py:51
 msgid "Part"
 msgstr ""
 
-#: journal/models/note.py:39
+#: journal/models/note.py:52
 msgid "Episode"
 msgstr ""
 
-#: journal/models/note.py:40
+#: journal/models/note.py:53
 msgid "Track"
 msgstr ""
 
-#: journal/models/note.py:41
+#: journal/models/note.py:54
 msgid "Cycle"
 msgstr ""
 
-#: journal/models/note.py:42
+#: journal/models/note.py:55
 msgid "Timestamp"
 msgstr ""
 
-#: journal/models/note.py:43
+#: journal/models/note.py:56
 msgid "Percentage"
 msgstr ""
 
-#: journal/models/note.py:60
+#: journal/models/note.py:77
 #, python-brace-format
 msgid "Page {value}"
 msgstr ""
 
-#: journal/models/note.py:61
+#: journal/models/note.py:78
 #, python-brace-format
 msgid "Chapter {value}"
 msgstr ""
 
-#: journal/models/note.py:64
+#: journal/models/note.py:81
 #, python-brace-format
 msgid "Part {value}"
 msgstr ""
 
-#: journal/models/note.py:65
+#: journal/models/note.py:82
 #, python-brace-format
 msgid "Episode {value}"
 msgstr ""
 
-#: journal/models/note.py:66
+#: journal/models/note.py:83
 #, python-brace-format
 msgid "Track {value}"
 msgstr ""
 
-#: journal/models/note.py:67
+#: journal/models/note.py:84
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr ""
@@ -5273,439 +5280,439 @@ msgstr ""
 msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr ""
 
-#: journal/models/review.py:78
+#: journal/models/review.py:79
 #, python-brace-format
 msgid "a review of {title}"
 msgstr ""
 
-#: journal/models/review.py:80
+#: journal/models/review.py:81
 msgid "(may contain spoilers)"
 msgstr ""
 
-#: journal/models/shelf.py:37
+#: journal/models/shelf.py:39
 msgid "WISHLIST"
 msgstr ""
 
-#: journal/models/shelf.py:38
+#: journal/models/shelf.py:40
 msgid "PROGRESS"
 msgstr ""
 
-#: journal/models/shelf.py:39
+#: journal/models/shelf.py:41
 msgid "COMPLETE"
 msgstr ""
 
-#: journal/models/shelf.py:40
+#: journal/models/shelf.py:42
 msgid "DROPPED"
 msgstr ""
 
-#: journal/models/shelf.py:49
+#: journal/models/shelf.py:51
 msgid "books to read"
 msgstr ""
 
-#: journal/models/shelf.py:50
+#: journal/models/shelf.py:52
 msgid "want to read"
 msgstr ""
 
-#: journal/models/shelf.py:51
+#: journal/models/shelf.py:53
 #, python-brace-format
 msgid "wants to read {item}"
 msgstr ""
 
-#: journal/models/shelf.py:52
+#: journal/models/shelf.py:54
 msgid "to read"
 msgstr ""
 
-#: journal/models/shelf.py:57
+#: journal/models/shelf.py:59
 msgid "books reading"
 msgstr ""
 
-#: journal/models/shelf.py:58
+#: journal/models/shelf.py:60
 msgid "start reading"
 msgstr ""
 
-#: journal/models/shelf.py:59
+#: journal/models/shelf.py:61
 #, python-brace-format
 msgid "started reading {item}"
 msgstr ""
 
-#: journal/models/shelf.py:60
+#: journal/models/shelf.py:62
 msgid "reading"
 msgstr ""
 
-#: journal/models/shelf.py:65
+#: journal/models/shelf.py:67
 msgid "books completed"
 msgstr ""
 
-#: journal/models/shelf.py:66
+#: journal/models/shelf.py:68
 msgid "finish reading"
 msgstr ""
 
-#: journal/models/shelf.py:67
+#: journal/models/shelf.py:69
 #, python-brace-format
 msgid "finished reading {item}"
 msgstr ""
 
-#: journal/models/shelf.py:68
+#: journal/models/shelf.py:70
 msgid "read"
 msgstr ""
 
-#: journal/models/shelf.py:73
+#: journal/models/shelf.py:75
 msgid "books dropped"
 msgstr ""
 
-#: journal/models/shelf.py:74
+#: journal/models/shelf.py:76
 msgid "stop reading"
 msgstr ""
 
-#: journal/models/shelf.py:75
+#: journal/models/shelf.py:77
 #, python-brace-format
 msgid "stopped reading {item}"
 msgstr ""
 
-#: journal/models/shelf.py:76
+#: journal/models/shelf.py:78
 msgid "stopped reading"
 msgstr ""
 
-#: journal/models/shelf.py:81
+#: journal/models/shelf.py:83
 msgid "books reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:82 journal/models/shelf.py:122
-#: journal/models/shelf.py:162 journal/models/shelf.py:202
-#: journal/models/shelf.py:242 journal/models/shelf.py:282
-#: journal/models/shelf.py:316
+#: journal/models/shelf.py:84 journal/models/shelf.py:124
+#: journal/models/shelf.py:164 journal/models/shelf.py:204
+#: journal/models/shelf.py:244 journal/models/shelf.py:284
+#: journal/models/shelf.py:318
 msgid "review"
 msgstr ""
 
-#: journal/models/shelf.py:83 journal/models/shelf.py:123
-#: journal/models/shelf.py:163 journal/models/shelf.py:203
-#: journal/models/shelf.py:243 journal/models/shelf.py:283
-#: journal/models/shelf.py:317
+#: journal/models/shelf.py:85 journal/models/shelf.py:125
+#: journal/models/shelf.py:165 journal/models/shelf.py:205
+#: journal/models/shelf.py:245 journal/models/shelf.py:285
+#: journal/models/shelf.py:319
 #, python-brace-format
 msgid "wrote a review of {item}"
 msgstr ""
 
-#: journal/models/shelf.py:89
+#: journal/models/shelf.py:91
 msgid "movies to watch"
 msgstr ""
 
-#: journal/models/shelf.py:90 journal/models/shelf.py:130
+#: journal/models/shelf.py:92 journal/models/shelf.py:132
 msgid "want to watch"
 msgstr ""
 
-#: journal/models/shelf.py:91 journal/models/shelf.py:131
+#: journal/models/shelf.py:93 journal/models/shelf.py:133
 #, python-brace-format
 msgid "wants to watch {item}"
 msgstr ""
 
-#: journal/models/shelf.py:92 journal/models/shelf.py:132
+#: journal/models/shelf.py:94 journal/models/shelf.py:134
 msgid "to watch"
 msgstr ""
 
-#: journal/models/shelf.py:97
+#: journal/models/shelf.py:99
 msgid "movies watching"
 msgstr ""
 
-#: journal/models/shelf.py:98 journal/models/shelf.py:138
+#: journal/models/shelf.py:100 journal/models/shelf.py:140
 msgid "start watching"
 msgstr ""
 
-#: journal/models/shelf.py:99 journal/models/shelf.py:139
+#: journal/models/shelf.py:101 journal/models/shelf.py:141
 #, python-brace-format
 msgid "started watching {item}"
 msgstr ""
 
-#: journal/models/shelf.py:100 journal/models/shelf.py:140
+#: journal/models/shelf.py:102 journal/models/shelf.py:142
 msgid "watching"
 msgstr ""
 
-#: journal/models/shelf.py:105
+#: journal/models/shelf.py:107
 msgid "movies watched"
 msgstr ""
 
-#: journal/models/shelf.py:106 journal/models/shelf.py:146
+#: journal/models/shelf.py:108 journal/models/shelf.py:148
 msgid "finish watching"
 msgstr ""
 
-#: journal/models/shelf.py:107 journal/models/shelf.py:147
+#: journal/models/shelf.py:109 journal/models/shelf.py:149
 #, python-brace-format
 msgid "finished watching {item}"
 msgstr ""
 
-#: journal/models/shelf.py:108 journal/models/shelf.py:148
+#: journal/models/shelf.py:110 journal/models/shelf.py:150
 msgid "watched"
 msgstr ""
 
-#: journal/models/shelf.py:113
+#: journal/models/shelf.py:115
 msgid "movies dropped"
 msgstr ""
 
-#: journal/models/shelf.py:114 journal/models/shelf.py:154
+#: journal/models/shelf.py:116 journal/models/shelf.py:156
 msgid "stop watching"
 msgstr ""
 
-#: journal/models/shelf.py:115 journal/models/shelf.py:155
+#: journal/models/shelf.py:117 journal/models/shelf.py:157
 #, python-brace-format
 msgid "stopped watching {item}"
 msgstr ""
 
-#: journal/models/shelf.py:116 journal/models/shelf.py:156
+#: journal/models/shelf.py:118 journal/models/shelf.py:158
 msgid "stopped watching"
 msgstr ""
 
-#: journal/models/shelf.py:121
+#: journal/models/shelf.py:123
 msgid "movies reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:129
+#: journal/models/shelf.py:131
 msgid "TV shows to watch"
 msgstr ""
 
-#: journal/models/shelf.py:137
+#: journal/models/shelf.py:139
 msgid "TV shows watching"
 msgstr ""
 
-#: journal/models/shelf.py:145
+#: journal/models/shelf.py:147
 msgid "TV shows watched"
 msgstr ""
 
-#: journal/models/shelf.py:153
+#: journal/models/shelf.py:155
 msgid "TV shows dropped"
 msgstr ""
 
-#: journal/models/shelf.py:161
+#: journal/models/shelf.py:163
 msgid "TV shows reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:169
+#: journal/models/shelf.py:171
 msgid "albums to listen"
 msgstr ""
 
-#: journal/models/shelf.py:170 journal/models/shelf.py:250
+#: journal/models/shelf.py:172 journal/models/shelf.py:252
 msgid "want to listen"
 msgstr ""
 
-#: journal/models/shelf.py:171 journal/models/shelf.py:251
+#: journal/models/shelf.py:173 journal/models/shelf.py:253
 #, python-brace-format
 msgid "wants to listen {item}"
 msgstr ""
 
-#: journal/models/shelf.py:172 journal/models/shelf.py:252
+#: journal/models/shelf.py:174 journal/models/shelf.py:254
 msgid "to listen"
 msgstr ""
 
-#: journal/models/shelf.py:177
+#: journal/models/shelf.py:179
 msgid "albums listening"
 msgstr ""
 
-#: journal/models/shelf.py:178 journal/models/shelf.py:258
+#: journal/models/shelf.py:180 journal/models/shelf.py:260
 msgid "start listening"
 msgstr ""
 
-#: journal/models/shelf.py:179 journal/models/shelf.py:259
+#: journal/models/shelf.py:181 journal/models/shelf.py:261
 #, python-brace-format
 msgid "started listening {item}"
 msgstr ""
 
-#: journal/models/shelf.py:180 journal/models/shelf.py:260
+#: journal/models/shelf.py:182 journal/models/shelf.py:262
 msgid "listening"
 msgstr ""
 
-#: journal/models/shelf.py:185
+#: journal/models/shelf.py:187
 msgid "albums listened"
 msgstr ""
 
-#: journal/models/shelf.py:186 journal/models/shelf.py:266
+#: journal/models/shelf.py:188 journal/models/shelf.py:268
 msgid "finish listening"
 msgstr ""
 
-#: journal/models/shelf.py:187 journal/models/shelf.py:267
+#: journal/models/shelf.py:189 journal/models/shelf.py:269
 #, python-brace-format
 msgid "finished listening {item}"
 msgstr ""
 
-#: journal/models/shelf.py:188 journal/models/shelf.py:268
+#: journal/models/shelf.py:190 journal/models/shelf.py:270
 msgid "listened"
 msgstr ""
 
-#: journal/models/shelf.py:193
+#: journal/models/shelf.py:195
 msgid "albums dropped"
 msgstr ""
 
-#: journal/models/shelf.py:194 journal/models/shelf.py:274
+#: journal/models/shelf.py:196 journal/models/shelf.py:276
 msgid "stop listening"
 msgstr ""
 
-#: journal/models/shelf.py:195 journal/models/shelf.py:275
+#: journal/models/shelf.py:197 journal/models/shelf.py:277
 #, python-brace-format
 msgid "stopped listening {item}"
 msgstr ""
 
-#: journal/models/shelf.py:196 journal/models/shelf.py:276
+#: journal/models/shelf.py:198 journal/models/shelf.py:278
 msgid "stopped listening"
 msgstr ""
 
-#: journal/models/shelf.py:201
+#: journal/models/shelf.py:203
 msgid "albums reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:209
+#: journal/models/shelf.py:211
 msgid "games to play"
 msgstr ""
 
-#: journal/models/shelf.py:210
+#: journal/models/shelf.py:212
 msgid "want to play"
 msgstr ""
 
-#: journal/models/shelf.py:211
+#: journal/models/shelf.py:213
 #, python-brace-format
 msgid "wants to play {item}"
 msgstr ""
 
-#: journal/models/shelf.py:212
+#: journal/models/shelf.py:214
 msgid "to play"
 msgstr ""
 
-#: journal/models/shelf.py:217
+#: journal/models/shelf.py:219
 msgid "games playing"
 msgstr ""
 
-#: journal/models/shelf.py:218
+#: journal/models/shelf.py:220
 msgid "start playing"
 msgstr ""
 
-#: journal/models/shelf.py:219
+#: journal/models/shelf.py:221
 #, python-brace-format
 msgid "started playing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:220
+#: journal/models/shelf.py:222
 msgid "playing"
 msgstr ""
 
-#: journal/models/shelf.py:225
+#: journal/models/shelf.py:227
 msgid "games played"
 msgstr ""
 
-#: journal/models/shelf.py:226
+#: journal/models/shelf.py:228
 msgid "finish playing"
 msgstr ""
 
-#: journal/models/shelf.py:227
+#: journal/models/shelf.py:229
 #, python-brace-format
 msgid "finished playing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:228
+#: journal/models/shelf.py:230
 msgid "played"
 msgstr ""
 
-#: journal/models/shelf.py:233
+#: journal/models/shelf.py:235
 msgid "games dropped"
 msgstr ""
 
-#: journal/models/shelf.py:234
+#: journal/models/shelf.py:236
 msgid "stop playing"
 msgstr ""
 
-#: journal/models/shelf.py:235
+#: journal/models/shelf.py:237
 #, python-brace-format
 msgid "stopped playing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:236
+#: journal/models/shelf.py:238
 msgid "stopped playing"
 msgstr ""
 
-#: journal/models/shelf.py:241
+#: journal/models/shelf.py:243
 msgid "games reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:249
+#: journal/models/shelf.py:251
 msgid "podcasts to listen"
 msgstr ""
 
-#: journal/models/shelf.py:257
+#: journal/models/shelf.py:259
 msgid "podcasts listening"
 msgstr ""
 
-#: journal/models/shelf.py:265
+#: journal/models/shelf.py:267
 msgid "podcasts listened"
 msgstr ""
 
-#: journal/models/shelf.py:273
+#: journal/models/shelf.py:275
 msgid "podcasts dropped"
 msgstr ""
 
-#: journal/models/shelf.py:281
+#: journal/models/shelf.py:283
 msgid "podcasts reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:289
+#: journal/models/shelf.py:291
 msgid "performances to see"
 msgstr ""
 
-#: journal/models/shelf.py:290
+#: journal/models/shelf.py:292
 msgid "want to see"
 msgstr ""
 
-#: journal/models/shelf.py:291
+#: journal/models/shelf.py:293
 #, python-brace-format
 msgid "wants to see {item}"
 msgstr ""
 
-#: journal/models/shelf.py:292
+#: journal/models/shelf.py:294
 msgid "to see"
 msgstr ""
 
-#: journal/models/shelf.py:299
+#: journal/models/shelf.py:301
 msgid "performances saw"
 msgstr ""
 
-#: journal/models/shelf.py:300
+#: journal/models/shelf.py:302
 msgid "finish seeing"
 msgstr ""
 
-#: journal/models/shelf.py:301
+#: journal/models/shelf.py:303
 #, python-brace-format
 msgid "finished seeing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:302
+#: journal/models/shelf.py:304
 msgid "seen"
 msgstr ""
 
-#: journal/models/shelf.py:307
+#: journal/models/shelf.py:309
 msgid "performances dropped"
 msgstr ""
 
-#: journal/models/shelf.py:308
+#: journal/models/shelf.py:310
 msgid "stop seeing"
 msgstr ""
 
-#: journal/models/shelf.py:309
+#: journal/models/shelf.py:311
 #, python-brace-format
 msgid "stopped seeing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:310
+#: journal/models/shelf.py:312
 msgid "stopped seeing"
 msgstr ""
 
-#: journal/models/shelf.py:315
+#: journal/models/shelf.py:317
 msgid "performances reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:323
+#: journal/models/shelf.py:325
 msgid "people following"
 msgstr ""
 
-#: journal/models/shelf.py:325
+#: journal/models/shelf.py:327
 #, python-brace-format
 msgid "started following {item}"
 msgstr ""
 
-#: journal/models/shelf.py:921
+#: journal/models/shelf.py:923
 msgid "removed mark"
 msgstr ""
 
@@ -5733,30 +5740,20 @@ msgstr ""
 msgid "Remove from collection"
 msgstr ""
 
-#: journal/templates/_list_item.html:34
-msgid "add mark"
-msgstr ""
-
-#: journal/templates/_list_item.html:42
-msgid "update mark"
-msgstr ""
-
-#: journal/templates/_list_item.html:60
+#: journal/templates/_list_item.html:43
 #: journal/templates/collection_update_item_note_ok.html:3
 msgid "Update note"
 msgstr ""
 
-#: journal/templates/_list_item.html:100 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:123
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
 msgstr ""
 
-#: journal/templates/_list_item.html:133
+#: journal/templates/_list_item.html:91
 #, python-format
-msgid ""
-"%(dups)s item(s) are from the same work or have the same identifier, click "
-"here to display:"
+msgid "%(dups)s item(s) are from the same work or have the same identifier, click here to display:"
 msgstr ""
 
 #: journal/templates/_sidebar_collection_filter.html:32
@@ -5864,6 +5861,14 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
+#: journal/templates/action_mark_item.html:10
+msgid "add mark"
+msgstr ""
+
+#: journal/templates/action_mark_item.html:18
+msgid "update mark"
+msgstr ""
+
 #: journal/templates/action_open_post.html:7
 msgid "Quiet Public"
 msgstr ""
@@ -5916,11 +5921,11 @@ msgstr ""
 msgid "Create a new collection"
 msgstr ""
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:81
+#: journal/templates/article.html:104 social/templates/_event_post.html:76
 msgid "wrote a review"
 msgstr ""
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:83
+#: journal/templates/article.html:106 social/templates/_event_post.html:78
 msgid "wrote an article"
 msgstr ""
 
@@ -6032,19 +6037,19 @@ msgstr ""
 msgid "Mark"
 msgstr ""
 
-#: journal/templates/mark.html:50
+#: journal/templates/mark.html:54
 msgid "not rated"
 msgstr ""
 
-#: journal/templates/mark.html:70
+#: journal/templates/mark.html:74
 msgid "add a tag and press Enter"
 msgstr ""
 
-#: journal/templates/mark.html:122
+#: journal/templates/mark.html:126
 msgid "change mark date"
 msgstr ""
 
-#: journal/templates/mark.html:148
+#: journal/templates/mark.html:156
 msgid "Sure to delete mark, comment and tags for this item?"
 msgstr ""
 
@@ -6087,12 +6092,11 @@ msgid ""
 "Content Cell  | Content Cell\n"
 "Content Cell  | Content Cell\n"
 "\n"
-"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/"
-"Wikipedia-logo-v2.svg)\n"
+"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 "\n"
 msgstr ""
 
-#: journal/templates/note.html:19 journal/views/note.py:23
+#: journal/templates/note.html:19 journal/views/note.py:22
 msgid "Note"
 msgstr ""
 
@@ -6117,9 +6121,7 @@ msgid "Are you sure to delete this entire content?"
 msgstr ""
 
 #: journal/templates/piece_delete.html:24
-msgid ""
-"By deleting it, you will also lose track of others' comments and feedbacks "
-"to your content."
+msgid "By deleting it, you will also lose track of others' comments and feedbacks to your content."
 msgstr ""
 
 #: journal/templates/piece_delete.html:25
@@ -6199,7 +6201,7 @@ msgstr ""
 msgid "Articles"
 msgstr ""
 
-#: journal/templates/profile.html:166 journal/views/collection.py:427
+#: journal/templates/profile.html:166 journal/views/collection.py:409
 #: journal/views/profile.py:401
 msgid "collection"
 msgstr ""
@@ -6233,9 +6235,7 @@ msgid "Personal"
 msgstr ""
 
 #: journal/templates/tag_edit.html:52
-msgid ""
-"Personal tags are not included in public index. However, if you use this tag "
-"when marking an item publicly, it might still be visible to others."
+msgid "Personal tags are not included in public index. However, if you use this tag when marking an item publicly, it might still be visible to others."
 msgstr ""
 
 #: journal/templates/tag_edit.html:55
@@ -6304,113 +6304,114 @@ msgstr ""
 msgid "Link invalid"
 msgstr ""
 
-#: journal/views/collection.py:58 journal/views/collection.py:96
+#: journal/views/collection.py:62 journal/views/collection.py:94
 #, python-brace-format
 msgid "Collection by {0}"
 msgstr ""
 
-#: journal/views/collection.py:432
+#: journal/views/collection.py:414
 msgid "shared my collection"
 msgstr ""
 
-#: journal/views/collection.py:435
+#: journal/views/collection.py:417
 #, python-brace-format
 msgid "shared {username}'s collection"
 msgstr ""
 
-#: journal/views/collection.py:502 journal/views/collection.py:541
-#: journal/views/collection.py:553 journal/views/collection.py:579
+#: journal/views/collection.py:484 journal/views/collection.py:523
+#: journal/views/collection.py:535 journal/views/collection.py:561
 msgid "Dynamic collection is not editable"
 msgstr ""
 
-#: journal/views/collection.py:518
+#: journal/views/collection.py:500
 msgid "The item is already in the collection."
 msgstr ""
 
-#: journal/views/collection.py:520
+#: journal/views/collection.py:502
 msgid "Unable to find the item, please use item url from this site."
 msgstr ""
 
-#: journal/views/collection.py:566
+#: journal/views/collection.py:548
 msgid "Saved."
 msgstr ""
 
-#: journal/views/common.py:119 journal/views/mark.py:225
-#: journal/views/mark.py:279 journal/views/note.py:175
+#: journal/views/common.py:126 journal/views/mark.py:273
+#: journal/views/mark.py:315 journal/views/note.py:167
 #: journal/views/profile.py:42 journal/views/review.py:59
 #: journal/views/review.py:79
 msgid "Content not found"
 msgstr ""
 
-#: journal/views/common.py:174 journal/views/mark.py:159
+#: journal/views/common.py:184 journal/views/mark.py:210
 msgid "Data saved but unable to crosspost to Fediverse instance."
 msgstr ""
 
-#: journal/views/common.py:176
+#: journal/views/common.py:186
 msgid "Redirecting to your Fediverse instance now to re-authenticate."
 msgstr ""
 
-#: journal/views/common.py:183
+#: journal/views/common.py:193
 msgid "List not found."
 msgstr ""
 
-#: journal/views/mark.py:150
+#: journal/views/mark.py:206
 msgid "Content too long for your Fediverse instance."
 msgstr ""
 
-#: journal/views/mark.py:178 journal/views/mark.py:238
+#: journal/views/mark.py:224 journal/views/mark.py:226
+#: journal/views/mark.py:280
 msgid "Invalid input"
 msgstr ""
 
-#: journal/views/note.py:23
+#: journal/views/note.py:22
 msgid "Progress"
 msgstr ""
 
-#: journal/views/note.py:28
+#: journal/views/note.py:27
 msgid "Update progress"
 msgstr ""
 
-#: journal/views/note.py:59
+#: journal/views/note.py:58
 msgid "Progress (optional)"
 msgstr ""
 
-#: journal/views/note.py:61
+#: journal/views/note.py:60
 msgid "Note Content"
 msgstr ""
 
-#: journal/views/note.py:63
+#: journal/views/note.py:62
 msgid "Content Warning (optional)"
 msgstr ""
 
-#: journal/views/note.py:85
+#: journal/views/note.py:84
 msgid "Progress Type (optional)"
 msgstr ""
 
-#: journal/views/note.py:123 journal/views/note.py:183
+#: journal/views/note.py:115 journal/views/note.py:175
 msgid "Only in-progress items can have progress."
 msgstr ""
 
-#: journal/views/post.py:98 journal/views/post.py:392
+#: journal/views/post.py:100 journal/views/post.py:388
 msgid "Post not found"
 msgstr ""
 
-#: journal/views/post.py:189
+#: journal/views/post.py:191
 msgid "Visibility too high for quoting this post"
 msgstr ""
 
-#: journal/views/post.py:337 journal/views/post.py:418
+#: journal/views/post.py:339 journal/views/post.py:414
 msgid "Content cannot be empty."
 msgstr ""
 
-#: journal/views/post.py:396
+#: journal/views/post.py:392
 msgid "This post cannot be edited here"
 msgstr ""
 
-#: journal/views/post.py:541
+#: journal/views/post.py:531
 msgid "Invalid choices"
 msgstr ""
 
-#: journal/views/post.py:544
+#: journal/views/post.py:534
 msgid "Invalid post"
 msgstr ""
 
@@ -6428,56 +6429,54 @@ msgstr ""
 msgid "may contain spoiler or triggering content"
 msgstr ""
 
-#: journal/views/tag.py:47 journal/views/tag.py:61
+#: journal/views/tag.py:46 journal/views/tag.py:60
 msgid "Invalid tag"
 msgstr ""
 
-#: journal/views/tag.py:50
+#: journal/views/tag.py:49
 msgid "Tag not found"
 msgstr ""
 
-#: journal/views/tag.py:72
+#: journal/views/tag.py:65
 msgid "Tag deleted."
 msgstr ""
 
-#: journal/views/tag.py:82
+#: journal/views/tag.py:75
 msgid "Duplicated tag."
 msgstr ""
 
-#: journal/views/tag.py:96
+#: journal/views/tag.py:83
 msgid "Tag updated."
 msgstr ""
 
-#: journal/views/wrapped.py:160
+#: journal/views/wrapped.py:161
 msgid "Summary posted to timeline."
 msgstr ""
 
-#: mastodon/models/common.py:29
+#: mastodon/models/common.py:31
 msgid "Mastodon"
 msgstr ""
 
-#: mastodon/models/common.py:30 users/templates/users/login.html:120
+#: mastodon/models/common.py:32 users/templates/users/login.html:114
 msgid "Threads"
 msgstr ""
 
-#: mastodon/models/common.py:31
+#: mastodon/models/common.py:33
 msgid "Bluesky"
 msgstr ""
 
-#: mastodon/models/email.py:59
+#: mastodon/models/email.py:63
 msgid ""
 "\n"
 "\n"
-"If you did not mean to register or login, please ignore this email. If you "
-"are concerned with your account security, please change the email linked "
-"with your account, or contact us."
+"If you did not mean to register or login, please ignore this email. If you are concerned with your account security, please change the email linked with your account, or contact us."
 msgstr ""
 
-#: mastodon/models/email.py:64 mastodon/models/email.py:69
+#: mastodon/models/email.py:68 mastodon/models/email.py:73
 msgid "Verification Code"
 msgstr ""
 
-#: mastodon/models/email.py:66
+#: mastodon/models/email.py:70
 #, python-brace-format
 msgid ""
 "Use this code to verify your email address {email}\n"
@@ -6485,7 +6484,7 @@ msgid ""
 "{code}"
 msgstr ""
 
-#: mastodon/models/email.py:70
+#: mastodon/models/email.py:74
 #, python-brace-format
 msgid ""
 "Use this code to login as {email}\n"
@@ -6493,23 +6492,21 @@ msgid ""
 "{code}"
 msgstr ""
 
-#: mastodon/models/email.py:74 users/templates/users/captcha.html:13
+#: mastodon/models/email.py:78 users/templates/users/captcha.html:13
 #: users/templates/users/captcha_solved.html:9
 #: users/templates/users/login.html:20 users/templates/users/register.html:9
 #: users/templates/users/welcome.html:10
 msgid "Register"
 msgstr ""
 
-#: mastodon/models/email.py:76
+#: mastodon/models/email.py:80
 #, python-brace-format
 msgid ""
 "There is no account registered with this email address yet: {email}\n"
 "\n"
-"If you already have an account with us, just login and add this email to you "
-"account.\n"
+"If you already have an account with us, just login and add this email to you account.\n"
 "\n"
-"If you prefer to register a new account with this email, please use this "
-"verification code: {code}"
+"If you prefer to register a new account with this email, please use this verification code: {code}"
 msgstr ""
 
 #: mastodon/models/mastodon.py:570
@@ -6552,44 +6549,49 @@ msgstr ""
 msgid "New Post"
 msgstr ""
 
-#: mastodon/views/bluesky.py:26 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:32 mastodon/views/bluesky.py:93
 msgid "Bluesky login is disabled."
 msgstr ""
 
-#: mastodon/views/bluesky.py:28 mastodon/views/email.py:35
-#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:29
-#: users/templates/users/login.html:6 users/views/webauthn.py:133
-msgid "Security check failed. Please try again."
-msgstr ""
-
-#: mastodon/views/bluesky.py:34 mastodon/views/bluesky.py:40
-#: mastodon/views/bluesky.py:64 mastodon/views/bluesky.py:72
-#: mastodon/views/bluesky.py:78 mastodon/views/common.py:36
-#: mastodon/views/mastodon.py:62 mastodon/views/mastodon.py:70
-#: mastodon/views/mastodon.py:77 mastodon/views/mastodon.py:87
-#: mastodon/views/mastodon.py:94 mastodon/views/threads.py:55
-#: mastodon/views/threads.py:63 mastodon/views/threads.py:69
-#: users/views/account.py:254 users/views/account.py:373
+#: mastodon/views/bluesky.py:47 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:65 mastodon/views/bluesky.py:98
+#: mastodon/views/bluesky.py:106 mastodon/views/bluesky.py:112
+#: mastodon/views/common.py:36 mastodon/views/mastodon.py:62
+#: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
+#: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
+#: mastodon/views/threads.py:57 mastodon/views/threads.py:65
+#: mastodon/views/threads.py:71 users/views/account.py:256
+#: users/views/account.py:375
 msgid "Authentication failed"
 msgstr ""
 
-#: mastodon/views/bluesky.py:35 mastodon/views/email.py:66
+#: mastodon/views/bluesky.py:47 mastodon/views/common.py:103
+msgid "Identity not found."
+msgstr ""
+
+#: mastodon/views/bluesky.py:53 mastodon/views/email.py:35
+#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:31
+#: users/templates/users/login.html:6 users/views/webauthn.py:136
+msgid "Security check failed. Please try again."
+msgstr ""
+
+#: mastodon/views/bluesky.py:60 mastodon/views/email.py:66
 msgid "Too many attempts, please try again later."
 msgstr ""
 
-#: mastodon/views/bluesky.py:40
+#: mastodon/views/bluesky.py:65
 msgid "ATProto handle is required."
 msgstr ""
 
-#: mastodon/views/bluesky.py:50
+#: mastodon/views/bluesky.py:84
 msgid "Error connecting to your ATProto server"
 msgstr ""
 
-#: mastodon/views/bluesky.py:73
+#: mastodon/views/bluesky.py:107
 msgid "Invalid response from ATProto authorization server."
 msgstr ""
 
-#: mastodon/views/bluesky.py:78
+#: mastodon/views/bluesky.py:112
 msgid "Invalid account data from Bluesky."
 msgstr ""
 
@@ -6597,7 +6599,7 @@ msgstr ""
 msgid "Invalid user."
 msgstr ""
 
-#: mastodon/views/common.py:52 users/views/account.py:414
+#: mastodon/views/common.py:52 users/views/account.py:416
 msgid "Registration failed"
 msgstr ""
 
@@ -6627,10 +6629,6 @@ msgstr ""
 #: mastodon/views/common.py:103 mastodon/views/common.py:107
 #: mastodon/views/common.py:116
 msgid "Disconnect identity failed"
-msgstr ""
-
-#: mastodon/views/common.py:103
-msgid "Identity not found."
 msgstr ""
 
 #: mastodon/views/common.py:117
@@ -6674,7 +6672,7 @@ msgstr ""
 msgid "Invalid response from Fediverse instance."
 msgstr ""
 
-#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:64
+#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:66
 msgid "Invalid OAuth state. Please try again."
 msgstr ""
 
@@ -6694,19 +6692,17 @@ msgstr ""
 msgid "Invalid account data from Fediverse instance."
 msgstr ""
 
-#: mastodon/views/threads.py:69
+#: mastodon/views/threads.py:71
 msgid "Invalid account data from Threads."
 msgstr ""
 
-#: mastodon/views/threads.py:147
+#: mastodon/views/threads.py:149
 msgid "Data deletion completed"
 msgstr ""
 
-#: mastodon/views/threads.py:149
+#: mastodon/views/threads.py:151
 #, python-brace-format
-msgid ""
-"Data linked to your Threads account has been deleted. Confirmation code: "
-"{code}"
+msgid "Data linked to your Threads account has been deleted. Confirmation code: {code}"
 msgstr ""
 
 #: social/templates/_article_teaser.html:10
@@ -6737,15 +6733,11 @@ msgstr ""
 msgid "play"
 msgstr ""
 
-#: social/templates/_event_post.html:50
-msgid "mark"
-msgstr ""
-
-#: social/templates/_event_post.html:79
+#: social/templates/_event_post.html:74
 msgid "wrote a note"
 msgstr ""
 
-#: social/templates/_event_post.html:88
+#: social/templates/_event_post.html:83
 msgid "replying to"
 msgstr ""
 
@@ -6758,7 +6750,7 @@ msgstr ""
 msgid "Untitled article"
 msgstr ""
 
-#: social/templates/event/boosted.html:3
+#: social/templates/event/boosted.html:2
 msgid "boosted your post"
 msgstr ""
 
@@ -6801,8 +6793,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
 #: social/templates/event/boosted_shelfmember.html:3
@@ -6820,7 +6811,7 @@ msgstr ""
 msgid "followed you"
 msgstr ""
 
-#: social/templates/event/liked.html:3
+#: social/templates/event/liked.html:2
 msgid "liked your post"
 msgstr ""
 
@@ -6863,8 +6854,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
 #: social/templates/event/liked_shelfmember.html:3
@@ -6874,7 +6864,7 @@ msgid ""
 "liked your mark on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
-#: social/templates/event/mentioned.html:3
+#: social/templates/event/mentioned.html:2
 msgid "mentioned you"
 msgstr ""
 
@@ -6917,8 +6907,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
 #: social/templates/event/mentioned_shelfmember.html:3
@@ -6928,26 +6917,38 @@ msgid ""
 "replied to your mark on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
-#: social/templates/feed.html:12 social/templates/feed.html:39
-#: social/templates/search_feed.html:12
-msgid "Activities from those you follow"
+#: social/templates/feed.html:39 users/templates/users/preferences.html:40
+#, fuzzy
+msgid "Activities"
+msgstr "世事"
+
+#: social/templates/feed.html:43 social/templates/feed.html:45
+msgid "world"
 msgstr ""
 
-#: social/templates/feed.html:42 social/templates/feed.html:44
+#: social/templates/feed.html:51 social/templates/feed.html:53
+msgid "local"
+msgstr ""
+
+#: social/templates/feed.html:58 social/templates/feed.html:60
+msgid "those you follow"
+msgstr ""
+
+#: social/templates/feed.html:64 social/templates/feed.html:66
 msgid "what they read/watch/..."
 msgstr ""
 
-#: social/templates/feed_events.html:30
+#: social/templates/feed_events.html:29
 msgid "no matching activities."
 msgstr ""
 
-#: social/templates/feed_events.html:33
+#: social/templates/feed_events.html:31
+msgid "no public activities yet."
+msgstr ""
+
+#: social/templates/feed_events.html:34
 #, python-format
-msgid ""
-"Find and mark some books/movies/podcasts/games, <a "
-"href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/"
-"Douban, follow some fellow %(site_name)s users on the fediverse, so their "
-"recent activities and yours will show up here."
+msgid "Find and mark some books/movies/podcasts/games, <a href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/Douban, follow some fellow %(site_name)s users on the fediverse, so their recent activities and yours will show up here."
 msgstr ""
 
 #: social/templates/notification.html:58
@@ -6980,6 +6981,10 @@ msgstr ""
 msgid "Poll ending at %(end_time)s"
 msgstr ""
 
+#: social/templates/search_feed.html:12 social/views.py:57 social/views.py:58
+msgid "Activities from those you follow"
+msgstr ""
+
 #: social/templates/single_post.html:13 social/templates/single_post.html:32
 msgid "Post"
 msgstr ""
@@ -6992,57 +6997,64 @@ msgstr ""
 msgid "Poll"
 msgstr ""
 
-#: takahe/models.py:453
+#: social/views.py:59
+#, fuzzy
+msgid "Activities on this site"
+msgstr "世事"
+
+#: social/views.py:60
+msgid "Activities from the fediverse"
+msgstr ""
+
+#: takahe/models.py:445
 msgid "Display Name"
 msgstr ""
 
-#: takahe/models.py:455
+#: takahe/models.py:447
 msgid "Bio"
 msgstr ""
 
-#: takahe/models.py:457
+#: takahe/models.py:449
 msgid "Manually approve new followers"
 msgstr ""
 
-#: takahe/models.py:461
+#: takahe/models.py:453
 msgid "Include profile, marks and posts in discovery"
 msgstr ""
 
-#: takahe/models.py:464
+#: takahe/models.py:456
 msgid "Include posts in search results"
 msgstr ""
 
-#: takahe/models.py:482
+#: takahe/models.py:474
 msgid "Profile picture"
 msgstr ""
 
-#: takahe/models.py:489
+#: takahe/models.py:481
 msgid "Header picture"
 msgstr ""
 
-#: users/models/task.py:22
+#: users/models/task.py:24
 msgid "Started"
 msgstr ""
 
-#: users/models/task.py:23
+#: users/models/task.py:25
 msgid "Complete"
 msgstr ""
 
-#: users/models/user.py:69
-msgid ""
-"Enter a valid username. This value may contain only unaccented lowercase a-z "
-"and uppercase A-Z letters, numbers, and _ characters."
+#: users/models/user.py:71
+msgid "Enter a valid username. This value may contain only unaccented lowercase a-z and uppercase A-Z letters, numbers, and _ characters."
 msgstr ""
 
-#: users/models/user.py:130
+#: users/models/user.py:132
 msgid "username"
 msgstr ""
 
-#: users/models/user.py:135
+#: users/models/user.py:137
 msgid "Required. 50 characters or fewer. Letters, digits and _ only."
 msgstr ""
 
-#: users/models/user.py:138
+#: users/models/user.py:140
 msgid "A user with that username already exists."
 msgstr ""
 
@@ -7173,9 +7185,7 @@ msgid "Cancel import"
 msgstr ""
 
 #: users/templates/users/_rym_section.html:29
-msgid ""
-"On RateYourMusic, go to your profile and use the <b>Export your music "
-"catalog</b> option to download your library as a CSV file."
+msgid "On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:31
@@ -7184,18 +7194,12 @@ msgid "Upload the downloaded CSV file below."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:33
-msgid ""
-"Albums are matched by title + artist (and year if present) — first against "
-"the local catalog, then MusicBrainz, then Spotify. After auto-matching, "
-"you'll preview the matches in a table, edit any link or shelf status, and "
-"confirm the import."
+msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:36
 #: users/templates/users/_storygraph_section.html:38
-msgid ""
-"You can also re-upload a previously-downloaded matched CSV — the existing "
-"<code>link</code> column will be honoured as the default match."
+msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:40
@@ -7222,18 +7226,11 @@ msgid "Cancel the StoryGraph import? Progress will be discarded."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:31
-msgid ""
-"On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to "
-"download your library as a CSV file."
+msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:35
-msgid ""
-"Books are matched by ISBN — first against the local catalog, then Google "
-"Books and OpenLibrary — with a title + author search as fallback. After auto-"
-"matching, you'll preview the matches in a table, edit any link or shelf "
-"status, and confirm the import."
+msgid "Books are matched by ISBN — first against the local catalog, then Google Books and OpenLibrary — with a title + author search as fallback. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/account.html:11
@@ -7245,9 +7242,7 @@ msgid "Display name, avatar and other information"
 msgstr ""
 
 #: users/templates/users/account.html:23
-msgid ""
-"Updating profile information here will turn off automatic sync of display "
-"name, bio and avatar from your Mastodon instance. Sure to continue?"
+msgid "Updating profile information here will turn off automatic sync of display name, bio and avatar from your Mastodon instance. Sure to continue?"
 msgstr ""
 
 #: users/templates/users/account.html:26
@@ -7260,16 +7255,11 @@ msgstr ""
 
 #: users/templates/users/account.html:59 users/templates/users/register.html:47
 #, python-format
-msgid ""
-"Please click the confirmation link in the email sent to %(pending_email)s; "
-"if you haven't received it for more than a few minutes, please input and "
-"save again."
+msgid "Please click the confirmation link in the email sent to %(pending_email)s; if you haven't received it for more than a few minutes, please input and save again."
 msgstr ""
 
 #: users/templates/users/account.html:61 users/templates/users/register.html:50
-msgid ""
-"Email is recommended as a backup login method, if you log in via a Fediverse "
-"instance"
+msgid "Email is recommended as a backup login method, if you log in via a Fediverse instance"
 msgstr ""
 
 #: users/templates/users/account.html:73 users/templates/users/login.html:84
@@ -7287,22 +7277,15 @@ msgid "Last updated"
 msgstr ""
 
 #: users/templates/users/account.html:92
-msgid ""
-"If you have not yet registered with any Federated instance, you may <a "
-"href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an "
-"instance</a> and register."
+msgid "If you have not yet registered with any Federated instance, you may <a href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an instance</a> and register."
 msgstr ""
 
 #: users/templates/users/account.html:97
-msgid ""
-"To associate with another federated identity, please enter the domain name "
-"of the instance where the new identity is located."
+msgid "To associate with another federated identity, please enter the domain name of the instance where the new identity is located."
 msgstr ""
 
 #: users/templates/users/account.html:99
-msgid ""
-"If you have registered with a Federated instance, please enter the instance "
-"domain name."
+msgid "If you have registered with a Federated instance, please enter the instance domain name."
 msgstr ""
 
 #: users/templates/users/account.html:104
@@ -7314,24 +7297,17 @@ msgid "Go to target instance and authorize with the identity"
 msgstr ""
 
 #: users/templates/users/account.html:113
-msgid ""
-"After replacing the association, you may use the new Fediverse identity to "
-"log in and control data visibility. Existing data such as tags, comments, "
-"and collections will not be affected."
+msgid "After replacing the association, you may use the new Fediverse identity to log in and control data visibility. Existing data such as tags, comments, and collections will not be affected."
 msgstr ""
 
 #: users/templates/users/account.html:115
-msgid ""
-"Once associated with Fediverse identity, you can discover more users and use "
-"the full features of this site."
+msgid "Once associated with Fediverse identity, you can discover more users and use the full features of this site."
 msgstr ""
 
 #: users/templates/users/account.html:123
 #: users/templates/users/account.html:160
 #: users/templates/users/account.html:206
-msgid ""
-"Once disconnected, you will no longer be able login with this identity. Are "
-"you sure to continue?"
+msgid "Once disconnected, you will no longer be able login with this identity. Are you sure to continue?"
 msgstr ""
 
 #: users/templates/users/account.html:126
@@ -7358,7 +7334,7 @@ msgstr ""
 msgid "Disconnect with Threads"
 msgstr ""
 
-#: users/templates/users/account.html:173 users/templates/users/login.html:112
+#: users/templates/users/account.html:173 users/templates/users/login.html:106
 msgid "Bluesky (ATProto)"
 msgstr ""
 
@@ -7366,7 +7342,7 @@ msgstr ""
 msgid "Verified ATProto identity"
 msgstr ""
 
-#: users/templates/users/account.html:194 users/templates/users/login.html:216
+#: users/templates/users/account.html:194 users/templates/users/login.html:210
 msgid "ATProto handle"
 msgstr ""
 
@@ -7391,7 +7367,7 @@ msgid "Name this passkey:"
 msgstr ""
 
 #: users/templates/users/account.html:227 users/templates/users/login.html:69
-#: users/templates/users/welcome.html:33 users/views/webauthn.py:106
+#: users/templates/users/welcome.html:33 users/views/webauthn.py:109
 msgid "Passkey"
 msgstr ""
 
@@ -7434,9 +7410,7 @@ msgid "Save sync settings"
 msgstr ""
 
 #: users/templates/users/account.html:297
-msgid ""
-"New follow, mute and blocks in the associated identity may be automatically "
-"imported; removal has to be done manually."
+msgid "New follow, mute and blocks in the associated identity may be automatically imported; removal has to be done manually."
 msgstr ""
 
 #: users/templates/users/account.html:304
@@ -7473,15 +7447,11 @@ msgid "Log out everywhere"
 msgstr ""
 
 #: users/templates/users/account.html:365
-msgid ""
-"This will log you out of all browsers and devices (including the current "
-"one), and revoke all API tokens. Continue?"
+msgid "This will log you out of all browsers and devices (including the current one), and revoke all API tokens. Continue?"
 msgstr ""
 
 #: users/templates/users/account.html:368
-msgid ""
-"If you notice any suspicious activity or have logged in on a shared "
-"computer, you can log out of all sessions and revoke all API tokens."
+msgid "If you notice any suspicious activity or have logged in on a shared computer, you can log out of all sessions and revoke all API tokens."
 msgstr ""
 
 #: users/templates/users/account.html:378
@@ -7542,10 +7512,10 @@ msgstr ""
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:74
-#: users/templates/users/data.html:126 users/templates/users/data.html:183
-#: users/templates/users/data.html:234 users/templates/users/data.html:298
-#: users/templates/users/data.html:358 users/templates/users/data.html:553
+#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/data.html:141 users/templates/users/data.html:198
+#: users/templates/users/data.html:249 users/templates/users/data.html:313
+#: users/templates/users/data.html:376 users/templates/users/data.html:553
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr ""
@@ -7570,9 +7540,7 @@ msgid "Migrate Account"
 msgstr ""
 
 #: users/templates/users/account.html:488
-msgid ""
-"Linking an email to your account is highly recommended before migrating from "
-"another Fediverse instance."
+msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
 msgstr ""
 
 #: users/templates/users/account.html:491
@@ -7592,9 +7560,7 @@ msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
 msgstr ""
 
 #: users/templates/users/account.html:507
-msgid ""
-"Enter full <code>username@instance.social</code> or <code>email@domain.com</"
-"code> to confirm deletion."
+msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
 msgstr ""
 
 #: users/templates/users/account.html:517
@@ -7646,9 +7612,7 @@ msgid "Token Created"
 msgstr ""
 
 #: users/templates/users/authorized_app_created.html:22
-msgid ""
-"Your new personal access token has been created. Copy it now -- you will not "
-"be able to see it again."
+msgid "Your new personal access token has been created. Copy it now -- you will not be able to see it again."
 msgstr ""
 
 #: users/templates/users/authorized_app_created.html:25
@@ -7676,9 +7640,7 @@ msgid "One quick check"
 msgstr ""
 
 #: users/templates/users/captcha.html:28
-msgid ""
-"Put every cover into the row it belongs to. Drag it, or select a cover and "
-"then select a row."
+msgid "Put every cover into the row it belongs to. Drag it, or select a cover and then select a row."
 msgstr ""
 
 #: users/templates/users/captcha.html:41 users/templates/users/captcha.html:43
@@ -7708,7 +7670,7 @@ msgstr ""
 msgid "That is all we needed. Let's get you a username."
 msgstr ""
 
-#: users/templates/users/captcha_solved.html:34
+#: users/templates/users/captcha_solved.html:32
 #: users/templates/users/login.html:63
 #: users/templates/users/verify_email.html:25
 #: users/templates/users/welcome.html:51
@@ -7728,10 +7690,7 @@ msgid "Failed Crossposts"
 msgstr ""
 
 #: users/templates/users/crossposts.html:42
-msgid ""
-"These posts could not be crossposted to your linked social accounts. Re-"
-"authorize the account if needed, then retry. In rare cases retrying may "
-"create a duplicate post."
+msgid "These posts could not be crossposted to your linked social accounts. Re-authorize the account if needed, then retry. In rare cases retrying may create a duplicate post."
 msgstr ""
 
 #: users/templates/users/crossposts.html:48
@@ -7750,208 +7709,161 @@ msgstr ""
 msgid "Data Management"
 msgstr ""
 
-#: users/templates/users/data.html:27
+#: users/templates/users/data.html:39
 msgid "Import Marks and Reviews from Douban"
 msgstr ""
 
-#: users/templates/users/data.html:31
-msgid ""
-"Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
-"target=\"_blank\" rel=\"noopener\">Doufen</a>"
+#: users/templates/users/data.html:43
+msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr ""
 
 #: users/templates/users/data.html:45
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
-"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
-"NeoDB Archive</a> below."
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON format instead; upload it under <a href=\"#import-neodb-archive\">Import NeoDB Archive</a> below."
 msgstr ""
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:256
+#: users/templates/users/data.html:49 users/templates/users/data.html:271
 msgid "Import Method"
 msgstr ""
 
-#: users/templates/users/data.html:37
-msgid ""
-"Merge: only update when status changes from wishlist to in-progress, or from "
-"in-progress to complete."
+#: users/templates/users/data.html:52
+msgid "Merge: only update when status changes from wishlist to in-progress, or from in-progress to complete."
 msgstr ""
 
-#: users/templates/users/data.html:41
+#: users/templates/users/data.html:56
 msgid "Overwrite: update all imported status."
 msgstr ""
 
-#: users/templates/users/data.html:74
-msgid ""
-"Another import is in progress, starting a new import may cause issues, sure "
-"to import?"
+#: users/templates/users/data.html:89
+msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
 msgstr ""
 
-#: users/templates/users/data.html:74
+#: users/templates/users/data.html:89 users/views/data.py:1130
 msgid "Import in progress, please wait"
 msgstr ""
 
-#: users/templates/users/data.html:81
+#: users/templates/users/data.html:96
 msgid "Import from Goodreads"
 msgstr ""
 
-#: users/templates/users/data.html:87
-msgid ""
-"On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download "
-"your library as a CSV file."
+#: users/templates/users/data.html:102
+msgid "On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download your library as a CSV file."
 msgstr ""
 
-#: users/templates/users/data.html:90
-msgid ""
-"Upload the downloaded <code>goodreads_library_export.csv</code> file below."
+#: users/templates/users/data.html:105
+msgid "Upload the downloaded <code>goodreads_library_export.csv</code> file below."
 msgstr ""
 
-#: users/templates/users/data.html:93
-msgid ""
-"want-to-read / currently-reading / read / did-not-finish books and their "
-"reviews will be imported."
-msgstr ""
-
-#: users/templates/users/data.html:134
-msgid "Import from Letterboxd"
-msgstr ""
-
-#: users/templates/users/data.html:140
-msgid ""
-"on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" "
-"target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap "
-"Advanced Settings in Settings, tap EXPORT YOUR DATA"
-msgstr ""
-
-#: users/templates/users/data.html:143
-msgid ""
-"download file with name like <code>letterboxd-username-2018-03-11-07-52-"
-"utc.zip</code>, do not unzip"
-msgstr ""
-
-#: users/templates/users/data.html:146
-msgid ""
-"the following files in the zip file will be processed: <code>reviews.csv</"
-"code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</"
-"code> <code>lists/*.csv</code>"
+#: users/templates/users/data.html:108
+msgid "want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported."
 msgstr ""
 
 #: users/templates/users/data.html:149
-msgid ""
-"exported file does not indicate whether a list is private, unlisted or "
-"public, so all imported marks, reviews and collections will be created with "
-"the visibility selected below"
+msgid "Import from Letterboxd"
 msgstr ""
 
-#: users/templates/users/data.html:184 users/templates/users/data.html:235
+#: users/templates/users/data.html:155
+msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
+msgstr ""
+
+#: users/templates/users/data.html:158
+msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
+msgstr ""
+
+#: users/templates/users/data.html:161
+msgid "the following files in the zip file will be processed: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
+msgstr ""
+
+#: users/templates/users/data.html:164
+msgid "exported file does not indicate whether a list is private, unlisted or public, so all imported marks, reviews and collections will be created with the visibility selected below"
+msgstr ""
+
+#: users/templates/users/data.html:199 users/templates/users/data.html:250
 msgid "Only forward changes(none->to-watch->watched) will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:191
+#: users/templates/users/data.html:206
 msgid "Import from Trakt"
 msgstr ""
 
-#: users/templates/users/data.html:197
-msgid ""
-"On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" "
-"rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait "
-"for the download link to appear."
+#: users/templates/users/data.html:212
+msgid "On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait for the download link to appear."
 msgstr ""
 
-#: users/templates/users/data.html:200
+#: users/templates/users/data.html:215
 msgid "Upload the downloaded <code>.zip</code> file below, do not unzip."
 msgstr ""
 
-#: users/templates/users/data.html:202
+#: users/templates/users/data.html:217
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:243
+#: users/templates/users/data.html:258
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr ""
 
-#: users/templates/users/data.html:246
+#: users/templates/users/data.html:261
 msgid "Login with Steam"
 msgstr ""
 
-#: users/templates/users/data.html:252
+#: users/templates/users/data.html:267
 msgid "Import Podcast Subscriptions"
 msgstr ""
 
-#: users/templates/users/data.html:263
+#: users/templates/users/data.html:278
 msgid "Mark as listening"
 msgstr ""
 
-#: users/templates/users/data.html:267
+#: users/templates/users/data.html:282
 msgid "Import as a new collection"
 msgstr ""
 
-#: users/templates/users/data.html:296
+#: users/templates/users/data.html:311
 msgid "Select OPML file"
 msgstr ""
 
-#: users/templates/users/data.html:306
+#: users/templates/users/data.html:321
 msgid "Import NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:312
-msgid ""
-"Upload a <code>.zip</code> file containing <code>.csv</code> or "
-"<code>.ndjson</code> files exported from NeoDB."
+#: users/templates/users/data.html:327
+msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr ""
 
 #: users/templates/users/data.html:330
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
-"imported here."
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is imported here."
 msgstr ""
 
-#: users/templates/users/data.html:314
+#: users/templates/users/data.html:332
 msgid "Existing data may be overwritten."
 msgstr ""
 
-#: users/templates/users/data.html:324
+#: users/templates/users/data.html:342
 msgid "Detected format"
 msgstr ""
 
-#: users/templates/users/data.html:385
+#: users/templates/users/data.html:403
 msgid "Detecting format..."
 msgstr ""
 
-#: users/templates/users/data.html:411
+#: users/templates/users/data.html:429
 msgid "Unknown format"
 msgstr ""
 
-#: users/templates/users/data.html:436
+#: users/templates/users/data.html:454
 msgid "Error detecting format"
 msgstr ""
 
-#: users/templates/users/data.html:460
+#: users/templates/users/data.html:478
 msgid "Export NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:464
+#: users/templates/users/data.html:482
 msgid "Export marks, reviews and notes in CSV"
 msgstr ""
 
-#: users/templates/users/data.html:471
+#: users/templates/users/data.html:489
 msgid "Export everything in NDJSON"
-msgstr ""
-
-#: users/templates/users/data.html:479
-msgid "Export marks and reviews in XLSX (Doufen format)"
-msgstr ""
-
-#: users/templates/users/data.html:482
-msgid "Last export"
-msgstr ""
-
-#: users/templates/users/data.html:487
-msgid "Download"
 msgstr ""
 
 #: users/templates/users/data.html:496
@@ -7959,22 +7871,15 @@ msgid "Import and Export Articles (WordPress)"
 msgstr ""
 
 #: users/templates/users/data.html:499
-msgid ""
-"Your articles are exchanged as WordPress posts in the WXR format, which "
-"WordPress and most blogging tools can read and write. Marks, reviews and "
-"notes are not included: use the NeoDB archive above for those."
+msgid "Your articles are exchanged as WordPress posts in the WXR format, which WordPress and most blogging tools can read and write. Marks, reviews and notes are not included: use the NeoDB archive above for those."
 msgstr ""
 
 #: users/templates/users/data.html:502
-msgid ""
-"Article title, body, excerpt, tags, dates and featured image are exchanged. "
-"Comments and custom fields are ignored."
+msgid "Article title, body, excerpt, tags, dates and featured image are exchanged. Comments and custom fields are ignored."
 msgstr ""
 
 #: users/templates/users/data.html:505
-msgid ""
-"The body is converted between Markdown and HTML, so formatting is kept but "
-"the text is not character-for-character identical."
+msgid "The body is converted between Markdown and HTML, so formatting is kept but the text is not character-for-character identical."
 msgstr ""
 
 #: users/templates/users/data.html:512
@@ -7982,16 +7887,11 @@ msgid "Export articles in WordPress format"
 msgstr ""
 
 #: users/templates/users/data.html:519
-msgid ""
-"In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download "
-"an <code>.xml</code> file, then upload it below."
+msgid "In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download an <code>.xml</code> file, then upload it below."
 msgstr ""
 
 #: users/templates/users/data.html:522
-msgid ""
-"Only published posts use the visibility below. Drafts, pending, private and "
-"password-protected posts are always imported as mentioned-only, so nothing "
-"unpublished becomes public."
+msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
 #: users/templates/users/data.html:560
@@ -7999,9 +7899,7 @@ msgid "View Annual Summary"
 msgstr ""
 
 #: users/templates/users/fetch_identity_failed.html:4
-msgid ""
-"Unable to find the user, please check your spelling; or the server may be "
-"busy, please try again later."
+msgid "Unable to find the user, please check your spelling; or the server may be busy, please try again later."
 msgstr ""
 
 #: users/templates/users/fetch_identity_pending.html:13
@@ -8021,94 +7919,76 @@ msgstr ""
 msgid "logo"
 msgstr ""
 
-#: users/templates/users/login.html:127
-msgid ""
-"Sign in with a passkey saved on this device or in your password manager."
+#: users/templates/users/login.html:121
+msgid "Sign in with a passkey saved on this device or in your password manager."
 msgstr ""
 
-#: users/templates/users/login.html:132
+#: users/templates/users/login.html:126
 msgid "Sign in with Passkey"
 msgstr ""
 
-#: users/templates/users/login.html:148
+#: users/templates/users/login.html:142
 msgid "Enter your email address"
 msgstr ""
 
-#: users/templates/users/login.html:152
+#: users/templates/users/login.html:146
 msgid "Send verification code"
 msgstr ""
 
-#: users/templates/users/login.html:171
+#: users/templates/users/login.html:165
 msgid "Domain of your instance, e.g. mastodon.social"
 msgstr ""
 
-#: users/templates/users/login.html:177
-msgid ""
-"Please enter domain of your instance; e.g. if your id is "
-"<i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
+#: users/templates/users/login.html:171
+msgid "Please enter domain of your instance; e.g. if your id is <i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
 msgstr ""
 
-#: users/templates/users/login.html:182 users/templates/users/login.html:246
+#: users/templates/users/login.html:176 users/templates/users/login.html:240
 msgid "Authorize via Fediverse instance"
 msgstr ""
 
-#: users/templates/users/login.html:187
-msgid ""
-"If you don't have a <a href=\"https://joinmastodon.org/servers\" "
-"target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or "
-"login with Email first, and link it with Fediverse (Mastodon) later in "
-"account settings."
+#: users/templates/users/login.html:181
+msgid "If you don't have a <a href=\"https://joinmastodon.org/servers\" target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or login with Email first, and link it with Fediverse (Mastodon) later in account settings."
 msgstr ""
 
-#: users/templates/users/login.html:200
+#: users/templates/users/login.html:194
 msgid "Authorize via Threads"
 msgstr ""
 
-#: users/templates/users/login.html:221
-msgid ""
-"Please input your ATProto handle (e.g. neodb.bsky.social, without the "
-"leading @), do not use email. If you changed handle recently, just use the "
-"latest one."
+#: users/templates/users/login.html:215
+msgid "Please input your ATProto handle (e.g. neodb.bsky.social, without the leading @), do not use email. If you changed handle recently, just use the latest one."
 msgstr ""
 
-#: users/templates/users/login.html:224
+#: users/templates/users/login.html:218
 msgid "Authorize via ATProto server"
 msgstr ""
 
-#: users/templates/users/login.html:231
+#: users/templates/users/login.html:225
 #, python-format
-msgid ""
-"Please choose one to register or login %(site_name)s. Have more than one of "
-"these identities? Don't worry, you may link them in account settings once "
-"logged in."
+msgid "Please choose one to register or login %(site_name)s. Have more than one of these identities? Don't worry, you may link them in account settings once logged in."
 msgstr ""
 
-#: users/templates/users/login.html:255
+#: users/templates/users/login.html:249
 msgid "Valid invitation code, please login or register."
 msgstr ""
 
-#: users/templates/users/login.html:257
-msgid ""
-"Please use invitation link to register a new account; existing user may "
-"login."
+#: users/templates/users/login.html:251
+msgid "Please use invitation link to register a new account; existing user may login."
 msgstr ""
 
-#: users/templates/users/login.html:259
+#: users/templates/users/login.html:253
 msgid "Invitation code invalid or expired."
 msgstr ""
 
-#: users/templates/users/login.html:267
+#: users/templates/users/login.html:261
 msgid "Loading timed out, please check your network (VPN) settings."
 msgstr ""
 
-#: users/templates/users/login.html:273
-msgid ""
-"Continue using this site implies consent to our <a href=\"/pages/rules/"
-"\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using "
-"cookies to provide necessary functionality."
+#: users/templates/users/login.html:267
+msgid "Continue using this site implies consent to our <a href=\"/pages/rules/\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using cookies to provide necessary functionality."
 msgstr ""
 
-#: users/templates/users/login.html:287
+#: users/templates/users/login.html:281
 msgid "Domain of your instance (excl. @)"
 msgstr ""
 
@@ -8118,9 +7998,7 @@ msgid "Migrate Here"
 msgstr ""
 
 #: users/templates/users/migrate_in.html:22
-msgid ""
-"To move another account to this one, first add it as an alias here, and then "
-"go to the server where it is hosted and initiate the move."
+msgid "To move another account to this one, first add it as an alias here, and then go to the server where it is hosted and initiate the move."
 msgstr ""
 
 #: users/templates/users/migrate_in.html:27
@@ -8162,16 +8040,11 @@ msgstr ""
 
 #: users/templates/users/migrate_out.html:46
 #, python-format
-msgid ""
-"To migrate to another account, first add <code>@%(handle)s</code> as an "
-"alias on the target server, and then type the target account below to start "
-"the migration."
+msgid "To migrate to another account, first add <code>@%(handle)s</code> as an alias on the target server, and then type the target account below to start the migration."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:50
-msgid ""
-"Are you sure you want to migrate your account? Your followers will be moved "
-"to the target account."
+msgid "Are you sure you want to migrate your account? Your followers will be moved to the target account."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:53
@@ -8185,11 +8058,6 @@ msgstr ""
 #: users/templates/users/preferences.html:28
 msgid "Default view once logged in"
 msgstr ""
-
-#: users/templates/users/preferences.html:40
-#, fuzzy
-msgid "Activities"
-msgstr "世事"
 
 #: users/templates/users/preferences.html:49
 msgid "Default visibility"
@@ -8218,9 +8086,7 @@ msgstr ""
 
 #: users/templates/users/preferences.html:111
 #: users/templates/users/register.html:88
-msgid ""
-"If a Mastodon account is linked with this identity, boosting a post will "
-"also make the same post boosted with that Mastodon account."
+msgid "If a Mastodon account is linked with this identity, boosting a post will also make the same post boosted with that Mastodon account."
 msgstr ""
 
 #: users/templates/users/preferences.html:115
@@ -8236,16 +8102,12 @@ msgid "Create a new post"
 msgstr ""
 
 #: users/templates/users/preferences.html:130
-msgid ""
-"this method is less optimal, may generate duplicated posts and miss "
-"reactions."
+msgid "this method is less optimal, may generate duplicated posts and miss reactions."
 msgstr ""
 
 #: users/templates/users/preferences.html:140
 #: users/templates/users/register.html:97
-msgid ""
-"Always publish my public marks, reviews and articles as data records to my "
-"PDS."
+msgid "Always publish my public marks, reviews and articles as data records to my PDS."
 msgstr ""
 
 #: users/templates/users/preferences.html:145
@@ -8265,12 +8127,7 @@ msgid "Automatic bookmark for these categories"
 msgstr ""
 
 #: users/templates/users/preferences.html:175
-msgid ""
-"When start to read/watch/play/... an item in these categories, a bookmark "
-"will be created automatically. Bookmarks can be viewed and managed in most "
-"<a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon "
-"compatible apps</a>; your replies to these posts will automatically become "
-"notes for the item."
+msgid "When start to read/watch/play/... an item in these categories, a bookmark will be created automatically. Bookmarks can be viewed and managed in most <a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon compatible apps</a>; your replies to these posts will automatically become notes for the item."
 msgstr ""
 
 #: users/templates/users/preferences.html:183
@@ -8290,9 +8147,7 @@ msgid "Profile visible to anonymous web visitors and search engines"
 msgstr ""
 
 #: users/templates/users/preferences.html:217
-msgid ""
-"this option limits web visits only; to limit fediverse visibility, choose "
-"followers only or mentioned only when posting"
+msgid "this option limits web visits only; to limit fediverse visibility, choose followers only or mentioned only when posting"
 msgstr ""
 
 #: users/templates/users/preferences.html:225
@@ -8304,17 +8159,7 @@ msgid "Do not show me item recommendations"
 msgstr ""
 
 #: users/templates/users/preferences.html:237
-msgid ""
-"Recommendations are generated only from public marks, processed in batch on "
-"this server. Your private and follower-only marks are never used as a signal "
-"for anyone, and we never share your data with third parties for this "
-"feature. When you share marks publicly and keep your profile discoverable, "
-"your marks help others here and across the Fediverse find things they might "
-"enjoy -- that voluntary contribution is what makes the feature work for "
-"everyone. If you'd rather not contribute, uncheck \"Include profile, marks "
-"and posts in discovery\" on your account page; this setting is published "
-"over ActivityPub, so other servers will also stop including you in their "
-"discovery features."
+msgid "Recommendations are generated only from public marks, processed in batch on this server. Your private and follower-only marks are never used as a signal for anyone, and we never share your data with third parties for this feature. When you share marks publicly and keep your profile discoverable, your marks help others here and across the Fediverse find things they might enjoy -- that voluntary contribution is what makes the feature work for everyone. If you'd rather not contribute, uncheck \"Include profile, marks and posts in discovery\" on your account page; this setting is published over ActivityPub, so other servers will also stop including you in their discovery features."
 msgstr ""
 
 #: users/templates/users/profile_actions.html:12
@@ -8415,19 +8260,11 @@ msgid "2-30 alphabets, numbers or underscore, can't be changed once saved"
 msgstr ""
 
 #: users/templates/users/register.html:72
-msgid ""
-"Use display name, bio and avatar from the social network you authenticated "
-"with"
+msgid "Use display name, bio and avatar from the social network you authenticated with"
 msgstr ""
 
 #: users/templates/users/register.html:80
-msgid ""
-"Add follow, mute and block list from the social network you authenticated "
-"with"
-msgstr ""
-
-#: users/templates/users/register.html:104
-msgid "Confirm and save"
+msgid "Add follow, mute and block list from the social network you authenticated with"
 msgstr ""
 
 #: users/templates/users/register.html:106
@@ -8456,8 +8293,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"              Matched %(local)s locally, %(external)s externally, "
-"%(unmatched)s unmatched out of %(total)s rows.\n"
+"              Matched %(local)s locally, %(external)s externally, %(unmatched)s unmatched out of %(total)s rows.\n"
 "            "
 msgstr ""
 
@@ -8574,9 +8410,7 @@ msgid "Played"
 msgstr ""
 
 #: users/templates/users/steam_import.html:90
-msgid ""
-"Games in wishlist; or purchased in library but never played, mark date will "
-"be set as today"
+msgid "Games in wishlist; or purchased in library but never played, mark date will be set as today"
 msgstr ""
 
 #: users/templates/users/steam_import.html:91
@@ -8616,15 +8450,11 @@ msgid "Comma-separated Steam AppIDs"
 msgstr ""
 
 #: users/templates/users/steam_import.html:121
-msgid ""
-"Allow reverse override of status (e.g. playing -> want to, or played -> "
-"playing)"
+msgid "Allow reverse override of status (e.g. playing -> want to, or played -> playing)"
 msgstr ""
 
 #: users/templates/users/steam_import.html:139
-msgid ""
-"To import from Steam, your game details must be visible to public in Steam "
-"privacy settings."
+msgid "To import from Steam, your game details must be visible to public in Steam privacy settings."
 msgstr ""
 
 #: users/templates/users/storygraph_import.html:9
@@ -8669,23 +8499,16 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"              %(site_name)s is flourishing because of collaborations and "
-"contributions from users like you. Please read our <a href=\"/pages/"
-"rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</"
-"a> if you have any question or feedback.\n"
+"              %(site_name)s is flourishing because of collaborations and contributions from users like you. Please read our <a href=\"/pages/rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</a> if you have any question or feedback.\n"
 "        "
 msgstr ""
 
 #: users/templates/users/welcome.html:37
-msgid ""
-"Set up a passkey to sign in quickly next time using your fingerprint, face, "
-"or screen lock."
+msgid "Set up a passkey to sign in quickly next time using your fingerprint, face, or screen lock."
 msgstr ""
 
 #: users/templates/users/welcome.html:39
-msgid ""
-"Creating a passkey is highly recommended, as the website or email you use to "
-"create this account may not be always available."
+msgid "Creating a passkey is highly recommended, as the website or email you use to create this account may not be always available."
 msgstr ""
 
 #: users/templates/users/welcome.html:43
@@ -8700,220 +8523,219 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:124
+#: users/views/account.py:126
 msgid "This username is already in use."
 msgstr ""
 
-#: users/views/account.py:135
+#: users/views/account.py:137
 msgid "This email address is already in use."
 msgstr ""
 
-#: users/views/account.py:255 users/views/account.py:374
+#: users/views/account.py:257 users/views/account.py:376
 msgid "Registration is for invitation only"
 msgstr ""
 
-#: users/views/account.py:266 users/views/account.py:338
+#: users/views/account.py:268 users/views/account.py:340
 msgid "Time is up"
 msgstr ""
 
-#: users/views/account.py:267 users/views/account.py:310
-#: users/views/account.py:339
+#: users/views/account.py:269 users/views/account.py:312
+#: users/views/account.py:341
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:313
+#: users/views/account.py:315
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:325
+#: users/views/account.py:327
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:326
+#: users/views/account.py:328
 msgid "Please try again later."
 msgstr ""
 
-#: users/views/account.py:415
+#: users/views/account.py:417
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:445
+#: users/views/account.py:447
 msgid "Valid username required"
 msgstr ""
 
-#: users/views/account.py:526
+#: users/views/account.py:518
 msgid "Account is being deleted."
 msgstr ""
 
-#: users/views/account.py:529
+#: users/views/account.py:521
 msgid "Account mismatch."
 msgstr ""
 
-#: users/views/data.py:262 users/views/data.py:294
+#: users/views/data.py:264 users/views/data.py:296
 msgid "Export file not available."
 msgstr ""
 
-#: users/views/data.py:288
+#: users/views/data.py:290
 msgid "Generating exports."
 msgstr ""
 
-#: users/views/data.py:306
+#: users/views/data.py:308
 msgid "Export file expired. Please export again."
 msgstr ""
 
-#: users/views/data.py:321 users/views/data.py:342 users/views/data.py:363
+#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
 msgid "Recent export still in progress."
 msgstr ""
 
-#: users/views/data.py:379 users/views/data.py:513 users/views/data.py:547
-#: users/views/data.py:772 users/views/data.py:989 users/views/data.py:1015
-#: users/views/data.py:1040 users/views/data.py:1065
+#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
+#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
+#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
 msgid "Invalid file."
 msgstr ""
 
-#: users/views/data.py:403
+#: users/views/data.py:405
 msgid "Sync in progress."
 msgstr ""
 
-#: users/views/data.py:417
+#: users/views/data.py:419
 msgid "Settings saved."
 msgstr ""
 
-#: users/views/data.py:472
+#: users/views/data.py:474
 msgid "Account no longer linked."
 msgstr ""
 
-#: users/views/data.py:475
+#: users/views/data.py:477
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:503
+#: users/views/data.py:505
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:583 users/views/data.py:808
+#: users/views/data.py:585 users/views/data.py:810
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:608 users/views/data.py:837
+#: users/views/data.py:610 users/views/data.py:839
 msgid "Cancelled."
 msgstr ""
 
-#: users/views/data.py:628
+#: users/views/data.py:630
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:636 users/views/data.py:746 users/views/data.py:867
-#: users/views/data.py:972
+#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
+#: users/views/data.py:974
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:732 users/views/data.py:958
+#: users/views/data.py:734 users/views/data.py:960
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:742 users/views/data.py:968
+#: users/views/data.py:744 users/views/data.py:970
 msgid "No matched file available."
 msgstr ""
 
-#: users/views/data.py:859
+#: users/views/data.py:861
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1188
+#: users/views/data.py:1226
 msgid "Name is required."
 msgstr ""
 
-#: users/views/data.py:1210
+#: users/views/data.py:1248
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1264
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1231
+#: users/views/data.py:1269
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1241 users/views/data.py:1292
+#: users/views/data.py:1279 users/views/data.py:1330
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:1248
+#: users/views/data.py:1286
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:1253
+#: users/views/data.py:1291
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:1279
+#: users/views/data.py:1317
 msgid "Migration cancelled."
 msgstr ""
 
-#: users/views/data.py:1284
+#: users/views/data.py:1322
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:1297
+#: users/views/data.py:1335
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:1308
+#: users/views/data.py:1346
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:1314
+#: users/views/data.py:1352
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr ""
 
-#: users/views/data.py:1372
+#: users/views/data.py:1410
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1388
+#: users/views/data.py:1426
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1392
+#: users/views/data.py:1430
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1402
+#: users/views/data.py:1440
 #, python-brace-format
-msgid ""
-"Import of {count} entries received. They will be processed in the background."
+msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""
 
-#: users/views/webauthn.py:103
+#: users/views/webauthn.py:106
 msgid "Passkey registration failed"
 msgstr ""
 
-#: users/views/webauthn.py:123
+#: users/views/webauthn.py:126
 msgid "Credential already registered"
 msgstr ""
 
-#: users/views/webauthn.py:165 users/views/webauthn.py:172
-#: users/views/webauthn.py:181
+#: users/views/webauthn.py:168 users/views/webauthn.py:175
+#: users/views/webauthn.py:184
 msgid "Passkey not recognized"
 msgstr ""
 
-#: users/views/webauthn.py:186
+#: users/views/webauthn.py:189
 msgid "Account is inactive"
 msgstr ""
 
-#: users/views/webauthn.py:202
+#: users/views/webauthn.py:205
 msgid "Passkey verification failed"
 msgstr ""
 
-#: users/views/webauthn.py:228 users/views/webauthn.py:250
+#: users/views/webauthn.py:231 users/views/webauthn.py:253
 msgid "Passkey not found"
 msgstr ""
 
-#: users/views/webauthn.py:244
+#: users/views/webauthn.py:247
 msgid "Name is required"
 msgstr ""

--- a/neodb/locale/pt/LC_MESSAGES/django.po
+++ b/neodb/locale/pt/LC_MESSAGES/django.po
@@ -7,11 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-23 15:40-0400\n"
+"POT-Creation-Date: 2026-09-06 20:04-0400\n"
 "PO-Revision-Date: 2026-08-09 06:32+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Portuguese <https://hosted.weblate.org/projects/neodb/neodb/"
-"pt/>\n"
+"Language-Team: Portuguese <https://hosted.weblate.org/projects/neodb/neodb/pt/>\n"
 "Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,161 +18,161 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: boofilsic/settings.py:472 common/models/lang.py:230
+#: boofilsic/settings.py:501 common/models/lang.py:232
 msgid "English"
 msgstr "Inglês"
 
-#: boofilsic/settings.py:473 common/models/lang.py:77
+#: boofilsic/settings.py:502 common/models/lang.py:79
 msgid "Danish"
 msgstr "Dinamarquês"
 
-#: boofilsic/settings.py:474 common/models/lang.py:78
+#: boofilsic/settings.py:503 common/models/lang.py:80
 msgid "German"
 msgstr "Alemão"
 
-#: boofilsic/settings.py:475 common/models/lang.py:183
+#: boofilsic/settings.py:504 common/models/lang.py:185
 msgid "Spanish"
 msgstr "Espanhol"
 
-#: boofilsic/settings.py:476 common/models/lang.py:87
+#: boofilsic/settings.py:505 common/models/lang.py:89
 msgid "French"
 msgstr "Francês"
 
-#: boofilsic/settings.py:477 common/models/lang.py:112
+#: boofilsic/settings.py:506 common/models/lang.py:114
 msgid "Italian"
 msgstr "Italiano"
 
-#: boofilsic/settings.py:478 common/models/lang.py:166
-#: common/models/lang.py:305
+#: boofilsic/settings.py:507 common/models/lang.py:168
+#: common/models/lang.py:307
 msgid "Portuguese"
 msgstr "Português"
 
-#: boofilsic/settings.py:479
+#: boofilsic/settings.py:508
 #, fuzzy
 #| msgid "Portuguese"
 msgid "Brazilian Portuguese"
 msgstr "Português"
 
-#: boofilsic/settings.py:480 common/models/lang.py:316
+#: boofilsic/settings.py:509 common/models/lang.py:318
 msgid "Simplified Chinese"
 msgstr "Chinês Simplificado"
 
-#: boofilsic/settings.py:481 common/models/lang.py:317
+#: boofilsic/settings.py:510 common/models/lang.py:319
 msgid "Traditional Chinese"
 msgstr "Chinês tradicional"
 
-#: catalog/forms.py:35 catalog/models/item.py:291
+#: catalog/forms.py:35 catalog/models/item.py:307
 msgid "Primary ID Type"
 msgstr "Tipo de Identificação primário"
 
-#: catalog/forms.py:40 catalog/models/item.py:294
+#: catalog/forms.py:40 catalog/models/item.py:310
 msgid "Primary ID Value"
 msgstr "Valor de Identificação primário"
 
-#: catalog/forms.py:181
+#: catalog/forms.py:176
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
-#: catalog/models/book.py:139 catalog/models/book.py:158
-#: catalog/models/common.py:280 catalog/models/common.py:298
+#: catalog/models/book.py:141 catalog/models/book.py:160
+#: catalog/models/common.py:279 catalog/models/common.py:297
 msgid "locale"
 msgstr "localização"
 
-#: catalog/models/book.py:142 catalog/models/book.py:161
-#: catalog/models/common.py:283 catalog/models/common.py:303
+#: catalog/models/book.py:144 catalog/models/book.py:163
+#: catalog/models/common.py:282 catalog/models/common.py:302
 msgid "text content"
 msgstr "conteúdo de texto"
 
-#: catalog/models/book.py:177
+#: catalog/models/book.py:179
 msgid "Paperback"
 msgstr "Livro de bolso (Capa mole)"
 
-#: catalog/models/book.py:178
+#: catalog/models/book.py:180
 msgid "Hardcover"
 msgstr "Capa dura"
 
-#: catalog/models/book.py:179
+#: catalog/models/book.py:181
 msgid "eBook"
 msgstr "e-book"
 
-#: catalog/models/book.py:180
+#: catalog/models/book.py:182
 msgid "Audiobook"
 msgstr "Audiolivro"
 
-#: catalog/models/book.py:182
+#: catalog/models/book.py:184
 msgid "Web Fiction"
 msgstr "Ficção Web"
 
-#: catalog/models/book.py:183 catalog/models/game.py:38
+#: catalog/models/book.py:185 catalog/models/game.py:38
 msgid "Other"
 msgstr "Outro"
 
-#: catalog/models/book.py:260
+#: catalog/models/book.py:262
 msgid "subtitle"
 msgstr "subtítulo"
 
-#: catalog/models/book.py:270 catalog/models/movie.py:120
-#: catalog/models/performance.py:385 catalog/models/tv.py:211
-#: catalog/models/tv.py:437
+#: catalog/models/book.py:272 catalog/models/movie.py:120
+#: catalog/models/performance.py:385 catalog/models/tv.py:213
+#: catalog/models/tv.py:439
 msgid "original title"
 msgstr "título original"
 
-#: catalog/models/book.py:274
+#: catalog/models/book.py:276
 msgid "other title"
 msgstr "outro título"
 
-#: catalog/models/book.py:280 catalog/models/book.py:564
-#: catalog/models/item.py:123
+#: catalog/models/book.py:282 catalog/models/book.py:566
+#: catalog/models/item.py:119
 msgid "author"
 msgstr "autor"
 
-#: catalog/models/book.py:287 catalog/models/item.py:124
+#: catalog/models/book.py:289 catalog/models/item.py:120
 msgid "translator"
 msgstr "tradutor"
 
-#: catalog/models/book.py:294 catalog/templates/edition.html:26
+#: catalog/models/book.py:296 catalog/templates/edition.html:26
 msgid "book format"
 msgstr "formato do livro"
 
-#: catalog/models/book.py:301 catalog/models/game.py:135
-#: catalog/models/item.py:138 catalog/models/music.py:142
+#: catalog/models/book.py:303 catalog/models/game.py:135
+#: catalog/models/item.py:134 catalog/models/music.py:142
 msgid "publisher"
 msgstr "publicadora"
 
-#: catalog/models/book.py:308
+#: catalog/models/book.py:310
 msgid "publication year"
 msgstr "ano de publicação"
 
-#: catalog/models/book.py:314
+#: catalog/models/book.py:316
 msgid "publication month"
 msgstr "mês de publicação"
 
-#: catalog/models/book.py:319
+#: catalog/models/book.py:321
 msgid "binding"
 msgstr "encadernação"
 
-#: catalog/models/book.py:320
+#: catalog/models/book.py:322
 msgid "pages"
 msgstr "páginas"
 
-#: catalog/models/book.py:321 catalog/templates/edition.html:45
+#: catalog/models/book.py:323 catalog/templates/edition.html:45
 msgid "series"
 msgstr "séries"
 
-#: catalog/models/book.py:322 catalog/templates/edition.html:65
+#: catalog/models/book.py:324 catalog/templates/edition.html:65
 msgid "contents"
 msgstr "conteúdos"
 
-#: catalog/models/book.py:323 catalog/templates/edition.html:51
+#: catalog/models/book.py:325 catalog/templates/edition.html:51
 msgid "price"
 msgstr "preço"
 
-#: catalog/models/book.py:324 catalog/models/item.py:149
+#: catalog/models/book.py:326 catalog/models/item.py:145
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr "selo editorial"
 
-#: catalog/models/common.py:26 common/models/lang.py:256
+#: catalog/models/common.py:26 common/models/lang.py:258
 msgid "Unknown"
 msgstr "Desconhecido"
 
@@ -181,11 +180,11 @@ msgstr "Desconhecido"
 msgid "Douban"
 msgstr "Douban"
 
-#: catalog/models/common.py:28 catalog/models/common.py:79
+#: catalog/models/common.py:28 catalog/models/common.py:81
 msgid "Goodreads"
 msgstr "Goodreads"
 
-#: catalog/models/common.py:29 catalog/models/common.py:81
+#: catalog/models/common.py:29 catalog/models/common.py:83
 msgid "Google Books"
 msgstr "Google Livros"
 
@@ -193,16 +192,16 @@ msgstr "Google Livros"
 msgid "BooksTW"
 msgstr "BooksTW"
 
-#: catalog/models/common.py:31 catalog/models/common.py:91
-#: catalog/models/common.py:93
+#: catalog/models/common.py:31 catalog/models/common.py:93
+#: catalog/models/common.py:95
 msgid "Bibliotek.dk"
 msgstr ""
 
-#: catalog/models/common.py:32 catalog/models/common.py:92
+#: catalog/models/common.py:32 catalog/models/common.py:94
 msgid "eReolen.dk"
 msgstr ""
 
-#: catalog/models/common.py:33 catalog/models/common.py:74
+#: catalog/models/common.py:33 catalog/models/common.py:76
 #: catalog/templates/movie.html:41 catalog/templates/people.html:37
 #: catalog/templates/tvseason.html:58 catalog/templates/tvshow.html:53
 msgid "IMDb"
@@ -212,7 +211,7 @@ msgstr "IMDb"
 msgid "TMDB"
 msgstr "TMDB"
 
-#: catalog/models/common.py:35 catalog/models/common.py:94
+#: catalog/models/common.py:35 catalog/models/common.py:96
 msgid "Bandcamp"
 msgstr "Bandcamp"
 
@@ -228,11 +227,11 @@ msgstr "IGDB"
 msgid "Steam"
 msgstr "Steam"
 
-#: catalog/models/common.py:39 catalog/models/common.py:114
+#: catalog/models/common.py:39 catalog/models/common.py:116
 msgid "itch.io"
 msgstr ""
 
-#: catalog/models/common.py:40 catalog/models/common.py:115
+#: catalog/models/common.py:40 catalog/models/common.py:117
 msgid "Bangumi"
 msgstr "Bangumi"
 
@@ -240,7 +239,7 @@ msgstr "Bangumi"
 msgid "BGG"
 msgstr "BGG"
 
-#: catalog/models/common.py:42 catalog/models/common.py:116
+#: catalog/models/common.py:42 catalog/models/common.py:118
 msgid "Apple Podcast"
 msgstr "Podcast Apple"
 
@@ -252,35 +251,35 @@ msgstr "RSS"
 msgid "Discogs"
 msgstr "Discogs"
 
-#: catalog/models/common.py:45 catalog/models/common.py:117
+#: catalog/models/common.py:45 catalog/models/common.py:119
 msgid "Apple Music"
 msgstr "Apple Music"
 
-#: catalog/models/common.py:46 catalog/models/common.py:119
+#: catalog/models/common.py:46 catalog/models/common.py:121
 msgid "Fediverse"
 msgstr "Fediverso"
 
-#: catalog/models/common.py:47 catalog/models/common.py:120
+#: catalog/models/common.py:47 catalog/models/common.py:122
 msgid "Qidian"
 msgstr "Qidian"
 
-#: catalog/models/common.py:48 catalog/models/common.py:121
+#: catalog/models/common.py:48 catalog/models/common.py:123
 msgid "Ypshuo"
 msgstr "Ypshuo"
 
-#: catalog/models/common.py:49 catalog/models/common.py:122
+#: catalog/models/common.py:49 catalog/models/common.py:124
 msgid "Archive of Our Own"
 msgstr "Archive of Our Own"
 
-#: catalog/models/common.py:50 catalog/models/common.py:123
+#: catalog/models/common.py:50 catalog/models/common.py:125
 msgid "JinJiang"
 msgstr "JinJiang"
 
-#: catalog/models/common.py:51 catalog/models/common.py:64
+#: catalog/models/common.py:51 catalog/models/common.py:66
 msgid "WikiData"
 msgstr "WikiData"
 
-#: catalog/models/common.py:52 catalog/models/common.py:124
+#: catalog/models/common.py:52 catalog/models/common.py:126
 msgid "Open Library"
 msgstr ""
 
@@ -294,17 +293,17 @@ msgstr "ID (identidade) MusicBrainz"
 msgid "WorldCat"
 msgstr ""
 
-#: catalog/models/common.py:55 catalog/models/common.py:126
+#: catalog/models/common.py:55 catalog/models/common.py:128
 #, fuzzy
 #| msgid "Game"
 msgid "MobyGames"
 msgstr "Jogo"
 
-#: catalog/models/common.py:56 catalog/models/common.py:127
+#: catalog/models/common.py:56 catalog/models/common.py:129
 msgid "StoryGraph"
 msgstr ""
 
-#: catalog/models/common.py:57 catalog/models/common.py:118
+#: catalog/models/common.py:57 catalog/models/common.py:120
 #, fuzzy
 #| msgid "Douban Music"
 msgid "YouTube Music"
@@ -322,363 +321,374 @@ msgstr ""
 msgid "Readmoo"
 msgstr ""
 
-#: catalog/models/common.py:65
+#: catalog/models/common.py:61
+msgid "MyAnimeList"
+msgstr ""
+
+#: catalog/models/common.py:62 catalog/models/common.py:140
+#, fuzzy
+#| msgid "Update"
+msgid "MangaUpdates"
+msgstr "Atualizar"
+
+#: catalog/models/common.py:67
 msgid "ISBN10"
 msgstr "ISBN10"
 
-#: catalog/models/common.py:66 catalog/templates/edition.html:19
+#: catalog/models/common.py:68 catalog/templates/edition.html:19
 msgid "ISBN"
 msgstr "ISBN"
 
-#: catalog/models/common.py:67
+#: catalog/models/common.py:69
 msgid "ASIN"
 msgstr "ASIN"
 
-#: catalog/models/common.py:68
+#: catalog/models/common.py:70
 msgid "ISSN"
 msgstr "ISSN"
 
-#: catalog/models/common.py:69
+#: catalog/models/common.py:71
 msgid "CUBN"
 msgstr "CUBN"
 
-#: catalog/models/common.py:70
+#: catalog/models/common.py:72
 msgid "ISRC"
 msgstr "ISRC"
 
-#: catalog/models/common.py:71
+#: catalog/models/common.py:73
 msgid "GTIN UPC EAN"
 msgstr "GTIN UPC EAN"
 
-#: catalog/models/common.py:72
+#: catalog/models/common.py:74
 msgid "OCLC Number"
 msgstr ""
 
-#: catalog/models/common.py:73
+#: catalog/models/common.py:75
 msgid "RSS Feed URL"
 msgstr "URL do RSS Feed"
 
-#: catalog/models/common.py:75
+#: catalog/models/common.py:77
 #, fuzzy
 #| msgid "TMDB TV Season"
 msgid "TMDB TV Series"
 msgstr "Temporada TMDB"
 
-#: catalog/models/common.py:76
+#: catalog/models/common.py:78
 msgid "TMDB TV Season"
 msgstr "Temporada TMDB"
 
-#: catalog/models/common.py:77
+#: catalog/models/common.py:79
 msgid "TMDB TV Episode"
 msgstr "Episódio TMDB"
 
-#: catalog/models/common.py:78
+#: catalog/models/common.py:80
 msgid "TMDB Movie"
 msgstr "Filme TMDB"
 
-#: catalog/models/common.py:80
+#: catalog/models/common.py:82
 msgid "Goodreads Work"
 msgstr "Obra Goodreads"
 
-#: catalog/models/common.py:82
+#: catalog/models/common.py:84
 msgid "Douban Book"
 msgstr "Livro Douban"
 
-#: catalog/models/common.py:83
+#: catalog/models/common.py:85
 msgid "Douban Book Work"
 msgstr "Obra Douban"
 
-#: catalog/models/common.py:84
+#: catalog/models/common.py:86
 msgid "Douban Movie"
 msgstr "Filme Douban"
 
-#: catalog/models/common.py:85
+#: catalog/models/common.py:87
 msgid "Douban Music"
 msgstr "Música Douban"
 
-#: catalog/models/common.py:86
+#: catalog/models/common.py:88
 msgid "Douban Game"
 msgstr "Jogo Douban"
 
-#: catalog/models/common.py:87
+#: catalog/models/common.py:89
 msgid "Douban Drama"
 msgstr "Drama Douban"
 
-#: catalog/models/common.py:88
+#: catalog/models/common.py:90
 msgid "Douban Drama Version"
 msgstr "Versão Drama Douban"
 
-#: catalog/models/common.py:89
+#: catalog/models/common.py:91
 msgid "BooksTW Book"
 msgstr "Livro BooksTW"
 
-#: catalog/models/common.py:90
+#: catalog/models/common.py:92
 msgid "Readmoo Book"
 msgstr ""
 
-#: catalog/models/common.py:95
+#: catalog/models/common.py:97
 msgid "Spotify Album"
 msgstr "Álbum Spotify"
 
-#: catalog/models/common.py:96
+#: catalog/models/common.py:98
 msgid "Spotify Podcast"
 msgstr "Podcast Spotify"
 
-#: catalog/models/common.py:97
+#: catalog/models/common.py:99
 msgid "Discogs Release"
 msgstr "Edição Discogs"
 
-#: catalog/models/common.py:98
+#: catalog/models/common.py:100
 msgid "Discogs Master"
 msgstr "Edição Mestre Discogs"
 
-#: catalog/models/common.py:101
+#: catalog/models/common.py:103
 #, fuzzy
 #| msgid "MusicBrainz ID"
 msgid "MusicBrainz Release Group"
 msgstr "ID (identidade) MusicBrainz"
 
-#: catalog/models/common.py:103
+#: catalog/models/common.py:105
 #, fuzzy
 #| msgid "MusicBrainz ID"
 msgid "MusicBrainz Release"
 msgstr "ID (identidade) MusicBrainz"
 
-#: catalog/models/common.py:104
+#: catalog/models/common.py:106
 #, fuzzy
 #| msgid "MusicBrainz ID"
 msgid "MusicBrainz Artist"
 msgstr "ID (identidade) MusicBrainz"
 
-#: catalog/models/common.py:105
+#: catalog/models/common.py:107
 #, fuzzy
 #| msgid "Douban Game"
 msgid "Douban Personage"
 msgstr "Jogo Douban"
 
-#: catalog/models/common.py:106
+#: catalog/models/common.py:108
 #, fuzzy
 #| msgid "Goodreads Work"
 msgid "Goodreads Author"
 msgstr "Obra Goodreads"
 
-#: catalog/models/common.py:107
+#: catalog/models/common.py:109
 #, fuzzy
 #| msgid "Spotify Podcast"
 msgid "Spotify Artist"
 msgstr "Podcast Spotify"
 
-#: catalog/models/common.py:108
+#: catalog/models/common.py:110
 #, fuzzy
 #| msgid "TMDB TV Season"
 msgid "TMDB Person"
 msgstr "Temporada TMDB"
 
-#: catalog/models/common.py:109
+#: catalog/models/common.py:111
 msgid "Open Library Author"
 msgstr ""
 
-#: catalog/models/common.py:110
+#: catalog/models/common.py:112
 msgid "IGDB Company"
 msgstr ""
 
-#: catalog/models/common.py:111
+#: catalog/models/common.py:113
 msgid "IGDB Game"
 msgstr "Jogo IGDB"
 
-#: catalog/models/common.py:112
+#: catalog/models/common.py:114
 msgid "BGG Boardgame"
 msgstr "Jogo de tabuleiro BGG"
 
-#: catalog/models/common.py:113
+#: catalog/models/common.py:115
 msgid "Steam Game"
 msgstr "Jogo Steam"
 
-#: catalog/models/common.py:125
+#: catalog/models/common.py:127
 msgid "Open Library Work"
 msgstr ""
 
-#: catalog/models/common.py:128
+#: catalog/models/common.py:130
 msgid "RateYourMusic Release"
 msgstr ""
 
-#: catalog/models/common.py:132
+#: catalog/models/common.py:134
 msgid "AniList Anime"
 msgstr ""
 
-#: catalog/models/common.py:133
+#: catalog/models/common.py:135
 msgid "AniList Manga"
 msgstr ""
 
-#: catalog/models/common.py:134
+#: catalog/models/common.py:136
 msgid "MyAnimeList Anime"
 msgstr ""
 
-#: catalog/models/common.py:135
+#: catalog/models/common.py:137
 msgid "MyAnimeList Manga"
 msgstr ""
 
-#: catalog/models/common.py:156
+#: catalog/models/common.py:161
 #, fuzzy
 #| msgid "Editions"
 msgid "Edition"
 msgstr "Edições"
 
-#: catalog/models/common.py:157 catalog/templates/_sidebar_edit.html:286
+#: catalog/models/common.py:162 catalog/templates/_sidebar_edit.html:289
 msgid "Work"
 msgstr "Obra"
 
-#: catalog/models/common.py:158
+#: catalog/models/common.py:163
 #, fuzzy
 #| msgid "series"
 msgid "TV Series"
 msgstr "séries"
 
-#: catalog/models/common.py:159 catalog/templates/_sidebar_edit.html:207
+#: catalog/models/common.py:164 catalog/templates/_sidebar_edit.html:202
+#: catalog/views/edit.py:385
 msgid "TV Season"
 msgstr "Temporada"
 
-#: catalog/models/common.py:160
+#: catalog/models/common.py:165
 msgid "TV Episode"
 msgstr "Episódio TV"
 
-#: catalog/models/common.py:161 catalog/models/common.py:177
-#: catalog/models/common.py:191 catalog/templates/_sidebar_edit.html:200
-#: journal/templates/_sidebar_user_mark_list.html:35
+#: catalog/models/common.py:166 catalog/models/common.py:182
+#: catalog/models/common.py:196 catalog/templates/_sidebar_edit.html:196
+#: catalog/views/edit.py:384 journal/templates/_sidebar_user_mark_list.html:35
 #: journal/templates/_sidebar_user_tag_filter.html:27
 msgid "Movie"
 msgstr "Filme"
 
-#: catalog/models/common.py:162
+#: catalog/models/common.py:167
 msgid "Album"
 msgstr "Álbum"
 
-#: catalog/models/common.py:163 catalog/models/common.py:180
-#: catalog/models/common.py:194 common/templates/_header.html:43
+#: catalog/models/common.py:168 catalog/models/common.py:185
+#: catalog/models/common.py:199 common/templates/_header.html:53
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
 msgstr "Jogo"
 
-#: catalog/models/common.py:164
+#: catalog/models/common.py:169
 msgid "Podcast Program"
 msgstr "Programa de Podcast"
 
-#: catalog/models/common.py:165
+#: catalog/models/common.py:170
 msgid "Podcast Episode"
 msgstr "Episódio de Podcast"
 
-#: catalog/models/common.py:166 catalog/models/common.py:182
-#: catalog/models/common.py:196 common/templates/_header.html:47
+#: catalog/models/common.py:171 catalog/models/common.py:187
+#: catalog/models/common.py:201 common/templates/_header.html:57
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
 msgstr "Espetáculo"
 
-#: catalog/models/common.py:167
+#: catalog/models/common.py:172
 msgid "Production"
 msgstr "Produção"
 
-#: catalog/models/common.py:168
+#: catalog/models/common.py:173
 msgid "Exhibition"
 msgstr "Exposição"
 
-#: catalog/models/common.py:169 catalog/models/common.py:186
+#: catalog/models/common.py:174 catalog/models/common.py:191
 #: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr "Coleção"
 
-#: catalog/models/common.py:172 catalog/models/common.py:185
+#: catalog/models/common.py:177 catalog/models/common.py:190
 msgid "Person / Organization"
 msgstr ""
 
-#: catalog/models/common.py:176 catalog/models/common.py:190
-#: common/templates/_header.html:27
+#: catalog/models/common.py:181 catalog/models/common.py:195
+#: common/templates/_header.html:37
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
 msgstr "Livro"
 
-#: catalog/models/common.py:178 catalog/models/common.py:192
+#: catalog/models/common.py:183 catalog/models/common.py:197
 #: journal/templates/_sidebar_user_mark_list.html:38
 #: journal/templates/_sidebar_user_tag_filter.html:30
 msgid "TV"
 msgstr "TV"
 
-#: catalog/models/common.py:179 catalog/models/common.py:193
-#: common/templates/_header.html:39
+#: catalog/models/common.py:184 catalog/models/common.py:198
+#: common/templates/_header.html:49
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr "Música"
 
-#: catalog/models/common.py:181 catalog/models/common.py:195
-#: catalog/templates/_sidebar_edit.html:219 common/templates/_header.html:35
+#: catalog/models/common.py:186 catalog/models/common.py:200
+#: catalog/templates/_sidebar_edit.html:213 common/templates/_header.html:45
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
 msgstr "Podcast"
 
-#: catalog/models/common.py:346 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:345 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr "género"
 
-#: catalog/models/common.py:384
+#: catalog/models/common.py:383
 #, fuzzy
 #| msgid "original creator"
 msgid "origin country"
 msgstr "criador original"
 
-#: catalog/models/common.py:413 catalog/templates/album.html:33
+#: catalog/models/common.py:412 catalog/templates/album.html:33
 msgid "album type"
 msgstr "tipo de álbum"
 
-#: catalog/models/common.py:417 catalog/templates/_platform_list.html:5
+#: catalog/models/common.py:416 catalog/templates/_platform_list.html:5
 msgid "platform"
 msgstr "plataforma"
 
-#: catalog/models/common.py:421
+#: catalog/models/common.py:420
 #, fuzzy
 #| msgid "media type"
 msgid "media format"
 msgstr "tipo de média"
 
-#: catalog/models/common.py:426 catalog/templates/_language_list.html:5
-#: users/models/user.py:142
+#: catalog/models/common.py:425 catalog/templates/_language_list.html:5
+#: users/models/user.py:144
 msgid "language"
 msgstr "idioma"
 
-#: catalog/models/creator.py:24
+#: catalog/models/creator.py:26
 #, fuzzy
 #| msgid "Pending"
 msgid "pending"
 msgstr "Pendente"
 
-#: catalog/models/creator.py:25
+#: catalog/models/creator.py:27
 msgid "verified"
 msgstr ""
 
-#: catalog/models/creator.py:26
+#: catalog/models/creator.py:28
 #, fuzzy
 #| msgid "Failed"
 msgid "failed"
 msgstr "Falhou"
 
-#: catalog/models/creator.py:29
+#: catalog/models/creator.py:31
 msgid "no feed url available for this item"
 msgstr ""
 
-#: catalog/models/creator.py:30
+#: catalog/models/creator.py:32
 msgid "unable to fetch or parse the feed"
 msgstr ""
 
-#: catalog/models/creator.py:31
+#: catalog/models/creator.py:33
 msgid "no audio episode found in the feed"
 msgstr ""
 
-#: catalog/models/creator.py:34
+#: catalog/models/creator.py:36
 msgid "no matching identity found in the feed or its linked website"
 msgstr ""
 
@@ -715,16 +725,16 @@ msgstr "Remake"
 msgid "Special Edition"
 msgstr "Edição especial"
 
-#: catalog/models/game.py:111 catalog/models/item.py:130
+#: catalog/models/game.py:111 catalog/models/item.py:126
 msgid "designer"
 msgstr "Criador"
 
-#: catalog/models/game.py:119 catalog/models/item.py:129
+#: catalog/models/game.py:119 catalog/models/item.py:125
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr "artista"
 
-#: catalog/models/game.py:127 catalog/models/item.py:139
+#: catalog/models/game.py:127 catalog/models/item.py:135
 msgid "developer"
 msgstr "desenvolvedora"
 
@@ -733,8 +743,8 @@ msgid "date of publication"
 msgstr "data de publicação"
 
 #: catalog/models/game.py:147 catalog/models/movie.py:156
-#: catalog/models/music.py:128 catalog/models/tv.py:247
-#: catalog/models/tv.py:473
+#: catalog/models/music.py:128 catalog/models/tv.py:249
+#: catalog/models/tv.py:475
 msgid "YYYY, YYYY-MM or YYYY-MM-DD"
 msgstr ""
 
@@ -745,7 +755,7 @@ msgstr "tipo de edição"
 #: catalog/models/game.py:180 catalog/models/movie.py:158
 #: catalog/models/people.py:178 catalog/models/performance.py:258
 #: catalog/models/performance.py:465 catalog/models/podcast.py:89
-#: catalog/models/tv.py:249 catalog/models/tv.py:476
+#: catalog/models/tv.py:251 catalog/models/tv.py:478
 #: catalog/templates/game.html:33 catalog/templates/movie.html:48
 #: catalog/templates/people.html:44 catalog/templates/performance.html:35
 #: catalog/templates/performanceproduction.html:35
@@ -754,152 +764,152 @@ msgstr "tipo de edição"
 msgid "website"
 msgstr "website"
 
-#: catalog/models/item.py:125 catalog/models/movie.py:123
+#: catalog/models/item.py:121 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
-#: catalog/models/tv.py:214 catalog/models/tv.py:440
+#: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr "diretor"
 
-#: catalog/models/item.py:126 catalog/models/movie.py:130
+#: catalog/models/item.py:122 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
-#: catalog/models/tv.py:221 catalog/models/tv.py:447
+#: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr "guionista"
 
-#: catalog/models/item.py:127 catalog/models/movie.py:137
+#: catalog/models/item.py:123 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
-#: catalog/models/tv.py:228 catalog/models/tv.py:454
+#: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr "ator"
 
-#: catalog/models/item.py:128 catalog/models/movie.py:144
-#: catalog/models/tv.py:235 catalog/models/tv.py:461
+#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/tv.py:237 catalog/models/tv.py:463
 #, fuzzy
 #| msgid "production"
 msgid "producer"
 msgstr "produção"
 
-#: catalog/models/item.py:131 catalog/models/performance.py:203
+#: catalog/models/item.py:127 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr "compositor"
 
-#: catalog/models/item.py:132 catalog/models/performance.py:210
+#: catalog/models/item.py:128 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr "coreógrafo"
 
-#: catalog/models/item.py:133 catalog/models/performance.py:224
+#: catalog/models/item.py:129 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr "performista"
 
-#: catalog/models/item.py:134 catalog/models/podcast.py:80
+#: catalog/models/item.py:130 catalog/models/podcast.py:80
 msgid "host"
 msgstr "apresentador(es)"
 
-#: catalog/models/item.py:135 catalog/models/performance.py:196
+#: catalog/models/item.py:131 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr "criador original"
 
-#: catalog/models/item.py:136 catalog/models/performance.py:238
+#: catalog/models/item.py:132 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr "grupo"
 
-#: catalog/models/item.py:140
+#: catalog/models/item.py:136
 #, fuzzy
 #| msgid "production"
 msgid "production company"
 msgstr "produção"
 
-#: catalog/models/item.py:141
+#: catalog/models/item.py:137
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:142
+#: catalog/models/item.py:138
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:139
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:144 catalog/models/performance.py:231
+#: catalog/models/item.py:140 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr "companhia"
 
-#: catalog/models/item.py:147
+#: catalog/models/item.py:143
 #, fuzzy
 #| msgid "director"
 msgid "voice actor"
 msgstr "diretor"
 
-#: catalog/models/item.py:148 catalog/templates/edition.html:30
+#: catalog/models/item.py:144 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr "editora"
 
-#: catalog/models/item.py:173 catalog/models/people.py:476
+#: catalog/models/item.py:169 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr "papel"
 
-#: catalog/models/item.py:174 catalog/models/people.py:155
+#: catalog/models/item.py:170 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr "nome"
 
-#: catalog/models/item.py:176 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:288 catalog/models/item.py:320
-#: journal/models/collection.py:96
+#: catalog/models/item.py:304 catalog/models/item.py:336
+#: journal/models/collection.py:100
 msgid "title"
 msgstr "título"
 
-#: catalog/models/item.py:289 catalog/models/item.py:328
-#: journal/models/collection.py:97
+#: catalog/models/item.py:305 catalog/models/item.py:344
+#: journal/models/collection.py:101
 msgid "description"
 msgstr "descrição"
 
-#: catalog/models/item.py:300 catalog/models/people.py:484
+#: catalog/models/item.py:316 catalog/models/people.py:484
 msgid "metadata"
 msgstr "metadados"
 
-#: catalog/models/item.py:302 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
 msgid "cover"
 msgstr "capa"
 
-#: catalog/models/item.py:1485
+#: catalog/models/item.py:1526
 msgid "source site"
 msgstr "fonte"
 
-#: catalog/models/item.py:1487
+#: catalog/models/item.py:1528
 msgid "ID on source site"
 msgstr "Identificação na fonte"
 
-#: catalog/models/item.py:1489
+#: catalog/models/item.py:1530
 msgid "source url"
 msgstr "url da fonte"
 
-#: catalog/models/item.py:1505
+#: catalog/models/item.py:1546
 msgid "IdType of the source site"
 msgstr "IdType do site de origem"
 
-#: catalog/models/item.py:1511
+#: catalog/models/item.py:1552
 msgid "Primary Id on the source site"
 msgstr "Identificação primária na fonte"
 
-#: catalog/models/item.py:1514
+#: catalog/models/item.py:1555
 msgid "url to the resource"
 msgstr "url para o recurso"
 
 #: catalog/models/movie.py:152 catalog/models/music.py:124
-#: catalog/models/tv.py:243 catalog/models/tv.py:469
+#: catalog/models/tv.py:245 catalog/models/tv.py:471
 #: catalog/templates/_item_card_metadata_album.html:16
 #: catalog/templates/album.html:17 catalog/templates/game.html:22
 #: catalog/templates/movie.html:36 catalog/templates/tvseason.html:53
@@ -914,7 +924,7 @@ msgid "length"
 msgstr "duração"
 
 #: catalog/models/movie.py:162 catalog/models/music.py:131
-#: catalog/models/tv.py:259 catalog/models/tv.py:486
+#: catalog/models/tv.py:261 catalog/models/tv.py:488
 #, fuzzy
 #| msgid "milliseconds"
 msgid "seconds"
@@ -1122,46 +1132,98 @@ msgstr "data de abertura"
 msgid "closing date"
 msgstr "data de encerramento"
 
-#: catalog/models/tv.py:186 catalog/templates/tvseason.html:38
+#: catalog/models/tv.py:188 catalog/templates/tvseason.html:38
 #: catalog/templates/tvshow.html:33
 msgid "number of seasons"
 msgstr "Número de temporadas"
 
-#: catalog/models/tv.py:189 catalog/models/tv.py:415
+#: catalog/models/tv.py:191 catalog/models/tv.py:417
 #: catalog/templates/tvseason.html:43 catalog/templates/tvshow.html:38
 msgid "number of episodes"
 msgstr "número de episódios"
 
-#: catalog/models/tv.py:256 catalog/models/tv.py:483
+#: catalog/models/tv.py:258 catalog/models/tv.py:485
 msgid "episode length"
 msgstr "duração do episódio"
 
-#: catalog/models/tv.py:412 catalog/templates/tvseason.html:33
+#: catalog/models/tv.py:414 catalog/templates/tvseason.html:33
 msgid "season number"
 msgstr "Número da temporada"
 
-#: catalog/models/tv.py:530
+#: catalog/models/tv.py:532
 #, python-brace-format
 msgid "{show_title} Season {season_number}"
 msgstr "{show_title} Temporada {season_number}"
 
-#: catalog/models/tv.py:684
+#: catalog/models/tv.py:686
 #, python-brace-format
 msgid "{season_title} E{episode_number}"
 msgstr "{season_title} Ep.{episode_number}"
+
+#: catalog/templates/_catalog_confirm_item.html:7
+#: catalog/templates/catalog_edit.html:62
+msgid "Item has been deleted."
+msgstr "O item foi eliminado."
+
+#: catalog/templates/_catalog_confirm_item.html:12
+#: catalog/templates/catalog_edit.html:65
+msgid "Item contains sub-items."
+msgstr "Item contém sub-itens."
+
+#: catalog/templates/_catalog_confirm_item.html:17
+msgid "Item has been merged to another item."
+msgstr "O elemento foi mesclado com outro elemento."
+
+#: catalog/templates/_catalog_confirm_item.html:22
+msgid "Item has been marked by users."
+msgstr "O item foi marcado por utilizadores."
+
+#: catalog/templates/_catalog_edit_preview.html:11
+#, fuzzy
+#| msgid "Confirm and save"
+msgid "Confirm changes"
+msgstr "Confirmar e guardar"
+
+#: catalog/templates/_catalog_edit_preview.html:16
+msgid "Please correct the errors below."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:24
+msgid "Field"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:25
+msgid "From"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:26
+msgid "To"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:45
+#, fuzzy
+#| msgid "Tag deleted."
+msgid "No changes detected."
+msgstr "Etiqueta eliminada."
+
+#: catalog/templates/_catalog_edit_preview.html:54
+#: users/templates/users/register.html:104
+msgid "Confirm and save"
+msgstr "Confirmar e guardar"
+
+#: catalog/templates/_catalog_edit_preview.html:57
+#, fuzzy
+#| msgid "back to item"
+msgid "Back to editing"
+msgstr "voltar para o artigo"
 
 #: catalog/templates/_country_list.html:5
 msgid "region"
 msgstr "região"
 
 #: catalog/templates/_fetch_failed.html:4
-msgid ""
-"Unable to fetch from the link, please check again. Some sites may require "
-"login for certain links, please manually create them here."
-msgstr ""
-"Não foi possível obter informação pelo link, verifique novamente. Alguns "
-"sites podem exigir login para determinados links, por favor crie-os aqui "
-"manualmente."
+msgid "Unable to fetch from the link, please check again. Some sites may require login for certain links, please manually create them here."
+msgstr "Não foi possível obter informação pelo link, verifique novamente. Alguns sites podem exigir login para determinados links, por favor crie-os aqui manualmente."
 
 #: catalog/templates/_item_card_metadata_album.html:7
 #: catalog/templates/_item_card_metadata_edition.html:7
@@ -1218,7 +1280,7 @@ msgstr "mostrar mais"
 #: journal/templates/profile_posts.html:21
 #: journal/templates/user_follow_list_items.html:63
 #: journal/templates/user_post_list_items.html:24
-#: social/templates/events.html:43 social/templates/feed_events.html:28
+#: social/templates/events.html:43 social/templates/feed_events.html:27
 msgid "nothing more."
 msgstr "sem nada."
 
@@ -1317,7 +1379,7 @@ msgid "Add note"
 msgstr "Adicionar filmes"
 
 #: catalog/templates/_item_user_pieces.html:83
-#: common/templates/_sidebar.html:196 journal/templates/profile_items.html:46
+#: common/templates/_sidebar.html:195 journal/templates/profile_items.html:46
 #, fuzzy
 #| msgid "Sync in progress."
 msgid "Set progress"
@@ -1346,6 +1408,12 @@ msgstr "minha coleção"
 #: catalog/templates/_item_user_pieces.html:214
 msgid "mark history"
 msgstr "histórico de marcações"
+
+#: catalog/templates/_search_suggest.html:2
+#, fuzzy
+#| msgid "Suggest Edits"
+msgid "Suggestions"
+msgstr "Sugerir alterações"
 
 #: catalog/templates/_sidebar_edit.html:8
 msgid "edit"
@@ -1376,15 +1444,15 @@ msgid "Edit Options"
 msgstr "Editar Opções"
 
 #: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
-#: catalog/views/edit.py:82 catalog/views/edit.py:143 catalog/views/edit.py:197
-#: catalog/views/edit.py:218 catalog/views/edit.py:259
-#: catalog/views/edit.py:328 catalog/views/edit.py:332
-#: catalog/views/edit.py:351 catalog/views/edit.py:400
-#: catalog/views/edit.py:425 catalog/views/edit.py:440
-#: catalog/views/edit.py:480 catalog/views/edit.py:490
-#: catalog/views/edit.py:517 catalog/views/edit.py:582
-#: catalog/views/edit.py:637 catalog/views/edit.py:659
-#: catalog/views/search.py:367
+#: catalog/views/edit.py:160 catalog/views/edit.py:221
+#: catalog/views/edit.py:288 catalog/views/edit.py:309
+#: catalog/views/edit.py:364 catalog/views/edit.py:471
+#: catalog/views/edit.py:475 catalog/views/edit.py:509
+#: catalog/views/edit.py:576 catalog/views/edit.py:601
+#: catalog/views/edit.py:624 catalog/views/edit.py:664
+#: catalog/views/edit.py:674 catalog/views/edit.py:703
+#: catalog/views/edit.py:782 catalog/views/edit.py:837
+#: catalog/views/edit.py:859 catalog/views/search.py:418
 #, fuzzy
 #| msgid "Edit this item"
 msgid "Editing this item is restricted."
@@ -1422,7 +1490,7 @@ msgstr "O item foi marcado por utilizadores."
 msgid "The following items are merged into this item"
 msgstr "Os elementos seguintes foram mesclados neste elemento"
 
-#: catalog/templates/_sidebar_edit.html:70
+#: catalog/templates/_sidebar_edit.html:70 catalog/views/edit.py:456
 msgid "External website"
 msgstr "Website externo"
 
@@ -1436,49 +1504,41 @@ msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:88
 msgid "Existing metadata might get overwritten, sure to proceed?"
-msgstr ""
-"Metadados existentes podem ser substituídos, tem a certeza que quer "
-"continuar?"
+msgstr "Metadados existentes podem ser substituídos, tem a certeza que quer continuar?"
 
 #: catalog/templates/_sidebar_edit.html:92
 msgid "Fetch again"
 msgstr "Obter novamente"
 
-#: catalog/templates/_sidebar_edit.html:97
-msgid "You may not be able to undo this operation, sure to remove?"
-msgstr ""
-"É provável que não seja possível reverter esta operação. De certeza que quer "
-"remover?"
-
-#: catalog/templates/_sidebar_edit.html:102
+#: catalog/templates/_sidebar_edit.html:100
 msgid "Remove link to site"
 msgstr "Remover ligação para site"
 
-#: catalog/templates/_sidebar_edit.html:110
+#: catalog/templates/_sidebar_edit.html:108
 #, fuzzy
 #| msgid "Discover"
 msgid "Choose cover"
 msgstr "Descobrir"
 
-#: catalog/templates/_sidebar_edit.html:119
+#: catalog/templates/_sidebar_edit.html:117
+#: catalog/templates/_sidebar_edit.html:118
 #: catalog/templates/_sidebar_edit.html:120
-#: catalog/templates/_sidebar_edit.html:122
 #, fuzzy
 #| msgid "Current Targets"
 msgid "Current cover"
 msgstr "Objetivos atuais"
 
-#: catalog/templates/_sidebar_edit.html:139
+#: catalog/templates/_sidebar_edit.html:137
 msgid "Select an image to use as the cover of this item."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:140
-#: catalog/templates/catalog_edit.html:65
-#: common/templates/manage/settings.html:136
+#: catalog/templates/_sidebar_edit.html:138
+#: catalog/templates/catalog_edit.html:78
+#: common/templates/manage/settings.html:19
 #: journal/templates/add_to_collection.html:43
 #: journal/templates/article_edit.html:60
 #: journal/templates/collection_edit.html:39 journal/templates/comment.html:41
-#: journal/templates/mark.html:134 journal/templates/note.html:65
+#: journal/templates/mark.html:138 journal/templates/note.html:65
 #: journal/templates/post_compose.html:103
 #: journal/templates/review_edit.html:46 journal/templates/tag_edit.html:51
 #: users/templates/users/_pref_device.html:37
@@ -1487,202 +1547,162 @@ msgstr ""
 msgid "Save"
 msgstr "Guardar"
 
-#: catalog/templates/_sidebar_edit.html:147
+#: catalog/templates/_sidebar_edit.html:145
 msgid "Edit sub-items"
 msgstr "Editar sub-itens"
 
-#: catalog/templates/_sidebar_edit.html:160
+#: catalog/templates/_sidebar_edit.html:158
 msgid "create"
 msgstr "criar"
 
-#: catalog/templates/_sidebar_edit.html:166
+#: catalog/templates/_sidebar_edit.html:164
 msgid "Fetch all episodes"
 msgstr "Obter todos os episódios"
 
-#: catalog/templates/_sidebar_edit.html:171
+#: catalog/templates/_sidebar_edit.html:169
 msgid "Fetch all"
 msgstr "Obter tudo"
 
-#: catalog/templates/_sidebar_edit.html:172
-msgid ""
-"Due to differences in how Douban, IMDB, and TMDB handle season data, a small "
-"number of TV shows and animations may not return correct results. Please "
-"manually verify and clean up after updating."
-msgstr ""
-"Devido às diferenças na forma como o Douban, o IMDB e o TMDB tratam os dados "
-"das temporadas, um pequeno número de programas de televisão e animações "
-"podem não apresentar resultados corretos. Verifique manualmente e "
-"reconfigure após a sua atualização."
+#: catalog/templates/_sidebar_edit.html:170
+msgid "Due to differences in how Douban, IMDB, and TMDB handle season data, a small number of TV shows and animations may not return correct results. Please manually verify and clean up after updating."
+msgstr "Devido às diferenças na forma como o Douban, o IMDB e o TMDB tratam os dados das temporadas, um pequeno número de programas de televisão e animações podem não apresentar resultados corretos. Verifique manualmente e reconfigure após a sua atualização."
 
-#: catalog/templates/_sidebar_edit.html:173
+#: catalog/templates/_sidebar_edit.html:171
 msgid "Up to 250 episodes will be fetched for a season."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:176
-msgid ""
-"To fetch all episodes, season numbers and IMDB information are required. If "
-"filling this out is inconvenient, you can also manually create sub-entries."
-msgstr ""
-"Para obter todos os episódios, o número das temporadas e informação do IMDb "
-"são necessários. Se preencher isto é inconveniente, também pode criar sub-"
-"entradas manualmente."
+#: catalog/templates/_sidebar_edit.html:174
+msgid "To fetch all episodes, season numbers and IMDB information are required. If filling this out is inconvenient, you can also manually create sub-entries."
+msgstr "Para obter todos os episódios, o número das temporadas e informação do IMDb são necessários. Se preencher isto é inconveniente, também pode criar sub-entradas manualmente."
 
-#: catalog/templates/_sidebar_edit.html:182
-#: catalog/templates/_sidebar_edit.html:194
-#: catalog/templates/_sidebar_edit.html:213
+#: catalog/templates/_sidebar_edit.html:180
+#: catalog/templates/_sidebar_edit.html:191
+#: catalog/templates/_sidebar_edit.html:208
 msgid "switch category"
 msgstr "trocar categoria"
 
-#: catalog/templates/_sidebar_edit.html:185
-msgid "Switching may remove some metadata. Sure to proceed?"
-msgstr ""
-"A troca pode remover alguns metadados. Tem certeza que deseja prosseguir?"
-
-#: catalog/templates/_sidebar_edit.html:188
+#: catalog/templates/_sidebar_edit.html:185 catalog/views/edit.py:383
 msgid "TV Show"
 msgstr "Programa de TV"
 
-#: catalog/templates/_sidebar_edit.html:227
+#: catalog/templates/_sidebar_edit.html:221
 msgid "Link to parent item"
 msgstr "Ligação para o elemento pai"
 
 #: catalog/templates/_sidebar_edit.html:230
-msgid "Sure to link?"
-msgstr "Criar ligação?"
-
-#: catalog/templates/_sidebar_edit.html:237
 msgid "Update link"
 msgstr "Atualizar ligação"
 
-#: catalog/templates/_sidebar_edit.html:243
+#: catalog/templates/_sidebar_edit.html:236
 msgid "Cleanup seasons"
 msgstr "Limpar temporadas"
 
-#: catalog/templates/_sidebar_edit.html:246
-#: catalog/templates/catalog_delete.html:45
-msgid "This operation cannot be undone. Sure to delete?"
-msgstr "Esta operação não pode ser revertida. Tem a certeza que quer apagar?"
-
-#: catalog/templates/_sidebar_edit.html:250
+#: catalog/templates/_sidebar_edit.html:242
 msgid "remove seasons not marked"
 msgstr "remover temporadas não marcadas"
 
-#: catalog/templates/_sidebar_edit.html:256
-#: catalog/templates/catalog_merge.html:12
+#: catalog/templates/_sidebar_edit.html:248
 msgid "Merge"
 msgstr "Mesclar"
 
-#: catalog/templates/_sidebar_edit.html:262
+#: catalog/templates/_sidebar_edit.html:254
 msgid "URL of target item, or empty if undo merge"
 msgstr "URL do elemento de destino, ou vazio, se a mesclagem for desfeita"
 
-#: catalog/templates/_sidebar_edit.html:268
-#: catalog/templates/_sidebar_edit.html:348
+#: catalog/templates/_sidebar_edit.html:260
+#: catalog/templates/_sidebar_edit.html:350
 msgid "merge to another item"
 msgstr "mesclar a outro elemento"
 
-#: catalog/templates/_sidebar_edit.html:273
-#: catalog/templates/_sidebar_edit.html:277
-#: catalog/templates/catalog_delete.html:12
+#: catalog/templates/_sidebar_edit.html:265
+#: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
 #: journal/templates/article.html:199 journal/templates/collection.html:188
-#: journal/templates/mark.html:149 journal/templates/note.html:82
+#: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
 #: users/templates/users/account.html:254
 msgid "Delete"
 msgstr "Apagar"
 
-#: catalog/templates/_sidebar_edit.html:287
+#: catalog/templates/_sidebar_edit.html:275
+#: catalog/templates/_sidebar_edit.html:279
+#, fuzzy
+#| msgid "Tag deleted."
+msgid "Undo delete"
+msgstr "Etiqueta eliminada."
+
+#: catalog/templates/_sidebar_edit.html:280
+msgid "Links to external sites and parent item were removed on delete and will not be restored."
+msgstr ""
+
+#: catalog/templates/_sidebar_edit.html:290
 msgid "This edition belongs to the following work"
 msgstr "Esta edição pertence à seguinte obra"
 
-#: catalog/templates/_sidebar_edit.html:292
-msgid "Sure to unlink?"
-msgstr "Tem certeza que deseja desvincular?"
-
-#: catalog/templates/_sidebar_edit.html:298
+#: catalog/templates/_sidebar_edit.html:300
 msgid "Unlink from work"
 msgstr "Desvincular do trabalho"
 
-#: catalog/templates/_sidebar_edit.html:304
+#: catalog/templates/_sidebar_edit.html:306
 msgid "Link"
 msgstr "Ligação"
 
-#: catalog/templates/_sidebar_edit.html:315
+#: catalog/templates/_sidebar_edit.html:317
 msgid "Link to another edition from same work"
 msgstr "Ligação para outra edição do mesmo trabalho"
 
-#: catalog/templates/_sidebar_edit.html:324
+#: catalog/templates/_sidebar_edit.html:326
 #, fuzzy
 #| msgid "description"
 msgid "Restriction"
 msgstr "descrição"
 
-#: catalog/templates/_sidebar_edit.html:337
+#: catalog/templates/_sidebar_edit.html:339
 #: journal/templates/collection_update_item_note.html:4
 msgid "Update"
 msgstr "Atualizar"
 
-#: catalog/templates/_sidebar_edit.html:342
+#: catalog/templates/_sidebar_edit.html:344
 msgid "Suggest Edits"
 msgstr "Sugerir alterações"
 
-#: catalog/templates/_sidebar_edit.html:347
+#: catalog/templates/_sidebar_edit.html:349
 msgid "proposed action"
 msgstr "ação proposta"
 
-#: catalog/templates/_sidebar_edit.html:349
+#: catalog/templates/_sidebar_edit.html:351
 msgid "link to another item"
 msgstr "ligação para outro elemento"
 
-#: catalog/templates/_sidebar_edit.html:350
+#: catalog/templates/_sidebar_edit.html:352
 msgid "change item category"
 msgstr "alterar categoria do item"
 
-#: catalog/templates/_sidebar_edit.html:351
+#: catalog/templates/_sidebar_edit.html:353
 msgid "change item metadata"
 msgstr "alterar metadados do artigo"
 
-#: catalog/templates/_sidebar_edit.html:352
+#: catalog/templates/_sidebar_edit.html:354
 msgid "remove item"
 msgstr "remover item"
 
-#: catalog/templates/_sidebar_edit.html:353
+#: catalog/templates/_sidebar_edit.html:355
 msgid "other"
 msgstr "outro"
 
-#: catalog/templates/_sidebar_edit.html:357
-msgid ""
-"To suggest merging or association, please include the URL of the target item"
-msgstr ""
-"Para propor uma fusão ou associação, por favor, inclua o URL do elemento em "
-"questão"
+#: catalog/templates/_sidebar_edit.html:359
+msgid "To suggest merging or association, please include the URL of the target item"
+msgstr "Para propor uma fusão ou associação, por favor, inclua o URL do elemento em questão"
 
-#: catalog/templates/_sidebar_edit.html:358
+#: catalog/templates/_sidebar_edit.html:360
 #: catalog/templates/catalog_verify.html:116
 msgid "submit"
 msgstr "submeter"
 
-#: catalog/templates/_sidebar_edit.html:359
-msgid ""
-"As a user of this community, you may edit some metadata of items on this "
-"site. If you are unsure whether your edits are appropriate or are unable to "
-"make a certain change, you can make suggestions here. Moderators will "
-"consider each suggestion, although there is no guarantee that they will "
-"always be fully adopted; suggestions may also be viewed or discussed by "
-"other community users. If you have suggestions that are not related to a "
-"specific item, please contact us. Thank you for your support and "
-"contribution."
-msgstr ""
-"Como utilizador desta comunidade, pode editar alguns metadados de itens "
-"neste site. Se não tiver a certeza de que as suas edições são adequadas ou "
-"se não conseguir efetuar uma determinada alteração, pode fazer sugestões "
-"aqui. Os moderadores terão em consideração cada sugestão, embora não haja "
-"garantias de que sejam sempre adoptadas na íntegra; as sugestões também "
-"podem ser vistas ou debatidas por outros utilizadores. Se tiver sugestões "
-"que não estejam relacionadas com um item específico, contacte-nos. Obrigado "
-"pelo seu apoio e contribuição."
+#: catalog/templates/_sidebar_edit.html:361
+msgid "As a user of this community, you may edit some metadata of items on this site. If you are unsure whether your edits are appropriate or are unable to make a certain change, you can make suggestions here. Moderators will consider each suggestion, although there is no guarantee that they will always be fully adopted; suggestions may also be viewed or discussed by other community users. If you have suggestions that are not related to a specific item, please contact us. Thank you for your support and contribution."
+msgstr "Como utilizador desta comunidade, pode editar alguns metadados de itens neste site. Se não tiver a certeza de que as suas edições são adequadas ou se não conseguir efetuar uma determinada alteração, pode fazer sugestões aqui. Os moderadores terão em consideração cada sugestão, embora não haja garantias de que sejam sempre adoptadas na íntegra; as sugestões também podem ser vistas ou debatidas por outros utilizadores. Se tiver sugestões que não estejam relacionadas com um item específico, contacte-nos. Obrigado pelo seu apoio e contribuição."
 
 #: catalog/templates/_sidebar_search.html:5
 #: journal/templates/_sidebar_search_journal.html:4
@@ -1785,9 +1805,7 @@ msgid "matched"
 msgstr "visto"
 
 #: catalog/templates/_verify_status.html:21
-msgid ""
-"Sure to remove your creator verification? Anyone will be able to edit this "
-"item again."
+msgid "Sure to remove your creator verification? Anyone will be able to edit this item again."
 msgstr ""
 
 #: catalog/templates/_verify_status.html:26
@@ -1796,7 +1814,7 @@ msgstr ""
 msgid "Remove my verification"
 msgstr "Remover da coleção"
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:309
+#: catalog/templates/_verify_status.html:31 users/views/account.py:311
 #, fuzzy
 #| msgid "Verification Code"
 msgid "Verification failed"
@@ -1839,43 +1857,11 @@ msgstr "código de barras"
 msgid "album media"
 msgstr "média do álbum"
 
-#: catalog/templates/catalog_delete.html:19
-msgid "Are you sure to delete?"
-msgstr "Tem a certeza que deseja apagar?"
-
-#: catalog/templates/catalog_delete.html:24
-#: catalog/templates/catalog_edit.html:52
-#: catalog/templates/catalog_merge.html:36
-#: catalog/templates/catalog_merge.html:64
-msgid "Item has been deleted."
-msgstr "O item foi eliminado."
-
-#: catalog/templates/catalog_delete.html:29
-#: catalog/templates/catalog_edit.html:55
-#: catalog/templates/catalog_merge.html:41
-#: catalog/templates/catalog_merge.html:69
-msgid "Item contains sub-items."
-msgstr "Item contém sub-itens."
-
-#: catalog/templates/catalog_delete.html:34
-#: catalog/templates/catalog_merge.html:46
-#: catalog/templates/catalog_merge.html:74
-msgid "Item has been merged to another item."
-msgstr "O elemento foi mesclado com outro elemento."
-
-#: catalog/templates/catalog_delete.html:39
-#: catalog/templates/catalog_merge.html:51
-#: catalog/templates/catalog_merge.html:79
-msgid "Item has been marked by users."
-msgstr "O item foi marcado por utilizadores."
-
-#: catalog/templates/catalog_delete.html:48
-#: catalog/templates/catalog_merge.html:92 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:55 common/views_manage.py:139
 msgid "Yes"
 msgstr "Sim"
 
-#: catalog/templates/catalog_delete.html:49
-#: catalog/templates/catalog_merge.html:93 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:56 common/views_manage.py:139
 msgid "No"
 msgstr "Não"
 
@@ -1884,36 +1870,18 @@ msgstr "Não"
 msgid "Create"
 msgstr "Criar"
 
-#: catalog/templates/catalog_edit.html:68
+#: catalog/templates/catalog_edit.html:81
 #: journal/templates/collection_update_item_note.html:8
 #: journal/templates/piece_delete.html:38
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: catalog/templates/catalog_edit.html:104
+#: catalog/templates/catalog_edit.html:118
 msgid "open linked people page"
 msgstr ""
 
-#: catalog/templates/catalog_merge.html:22
-msgid "Are you sure to merge?"
-msgstr "Tem certeza que deseja mesclar?"
-
-#: catalog/templates/catalog_merge.html:24
-msgid "Are you sure to cancel merge?"
-msgstr "Tem certeza que deseja cancelar a mesclagem?"
-
-#: catalog/templates/catalog_merge.html:27
-msgid "Are you sure to link?"
-msgstr "Tem certeza que deseja vincular?"
-
-#: catalog/templates/catalog_merge.html:86
-msgid "This operation cannot be undone. Sure to merge?"
-msgstr "Esta operação não pode ser desfeita. Tem certeza que deseja mesclar?"
-
 #: catalog/templates/catalog_verify.html:21
-msgid ""
-"If you are a creator of this podcast, you may verify the ownership, so that "
-"only you (and other verified creators) can edit its metadata on this site."
+msgid "If you are a creator of this podcast, you may verify the ownership, so that only you (and other verified creators) can edit its metadata on this site."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:22
@@ -1921,9 +1889,7 @@ msgid "Your recent episodes may also occasionally be featured in discovery."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:24
-msgid ""
-"To verify, prove you control one of the following identifiers of your "
-"account (click to copy):"
+msgid "To verify, prove you control one of the following identifiers of your account (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:30
@@ -1934,18 +1900,11 @@ msgid "copied"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:35
-msgid ""
-"You can prove this in a few ways, then start verification: add one of the "
-"identifiers above to the podcast feed's description; add a <code>rel=\"me\"</"
-"code> link back to one of them on the web page your feed links to (the link "
-"verification Mastodon uses); or point your feed's website at your Bluesky "
-"handle's own domain."
+msgid "You can prove this in a few ways, then start verification: add one of the identifiers above to the podcast feed's description; add a <code>rel=\"me\"</code> link back to one of them on the web page your feed links to (the link verification Mastodon uses); or point your feed's website at your Bluesky handle's own domain."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:44
-msgid ""
-"For example, add this rel=me link to the web page your feed links to (click "
-"to copy):"
+msgid "For example, add this rel=me link to the web page your feed links to (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:50
@@ -1953,9 +1912,7 @@ msgid "or, in the page's head:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:57
-msgid ""
-"Can't edit the website? Just add a line like this to your feed's description "
-"instead (click to copy):"
+msgid "Can't edit the website? Just add a line like this to your feed's description instead (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:62
@@ -1963,10 +1920,7 @@ msgid "Welcome to follow me on the Fediverse:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:66
-msgid ""
-"NeoDB does not re-check this periodically at the moment, but we recommend "
-"you keep it so that your audience can discover and connect with you in "
-"distributed social media."
+msgid "NeoDB does not re-check this periodically at the moment, but we recommend you keep it so that your audience can discover and connect with you in distributed social media."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:72
@@ -1996,12 +1950,11 @@ msgid "Send feedback"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:115
-msgid ""
-"Questions or issues with creator verification? Let the site moderators know."
+msgid "Questions or issues with creator verification? Let the site moderators know."
 msgstr ""
 
-#: catalog/templates/discover.html:28 common/views_manage.py:145
-#: common/views_manage.py:353 users/templates/users/preferences.html:34
+#: catalog/templates/discover.html:28 common/views_manage.py:35
+#: common/views_manage.py:431 users/templates/users/preferences.html:34
 msgid "Discover"
 msgstr "Descobrir"
 
@@ -2039,17 +1992,17 @@ msgstr "mostrar"
 msgid "hide"
 msgstr "ocultar"
 
-#: catalog/templates/discover.html:206 common/templates/_sidebar.html:14
+#: catalog/templates/discover.html:206 common/templates/_sidebar.html:13
 msgid "Unread Announcements"
 msgstr "Anúncios não lidos"
 
-#: catalog/templates/discover.html:212 common/templates/_sidebar.html:20
+#: catalog/templates/discover.html:212 common/templates/_sidebar.html:19
 #: social/templates/notification.html:67
 msgid "mark all as read"
 msgstr "Marcar tudo como lido"
 
 #: catalog/templates/discover.html:222
-#: common/templates/_sidebar_anonymous.html:55
+#: common/templates/_sidebar_anonymous.html:54
 msgid "Popular Tags"
 msgstr "Etiquetas populares"
 
@@ -2060,9 +2013,9 @@ msgstr "Etiquetas populares"
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
 #: catalog/templates/user_verified_works.html:23
-#: common/templates/_sidebar.html:127
-#: common/templates/_sidebar_anonymous.html:46
-#: common/templates/_sidebar_anonymous.html:62 journal/templates/posts.html:8
+#: common/templates/_sidebar.html:126
+#: common/templates/_sidebar_anonymous.html:45
+#: common/templates/_sidebar_anonymous.html:61 journal/templates/posts.html:7
 #: journal/templates/profile_articles.html:24
 #: journal/templates/profile_articles.html:26
 #: journal/templates/profile_items.html:65
@@ -2078,7 +2031,7 @@ msgstr "Etiquetas populares"
 msgid "nothing so far."
 msgstr "Nada, para já."
 
-#: catalog/templates/discover.html:239 common/templates/_sidebar.html:269
+#: catalog/templates/discover.html:239 common/templates/_sidebar.html:268
 msgid "Recent Posts"
 msgstr "Posts recentes"
 
@@ -2107,15 +2060,9 @@ msgstr "Requisitar ou comprar"
 
 #: catalog/templates/external_search_results.html:10
 #, fuzzy
-#| msgid ""
-#| "System will search other websites and instances, click title of the item "
-#| "to save them locally. "
-msgid ""
-"Some items were found from other websites and instances, click their title "
-"to save them locally."
-msgstr ""
-"O sistema irá procurar noutros sites e instâncias. Clique no título do item "
-"para guardá-lo localmente. "
+#| msgid "System will search other websites and instances, click title of the item to save them locally. "
+msgid "Some items were found from other websites and instances, click their title to save them locally."
+msgstr "O sistema irá procurar noutros sites e instâncias. Clique no título do item para guardá-lo localmente. "
 
 #: catalog/templates/fetch_pending.html:13
 msgid "Search results"
@@ -2129,8 +2076,7 @@ msgstr "Obtendo de %(site_label)s"
 #: catalog/templates/fetch_pending.html:29
 #: users/templates/users/fetch_identity_pending.html:29
 msgid "System busy, please try again in a minute."
-msgstr ""
-"Sistema sobrecarregado. Por favor, tente novamente dentro de um minuto."
+msgstr "Sistema sobrecarregado. Por favor, tente novamente dentro de um minuto."
 
 #: catalog/templates/item_base.html:95
 msgid "select one of the seasons to comment"
@@ -2142,9 +2088,7 @@ msgstr "marcar, comentar e coleccionar"
 
 #: catalog/templates/item_base.html:142
 msgid "Login or register to review or add this item to your collection."
-msgstr ""
-"Registe-se ou faça Login para escrever uma crítica ou adicionar este item à "
-"sua coleção."
+msgstr "Registe-se ou faça Login para escrever uma crítica ou adicionar este item à sua coleção."
 
 #: catalog/templates/item_base.html:151
 msgid "Related Collections"
@@ -2219,14 +2163,14 @@ msgstr "número de Temporadas"
 msgid "number of Episodes"
 msgstr "número de Episódios"
 
-#: catalog/templates/people.html:13 common/templates/_sidebar.html:77
-#: common/templates/_sidebar.html:84 journal/models/shelf.py:326
+#: catalog/templates/people.html:13 common/templates/_sidebar.html:76
+#: common/templates/_sidebar.html:83 journal/models/shelf.py:328
 #, fuzzy
 #| msgid "following you"
 msgid "following"
 msgstr "segue-o"
 
-#: catalog/templates/people.html:15 journal/models/shelf.py:324
+#: catalog/templates/people.html:15 journal/models/shelf.py:326
 #: social/templates/notification.html:60
 msgid "follow"
 msgstr "seguir"
@@ -2245,7 +2189,6 @@ msgstr ""
 #: journal/templates/_sidebar_collection_filter.html:14
 #: journal/templates/_sidebar_collection_filter.html:28
 #: journal/templates/_sidebar_user_mark_list.html:56
-#: social/templates/feed.html:42 social/templates/feed.html:44
 #: social/templates/notification.html:56
 msgid "all"
 msgstr "tudo"
@@ -2273,7 +2216,7 @@ msgstr "Completo"
 msgid "production"
 msgstr "produção"
 
-#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:54
+#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:53
 #, fuzzy
 #| msgid "original creator"
 msgid "verified creator"
@@ -2358,14 +2301,8 @@ msgid "No items matching your search query."
 msgstr "Não foi encontrado nenhum item referente à sua pesquisa."
 
 #: catalog/templates/search_results.html:34
-msgid ""
-"If you have URL from one of these sites, please put the full URL (e.g. "
-"<code>https://www.imdb.com/title/tt2513074/</code>) to the search box and "
-"press Enter."
-msgstr ""
-"Se tem um URL de algum destes sites, por favor, coloque o URL completo (p.e. "
-"<code>https://www.imdb.com/title/tt2513074/</code>) na caixa de pesquisa e "
-"clique Enter."
+msgid "If you have URL from one of these sites, please put the full URL (e.g. <code>https://www.imdb.com/title/tt2513074/</code>) to the search box and press Enter."
+msgstr "Se tem um URL de algum destes sites, por favor, coloque o URL completo (p.e. <code>https://www.imdb.com/title/tt2513074/</code>) na caixa de pesquisa e clique Enter."
 
 #: catalog/templates/search_results.html:48
 msgid "Searching from other sites"
@@ -2373,9 +2310,7 @@ msgstr "Procurar noutros sites"
 
 #: catalog/templates/search_results.html:51
 msgid "Logged in user may see search results from other sites."
-msgstr ""
-"Utilizadores com início de sessão aberta poderão ver resultados de pesquisa "
-"de outros sites."
+msgstr "Utilizadores com início de sessão aberta poderão ver resultados de pesquisa de outros sites."
 
 #: catalog/templates/search_results_people.html:12
 #: journal/templates/profile.html:200 journal/views/profile.py:614
@@ -2405,99 +2340,192 @@ msgstr ""
 msgid "Editions"
 msgstr "Edições"
 
-#: catalog/views/edit.py:202 catalog/views/edit.py:205
-#: catalog/views/edit.py:306 catalog/views/edit.py:309
-#: catalog/views/verify.py:197 journal/views/collection.py:77
-#: journal/views/collection.py:102 journal/views/collection.py:556
-#: journal/views/collection.py:651 journal/views/common.py:221
-#: journal/views/mark.py:196 journal/views/post.py:117
-#: journal/views/post.py:119 journal/views/post.py:166
-#: journal/views/post.py:185 journal/views/post.py:187
-#: journal/views/post.py:228 journal/views/post.py:241
+#: catalog/views/edit.py:293 catalog/views/edit.py:296
+#: catalog/views/edit.py:440 catalog/views/edit.py:443
+#: catalog/views/verify.py:197 journal/views/collection.py:75
+#: journal/views/collection.py:100 journal/views/collection.py:538
+#: journal/views/collection.py:634 journal/views/common.py:231
+#: journal/views/mark.py:244 journal/views/post.py:119
+#: journal/views/post.py:121 journal/views/post.py:168
+#: journal/views/post.py:187 journal/views/post.py:189
+#: journal/views/post.py:230 journal/views/post.py:243
 #: journal/views/review.py:154 journal/views/review.py:158
-#: users/views/actions.py:179
+#: users/views/actions.py:178
 msgid "Invalid parameter"
 msgstr "Parâmetro inválido"
 
-#: catalog/views/edit.py:220
+#: catalog/views/edit.py:313
 msgid "Item in use."
 msgstr "Item em uso."
 
-#: catalog/views/edit.py:222
+#: catalog/views/edit.py:315
 msgid "Item cannot be deleted."
 msgstr "Este item não pode ser apagado."
 
-#: catalog/views/edit.py:247 catalog/views/edit.py:303
-#: catalog/views/edit.py:427 catalog/views/edit.py:519
-#: catalog/views/edit.py:552 catalog/views/verify.py:158
+#: catalog/views/edit.py:319 catalog/views/edit.py:515
+msgid "Are you sure to delete?"
+msgstr "Tem a certeza que deseja apagar?"
+
+#: catalog/views/edit.py:323 catalog/views/edit.py:518
+#: catalog/views/edit.py:617
+#, fuzzy
+#| msgid "This operation cannot be undone. Sure to merge?"
+msgid "This operation cannot be undone."
+msgstr "Esta operação não pode ser desfeita. Tem certeza que deseja mesclar?"
+
+#: catalog/views/edit.py:344 catalog/views/edit.py:437
+#: catalog/views/edit.py:603 catalog/views/edit.py:705
+#: catalog/views/edit.py:752 catalog/views/verify.py:158
 #: catalog/views/verify.py:206 journal/views/article.py:44
 #: journal/views/article.py:133 journal/views/article.py:153
 #: journal/views/collection.py:248 journal/views/collection.py:341
-#: journal/views/collection.py:360 journal/views/collection.py:384
-#: journal/views/collection.py:457 journal/views/collection.py:500
-#: journal/views/collection.py:539 journal/views/collection.py:551
-#: journal/views/collection.py:576 journal/views/collection.py:613
-#: journal/views/common.py:300 journal/views/mark.py:281
-#: journal/views/post.py:58 journal/views/post.py:78 journal/views/post.py:100
-#: journal/views/post.py:170 journal/views/post.py:199
-#: journal/views/post.py:272 journal/views/post.py:287
-#: journal/views/post.py:394 journal/views/post.py:549
+#: journal/views/collection.py:354 journal/views/collection.py:372
+#: journal/views/collection.py:439 journal/views/collection.py:482
+#: journal/views/collection.py:521 journal/views/collection.py:533
+#: journal/views/collection.py:558 journal/views/collection.py:595
+#: journal/views/common.py:304 journal/views/mark.py:317
+#: journal/views/post.py:60 journal/views/post.py:80 journal/views/post.py:102
+#: journal/views/post.py:172 journal/views/post.py:201
+#: journal/views/post.py:274 journal/views/post.py:289
+#: journal/views/post.py:390 journal/views/post.py:539
 #: journal/views/review.py:64 journal/views/review.py:81
 #: journal/views/review.py:106
 msgid "Insufficient permission"
 msgstr "Permissões insuficientes"
 
-#: catalog/views/edit.py:374
+#: catalog/views/edit.py:346
+#, fuzzy
+#| msgid "Item has been deleted."
+msgid "Item is not deleted"
+msgstr "O item foi eliminado."
+
+#: catalog/views/edit.py:389
+#, fuzzy
+#| msgid "Switching may remove some metadata. Sure to proceed?"
+msgid "Switching may remove some metadata."
+msgstr "A troca pode remover alguns metadados. Tem certeza que deseja prosseguir?"
+
+#: catalog/views/edit.py:395
+#, fuzzy
+#| msgid "The following items are merged into this item"
+msgid "The following seasons will be detached from this show"
+msgstr "Os elementos seguintes foram mesclados neste elemento"
+
+#: catalog/views/edit.py:400
+msgid "Links to IMDB and TMDB will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:403
+#, fuzzy
+#| msgid "Are you sure to merge?"
+msgid "Are you sure to switch category?"
+msgstr "Tem certeza que deseja mesclar?"
+
+#: catalog/views/edit.py:451
+#, fuzzy
+#| msgid "Are you sure to delete this post?"
+msgid "Are you sure to remove the link to this site?"
+msgstr "Tem a certeza que pretende apagar este post?"
+
+#: catalog/views/edit.py:457
+#, fuzzy
+#| msgid "You may not be able to undo this operation, sure to remove?"
+msgid "You may not be able to undo this operation."
+msgstr "É provável que não seja possível reverter esta operação. De certeza que quer remover?"
+
+#: catalog/views/edit.py:483
+#, fuzzy
+#| msgid "Link to parent item"
+msgid "Current parent item"
+msgstr "Ligação para o elemento pai"
+
+#: catalog/views/edit.py:487
+msgid "The link to the parent item will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:490 catalog/views/edit.py:680
+msgid "Are you sure to link?"
+msgstr "Tem certeza que deseja vincular?"
+
+#: catalog/views/edit.py:521
+msgid "The following seasons will be deleted"
+msgstr ""
+
+#: catalog/views/edit.py:525
+msgid "The following seasons will be kept"
+msgstr ""
+
+#: catalog/views/edit.py:550
 msgid "TV Season with IMDB id and season number required."
 msgstr "Temporada de TV com ID do IMDB e número de temporada necessária."
 
-#: catalog/views/edit.py:380
+#: catalog/views/edit.py:556
 msgid "Updating episodes"
 msgstr "A atualizar episódios"
 
-#: catalog/views/edit.py:405
+#: catalog/views/edit.py:581
 msgid "This person has no supported source to fetch works from."
 msgstr ""
 
-#: catalog/views/edit.py:412
+#: catalog/views/edit.py:588
 msgid "Already pulling works for this person, try again later."
 msgstr ""
 
-#: catalog/views/edit.py:416
+#: catalog/views/edit.py:592
 msgid "Pulling works in background."
 msgstr ""
 
-#: catalog/views/edit.py:438
+#: catalog/views/edit.py:609
+msgid "Are you sure to merge?"
+msgstr "Tem certeza que deseja mesclar?"
+
+#: catalog/views/edit.py:611
+msgid "Are you sure to cancel merge?"
+msgstr "Tem certeza que deseja cancelar a mesclagem?"
+
+#: catalog/views/edit.py:622
 msgid "Cannot be merged to an item already deleted or merged"
 msgstr "Não pode ser mesclado com um elemento já apagado ou mesclado"
 
-#: catalog/views/edit.py:443
+#: catalog/views/edit.py:627
 msgid "Cannot merge items in different categories"
 msgstr "Não é possível mesclar elementos em categorias diferentes"
 
-#: catalog/views/edit.py:447
+#: catalog/views/edit.py:631
 #, fuzzy
 #| msgid "Cannot merge items in different categories"
 msgid "Cannot merge an item to itself"
 msgstr "Não é possível mesclar elementos em categorias diferentes"
 
-#: catalog/views/edit.py:488
+#: catalog/views/edit.py:672
 msgid "Cannot be linked to an item already deleted or merged"
 msgstr "Não pode ser vinculado a um elemento já apagado ou mesclado"
 
-#: catalog/views/edit.py:492
+#: catalog/views/edit.py:676
 msgid "Cannot link items other than editions"
 msgstr "Não é possível vincular elementos que não sejam edições"
 
-#: catalog/views/search.py:96
+#: catalog/views/edit.py:710
+#, fuzzy
+#| msgid "Are you sure to link?"
+msgid "Are you sure to unlink?"
+msgstr "Tem certeza que deseja vincular?"
+
+#: catalog/views/edit.py:715
+#, fuzzy
+#| msgid "This edition belongs to the following work"
+msgid "This edition will be unlinked from the following work"
+msgstr "Esta edição pertence à seguinte obra"
+
+#: catalog/views/search.py:113
 msgid "the internet"
 msgstr ""
 
-#: catalog/views/search.py:359
+#: catalog/views/search.py:410
 msgid "Invalid URL"
 msgstr "URL inválido"
 
-#: catalog/views/search.py:362
+#: catalog/views/search.py:413
 #, fuzzy
 #| msgid "Unsupported item type."
 msgid "Unsupported URL"
@@ -2523,9 +2551,9 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:122 common/utils.py:163
+#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
 #: journal/views/article.py:186 journal/views/review.py:182
-#: users/views/actions.py:45 users/views/actions.py:131
+#: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
 msgstr "Utilizador não encontrado"
 
@@ -2539,15 +2567,15 @@ msgstr ""
 msgid "Creator verification removed."
 msgstr "Enviar código de verificação"
 
-#: catalog/views/view.py:74 catalog/views/view.py:99
+#: catalog/views/view.py:77 catalog/views/view.py:102
 msgid "Item not found"
 msgstr "Item não encontrado"
 
-#: catalog/views/view.py:78 catalog/views/view.py:107 catalog/views/view.py:190
+#: catalog/views/view.py:81 catalog/views/view.py:110 catalog/views/view.py:193
 msgid "Item no longer exists"
 msgstr "Este item já não existe"
 
-#: catalog/views/view.py:187
+#: catalog/views/view.py:190
 #, fuzzy
 #| msgid "Invalid file."
 msgid "Invalid role"
@@ -3095,759 +3123,759 @@ msgctxt "genre"
 msgid "Health"
 msgstr ""
 
-#: common/models/lang.py:54
+#: common/models/lang.py:56
 msgid "Afar"
 msgstr "Afar"
 
-#: common/models/lang.py:55
+#: common/models/lang.py:57
 msgid "Afrikaans"
 msgstr "Afrikaans"
 
-#: common/models/lang.py:56
+#: common/models/lang.py:58
 msgid "Akan"
 msgstr "Akan"
 
-#: common/models/lang.py:57
+#: common/models/lang.py:59
 msgid "Aragonese"
 msgstr "Aragonês"
 
-#: common/models/lang.py:58
+#: common/models/lang.py:60
 msgid "Assamese"
 msgstr "Assamese"
 
-#: common/models/lang.py:59
+#: common/models/lang.py:61
 msgid "Avaric"
 msgstr "Avaric"
 
-#: common/models/lang.py:60
+#: common/models/lang.py:62
 msgid "Avestan"
 msgstr "Avestan"
 
-#: common/models/lang.py:61
+#: common/models/lang.py:63
 msgid "Aymara"
 msgstr "Aymara"
 
-#: common/models/lang.py:62
+#: common/models/lang.py:64
 msgid "Azerbaijani"
 msgstr "Azeri"
 
-#: common/models/lang.py:63
+#: common/models/lang.py:65
 msgid "Bashkir"
 msgstr "Bashkir"
 
-#: common/models/lang.py:64
+#: common/models/lang.py:66
 msgid "Bambara"
 msgstr "Bambara"
 
-#: common/models/lang.py:65
+#: common/models/lang.py:67
 msgid "Bislama"
 msgstr "Bislama"
 
-#: common/models/lang.py:66
+#: common/models/lang.py:68
 msgid "Tibetan"
 msgstr "Tibetano"
 
-#: common/models/lang.py:67
+#: common/models/lang.py:69
 msgid "Breton"
 msgstr "Bretão"
 
-#: common/models/lang.py:68
+#: common/models/lang.py:70
 msgid "Catalan"
 msgstr "Catalão"
 
-#: common/models/lang.py:69
+#: common/models/lang.py:71
 msgid "Czech"
 msgstr "Checo"
 
-#: common/models/lang.py:70
+#: common/models/lang.py:72
 msgid "Chechen"
 msgstr "Checheno"
 
-#: common/models/lang.py:71
+#: common/models/lang.py:73
 msgid "Slavic"
 msgstr "Eslavo"
 
-#: common/models/lang.py:72
+#: common/models/lang.py:74
 msgid "Chuvash"
 msgstr "Chuvash"
 
-#: common/models/lang.py:73
+#: common/models/lang.py:75
 msgid "Cornish"
 msgstr "Cornish"
 
-#: common/models/lang.py:74
+#: common/models/lang.py:76
 msgid "Corsican"
 msgstr "Corsican"
 
-#: common/models/lang.py:75
+#: common/models/lang.py:77
 msgid "Cree"
 msgstr "Cree"
 
-#: common/models/lang.py:76
+#: common/models/lang.py:78
 msgid "Welsh"
 msgstr "Galês"
 
-#: common/models/lang.py:79
+#: common/models/lang.py:81
 msgid "Divehi"
 msgstr "Divehi"
 
-#: common/models/lang.py:80
+#: common/models/lang.py:82
 msgid "Dzongkha"
 msgstr "Dzongkha"
 
-#: common/models/lang.py:81
+#: common/models/lang.py:83
 msgid "Esperanto"
 msgstr "Esperanto"
 
-#: common/models/lang.py:82
+#: common/models/lang.py:84
 msgid "Estonian"
 msgstr "Estónio"
 
-#: common/models/lang.py:83
+#: common/models/lang.py:85
 msgid "Basque"
 msgstr "Basco"
 
-#: common/models/lang.py:84
+#: common/models/lang.py:86
 msgid "Faroese"
 msgstr "Feroês"
 
-#: common/models/lang.py:85
+#: common/models/lang.py:87
 msgid "Fijian"
 msgstr "Fijiano"
 
-#: common/models/lang.py:86
+#: common/models/lang.py:88
 msgid "Finnish"
 msgstr "Finlandês"
 
-#: common/models/lang.py:88
+#: common/models/lang.py:90
 msgid "Frisian"
 msgstr "Frísio"
 
-#: common/models/lang.py:89
+#: common/models/lang.py:91
 msgid "Fulah"
 msgstr "Fulah"
 
-#: common/models/lang.py:90
+#: common/models/lang.py:92
 msgid "Gaelic"
 msgstr "Gaélico"
 
-#: common/models/lang.py:91
+#: common/models/lang.py:93
 msgid "Irish"
 msgstr "Irlandês"
 
-#: common/models/lang.py:92
+#: common/models/lang.py:94
 msgid "Galician"
 msgstr "Galego"
 
-#: common/models/lang.py:93
+#: common/models/lang.py:95
 msgid "Manx"
 msgstr "Manx"
 
-#: common/models/lang.py:94
+#: common/models/lang.py:96
 msgid "Guarani"
 msgstr "Guarani"
 
-#: common/models/lang.py:95
+#: common/models/lang.py:97
 msgid "Gujarati"
 msgstr "Guzerate"
 
-#: common/models/lang.py:96
+#: common/models/lang.py:98
 msgid "Haitian; Haitian Creole"
 msgstr "Haitian; Haitian Creole"
 
-#: common/models/lang.py:97
+#: common/models/lang.py:99
 msgid "Hausa"
 msgstr "Hausa"
 
-#: common/models/lang.py:98
+#: common/models/lang.py:100
 msgid "Serbo-Croatian"
 msgstr "Servo-croata"
 
-#: common/models/lang.py:99
+#: common/models/lang.py:101
 msgid "Herero"
 msgstr "Herero"
 
-#: common/models/lang.py:100
+#: common/models/lang.py:102
 msgid "Hiri Motu"
 msgstr "Hiri Motu"
 
-#: common/models/lang.py:101
+#: common/models/lang.py:103
 msgid "Croatian"
 msgstr "Croata"
 
-#: common/models/lang.py:102
+#: common/models/lang.py:104
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: common/models/lang.py:103
+#: common/models/lang.py:105
 msgid "Igbo"
 msgstr "Igbo"
 
-#: common/models/lang.py:104
+#: common/models/lang.py:106
 msgid "Ido"
 msgstr "Ido"
 
-#: common/models/lang.py:105
+#: common/models/lang.py:107
 msgid "Yi"
 msgstr "Yi"
 
-#: common/models/lang.py:106
+#: common/models/lang.py:108
 msgid "Inuktitut"
 msgstr "Inuktitut"
 
-#: common/models/lang.py:107
+#: common/models/lang.py:109
 msgid "Interlingue"
 msgstr "Interlíngua"
 
-#: common/models/lang.py:108
+#: common/models/lang.py:110
 msgid "Interlingua"
 msgstr "Interlíngua"
 
-#: common/models/lang.py:109
+#: common/models/lang.py:111
 msgid "Indonesian"
 msgstr "Indonésio"
 
-#: common/models/lang.py:110
+#: common/models/lang.py:112
 msgid "Inupiaq"
 msgstr "Inupiaq"
 
-#: common/models/lang.py:111
+#: common/models/lang.py:113
 msgid "Icelandic"
 msgstr "Islandês"
 
-#: common/models/lang.py:113
+#: common/models/lang.py:115
 msgid "Javanese"
 msgstr "Javanês"
 
-#: common/models/lang.py:114
+#: common/models/lang.py:116
 msgid "Japanese"
 msgstr "Japonês"
 
-#: common/models/lang.py:115
+#: common/models/lang.py:117
 msgid "Kalaallisut"
 msgstr "Kalaallisut"
 
-#: common/models/lang.py:116
+#: common/models/lang.py:118
 msgid "Kannada"
 msgstr "Kannada"
 
-#: common/models/lang.py:117
+#: common/models/lang.py:119
 msgid "Kashmiri"
 msgstr "Kashmiri"
 
-#: common/models/lang.py:118
+#: common/models/lang.py:120
 msgid "Kanuri"
 msgstr "Kanuri"
 
-#: common/models/lang.py:119
+#: common/models/lang.py:121
 msgid "Kazakh"
 msgstr "Cazaque"
 
-#: common/models/lang.py:120
+#: common/models/lang.py:122
 msgid "Khmer"
 msgstr "Khmer"
 
-#: common/models/lang.py:121
+#: common/models/lang.py:123
 msgid "Kikuyu"
 msgstr "Kikuyu"
 
-#: common/models/lang.py:122
+#: common/models/lang.py:124
 msgid "Kinyarwanda"
 msgstr "Kinyarwanda"
 
-#: common/models/lang.py:123
+#: common/models/lang.py:125
 msgid "Kirghiz"
 msgstr "Quirguiz"
 
-#: common/models/lang.py:124
+#: common/models/lang.py:126
 msgid "Komi"
 msgstr "Komi"
 
-#: common/models/lang.py:125
+#: common/models/lang.py:127
 msgid "Kongo"
 msgstr "Kongo"
 
-#: common/models/lang.py:126
+#: common/models/lang.py:128
 msgid "Korean"
 msgstr "Coreano"
 
-#: common/models/lang.py:127
+#: common/models/lang.py:129
 msgid "Kuanyama"
 msgstr "Kuanyama"
 
-#: common/models/lang.py:128
+#: common/models/lang.py:130
 msgid "Kurdish"
 msgstr "Curdo"
 
-#: common/models/lang.py:129
+#: common/models/lang.py:131
 msgid "Lao"
 msgstr "Lao"
 
-#: common/models/lang.py:130
+#: common/models/lang.py:132
 msgid "Latin"
 msgstr "Latim"
 
-#: common/models/lang.py:131
+#: common/models/lang.py:133
 msgid "Latvian"
 msgstr "Letão"
 
-#: common/models/lang.py:132
+#: common/models/lang.py:134
 msgid "Limburgish"
 msgstr "Limburguês"
 
-#: common/models/lang.py:133
+#: common/models/lang.py:135
 msgid "Lingala"
 msgstr "Lingala"
 
-#: common/models/lang.py:134
+#: common/models/lang.py:136
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: common/models/lang.py:135
+#: common/models/lang.py:137
 msgid "Letzeburgesch"
 msgstr "Letzeburgesch"
 
-#: common/models/lang.py:136
+#: common/models/lang.py:138
 msgid "Luba-Katanga"
 msgstr "Luba-Katanga"
 
-#: common/models/lang.py:137
+#: common/models/lang.py:139
 msgid "Ganda"
 msgstr "Ganda"
 
-#: common/models/lang.py:138
+#: common/models/lang.py:140
 msgid "Marshall"
 msgstr "Marshall"
 
-#: common/models/lang.py:139
+#: common/models/lang.py:141
 msgid "Malayalam"
 msgstr "Malayalam"
 
-#: common/models/lang.py:140
+#: common/models/lang.py:142
 msgid "Marathi"
 msgstr "Marata"
 
-#: common/models/lang.py:141
+#: common/models/lang.py:143
 msgid "Malagasy"
 msgstr "Malagasy"
 
-#: common/models/lang.py:142
+#: common/models/lang.py:144
 msgid "Maltese"
 msgstr "Maltês"
 
-#: common/models/lang.py:143
+#: common/models/lang.py:145
 msgid "Moldavian"
 msgstr "Moldavo"
 
-#: common/models/lang.py:144
+#: common/models/lang.py:146
 msgid "Mongolian"
 msgstr "Mongol"
 
-#: common/models/lang.py:145
+#: common/models/lang.py:147
 msgid "Maori"
 msgstr "Maori"
 
-#: common/models/lang.py:146
+#: common/models/lang.py:148
 msgid "Malay"
 msgstr "Malaio"
 
-#: common/models/lang.py:147
+#: common/models/lang.py:149
 msgid "Burmese"
 msgstr "Birmanês"
 
-#: common/models/lang.py:148
+#: common/models/lang.py:150
 msgid "Nauru"
 msgstr "Nauru"
 
-#: common/models/lang.py:149
+#: common/models/lang.py:151
 msgid "Navajo"
 msgstr "Navajo"
 
-#: common/models/lang.py:150 common/models/lang.py:151
+#: common/models/lang.py:152 common/models/lang.py:153
 msgid "Ndebele"
 msgstr "Ndebele"
 
-#: common/models/lang.py:152
+#: common/models/lang.py:154
 msgid "Ndonga"
 msgstr "Ndonga"
 
-#: common/models/lang.py:153
+#: common/models/lang.py:155
 msgid "Nepali"
 msgstr "Nepalês"
 
-#: common/models/lang.py:154
+#: common/models/lang.py:156
 msgid "Dutch"
 msgstr "Neerlandês"
 
-#: common/models/lang.py:155
+#: common/models/lang.py:157
 msgid "Norwegian Nynorsk"
 msgstr "Norueguês Nynorsk"
 
-#: common/models/lang.py:156
+#: common/models/lang.py:158
 msgid "Norwegian Bokmål"
 msgstr "Norueguês Bokmål"
 
-#: common/models/lang.py:157
+#: common/models/lang.py:159
 msgid "Norwegian"
 msgstr "Norueguês"
 
-#: common/models/lang.py:158
+#: common/models/lang.py:160
 msgid "Chichewa; Nyanja"
 msgstr "Chichewa; Nyanja"
 
-#: common/models/lang.py:159
+#: common/models/lang.py:161
 msgid "Occitan"
 msgstr "Occitano"
 
-#: common/models/lang.py:160
+#: common/models/lang.py:162
 msgid "Ojibwa"
 msgstr "Ojibwa"
 
-#: common/models/lang.py:161
+#: common/models/lang.py:163
 msgid "Oriya"
 msgstr "Oriá"
 
-#: common/models/lang.py:162
+#: common/models/lang.py:164
 msgid "Oromo"
 msgstr "Oromo"
 
-#: common/models/lang.py:163
+#: common/models/lang.py:165
 msgid "Ossetian; Ossetic"
 msgstr "Ossetian; Ossetic"
 
-#: common/models/lang.py:164
+#: common/models/lang.py:166
 msgid "Pali"
 msgstr "Pali"
 
-#: common/models/lang.py:165
+#: common/models/lang.py:167
 msgid "Polish"
 msgstr "Polaco"
 
-#: common/models/lang.py:167
+#: common/models/lang.py:169
 msgid "Quechua"
 msgstr "Quechua"
 
-#: common/models/lang.py:168
+#: common/models/lang.py:170
 msgid "Raeto-Romance"
 msgstr "Reto-romano"
 
-#: common/models/lang.py:169
+#: common/models/lang.py:171
 msgid "Romanian"
 msgstr "Romeno"
 
-#: common/models/lang.py:170
+#: common/models/lang.py:172
 msgid "Rundi"
 msgstr "Rundi"
 
-#: common/models/lang.py:171
+#: common/models/lang.py:173
 msgid "Russian"
 msgstr "Russo"
 
-#: common/models/lang.py:172
+#: common/models/lang.py:174
 msgid "Sango"
 msgstr "Sango"
 
-#: common/models/lang.py:173
+#: common/models/lang.py:175
 msgid "Sanskrit"
 msgstr "Sânscrito"
 
-#: common/models/lang.py:174
+#: common/models/lang.py:176
 msgid "Sinhalese"
 msgstr "Cingalês"
 
-#: common/models/lang.py:175
+#: common/models/lang.py:177
 msgid "Slovak"
 msgstr "Eslovaco"
 
-#: common/models/lang.py:176
+#: common/models/lang.py:178
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: common/models/lang.py:177
+#: common/models/lang.py:179
 msgid "Northern Sami"
 msgstr "Sami do Norte"
 
-#: common/models/lang.py:178
+#: common/models/lang.py:180
 msgid "Samoan"
 msgstr "Samoano"
 
-#: common/models/lang.py:179
+#: common/models/lang.py:181
 msgid "Shona"
 msgstr "Shona"
 
-#: common/models/lang.py:180
+#: common/models/lang.py:182
 msgid "Sindhi"
 msgstr "Sindi"
 
-#: common/models/lang.py:181
+#: common/models/lang.py:183
 msgid "Somali"
 msgstr "Somali"
 
-#: common/models/lang.py:182
+#: common/models/lang.py:184
 msgid "Sotho"
 msgstr "Sotho"
 
-#: common/models/lang.py:184
+#: common/models/lang.py:186
 msgid "Albanian"
 msgstr "Albanês"
 
-#: common/models/lang.py:185
+#: common/models/lang.py:187
 msgid "Sardinian"
 msgstr "Sardenho"
 
-#: common/models/lang.py:186
+#: common/models/lang.py:188
 msgid "Serbian"
 msgstr "Sérvio"
 
-#: common/models/lang.py:187
+#: common/models/lang.py:189
 msgid "Swati"
 msgstr "Swati"
 
-#: common/models/lang.py:188
+#: common/models/lang.py:190
 msgid "Sundanese"
 msgstr "Sudanês"
 
-#: common/models/lang.py:189
+#: common/models/lang.py:191
 msgid "Swahili"
 msgstr "Suaíli"
 
-#: common/models/lang.py:190
+#: common/models/lang.py:192
 msgid "Swedish"
 msgstr "Sueco"
 
-#: common/models/lang.py:191
+#: common/models/lang.py:193
 msgid "Tahitian"
 msgstr "Taitiano"
 
-#: common/models/lang.py:192
+#: common/models/lang.py:194
 msgid "Tamil"
 msgstr "Tamil"
 
-#: common/models/lang.py:193
+#: common/models/lang.py:195
 msgid "Tatar"
 msgstr "Tatar"
 
-#: common/models/lang.py:194
+#: common/models/lang.py:196
 msgid "Telugu"
 msgstr "Telugu"
 
-#: common/models/lang.py:195
+#: common/models/lang.py:197
 msgid "Tajik"
 msgstr "Tajik"
 
-#: common/models/lang.py:196
+#: common/models/lang.py:198
 msgid "Tagalog"
 msgstr "Tagalog"
 
-#: common/models/lang.py:197
+#: common/models/lang.py:199
 msgid "Thai"
 msgstr "Tailandês"
 
-#: common/models/lang.py:198
+#: common/models/lang.py:200
 msgid "Tigrinya"
 msgstr "Tigrínia"
 
-#: common/models/lang.py:199
+#: common/models/lang.py:201
 msgid "Tonga"
 msgstr "Tonga"
 
-#: common/models/lang.py:200
+#: common/models/lang.py:202
 msgid "Tswana"
 msgstr "Tsuana"
 
-#: common/models/lang.py:201
+#: common/models/lang.py:203
 msgid "Tsonga"
 msgstr "Tsonga"
 
-#: common/models/lang.py:202
+#: common/models/lang.py:204
 msgid "Turkmen"
 msgstr "Turquemeno"
 
-#: common/models/lang.py:203
+#: common/models/lang.py:205
 msgid "Turkish"
 msgstr "Turco"
 
-#: common/models/lang.py:204
+#: common/models/lang.py:206
 msgid "Twi"
 msgstr "Twi"
 
-#: common/models/lang.py:205
+#: common/models/lang.py:207
 msgid "Uighur"
 msgstr "Uigur"
 
-#: common/models/lang.py:206
+#: common/models/lang.py:208
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: common/models/lang.py:207
+#: common/models/lang.py:209
 msgid "Urdu"
 msgstr "Urdu"
 
-#: common/models/lang.py:208
+#: common/models/lang.py:210
 msgid "Uzbek"
 msgstr "Uzbeque"
 
-#: common/models/lang.py:209
+#: common/models/lang.py:211
 msgid "Venda"
 msgstr "Venda"
 
-#: common/models/lang.py:210
+#: common/models/lang.py:212
 msgid "Vietnamese"
 msgstr "Vietnamita"
 
-#: common/models/lang.py:211
+#: common/models/lang.py:213
 msgid "Volapük"
 msgstr "Volapük"
 
-#: common/models/lang.py:212
+#: common/models/lang.py:214
 msgid "Walloon"
 msgstr "Walloon"
 
-#: common/models/lang.py:213
+#: common/models/lang.py:215
 msgid "Wolof"
 msgstr "Wolof"
 
-#: common/models/lang.py:214
+#: common/models/lang.py:216
 msgid "Xhosa"
 msgstr "Xhosa"
 
-#: common/models/lang.py:215
+#: common/models/lang.py:217
 msgid "Yiddish"
 msgstr "Yiddish"
 
-#: common/models/lang.py:216
+#: common/models/lang.py:218
 msgid "Zhuang"
 msgstr "Zhuang"
 
-#: common/models/lang.py:217
+#: common/models/lang.py:219
 msgid "Zulu"
 msgstr "Zulu"
 
-#: common/models/lang.py:218
+#: common/models/lang.py:220
 msgid "Abkhazian"
 msgstr "Abcásio"
 
-#: common/models/lang.py:219
+#: common/models/lang.py:221
 msgid "Chinese"
 msgstr "Chinês"
 
-#: common/models/lang.py:220
+#: common/models/lang.py:222
 msgid "Pushto"
 msgstr "Pushto"
 
-#: common/models/lang.py:221
+#: common/models/lang.py:223
 msgid "Amharic"
 msgstr "Amárico"
 
-#: common/models/lang.py:222
+#: common/models/lang.py:224
 msgid "Arabic"
 msgstr "Árabe"
 
-#: common/models/lang.py:223
+#: common/models/lang.py:225
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: common/models/lang.py:224
+#: common/models/lang.py:226
 msgid "Macedonian"
 msgstr "Macedónio"
 
-#: common/models/lang.py:225
+#: common/models/lang.py:227
 msgid "Greek"
 msgstr "Grego"
 
-#: common/models/lang.py:226
+#: common/models/lang.py:228
 msgid "Persian"
 msgstr "Persa"
 
-#: common/models/lang.py:227
+#: common/models/lang.py:229
 msgid "Hebrew"
 msgstr "Hebraico"
 
-#: common/models/lang.py:228
+#: common/models/lang.py:230
 msgid "Hindi"
 msgstr "Hindi"
 
-#: common/models/lang.py:229
+#: common/models/lang.py:231
 msgid "Armenian"
 msgstr "Armenio"
 
-#: common/models/lang.py:231
+#: common/models/lang.py:233
 msgid "Ewe"
 msgstr "Ewe"
 
-#: common/models/lang.py:232
+#: common/models/lang.py:234
 msgid "Georgian"
 msgstr "Georgiano"
 
-#: common/models/lang.py:233
+#: common/models/lang.py:235
 msgid "Punjabi"
 msgstr "Punjabi"
 
-#: common/models/lang.py:234
+#: common/models/lang.py:236
 msgid "Bengali"
 msgstr "Bengali"
 
-#: common/models/lang.py:235
+#: common/models/lang.py:237
 msgid "Bosnian"
 msgstr "Bósnio"
 
-#: common/models/lang.py:236
+#: common/models/lang.py:238
 msgid "Chamorro"
 msgstr "Chamorro"
 
-#: common/models/lang.py:237
+#: common/models/lang.py:239
 msgid "Belarusian"
 msgstr "Bielorrusso"
 
-#: common/models/lang.py:238
+#: common/models/lang.py:240
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: common/models/lang.py:300
+#: common/models/lang.py:302
 msgid "Simplified Chinese (Mainland)"
 msgstr "Chinês Simplificado (Continental)"
 
-#: common/models/lang.py:301
+#: common/models/lang.py:303
 msgid "Traditional Chinese (Taiwan)"
 msgstr "Chinês Tradicional (Taiwan)"
 
-#: common/models/lang.py:302
+#: common/models/lang.py:304
 msgid "Traditional Chinese (Hongkong)"
 msgstr "Chinês Tradicional (Hongkong)"
 
-#: common/models/lang.py:310
+#: common/models/lang.py:312
 msgid "Portuguese (Brazil)"
 msgstr "Português (Brasil)"
 
-#: common/models/lang.py:313
+#: common/models/lang.py:315
 msgid "Simplified Chinese (Singapore)"
 msgstr "Chinês Simplificado (Singapura)"
 
-#: common/models/lang.py:314
+#: common/models/lang.py:316
 msgid "Simplified Chinese (Malaysia)"
 msgstr "Chinês Simplificado (Malásia)"
 
-#: common/models/lang.py:315
+#: common/models/lang.py:317
 msgid "Traditional Chinese (Macau)"
 msgstr "Chinês Tradicional (Macau)"
 
-#: common/models/lang.py:323
+#: common/models/lang.py:325
 msgid "Mandarin Chinese"
 msgstr "Mandarim Chinês"
 
-#: common/models/lang.py:324
+#: common/models/lang.py:326
 msgid "Yue Chinese"
 msgstr "Yue Chinês"
 
-#: common/models/lang.py:328
+#: common/models/lang.py:330
 msgid "Min Nan Chinese"
 msgstr "Min Nan Chinês"
 
-#: common/models/lang.py:329
+#: common/models/lang.py:331
 msgid "Wu Chinese"
 msgstr "Wu Chinês"
 
-#: common/models/lang.py:330
+#: common/models/lang.py:332
 msgid "Hakka Chinese"
 msgstr "Hakka Chinês"
 
@@ -3993,61 +4021,37 @@ msgid "VCD"
 msgstr ""
 
 #: common/templates/400.html:23
-msgid ""
-"You may have submitted invalid data, or the content may have been deleted by "
-"the author."
-msgstr ""
-"Pode ter inserido dados inválidos, ou o conteúdo em causa pode ter sido "
-"eliminado pelo autor em questão."
+msgid "You may have submitted invalid data, or the content may have been deleted by the author."
+msgstr "Pode ter inserido dados inválidos, ou o conteúdo em causa pode ter sido eliminado pelo autor em questão."
 
 #: common/templates/400.html:25 common/templates/403.html:24
 #: common/templates/404.html:24
-msgid ""
-"If you believe this is our mistake, please contact us through the link at "
-"the bottom of the page."
-msgstr ""
-"Se acha que se trata de um erro nosso, por favor, contacte-nos através do "
-"link no final da página."
+msgid "If you believe this is our mistake, please contact us through the link at the bottom of the page."
+msgstr "Se acha que se trata de um erro nosso, por favor, contacte-nos através do link no final da página."
 
 #: common/templates/403.html:22
-msgid ""
-"Author may require you to log in before accessing this content, or you do "
-"not have permission to view it."
-msgstr ""
-"O autor requer que inicie sessão para aceder a este conteúdo, ou então não "
-"conseguirá visualizá-lo."
+msgid "Author may require you to log in before accessing this content, or you do not have permission to view it."
+msgstr "O autor requer que inicie sessão para aceder a este conteúdo, ou então não conseguirá visualizá-lo."
 
 #: common/templates/404.html:20
 msgid "Something is missing"
 msgstr "Está algo em falta"
 
 #: common/templates/404.html:22
-msgid ""
-"You may have visited an incorrect URL, or the content you are looking for "
-"has been deleted by the author."
-msgstr ""
-"Talvez tenha entrado num URL incorrecto, ou o conteúdo que procurava foi "
-"eliminado pelo autor."
+msgid "You may have visited an incorrect URL, or the content you are looking for has been deleted by the author."
+msgstr "Talvez tenha entrado num URL incorrecto, ou o conteúdo que procurava foi eliminado pelo autor."
 
 #: common/templates/404.html:26
 msgid "Go to Home"
 msgstr ""
 
 #: common/templates/500.html:22
-msgid ""
-"An internal error occurred. If this error occurs repeatedly, it will be "
-"recorded and handled by a human."
-msgstr ""
-"Ocorreu um erro interno. Se o erro persistir, será registado e tratado pelos "
-"responsáveis."
+msgid "An internal error occurred. If this error occurs repeatedly, it will be recorded and handled by a human."
+msgstr "Ocorreu um erro interno. Se o erro persistir, será registado e tratado pelos responsáveis."
 
 #: common/templates/500.html:24
-msgid ""
-"If you have an urgent situation or any questions, please contact us through "
-"the link at the bottom of the page."
-msgstr ""
-"Se possui alguma questão ou situação/dúvida urgente, por favor, contacte-nos "
-"através do link no final da página."
+msgid "If you have an urgent situation or any questions, please contact us through the link at the bottom of the page."
+msgstr "Se possui alguma questão ou situação/dúvida urgente, por favor, contacte-nos através do link no final da página."
 
 #: common/templates/_footer.html:6
 msgid "Rules"
@@ -4061,284 +4065,226 @@ msgstr "Termos"
 msgid "About"
 msgstr ""
 
-#: common/templates/_footer.html:12 users/templates/users/login.html:265
+#: common/templates/_footer.html:12 users/templates/users/login.html:259
 #, python-format
-msgid ""
-"You are visiting an alternative domain for %(site_name)s, please always use "
-"<a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if "
-"possible."
-msgstr ""
-"Está a consultar um domínio/site alternativo a %(site_name)s. Por favor, use "
-"sempre a <a href=\"%(site_url)s%(request.get_full_path)s\">versão original</"
-"a> , se possível."
+msgid "You are visiting an alternative domain for %(site_name)s, please always use <a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if possible."
+msgstr "Está a consultar um domínio/site alternativo a %(site_name)s. Por favor, use sempre a <a href=\"%(site_url)s%(request.get_full_path)s\">versão original</a> , se possível."
 
-#: common/templates/_header.html:19 common/templates/_header.html:164
+#: common/templates/_header.html:19 common/templates/_header.html:177
 msgid "title, creator, ISBN, item url, @user, @user@instance"
 msgstr "título, criador, ISBN, url do item, @utilizador, @utilizador@instância"
 
-#: common/templates/_header.html:24
+#: common/templates/_header.html:34
 msgid "All Items"
 msgstr "Todos os itens"
 
-#: common/templates/_header.html:31
+#: common/templates/_header.html:41
 msgid "Movie & TV"
 msgstr "Filme & TV"
 
-#: common/templates/_header.html:50
+#: common/templates/_header.html:60
 msgid "People & Organizations"
 msgstr ""
 
-#: common/templates/_header.html:52
+#: common/templates/_header.html:62
 msgid "Journal"
 msgstr "Registo"
 
-#: common/templates/_header.html:54 journal/templates/user_post_list.html:10
+#: common/templates/_header.html:64 journal/templates/user_post_list.html:10
 #: journal/templates/user_post_list.html:23
 msgid "Posts"
 msgstr "Posts"
 
-#: common/templates/_header.html:89
+#: common/templates/_header.html:102
 msgid "Explore"
 msgstr "Explorar"
 
-#: common/templates/_header.html:93
+#: common/templates/_header.html:106 common/views_manage.py:36
 #, fuzzy
 msgid "Feed"
 msgstr "Feed"
 
-#: common/templates/_header.html:98 journal/templates/profile.html:13
+#: common/templates/_header.html:111 journal/templates/profile.html:13
 #: users/templates/users/preferences.html:46
 msgid "Home"
 msgstr "Início"
 
-#: common/templates/_header.html:114 common/templates/common/scan.html:9
+#: common/templates/_header.html:127 common/templates/common/scan.html:9
 #: common/templates/common/scan.html:42
 #, fuzzy
 #| msgid "barcode"
 msgid "Scan Barcode"
 msgstr "código de barras"
 
-#: common/templates/_header.html:118 social/templates/notification.html:12
+#: common/templates/_header.html:131 social/templates/notification.html:12
 #: social/templates/notification.html:53
 msgid "Notification"
 msgstr "Notificação"
 
-#: common/templates/_header.html:122 users/models/task.py:21
+#: common/templates/_header.html:135 users/models/task.py:23
 #: users/templates/users/account.html:219
 #: users/templates/users/crossposts.html:9
 msgid "Pending"
 msgstr "Pendente"
 
-#: common/templates/_header.html:125
+#: common/templates/_header.html:138
 msgid "Data"
 msgstr "Dados"
 
-#: common/templates/_header.html:128 common/templates/_header.html:146
+#: common/templates/_header.html:141 common/templates/_header.html:159
 #: users/templates/users/preferences.html:12
 #: users/templates/users/preferences.html:23
 #: users/templates/users/preferences_anonymous.html:13
 msgid "Preferences"
 msgstr "Preferências"
 
-#: common/templates/_header.html:131
+#: common/templates/_header.html:144
 msgid "Account"
 msgstr "Conta"
 
-#: common/templates/_header.html:135
+#: common/templates/_header.html:148
 msgid "Manage"
 msgstr "Gerir"
 
-#: common/templates/_header.html:139
+#: common/templates/_header.html:152
 msgid "Logout"
 msgstr "Desconectar"
 
-#: common/templates/_header.html:143
+#: common/templates/_header.html:156
 msgid "Sign up or Login"
 msgstr "Registar-se ou iniciar sessão"
 
-#: common/templates/_header.html:160
-msgid ""
-"title or content  category:tv  status:complete  rating:8..10  "
-"date:2021-09-11..2022-02"
-msgstr ""
-"título ou conteúdo  categoria:tv  estado:completo  avaliação:8..10  "
-"data:2021-09-11..2022-02"
+#: common/templates/_header.html:173
+msgid "title or content  category:tv  status:complete  rating:8..10  date:2021-09-11..2022-02"
+msgstr "título ou conteúdo  categoria:tv  estado:completo  avaliação:8..10  data:2021-09-11..2022-02"
 
-#: common/templates/_header.html:162
+#: common/templates/_header.html:175
 msgid "name of a person or company"
 msgstr ""
 
-#: common/templates/_header.html:179
+#: common/templates/_header.html:192
 msgid "Open"
 msgstr "Abrir"
 
-#: common/templates/_sidebar.html:62
+#: common/templates/_sidebar.html:61
 #: users/templates/users/profile_actions.html:36
 msgid "approving followers manually"
 msgstr "Aprovar seguidores manualmente"
 
-#: common/templates/_sidebar.html:81 common/templates/_sidebar.html:86
+#: common/templates/_sidebar.html:80 common/templates/_sidebar.html:85
 #, fuzzy
 #| msgid "followed"
 msgid "followers"
 msgstr "seguido"
 
-#: common/templates/_sidebar.html:112
+#: common/templates/_sidebar.html:111
 msgid "Current Targets"
 msgstr "Objetivos atuais"
 
-#: common/templates/_sidebar.html:125
+#: common/templates/_sidebar.html:124
 msgid "Set a collection as target, its progress will show up here."
 msgstr "Defina uma coleção como objetivo, o seu progresso aparecerá aqui."
 
-#: common/templates/_sidebar.html:138
+#: common/templates/_sidebar.html:137
 msgid "Recent podcast episodes"
 msgstr "Episódios recentes de podcast"
 
-#: common/templates/_sidebar.html:173
+#: common/templates/_sidebar.html:172
 msgid "Currently reading"
 msgstr "Atualmente a ler"
 
-#: common/templates/_sidebar.html:215
+#: common/templates/_sidebar.html:214
 msgid "Currently watching"
 msgstr "Atualmente a ver"
 
-#: common/templates/_sidebar.html:238 journal/forms.py:217
+#: common/templates/_sidebar.html:237 journal/forms.py:217
 #: journal/templates/user_tag_list.html:13
 #: journal/templates/user_tagmember_list.html:4
 msgid "Tags"
 msgstr "Etiquetas"
 
-#: common/templates/_sidebar.html:244 journal/templates/user_tag_list.html:28
+#: common/templates/_sidebar.html:243 journal/templates/user_tag_list.html:28
 #: journal/templates/user_tagmember_list.html:10
 msgid "featured tag"
 msgstr "etiqueta em destaque"
 
-#: common/templates/_sidebar.html:247 journal/templates/user_tag_list.html:31
+#: common/templates/_sidebar.html:246 journal/templates/user_tag_list.html:31
 #: journal/templates/user_tagmember_list.html:15
 msgid "personal tag"
 msgstr "etiqueta pessoal"
 
-#: common/templates/_sidebar.html:254 journal/templates/user_tag_list.html:39
+#: common/templates/_sidebar.html:253 journal/templates/user_tag_list.html:39
 msgid "no tags so far."
 msgstr "sem etiquetas, para já."
 
-#: common/templates/_sidebar.html:258 common/templates/_sidebar.html:271
+#: common/templates/_sidebar.html:257 common/templates/_sidebar.html:270
 msgid "show all"
 msgstr "mostrar tudo"
 
-#: common/templates/_sidebar_anonymous.html:16
+#: common/templates/_sidebar_anonymous.html:15
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
 #| "        <h3>Welcome 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s "
-#| "is committed to creating a free, open, and interconnected space for "
-#| "collecting and reviewing books, movies, music, games, and podcasts. Here, "
-#| "you can document your collections and thoughts, discover new content, and "
-#| "connect with others.\n"
+#| "          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is committed to creating a free, open, and interconnected space for collecting and reviewing books, movies, music, games, and podcasts. Here, you can document your collections and thoughts, discover new content, and connect with others.\n"
 #| "        </p>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log "
-#| "in to %(site_name)s is through a Fediverse (a distributed social network, "
-#| "including Mastodon/Pleroma/etc) instance account. If you haven’t "
-#| "registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" "
-#| "target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
+#| "          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in to %(site_name)s is through a Fediverse (a distributed social network, including Mastodon/Pleroma/etc) instance account. If you haven’t registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
 #| "        </p>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not "
-#| "ready to join the Fediverse, that’s perfectly fine. You can create an "
-#| "account here using your email address, and link it to the Fediverse "
-#| "whenever you’re ready.\n"
+#| "          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready to join the Fediverse, that’s perfectly fine. You can create an account here using your email address, and link it to the Fediverse whenever you’re ready.\n"
 #| "        </p>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you "
-#| "have any questions or suggestions, feel free to contact us via <a "
-#| "href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a "
-#| "href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
+#| "          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have any questions or suggestions, feel free to contact us via <a href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 #| "        </p>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-#| "href=\"%(login_url)s\">Click here</a> to register or log in.\n"
+#| "          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Click here</a> to register or log in.\n"
 #| "        </p>\n"
 #| "        "
 msgid ""
 "\n"
 "        <h3>Welcome 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is "
-"committed to creating a free, open, and interconnected space for collecting "
-"and reviewing books, movies, music, games, and podcasts. Here, you can "
-"manage your collections, share your thoughts, discover new content, and "
-"connect with others.\n"
+"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is committed to creating a free, open, and interconnected space for collecting and reviewing books, movies, music, games, and podcasts. Here, you can manage your collections, share your thoughts, discover new content, and connect with others.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in "
-"to %(site_name)s is through a Fediverse (a distributed social network, "
-"including Mastodon/Pleroma/etc) instance account. If you haven’t registered "
-"yet, you can <a href=\"https://joinmastodon.org/en/servers\" "
-"target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
+"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in to %(site_name)s is through a Fediverse (a distributed social network, including Mastodon/Pleroma/etc) instance account. If you haven’t registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log "
-"in is through a Bluesky (another distributed social network, also called "
-"ATProto) account. If you haven’t registered yet, you may <a href=\"https://"
-"bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
+"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log in is through a Bluesky (another distributed social network, also called ATProto) account. If you haven’t registered yet, you may <a href=\"https://bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready "
-"to join either Fediverse or Bluesky, that’s perfectly fine. You can create "
-"an account here using your email address, and link it to the Fediverse and "
-"Bluesky in settings whenever you’re ready.\n"
+"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready to join either Fediverse or Bluesky, that’s perfectly fine. You can create an account here using your email address, and link it to the Fediverse and Bluesky in settings whenever you’re ready.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have "
-"any questions or suggestions, please feel free to contact us via <a "
-"href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://"
-"discord.gg/uprvcH8gqD\">Discord</a>.\n"
+"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have any questions or suggestions, please feel free to contact us via <a href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-"href=\"%(login_url)s\">Click here</a> to register or log in.\n"
+"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Click here</a> to register or log in.\n"
 "        </p>\n"
 "        "
 msgstr ""
 "\n"
 "        <h3>Bem-vindo 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s "
-"está empenhada em criar um espaço livre, aberto e interligado para "
-"colecionar e opinar sobre livros, filmes, música, jogos e podcasts. Aqui, "
-"pode documentar as suas coleções e pensamentos, descobrir novos conteúdos e "
-"estabelecer ligações com outros utilizadores.\n"
+"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s está empenhada em criar um espaço livre, aberto e interligado para colecionar e opinar sobre livros, filmes, música, jogos e podcasts. Aqui, pode documentar as suas coleções e pensamentos, descobrir novos conteúdos e estabelecer ligações com outros utilizadores.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-globe\"></i> &nbsp; A melhor maneira de "
-"iniciar sessão é %(site_name)s através de uma conta numa instância do "
-"Fediverso (como Mastodon/Pleroma/etc). Se ainda não se registou, pode <a "
-"href=\"https://joinmastodon.org/en/servers\" target=\"_blank\"> escolher uma "
-"instância no Fediverso e registar-se</a>.\n"
+"          <i class=\"fa-solid fa-globe\"></i> &nbsp; A melhor maneira de iniciar sessão é %(site_name)s através de uma conta numa instância do Fediverso (como Mastodon/Pleroma/etc). Se ainda não se registou, pode <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\"> escolher uma instância no Fediverso e registar-se</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; Se ainda não se "
-"sente preparado para aderir ao Fediverso, não se preocupe! Pode criar uma "
-"conta aqui, usando um endereço de email e, mais tarde, conectar-se com o "
-"Fediverso.\n"
+"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; Se ainda não se sente preparado para aderir ao Fediverso, não se preocupe! Pode criar uma conta aqui, usando um endereço de email e, mais tarde, conectar-se com o Fediverso.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp;  Se tem "
-"dúvidas ou sugestões, não hesite em contactar-nos através do <a "
-"href=\"https://mastodon.social/@neodb\">Fediverso</a> ou <a href=\"https://"
-"discord.gg/uprvcH8gqD\">Discord</a>.\n"
+"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp;  Se tem dúvidas ou sugestões, não hesite em contactar-nos através do <a href=\"https://mastodon.social/@neodb\">Fediverso</a> ou <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-"href=\"%(login_url)s\">Clique aqui</a> para se registar ou iniciar sessão.\n"
+"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Clique aqui</a> para se registar ou iniciar sessão.\n"
 "        </p>\n"
 "        "
 
-#: common/templates/_sidebar_anonymous.html:43
+#: common/templates/_sidebar_anonymous.html:42
 #: users/templates/users/announcements.html:12
 #: users/templates/users/announcements.html:39
 msgid "Announcements"
@@ -4366,7 +4312,7 @@ msgstr "Código Fonte"
 msgid "Registration"
 msgstr "Falha ao registar-se"
 
-#: common/templates/common/about.html:35 common/views_manage.py:493
+#: common/templates/common/about.html:35 common/views_manage.py:594
 #, fuzzy
 #| msgid "Mentioned Only"
 msgid "Invite Only"
@@ -4378,7 +4324,7 @@ msgstr "Apenas mencionado"
 msgid "Open Registration"
 msgstr "Falha ao registar-se"
 
-#: common/templates/common/about.html:40 common/views_manage.py:556
+#: common/templates/common/about.html:40 common/views_manage.py:657
 #, fuzzy
 #| msgid "Preferences"
 msgid "Preferred Languages"
@@ -4433,9 +4379,7 @@ msgid "Error"
 msgstr "Erro"
 
 #: common/templates/common/scan.html:45
-msgid ""
-"Point the camera at a book ISBN or product barcode (EAN / UPC). You will be "
-"redirected to the search once a code is detected."
+msgid "Point the camera at a book ISBN or product barcode (EAN / UPC). You will be redirected to the search once a code is detected."
 msgstr ""
 
 #: common/templates/common/scan.html:50
@@ -4446,7 +4390,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:628
+#: common/templates/common/scan.html:60 common/views_manage.py:738
 #, fuzzy
 #| msgid "Search results"
 msgid "Search"
@@ -4480,21 +4424,33 @@ msgstr ""
 msgid "Camera unavailable. Use manual entry below."
 msgstr ""
 
-#: common/templates/manage/settings.html:9
+#: common/templates/manage/base.html:9
 #, fuzzy
 #| msgid "Additional Settings"
 msgid "Site Settings"
 msgstr "Definições adicionais"
 
-#: common/templates/manage/settings.html:109
+#: common/templates/manage/base.html:127
 msgid "Takahe Admin"
 msgstr ""
 
-#: common/templates/manage/settings.html:112
+#: common/templates/manage/base.html:130
 #, fuzzy
 #| msgid "Database"
 msgid "Database Admin"
 msgstr "Base de dados"
+
+#: common/templates/manage/environment.html:6
+msgid "These settings come from environment variables and cannot be changed here. Edit .env and restart the server to change them. Passwords and keys are hidden."
+msgstr ""
+
+#: common/templates/manage/environment.html:23
+msgid "(empty)"
+msgstr ""
+
+#: common/templates/manage/environment.html:26
+msgid "default"
+msgstr ""
 
 #: common/templatetags/duration.py:59
 msgid "just now"
@@ -4512,7 +4468,7 @@ msgstr "seguido"
 msgid "following you"
 msgstr "segue-o"
 
-#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:95
+#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:90
 msgid "you"
 msgstr "Você"
 
@@ -4520,874 +4476,887 @@ msgstr "Você"
 msgid "unavailable"
 msgstr "indisponível"
 
-#: common/utils.py:126 common/utils.py:167 users/views/actions.py:134
+#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr "Este utilizador já não existe"
 
-#: common/utils.py:133 common/utils.py:135 common/utils.py:138
-#: common/utils.py:174 common/utils.py:178 journal/views/profile.py:499
+#: common/utils.py:135 common/utils.py:137 common/utils.py:140
+#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
 msgid "Access denied"
 msgstr "Acesso negado"
 
-#: common/utils.py:141 common/utils.py:143 journal/views/article.py:204
+#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr "Requer iniciar sessão"
 
-#: common/views_manage.py:144 common/views_manage.py:295
+#: common/views_manage.py:34 common/views_manage.py:373
 #, fuzzy
 #| msgid "reading"
 msgid "Branding"
 msgstr "a ler"
 
-#: common/views_manage.py:146
+#: common/views_manage.py:37
 #, fuzzy
 #| msgid "comments"
 msgid "Recommendations"
 msgstr "comentários"
 
-#: common/views_manage.py:147
+#: common/views_manage.py:38
 #, fuzzy
 #| msgid "Access denied"
 msgid "Access"
 msgstr "Acesso negado"
 
-#: common/views_manage.py:148 common/views_manage.py:623
+#: common/views_manage.py:39 common/views_manage.py:733
 #, fuzzy
 #| msgid "duration"
 msgid "Federation"
 msgstr "duração"
 
-#: common/views_manage.py:149
+#: common/views_manage.py:40
 #, fuzzy
 #| msgid "Catalan"
 msgid "Catalog"
 msgstr "Catalão"
 
-#: common/views_manage.py:150
+#: common/views_manage.py:41
 msgid "API Keys"
 msgstr ""
 
-#: common/views_manage.py:151
+#: common/views_manage.py:42
 #, fuzzy
 #| msgid "Download"
 msgid "Downloader"
 msgstr "Download"
 
-#: common/views_manage.py:152 common/views_manage.py:303
+#: common/views_manage.py:43 common/views_manage.py:381
 #: users/templates/users/steam_import.html:113
 msgid "Advanced"
 msgstr ""
 
-#: common/views_manage.py:202
+#: common/views_manage.py:44
+msgid "Environment"
+msgstr ""
+
+#: common/views_manage.py:280
 #, fuzzy
 #| msgid "Invalid user."
 msgid "Invalid value."
 msgstr "Utilizador inválido."
 
-#: common/views_manage.py:206
+#: common/views_manage.py:284
 msgid "Invalid configuration. Please check your input."
 msgstr ""
 
-#: common/views_manage.py:211
+#: common/views_manage.py:289
 #, fuzzy
 #| msgid "Settings saved."
 msgid "Settings have been saved."
 msgstr "Definições guardadas."
 
-#: common/views_manage.py:231
+#: common/views_manage.py:309
 msgid "Site Name"
 msgstr ""
 
-#: common/views_manage.py:234
+#: common/views_manage.py:312
 #, fuzzy
 #| msgid "Title and Description"
 msgid "Site Description"
 msgstr "Título e Descrição"
 
-#: common/views_manage.py:235
+#: common/views_manage.py:313
 msgid "Short description shown in metadata and about page."
 msgstr ""
 
-#: common/views_manage.py:238
+#: common/views_manage.py:316
 msgid "Site Logo URL"
 msgstr ""
 
-#: common/views_manage.py:239
+#: common/views_manage.py:317
 msgid "URL path to the site logo image."
 msgstr ""
 
-#: common/views_manage.py:242
+#: common/views_manage.py:320
 msgid "Site Icon URL"
 msgstr ""
 
-#: common/views_manage.py:243
+#: common/views_manage.py:321
 msgid "URL path to the site icon/favicon."
 msgstr ""
 
-#: common/views_manage.py:246
+#: common/views_manage.py:324
 msgid "Default User Avatar URL"
 msgstr ""
 
-#: common/views_manage.py:247
+#: common/views_manage.py:325
 msgid "URL path to the default user avatar."
 msgstr ""
 
-#: common/views_manage.py:250
+#: common/views_manage.py:328
 msgid "Site Color Theme"
 msgstr ""
 
-#: common/views_manage.py:251
+#: common/views_manage.py:329
 msgid "PicoCSS color theme."
 msgstr ""
 
-#: common/views_manage.py:276
+#: common/views_manage.py:354
 #, fuzzy
 #| msgid "Production"
 msgid "Site Introduction"
 msgstr "Produção"
 
-#: common/views_manage.py:277
+#: common/views_manage.py:355
 msgid "URL path for the intro/welcome sidebar page."
 msgstr ""
 
-#: common/views_manage.py:280
+#: common/views_manage.py:358
 msgid "Custom HTML Head"
 msgstr ""
 
-#: common/views_manage.py:281
+#: common/views_manage.py:359
 msgid "Extra HTML injected into the <head> of all pages."
 msgstr ""
 
-#: common/views_manage.py:285
+#: common/views_manage.py:363
 msgid "Footer Links"
 msgstr ""
 
-#: common/views_manage.py:286
+#: common/views_manage.py:364
 msgid "Link title mapped to URL."
 msgstr ""
 
-#: common/views_manage.py:315
+#: common/views_manage.py:393
 msgid "Minimum Marks for Discover"
 msgstr ""
 
-#: common/views_manage.py:317
+#: common/views_manage.py:395
 msgid "Number of marks required for an item to appear in discover."
 msgstr ""
 
-#: common/views_manage.py:322
+#: common/views_manage.py:400
 msgid "Update Interval (minutes)"
 msgstr ""
 
-#: common/views_manage.py:323
+#: common/views_manage.py:401
 msgid "How often to refresh the popular items list."
 msgstr ""
 
-#: common/views_manage.py:327
+#: common/views_manage.py:405
 msgid "Filter by Preferred Languages"
 msgstr ""
 
-#: common/views_manage.py:328
+#: common/views_manage.py:406
 msgid "Only show items with titles in the preferred languages."
 msgstr ""
 
-#: common/views_manage.py:331
+#: common/views_manage.py:409
 #, fuzzy
 #| msgid "show all"
 msgid "Show Local Only"
 msgstr "mostrar tudo"
 
-#: common/views_manage.py:333
+#: common/views_manage.py:411
 msgid "Only show items marked by local users, not the entire network."
 msgstr ""
 
-#: common/views_manage.py:337
+#: common/views_manage.py:415
 #, fuzzy
 #| msgid "Popular Tags"
 msgid "Show Popular Posts"
 msgstr "Etiquetas populares"
 
-#: common/views_manage.py:338
+#: common/views_manage.py:416
 msgid "Show popular public posts instead of recent ones."
 msgstr ""
 
-#: common/views_manage.py:341
+#: common/views_manage.py:419
 #, fuzzy
 #| msgid "Popular Tags"
 msgid "Show Popular Tags"
 msgstr "Etiquetas populares"
 
-#: common/views_manage.py:342
+#: common/views_manage.py:420
 msgid "Show popular public tags on the discover page."
 msgstr ""
 
-#: common/views_manage.py:345
+#: common/views_manage.py:423
 #, fuzzy
 #| msgid "Spotify Podcast"
 msgid "Show Verified Podcasts"
 msgstr "Podcast Spotify"
 
-#: common/views_manage.py:347
-msgid ""
-"Show a shelf of recent episodes from podcasts with a verified creator on the "
-"discover page."
+#: common/views_manage.py:425
+msgid "Show a shelf of recent episodes from podcasts with a verified creator on the discover page."
 msgstr ""
 
-#: common/views_manage.py:386
+#: common/views_manage.py:447
+#, fuzzy
+#| msgid "your timeline"
+msgid "Show World Timeline"
+msgstr "a sua cronologia"
+
+#: common/views_manage.py:449
+msgid "Offer a tab with public posts from this site and every server it federates with."
+msgstr ""
+
+#: common/views_manage.py:454
+#, fuzzy
+#| msgid "show all"
+msgid "Show Local Timeline"
+msgstr "mostrar tudo"
+
+#: common/views_manage.py:455
+msgid "Offer a tab with public posts from this site only."
+msgstr ""
+
+#: common/views_manage.py:459
+#, fuzzy
+#| msgid "your timeline"
+msgid "Timelines"
+msgstr "a sua cronologia"
+
+#: common/views_manage.py:487
 msgid "Enable Recommendations"
 msgstr ""
 
-#: common/views_manage.py:388
-msgid ""
-"Master switch. When off, all recommendation surfaces are hidden and the cron "
-"jobs are not scheduled."
+#: common/views_manage.py:489
+msgid "Master switch. When off, all recommendation surfaces are hidden and the cron jobs are not scheduled."
 msgstr ""
 
-#: common/views_manage.py:393
+#: common/views_manage.py:494
 msgid "Source Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:395
-msgid ""
-"Minimum public marks an item needs before similarity rows are built for it."
+#: common/views_manage.py:496
+msgid "Minimum public marks an item needs before similarity rows are built for it."
 msgstr ""
 
-#: common/views_manage.py:401
+#: common/views_manage.py:502
 msgid "Target Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:403
-msgid ""
-"Minimum public marks an item needs to be eligible as a recommendation target."
+#: common/views_manage.py:504
+msgid "Minimum public marks an item needs to be eligible as a recommendation target."
 msgstr ""
 
-#: common/views_manage.py:409
+#: common/views_manage.py:510
 msgid "Top-K Similar Items per Source"
 msgstr ""
 
-#: common/views_manage.py:410
+#: common/views_manage.py:511
 msgid "Number of similar items stored per source item."
 msgstr ""
 
-#: common/views_manage.py:414
+#: common/views_manage.py:515
 msgid "Top-N Recommendations per User"
 msgstr ""
 
-#: common/views_manage.py:415
+#: common/views_manage.py:516
 msgid "Number of personalised rows stored per user."
 msgstr ""
 
-#: common/views_manage.py:419
+#: common/views_manage.py:520
 msgid "Dampen Heavy Shelvers"
 msgstr ""
 
-#: common/views_manage.py:421
-msgid ""
-"Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-"
-"shelvers in similarity scoring."
+#: common/views_manage.py:522
+msgid "Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-shelvers in similarity scoring."
 msgstr ""
 
-#: common/views_manage.py:426
+#: common/views_manage.py:527
 msgid "Per-User Mark Cap (training)"
 msgstr ""
 
-#: common/views_manage.py:428
-msgid ""
-"Truncate each user's contribution to their N most recent marks when building "
-"the similarity matrix."
+#: common/views_manage.py:529
+msgid "Truncate each user's contribution to their N most recent marks when building the similarity matrix."
 msgstr ""
 
-#: common/views_manage.py:434
+#: common/views_manage.py:535
 msgid "Active-User Window (days)"
 msgstr ""
 
-#: common/views_manage.py:436
-msgid ""
-"Refresh personalised recommendations for users with at least one public mark "
-"in the last N days."
+#: common/views_manage.py:537
+msgid "Refresh personalised recommendations for users with at least one public mark in the last N days."
 msgstr ""
 
-#: common/views_manage.py:442
+#: common/views_manage.py:543
 msgid "Per-User Seed Cap (serving)"
 msgstr ""
 
-#: common/views_manage.py:444
-msgid ""
-"Number of recent marks used as seeds when scoring personalised "
-"recommendations for one user."
+#: common/views_manage.py:545
+msgid "Number of recent marks used as seeds when scoring personalised recommendations for one user."
 msgstr ""
 
-#: common/views_manage.py:450
+#: common/views_manage.py:551
 msgid "Lazy Refresh TTL (days)"
 msgstr ""
 
-#: common/views_manage.py:452
-msgid ""
-"How long cached on-demand recommendations are valid before the next request "
-"triggers a refresh."
+#: common/views_manage.py:553
+msgid "How long cached on-demand recommendations are valid before the next request triggers a refresh."
 msgstr ""
 
-#: common/views_manage.py:458
+#: common/views_manage.py:559
 msgid "Circles Window (days)"
 msgstr ""
 
-#: common/views_manage.py:460
-msgid ""
-"Look back N days when finding items recently marked by people the viewer "
-"follows."
+#: common/views_manage.py:561
+msgid "Look back N days when finding items recently marked by people the viewer follows."
 msgstr ""
 
-#: common/views_manage.py:467
+#: common/views_manage.py:568
 msgid "Master Switch"
 msgstr ""
 
-#: common/views_manage.py:470
+#: common/views_manage.py:571
 msgid "Similarity Builder"
 msgstr ""
 
-#: common/views_manage.py:477
+#: common/views_manage.py:578
 #, fuzzy
 #| msgid "Personal"
 msgid "Personalisation"
 msgstr "Pessoal"
 
-#: common/views_manage.py:495
-msgid ""
-"Require an invite token to register. Invite tokens can be generated with "
-"neodb-manage invite --create."
+#: common/views_manage.py:596
+msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
 msgstr ""
 
-#: common/views_manage.py:500
+#: common/views_manage.py:601
 msgid "Enable Local-Only Posting"
 msgstr ""
 
-#: common/views_manage.py:501
+#: common/views_manage.py:602
 msgid "Allow users to create posts visible only to local users."
 msgstr ""
 
-#: common/views_manage.py:504
+#: common/views_manage.py:605
 msgid "Mastodon Login Whitelist"
 msgstr ""
 
-#: common/views_manage.py:505
+#: common/views_manage.py:606
 msgid "One domain per line. Leave empty to allow any instance."
 msgstr ""
 
-#: common/views_manage.py:508
+#: common/views_manage.py:609
 #, fuzzy
 #| msgid "Registration failed"
 msgid "Registration Captcha Items"
 msgstr "Falha ao registar-se"
 
-#: common/views_manage.py:512
-msgid ""
-"Number of item covers a new user must sort into two category rows before "
-"choosing a username. 0 disables the captcha; 5-6 is recommended. The covers "
-"carry no title text, so this cannot be solved with a screen reader: if you "
-"enable it, keep another way in, such as an invite link."
+#: common/views_manage.py:613
+msgid "Number of item covers a new user must sort into two category rows before choosing a username. 0 disables the captcha; 5-6 is recommended. The covers carry no title text, so this cannot be solved with a screen reader: if you enable it, keep another way in, such as an invite link."
 msgstr ""
 
-#: common/views_manage.py:520
+#: common/views_manage.py:621
 msgid "Registration Captcha Minimum Marks"
 msgstr ""
 
-#: common/views_manage.py:523
-msgid ""
-"Marks an item needs before the captcha treats it as well known enough to be "
-"recognizable. Categories with too few such items fall back to any item."
+#: common/views_manage.py:624
+msgid "Marks an item needs before the captcha treats it as well known enough to be recognizable. Categories with too few such items fall back to any item."
 msgstr ""
 
-#: common/views_manage.py:529
+#: common/views_manage.py:630
 msgid "Enable Mastodon Login"
 msgstr ""
 
-#: common/views_manage.py:532
+#: common/views_manage.py:633
 #, fuzzy
 #| msgid "Bluesky Login ID"
 msgid "Enable Bluesky Login"
 msgstr "Iniciar sessão com ID de Bluesky"
 
-#: common/views_manage.py:535
+#: common/views_manage.py:636
 msgid "Enable Threads Login"
 msgstr ""
 
-#: common/views_manage.py:538
+#: common/views_manage.py:639
 #, fuzzy
 #| msgid "Email"
 msgid "Email URL"
 msgstr "Email"
 
-#: common/views_manage.py:540
+#: common/views_manage.py:641
 msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
 msgstr ""
 
-#: common/views_manage.py:544
+#: common/views_manage.py:645
 #, fuzzy
 #| msgid "Email"
 msgid "Email From"
 msgstr "Email"
 
-#: common/views_manage.py:545
+#: common/views_manage.py:646
 msgid "Sender name and address for outgoing email."
 msgstr ""
 
-#: common/views_manage.py:548
+#: common/views_manage.py:649
 #, fuzzy
 #| msgid "Language"
 msgid "Default Language"
 msgstr "Idioma"
 
-#: common/views_manage.py:551
-msgid ""
-"Interface language for visitors and for users who have not chosen one "
-"themselves."
+#: common/views_manage.py:652
+msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:558
-msgid ""
-"Language codes, one per line (e.g. en, zh, ja). First language is the "
-"default."
+#: common/views_manage.py:659
+msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:564
+#: common/views_manage.py:665
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:571
+#: common/views_manage.py:672
 #, fuzzy
 #| msgid "Import Method"
 msgid "Login Methods"
 msgstr "Método de importação"
 
-#: common/views_manage.py:576 mastodon/models/common.py:28
+#: common/views_manage.py:677 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr "Email"
 
-#: common/views_manage.py:580
+#: common/views_manage.py:681
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:591
+#: common/views_manage.py:692
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:593
-msgid ""
-"Disable relay.neodb.net federation for sharing public ratings across "
-"instances."
+#: common/views_manage.py:694
+msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:598
+#: common/views_manage.py:699
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:599
+#: common/views_manage.py:700
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:603
+#: common/views_manage.py:704
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:605
+#: common/views_manage.py:706
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:610
+#: common/views_manage.py:711
 #, fuzzy
 #| msgid "Search results"
 msgid "Search Sites"
 msgstr "Procurar resultados"
 
-#: common/views_manage.py:611
+#: common/views_manage.py:712
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:614
+#: common/views_manage.py:715
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:615
+#: common/views_manage.py:716
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:618
+#: common/views_manage.py:719
 #, fuzzy
 #| msgid "Add tv series"
 msgid "Hidden Categories"
 msgstr "Adicionar séries de tv"
 
-#: common/views_manage.py:619
+#: common/views_manage.py:720
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:640
+#: common/views_manage.py:723
+msgid "Guest Search Page Limit"
+msgstr ""
+
+#: common/views_manage.py:725
+msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
+msgstr ""
+
+#: common/views_manage.py:751
 #, fuzzy
 #| msgid "Spotify Album"
 msgid "Spotify API Key"
 msgstr "Álbum Spotify"
 
-#: common/views_manage.py:641
+#: common/views_manage.py:752
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:644
+#: common/views_manage.py:755
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:645
+#: common/views_manage.py:756
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:648
+#: common/views_manage.py:759
 #, fuzzy
 #| msgid "Google Books"
 msgid "Google Books API Key"
 msgstr "Google Livros"
 
-#: common/views_manage.py:649
+#: common/views_manage.py:760
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:652
+#: common/views_manage.py:763
 #, fuzzy
 #| msgid "Discogs"
 msgid "Discogs API Key"
 msgstr "Discogs"
 
-#: common/views_manage.py:654
+#: common/views_manage.py:765
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:658
+#: common/views_manage.py:769
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:770
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:662
+#: common/views_manage.py:773
 #, fuzzy
 #| msgid "client secret"
 msgid "IGDB Client Secret"
 msgstr "segredo do cliente"
 
-#: common/views_manage.py:665
+#: common/views_manage.py:776
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:667
-msgid ""
-"Bearer token from https://boardgamegeek.com/applications (see https://"
-"boardgamegeek.com/using_the_xml_api#toc9)."
+#: common/views_manage.py:778
+msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:672 users/templates/users/steam_import.html:26
+#: common/views_manage.py:783
+msgid "MyAnimeList Client ID"
+msgstr ""
+
+#: common/views_manage.py:785
+msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
+msgstr ""
+
+#: common/views_manage.py:790 users/templates/users/steam_import.html:26
 #, fuzzy
 #| msgid "Steam Game"
 msgid "Steam API Key"
 msgstr "Jogo Steam"
 
-#: common/views_manage.py:674
-msgid ""
-"https://steamcommunity.com/dev - fallback key for Steam importer. Users can "
-"provide their own key when importing."
+#: common/views_manage.py:792
+msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:679
+#: common/views_manage.py:797
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:680
+#: common/views_manage.py:798
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:683
+#: common/views_manage.py:801
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:686
+#: common/views_manage.py:804
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:689
+#: common/views_manage.py:807
 #, fuzzy
 #| msgid "Threads"
 msgid "Threads App ID"
 msgstr "Threads"
 
-#: common/views_manage.py:690
+#: common/views_manage.py:808
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:693
+#: common/views_manage.py:811
 #, fuzzy
 #| msgid "Threads.net"
 msgid "Threads App Secret"
 msgstr "Threads.net"
 
-#: common/views_manage.py:696
+#: common/views_manage.py:814
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:698
-msgid ""
-"Webhook URLs keyed by channel (default, report, audit, suggest, system). All "
-"channels must be Discord forum or media channels (thread mode) because "
-"notifications are posted as threads."
+#: common/views_manage.py:816
+msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:715
+#: common/views_manage.py:833
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:844
 #, fuzzy
 #| msgid "translator"
 msgid "Translation"
 msgstr "tradutor"
 
-#: common/views_manage.py:730
+#: common/views_manage.py:849
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:734 social/templates/feed.html:27
+#: common/views_manage.py:853 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr "Notificações"
 
-#: common/views_manage.py:744
+#: common/views_manage.py:863
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:745
+#: common/views_manage.py:864
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:748
+#: common/views_manage.py:867
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:749
+#: common/views_manage.py:868
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:752
+#: common/views_manage.py:871
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:874
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:758
+#: common/views_manage.py:877
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:761
+#: common/views_manage.py:880
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:764
+#: common/views_manage.py:883
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:767
+#: common/views_manage.py:886
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:768
+#: common/views_manage.py:887
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:771
+#: common/views_manage.py:890
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:775
+#: common/views_manage.py:894
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:779
+#: common/views_manage.py:898
 #, fuzzy
 #| msgid "series"
 msgid "Retries"
 msgstr "séries"
 
-#: common/views_manage.py:784
+#: common/views_manage.py:903
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:789
+#: common/views_manage.py:908
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:796
+#: common/views_manage.py:915
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:808
+#: common/views_manage.py:927
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:809
+#: common/views_manage.py:928
 #, fuzzy
 #| msgid "site domain name"
 msgid "One domain per line."
 msgstr "nome do domínio do site"
 
-#: common/views_manage.py:812
+#: common/views_manage.py:931
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:813
+#: common/views_manage.py:932
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:935
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:818
-msgid ""
-"Timeout for requests to Mastodon instances and remote fediverse servers."
+#: common/views_manage.py:937
+msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:824
+#: common/views_manage.py:943
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:825
+#: common/views_manage.py:944
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:828
+#: common/views_manage.py:947
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:829
+#: common/views_manage.py:948
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:839
+#: common/views_manage.py:958
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:841
-msgid ""
-"Delete import/export tasks and their files after this many days. Set to 0 to "
-"disable cleanup."
+#: common/views_manage.py:960
+msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:847
+#: common/views_manage.py:966
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:849
-msgid ""
-"Post-migration job keys to skip, one per line (e.g. normalize_genre). "
-"Checked by the worker at dequeue time; skipped jobs log a warning and notify "
-"the Discord system channel."
+#: common/views_manage.py:968
+msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:855
+#: common/views_manage.py:974
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:857
-msgid ""
-"Private key (JWK) identifying this site to ATProto authorization servers. "
-"Auto-generated on first Bluesky login; clear to regenerate."
+#: common/views_manage.py:976
+msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:983
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:986
 #, fuzzy
 #| msgid "optional"
 msgid "Operational"
 msgstr "opcional"
 
-#: common/views_manage.py:883
+#: common/views_manage.py:1002
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:885
-msgid ""
-"Genre codes offered in the Movie edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1004
+msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:1009
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:892
-msgid ""
-"Genre codes offered in the TV edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1011
+msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:897
+#: common/views_manage.py:1016
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:899
-msgid ""
-"Genre codes offered in the Music edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1018
+msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:904
+#: common/views_manage.py:1023
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:906
-msgid ""
-"Genre codes offered in the Game edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1025
+msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:911
+#: common/views_manage.py:1030
 #, fuzzy
 #| msgid "Podcast"
 msgid "Podcast Genres"
 msgstr "Podcast"
 
-#: common/views_manage.py:913
-msgid ""
-"Genre codes offered in the Podcast edit dropdown, one per line. Leave empty "
-"to use the built-in default."
+#: common/views_manage.py:1032
+msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:918
+#: common/views_manage.py:1037
 #, fuzzy
 #| msgid "Performance"
 msgid "Performance Genres"
 msgstr "Espetáculo"
 
-#: common/views_manage.py:920
-msgid ""
-"Genre codes offered in the Performance edit dropdown, one per line. Leave "
-"empty to use the built-in default."
+#: common/views_manage.py:1039
+msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:926
+#: common/views_manage.py:1045
 msgid "Genres by Category"
 msgstr ""
 
-#: journal/forms.py:12
-msgid ""
-"Tips: use >!text!< for spoilers; some instances may not be able to show "
-"posts longer than 360 charactors."
+#: common/views_manage.py:1069
+msgid "Site"
 msgstr ""
-"Dicas: utilize &gt;!text!&lt; para spoilers; algumas instâncias podem não "
-"conseguir mostrar posts com mais de 360 caracteres."
+
+#: common/views_manage.py:1079
+#, fuzzy
+#| msgid "Database"
+msgid "Database and Services"
+msgstr "Base de dados"
+
+#: common/views_manage.py:1089
+msgid "Media and Files"
+msgstr ""
+
+#: common/views_manage.py:1098
+msgid "Monitoring"
+msgstr ""
+
+#: common/views_manage.py:1102
+msgid "Security"
+msgstr ""
+
+#: common/views_manage.py:1111
+msgid "Other Environment Variables"
+msgstr ""
+
+#: common/views_manage.py:1113
+msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
+msgstr ""
+
+#: journal/forms.py:12
+msgid "Tips: use >!text!< for spoilers; some instances may not be able to show posts longer than 360 charactors."
+msgstr "Dicas: utilize &gt;!text!&lt; para spoilers; algumas instâncias podem não conseguir mostrar posts com mais de 360 caracteres."
 
 #: journal/forms.py:29 journal/forms.py:31 journal/forms.py:80
 #: journal/forms.py:83 journal/forms.py:153
@@ -5401,14 +5370,14 @@ msgid "Content (Markdown)"
 msgstr "Conteúdo (Markdown)"
 
 #: journal/forms.py:46 journal/forms.py:124 journal/forms.py:226
-#: journal/forms.py:288 journal/views/note.py:38
+#: journal/forms.py:288 journal/views/note.py:37
 #, fuzzy
 #| msgid "Crosspost to timeline"
 msgid "Crosspost"
 msgstr "Fazer crosspost para a cronologia"
 
 #: journal/forms.py:47 journal/forms.py:125 journal/forms.py:227
-#: journal/forms.py:289 journal/views/note.py:39
+#: journal/forms.py:289 journal/views/note.py:38
 #, fuzzy
 #| msgid "Turn on crosspost to other social networks by default"
 msgid "Crosspost to your connected social networks"
@@ -5425,10 +5394,10 @@ msgstr "Ao gravar, substituir espaços iniciais por espaços de largura total"
 #: journal/forms.py:59 journal/forms.py:137 journal/forms.py:162
 #: journal/forms.py:219 journal/forms.py:281
 #: journal/templates/collection_share.html:24
-#: journal/templates/wrapped_share.html:36 journal/views/note.py:31
-#: users/templates/users/data.html:45 users/templates/users/data.html:98
-#: users/templates/users/data.html:155 users/templates/users/data.html:206
-#: users/templates/users/data.html:269 users/templates/users/data.html:328
+#: journal/templates/wrapped_share.html:36 journal/views/note.py:30
+#: users/templates/users/data.html:60 users/templates/users/data.html:113
+#: users/templates/users/data.html:170 users/templates/users/data.html:221
+#: users/templates/users/data.html:284 users/templates/users/data.html:346
 #: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
@@ -5473,7 +5442,6 @@ msgid "Collaborative editing"
 msgstr "Editar em grupo/colaboração"
 
 #: journal/forms.py:204 users/templates/users/crossposts.html:51
-#: users/templates/users/data.html:483
 msgid "Status"
 msgstr "Estado"
 
@@ -5487,48 +5455,46 @@ msgstr "Comentário"
 msgid "Rating"
 msgstr "avaliação"
 
-#: journal/importers/goodreads.py:196 journal/importers/letterboxd.py:144
-#: journal/importers/rym.py:442 journal/importers/storygraph.py:500
+#: journal/importers/goodreads.py:198 journal/importers/letterboxd.py:147
+#: journal/importers/rym.py:444 journal/importers/storygraph.py:504
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr "uma crítica de {item_title}"
 
-#: journal/importers/opml.py:45
+#: journal/importers/opml.py:49
 #, python-brace-format
 msgid "{username}'s podcast subscriptions"
 msgstr "Subscrições de podcasts de {username}'"
 
-#: journal/importers/rym.py:168 journal/importers/storygraph.py:128
+#: journal/importers/rym.py:170 journal/importers/storygraph.py:132
 #, python-brace-format
-msgid ""
-"Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
+msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:178 journal/importers/storygraph.py:138
+#: journal/importers/rym.py:180 journal/importers/storygraph.py:142
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/importers/rym.py:233 journal/importers/storygraph.py:184
+#: journal/importers/rym.py:235 journal/importers/storygraph.py:188
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:348 journal/importers/storygraph.py:389
+#: journal/importers/rym.py:350 journal/importers/storygraph.py:393
 msgid "Matched file missing; cannot import."
 msgstr ""
 
-#: journal/importers/rym.py:376 journal/importers/storygraph.py:412
+#: journal/importers/rym.py:378 journal/importers/storygraph.py:416
 #, python-brace-format
-msgid ""
-"Import complete: {imported} imported, {skipped} skipped, {failed} failed"
+msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:212 journal/views/article.py:218
+#: journal/models/article.py:215 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
-#: journal/models/collection.py:44 journal/templates/add_to_collection.html:39
+#: journal/models/collection.py:48 journal/templates/add_to_collection.html:39
 #: journal/templates/collection_edit.html:64
 #: journal/templates/collection_share.html:63
 #: journal/templates/collection_update_item_note.html:3
@@ -5536,75 +5502,75 @@ msgstr ""
 msgid "note"
 msgstr "nota"
 
-#: journal/models/collection.py:111
+#: journal/models/collection.py:115
 #, fuzzy
 #| msgid "shared {username}'s collection"
 msgid "search query for dynamic collection"
 msgstr "partilhou a coleção de {username}"
 
-#: journal/models/collection.py:524 journal/templatetags/collection.py:35
+#: journal/models/collection.py:566 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] "%(count)d livro"
 msgstr[1] "%(count)d livros"
 
-#: journal/models/collection.py:529 journal/templatetags/collection.py:43
+#: journal/models/collection.py:571 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] "%(count)d filme"
 msgstr[1] "%(count)d filmes"
 
-#: journal/models/collection.py:534 journal/templatetags/collection.py:51
+#: journal/models/collection.py:576 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] "%(count)d programa de tv"
 msgstr[1] "%(count)d programas de tv"
 
-#: journal/models/collection.py:539 journal/templatetags/collection.py:59
+#: journal/models/collection.py:581 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] "%(count)d álbum"
 msgstr[1] "%(count)d álbuns"
 
-#: journal/models/collection.py:544 journal/templatetags/collection.py:67
+#: journal/models/collection.py:586 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] "%(count)d jogo"
 msgstr[1] "%(count)d jogos"
 
-#: journal/models/collection.py:549 journal/templatetags/collection.py:75
+#: journal/models/collection.py:591 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] "%(count)d podcast"
 msgstr[1] "%(count)d podcasts"
 
-#: journal/models/collection.py:555 journal/templatetags/collection.py:83
+#: journal/models/collection.py:597 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] "%(count)d espetáculo"
 msgstr[1] "%(count)d espetáculos"
 
-#: journal/models/collection.py:563 journal/templatetags/collection.py:91
+#: journal/models/collection.py:605 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] "%(count)d artigo"
 msgstr[1] "%(count)d artigos"
 
-#: journal/models/common.py:50 journal/templates/action_open_post.html:15
-#: journal/templates/collection_share.html:35 journal/templates/mark.html:84
+#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
-#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:54
-#: users/templates/users/data.html:107 users/templates/users/data.html:164
-#: users/templates/users/data.html:215 users/templates/users/data.html:277
-#: users/templates/users/data.html:337 users/templates/users/data.html:534
+#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
+#: users/templates/users/data.html:122 users/templates/users/data.html:179
+#: users/templates/users/data.html:230 users/templates/users/data.html:292
+#: users/templates/users/data.html:355 users/templates/users/data.html:534
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5612,13 +5578,13 @@ msgstr[1] "%(count)d artigos"
 msgid "Public"
 msgstr "Público"
 
-#: journal/models/common.py:51 journal/templates/action_open_post.html:9
-#: journal/templates/collection_share.html:46 journal/templates/mark.html:91
+#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
-#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
-#: users/templates/users/data.html:115 users/templates/users/data.html:172
-#: users/templates/users/data.html:223 users/templates/users/data.html:285
-#: users/templates/users/data.html:345 users/templates/users/data.html:542
+#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
+#: users/templates/users/data.html:130 users/templates/users/data.html:187
+#: users/templates/users/data.html:238 users/templates/users/data.html:300
+#: users/templates/users/data.html:363 users/templates/users/data.html:542
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5626,12 +5592,12 @@ msgstr "Público"
 msgid "Followers Only"
 msgstr "Apenas seguidores"
 
-#: journal/models/common.py:52 journal/templates/collection_share.html:57
-#: journal/templates/mark.html:98 journal/templates/post_compose.html:72
-#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
-#: users/templates/users/data.html:123 users/templates/users/data.html:180
-#: users/templates/users/data.html:231 users/templates/users/data.html:293
-#: users/templates/users/data.html:353 users/templates/users/data.html:550
+#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/templates/mark.html:102 journal/templates/post_compose.html:72
+#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
+#: users/templates/users/data.html:138 users/templates/users/data.html:195
+#: users/templates/users/data.html:246 users/templates/users/data.html:308
+#: users/templates/users/data.html:371 users/templates/users/data.html:550
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5639,37 +5605,33 @@ msgstr "Apenas seguidores"
 msgid "Mentioned Only"
 msgstr "Apenas mencionado"
 
-#: journal/models/common.py:790
+#: journal/models/common.py:806
 #, fuzzy
 #| msgid "A recent post was not posted to Mastodon, please re-authorize."
-msgid ""
-"A recent post was not posted to Bluesky, please login NeoDB using ATProto "
-"again to re-authorize."
-msgstr ""
-"Um post recente não foi publicado no Mastodon. Por favor, volte a autorizar."
+msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
+msgstr "Um post recente não foi publicado no Mastodon. Por favor, volte a autorizar."
 
-#: journal/models/common.py:987
+#: journal/models/common.py:1003
 msgid "A recent post was not posted to Threads."
 msgstr "Um post recente não foi publicado no Threads."
 
-#: journal/models/common.py:1020
+#: journal/models/common.py:1036
 #, fuzzy
 #| msgid "A recent post was not posted to Mastodon."
 msgid "A recent post was not boosted on Mastodon."
 msgstr "Um post recente não foi publicado no Mastodon."
 
-#: journal/models/common.py:1030
+#: journal/models/common.py:1046
 #, fuzzy
 #| msgid "Item no longer exists"
 msgid "Original post no longer exists."
 msgstr "Este item já não existe"
 
-#: journal/models/common.py:1044
+#: journal/models/common.py:1060
 msgid "A recent post was not posted to Mastodon, please re-authorize."
-msgstr ""
-"Um post recente não foi publicado no Mastodon. Por favor, volte a autorizar."
+msgstr "Um post recente não foi publicado no Mastodon. Por favor, volte a autorizar."
 
-#: journal/models/common.py:1053
+#: journal/models/common.py:1069
 msgid "A recent post was not posted to Mastodon."
 msgstr "Um post recente não foi publicado no Mastodon."
 
@@ -5679,7 +5641,7 @@ msgstr "Um post recente não foi publicado no Mastodon."
 msgid "Authorization expired"
 msgstr "A autenticação falhou"
 
-#: journal/models/crosspost.py:17 users/models/task.py:24
+#: journal/models/crosspost.py:17 users/models/task.py:26
 msgid "Failed"
 msgstr "Falhou"
 
@@ -5687,85 +5649,85 @@ msgstr "Falhou"
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:469
+#: journal/models/mark.py:475
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:473
+#: journal/models/mark.py:479
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:480
+#: journal/models/mark.py:486
 #, fuzzy
 #| msgid "Invalid parameter"
 msgid "Invalid progress type."
 msgstr "Parâmetro inválido"
 
-#: journal/models/mark.py:482
+#: journal/models/mark.py:488
 #, fuzzy
 #| msgid "Invalid response from Fediverse instance."
 msgid "Invalid progress type for this item."
 msgstr "Resposta inválida da instância do Fediverso."
 
-#: journal/models/note.py:34 users/templates/users/rym_import.html:73
+#: journal/models/note.py:47 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr "Página"
 
-#: journal/models/note.py:35
+#: journal/models/note.py:48
 msgid "Chapter"
 msgstr "Capítulo"
 
-#: journal/models/note.py:38
+#: journal/models/note.py:51
 msgid "Part"
 msgstr "Parte"
 
-#: journal/models/note.py:39
+#: journal/models/note.py:52
 msgid "Episode"
 msgstr "Episódio"
 
-#: journal/models/note.py:40
+#: journal/models/note.py:53
 msgid "Track"
 msgstr "Faixa"
 
-#: journal/models/note.py:41
+#: journal/models/note.py:54
 msgid "Cycle"
 msgstr "Ciclo"
 
-#: journal/models/note.py:42
+#: journal/models/note.py:55
 msgid "Timestamp"
 msgstr "Marca temporal"
 
-#: journal/models/note.py:43
+#: journal/models/note.py:56
 msgid "Percentage"
 msgstr "Percentagem"
 
-#: journal/models/note.py:60
+#: journal/models/note.py:77
 #, python-brace-format
 msgid "Page {value}"
 msgstr "Página {value}"
 
-#: journal/models/note.py:61
+#: journal/models/note.py:78
 #, python-brace-format
 msgid "Chapter {value}"
 msgstr "Capítulo {value}"
 
-#: journal/models/note.py:64
+#: journal/models/note.py:81
 #, python-brace-format
 msgid "Part {value}"
 msgstr "Parte {value}"
 
-#: journal/models/note.py:65
+#: journal/models/note.py:82
 #, python-brace-format
 msgid "Episode {value}"
 msgstr "Episódio {value}"
 
-#: journal/models/note.py:66
+#: journal/models/note.py:83
 #, python-brace-format
 msgid "Track {value}"
 msgstr "Faixa {value}"
 
-#: journal/models/note.py:67
+#: journal/models/note.py:84
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr "Ciclo {value}"
@@ -5773,448 +5735,447 @@ msgstr "Ciclo {value}"
 #: journal/models/renderers.py:208
 #, python-brace-format
 msgid "regarding {item_title}, may contain spoiler or triggering content"
-msgstr ""
-"Relativamente a {item_title}, pode conter spoilers e conteúdo inapropriado"
+msgstr "Relativamente a {item_title}, pode conter spoilers e conteúdo inapropriado"
 
-#: journal/models/review.py:78
+#: journal/models/review.py:79
 #, fuzzy, python-brace-format
 #| msgid "a review of {item_title}"
 msgid "a review of {title}"
 msgstr "uma crítica de {item_title}"
 
-#: journal/models/review.py:80
+#: journal/models/review.py:81
 #, fuzzy
 #| msgid "Item contains sub-items."
 msgid "(may contain spoilers)"
 msgstr "Item contém sub-itens."
 
-#: journal/models/shelf.py:37
+#: journal/models/shelf.py:39
 msgid "WISHLIST"
 msgstr "LISTA DE DESEJOS"
 
-#: journal/models/shelf.py:38
+#: journal/models/shelf.py:40
 msgid "PROGRESS"
 msgstr "PROGRESSO"
 
-#: journal/models/shelf.py:39
+#: journal/models/shelf.py:41
 msgid "COMPLETE"
 msgstr "COMPLETO"
 
-#: journal/models/shelf.py:40
+#: journal/models/shelf.py:42
 msgid "DROPPED"
 msgstr "DEIXADO"
 
-#: journal/models/shelf.py:49
+#: journal/models/shelf.py:51
 msgid "books to read"
 msgstr "livros para ler"
 
-#: journal/models/shelf.py:50
+#: journal/models/shelf.py:52
 msgid "want to read"
 msgstr "quer ler"
 
-#: journal/models/shelf.py:51
+#: journal/models/shelf.py:53
 #, python-brace-format
 msgid "wants to read {item}"
 msgstr "quer ler {item}"
 
-#: journal/models/shelf.py:52
+#: journal/models/shelf.py:54
 msgid "to read"
 msgstr "para ler"
 
-#: journal/models/shelf.py:57
+#: journal/models/shelf.py:59
 msgid "books reading"
 msgstr "livros a ler"
 
-#: journal/models/shelf.py:58
+#: journal/models/shelf.py:60
 msgid "start reading"
 msgstr "começar a ler"
 
-#: journal/models/shelf.py:59
+#: journal/models/shelf.py:61
 #, python-brace-format
 msgid "started reading {item}"
 msgstr "começou a ler {item}"
 
-#: journal/models/shelf.py:60
+#: journal/models/shelf.py:62
 msgid "reading"
 msgstr "a ler"
 
-#: journal/models/shelf.py:65
+#: journal/models/shelf.py:67
 msgid "books completed"
 msgstr "livros concluídos"
 
-#: journal/models/shelf.py:66
+#: journal/models/shelf.py:68
 msgid "finish reading"
 msgstr "terminar de ler"
 
-#: journal/models/shelf.py:67
+#: journal/models/shelf.py:69
 #, python-brace-format
 msgid "finished reading {item}"
 msgstr "acabou de ler {item}"
 
-#: journal/models/shelf.py:68
+#: journal/models/shelf.py:70
 msgid "read"
 msgstr "ler"
 
-#: journal/models/shelf.py:73
+#: journal/models/shelf.py:75
 msgid "books dropped"
 msgstr "livros deixados"
 
-#: journal/models/shelf.py:74
+#: journal/models/shelf.py:76
 msgid "stop reading"
 msgstr "parar de ler"
 
-#: journal/models/shelf.py:75
+#: journal/models/shelf.py:77
 #, python-brace-format
 msgid "stopped reading {item}"
 msgstr "parou de ler {item}"
 
-#: journal/models/shelf.py:76
+#: journal/models/shelf.py:78
 msgid "stopped reading"
 msgstr "parou de ler"
 
-#: journal/models/shelf.py:81
+#: journal/models/shelf.py:83
 msgid "books reviewed"
 msgstr "livros resenhados"
 
-#: journal/models/shelf.py:82 journal/models/shelf.py:122
-#: journal/models/shelf.py:162 journal/models/shelf.py:202
-#: journal/models/shelf.py:242 journal/models/shelf.py:282
-#: journal/models/shelf.py:316
+#: journal/models/shelf.py:84 journal/models/shelf.py:124
+#: journal/models/shelf.py:164 journal/models/shelf.py:204
+#: journal/models/shelf.py:244 journal/models/shelf.py:284
+#: journal/models/shelf.py:318
 msgid "review"
 msgstr "crítica"
 
-#: journal/models/shelf.py:83 journal/models/shelf.py:123
-#: journal/models/shelf.py:163 journal/models/shelf.py:203
-#: journal/models/shelf.py:243 journal/models/shelf.py:283
-#: journal/models/shelf.py:317
+#: journal/models/shelf.py:85 journal/models/shelf.py:125
+#: journal/models/shelf.py:165 journal/models/shelf.py:205
+#: journal/models/shelf.py:245 journal/models/shelf.py:285
+#: journal/models/shelf.py:319
 #, python-brace-format
 msgid "wrote a review of {item}"
 msgstr "escreveu uma resenha sobre {item}"
 
-#: journal/models/shelf.py:89
+#: journal/models/shelf.py:91
 msgid "movies to watch"
 msgstr "filmes para ver"
 
-#: journal/models/shelf.py:90 journal/models/shelf.py:130
+#: journal/models/shelf.py:92 journal/models/shelf.py:132
 msgid "want to watch"
 msgstr "quero ver"
 
-#: journal/models/shelf.py:91 journal/models/shelf.py:131
+#: journal/models/shelf.py:93 journal/models/shelf.py:133
 #, python-brace-format
 msgid "wants to watch {item}"
 msgstr "quer ver {item}"
 
-#: journal/models/shelf.py:92 journal/models/shelf.py:132
+#: journal/models/shelf.py:94 journal/models/shelf.py:134
 msgid "to watch"
 msgstr "para ver"
 
-#: journal/models/shelf.py:97
+#: journal/models/shelf.py:99
 msgid "movies watching"
 msgstr "filmes a ver"
 
-#: journal/models/shelf.py:98 journal/models/shelf.py:138
+#: journal/models/shelf.py:100 journal/models/shelf.py:140
 msgid "start watching"
 msgstr "começar a ver"
 
-#: journal/models/shelf.py:99 journal/models/shelf.py:139
+#: journal/models/shelf.py:101 journal/models/shelf.py:141
 #, python-brace-format
 msgid "started watching {item}"
 msgstr "começou a ver {item}"
 
-#: journal/models/shelf.py:100 journal/models/shelf.py:140
+#: journal/models/shelf.py:102 journal/models/shelf.py:142
 msgid "watching"
 msgstr "a ver"
 
-#: journal/models/shelf.py:105
+#: journal/models/shelf.py:107
 msgid "movies watched"
 msgstr "filmes vistos"
 
-#: journal/models/shelf.py:106 journal/models/shelf.py:146
+#: journal/models/shelf.py:108 journal/models/shelf.py:148
 msgid "finish watching"
 msgstr "acabar de ver"
 
-#: journal/models/shelf.py:107 journal/models/shelf.py:147
+#: journal/models/shelf.py:109 journal/models/shelf.py:149
 #, python-brace-format
 msgid "finished watching {item}"
 msgstr "acabou de ver {item}"
 
-#: journal/models/shelf.py:108 journal/models/shelf.py:148
+#: journal/models/shelf.py:110 journal/models/shelf.py:150
 msgid "watched"
 msgstr "visto"
 
-#: journal/models/shelf.py:113
+#: journal/models/shelf.py:115
 msgid "movies dropped"
 msgstr "filmes deixados"
 
-#: journal/models/shelf.py:114 journal/models/shelf.py:154
+#: journal/models/shelf.py:116 journal/models/shelf.py:156
 msgid "stop watching"
 msgstr "parar de ver"
 
-#: journal/models/shelf.py:115 journal/models/shelf.py:155
+#: journal/models/shelf.py:117 journal/models/shelf.py:157
 #, python-brace-format
 msgid "stopped watching {item}"
 msgstr "parou de ver {item}"
 
-#: journal/models/shelf.py:116 journal/models/shelf.py:156
+#: journal/models/shelf.py:118 journal/models/shelf.py:158
 msgid "stopped watching"
 msgstr "parou de ver"
 
-#: journal/models/shelf.py:121
+#: journal/models/shelf.py:123
 msgid "movies reviewed"
 msgstr "filmes resenhados"
 
-#: journal/models/shelf.py:129
+#: journal/models/shelf.py:131
 msgid "TV shows to watch"
 msgstr "programas para ver"
 
-#: journal/models/shelf.py:137
+#: journal/models/shelf.py:139
 msgid "TV shows watching"
 msgstr "programas a ver"
 
-#: journal/models/shelf.py:145
+#: journal/models/shelf.py:147
 msgid "TV shows watched"
 msgstr "programas vistos"
 
-#: journal/models/shelf.py:153
+#: journal/models/shelf.py:155
 msgid "TV shows dropped"
 msgstr "programas deixados"
 
-#: journal/models/shelf.py:161
+#: journal/models/shelf.py:163
 msgid "TV shows reviewed"
 msgstr "programas resenhados"
 
-#: journal/models/shelf.py:169
+#: journal/models/shelf.py:171
 msgid "albums to listen"
 msgstr "álbuns para ouvir"
 
-#: journal/models/shelf.py:170 journal/models/shelf.py:250
+#: journal/models/shelf.py:172 journal/models/shelf.py:252
 msgid "want to listen"
 msgstr "quer ouvir"
 
-#: journal/models/shelf.py:171 journal/models/shelf.py:251
+#: journal/models/shelf.py:173 journal/models/shelf.py:253
 #, python-brace-format
 msgid "wants to listen {item}"
 msgstr "quer ouvir {item}"
 
-#: journal/models/shelf.py:172 journal/models/shelf.py:252
+#: journal/models/shelf.py:174 journal/models/shelf.py:254
 msgid "to listen"
 msgstr "para ouvir"
 
-#: journal/models/shelf.py:177
+#: journal/models/shelf.py:179
 msgid "albums listening"
 msgstr "álbuns a ouvir"
 
-#: journal/models/shelf.py:178 journal/models/shelf.py:258
+#: journal/models/shelf.py:180 journal/models/shelf.py:260
 msgid "start listening"
 msgstr "começou a ouvir"
 
-#: journal/models/shelf.py:179 journal/models/shelf.py:259
+#: journal/models/shelf.py:181 journal/models/shelf.py:261
 #, python-brace-format
 msgid "started listening {item}"
 msgstr "começou a ouvir {item}"
 
-#: journal/models/shelf.py:180 journal/models/shelf.py:260
+#: journal/models/shelf.py:182 journal/models/shelf.py:262
 msgid "listening"
 msgstr "a ouvir"
 
-#: journal/models/shelf.py:185
+#: journal/models/shelf.py:187
 msgid "albums listened"
 msgstr "álbuns ouvidos"
 
-#: journal/models/shelf.py:186 journal/models/shelf.py:266
+#: journal/models/shelf.py:188 journal/models/shelf.py:268
 msgid "finish listening"
 msgstr "acabou de ouvir"
 
-#: journal/models/shelf.py:187 journal/models/shelf.py:267
+#: journal/models/shelf.py:189 journal/models/shelf.py:269
 #, python-brace-format
 msgid "finished listening {item}"
 msgstr "acabou de ouvir {item}"
 
-#: journal/models/shelf.py:188 journal/models/shelf.py:268
+#: journal/models/shelf.py:190 journal/models/shelf.py:270
 msgid "listened"
 msgstr "ouvido"
 
-#: journal/models/shelf.py:193
+#: journal/models/shelf.py:195
 msgid "albums dropped"
 msgstr "álbuns deixados"
 
-#: journal/models/shelf.py:194 journal/models/shelf.py:274
+#: journal/models/shelf.py:196 journal/models/shelf.py:276
 msgid "stop listening"
 msgstr "parar de ouvir"
 
-#: journal/models/shelf.py:195 journal/models/shelf.py:275
+#: journal/models/shelf.py:197 journal/models/shelf.py:277
 #, python-brace-format
 msgid "stopped listening {item}"
 msgstr "parou de ouvir {item}"
 
-#: journal/models/shelf.py:196 journal/models/shelf.py:276
+#: journal/models/shelf.py:198 journal/models/shelf.py:278
 msgid "stopped listening"
 msgstr "parou de ouvir"
 
-#: journal/models/shelf.py:201
+#: journal/models/shelf.py:203
 msgid "albums reviewed"
 msgstr "álbuns resenhados"
 
-#: journal/models/shelf.py:209
+#: journal/models/shelf.py:211
 msgid "games to play"
 msgstr "jogos para jogar"
 
-#: journal/models/shelf.py:210
+#: journal/models/shelf.py:212
 msgid "want to play"
 msgstr "quer jogar"
 
-#: journal/models/shelf.py:211
+#: journal/models/shelf.py:213
 #, python-brace-format
 msgid "wants to play {item}"
 msgstr "quer jogar {item}"
 
-#: journal/models/shelf.py:212
+#: journal/models/shelf.py:214
 msgid "to play"
 msgstr "para jogar"
 
-#: journal/models/shelf.py:217
+#: journal/models/shelf.py:219
 msgid "games playing"
 msgstr "jogos em curso"
 
-#: journal/models/shelf.py:218
+#: journal/models/shelf.py:220
 msgid "start playing"
 msgstr "começar a jogar"
 
-#: journal/models/shelf.py:219
+#: journal/models/shelf.py:221
 #, python-brace-format
 msgid "started playing {item}"
 msgstr "começou a jogar {item}"
 
-#: journal/models/shelf.py:220
+#: journal/models/shelf.py:222
 msgid "playing"
 msgstr "a jogar"
 
-#: journal/models/shelf.py:225
+#: journal/models/shelf.py:227
 msgid "games played"
 msgstr "jogos jogados"
 
-#: journal/models/shelf.py:226
+#: journal/models/shelf.py:228
 msgid "finish playing"
 msgstr "terminar o jogo"
 
-#: journal/models/shelf.py:227
+#: journal/models/shelf.py:229
 #, python-brace-format
 msgid "finished playing {item}"
 msgstr "terminou o jogo {item}"
 
-#: journal/models/shelf.py:228
+#: journal/models/shelf.py:230
 msgid "played"
 msgstr "jogado"
 
-#: journal/models/shelf.py:233
+#: journal/models/shelf.py:235
 msgid "games dropped"
 msgstr "jogos deixados"
 
-#: journal/models/shelf.py:234
+#: journal/models/shelf.py:236
 msgid "stop playing"
 msgstr "parar de jogar"
 
-#: journal/models/shelf.py:235
+#: journal/models/shelf.py:237
 #, python-brace-format
 msgid "stopped playing {item}"
 msgstr "parou de jogar {item}"
 
-#: journal/models/shelf.py:236
+#: journal/models/shelf.py:238
 msgid "stopped playing"
 msgstr "parou de jogar"
 
-#: journal/models/shelf.py:241
+#: journal/models/shelf.py:243
 msgid "games reviewed"
 msgstr "jogos resenhados"
 
-#: journal/models/shelf.py:249
+#: journal/models/shelf.py:251
 msgid "podcasts to listen"
 msgstr "podcasts para ouvir"
 
-#: journal/models/shelf.py:257
+#: journal/models/shelf.py:259
 msgid "podcasts listening"
 msgstr "podcasts a ouvir"
 
-#: journal/models/shelf.py:265
+#: journal/models/shelf.py:267
 msgid "podcasts listened"
 msgstr "podcasts ouvidos"
 
-#: journal/models/shelf.py:273
+#: journal/models/shelf.py:275
 msgid "podcasts dropped"
 msgstr "podcasts deixados"
 
-#: journal/models/shelf.py:281
+#: journal/models/shelf.py:283
 msgid "podcasts reviewed"
 msgstr "podcasts resenhados"
 
-#: journal/models/shelf.py:289
+#: journal/models/shelf.py:291
 msgid "performances to see"
 msgstr "espetáculos para ver"
 
-#: journal/models/shelf.py:290
+#: journal/models/shelf.py:292
 msgid "want to see"
 msgstr "quero assistir"
 
-#: journal/models/shelf.py:291
+#: journal/models/shelf.py:293
 #, python-brace-format
 msgid "wants to see {item}"
 msgstr "quer assistir {item}"
 
-#: journal/models/shelf.py:292
+#: journal/models/shelf.py:294
 msgid "to see"
 msgstr "para assistir"
 
-#: journal/models/shelf.py:299
+#: journal/models/shelf.py:301
 msgid "performances saw"
 msgstr "espetáculos assistidos"
 
-#: journal/models/shelf.py:300
+#: journal/models/shelf.py:302
 msgid "finish seeing"
 msgstr "terminar de assistir"
 
-#: journal/models/shelf.py:301
+#: journal/models/shelf.py:303
 #, python-brace-format
 msgid "finished seeing {item}"
 msgstr "acabou de assistir {item}"
 
-#: journal/models/shelf.py:302
+#: journal/models/shelf.py:304
 msgid "seen"
 msgstr "assistido"
 
-#: journal/models/shelf.py:307
+#: journal/models/shelf.py:309
 msgid "performances dropped"
 msgstr "espetáculo deixado"
 
-#: journal/models/shelf.py:308
+#: journal/models/shelf.py:310
 msgid "stop seeing"
 msgstr "parar de assistir"
 
-#: journal/models/shelf.py:309
+#: journal/models/shelf.py:311
 #, python-brace-format
 msgid "stopped seeing {item}"
 msgstr "parou de assistir {item}"
 
-#: journal/models/shelf.py:310
+#: journal/models/shelf.py:312
 msgid "stopped seeing"
 msgstr "parou de assistir"
 
-#: journal/models/shelf.py:315
+#: journal/models/shelf.py:317
 msgid "performances reviewed"
 msgstr "espetáculos resenhados"
 
-#: journal/models/shelf.py:323
+#: journal/models/shelf.py:325
 #, fuzzy
 #| msgid "Users you are following"
 msgid "people following"
 msgstr "Utilizadores que está a seguir"
 
-#: journal/models/shelf.py:325
+#: journal/models/shelf.py:327
 #, fuzzy, python-brace-format
 #| msgid "started playing {item}"
 msgid "started following {item}"
 msgstr "começou a jogar {item}"
 
-#: journal/models/shelf.py:921
+#: journal/models/shelf.py:923
 msgid "removed mark"
 msgstr "marcação removida"
 
@@ -6244,38 +6205,22 @@ msgstr ""
 msgid "Remove from collection"
 msgstr "Remover da coleção"
 
-#: journal/templates/_list_item.html:34
-msgid "add mark"
-msgstr "Adicionar marcação"
-
-#: journal/templates/_list_item.html:42
-msgid "update mark"
-msgstr "Atualizar marcação"
-
-#: journal/templates/_list_item.html:60
+#: journal/templates/_list_item.html:43
 #: journal/templates/collection_update_item_note_ok.html:3
 msgid "Update note"
 msgstr "Atualizar nota"
 
-#: journal/templates/_list_item.html:100 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:123
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
 msgstr "Resenha"
 
-#: journal/templates/_list_item.html:133
+#: journal/templates/_list_item.html:91
 #, fuzzy, python-format
-#| msgid ""
-#| " %(dups)s items are from the same work or have the same identifier, they "
-#| "are hidden from the search results, <a _=\"on click toggle .unfold on "
-#| "#dup\">click here to show them.</a> "
-msgid ""
-"%(dups)s item(s) are from the same work or have the same identifier, click "
-"here to display:"
-msgstr ""
-" %(dups)s itens são da mesma obra ou pertencem à mesma pessoa. Estes itens "
-"estão ocultos dos resultados de pesquisa., <a _=\"on click toggle .unfold on "
-"#dup\"> Clique aqui para vê-los.</a> "
+#| msgid " %(dups)s items are from the same work or have the same identifier, they are hidden from the search results, <a _=\"on click toggle .unfold on #dup\">click here to show them.</a> "
+msgid "%(dups)s item(s) are from the same work or have the same identifier, click here to display:"
+msgstr " %(dups)s itens são da mesma obra ou pertencem à mesma pessoa. Estes itens estão ocultos dos resultados de pesquisa., <a _=\"on click toggle .unfold on #dup\"> Clique aqui para vê-los.</a> "
 
 #: journal/templates/_sidebar_collection_filter.html:32
 #, fuzzy
@@ -6365,9 +6310,7 @@ msgstr "Boost"
 
 #: journal/templates/action_delete_post.html:7
 msgid "Are you sure to delete this post and the mark or note related with it?"
-msgstr ""
-"Tem a certeza que pretende apagar este post, bem como a marcação e a nota "
-"relacionada?"
+msgstr "Tem a certeza que pretende apagar este post, bem como a marcação e a nota relacionada?"
 
 #: journal/templates/action_delete_post.html:7
 msgid "Are you sure to delete this reply?"
@@ -6395,6 +6338,14 @@ msgstr "gostei"
 #: journal/templates/action_like_post.html:16
 msgid "Like"
 msgstr ""
+
+#: journal/templates/action_mark_item.html:10
+msgid "add mark"
+msgstr "Adicionar marcação"
+
+#: journal/templates/action_mark_item.html:18
+msgid "update mark"
+msgstr "Atualizar marcação"
 
 #: journal/templates/action_open_post.html:7
 #, fuzzy
@@ -6456,13 +6407,13 @@ msgstr "Adicionar à coleção"
 msgid "Create a new collection"
 msgstr "Criar nova coleção"
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:81
+#: journal/templates/article.html:104 social/templates/_event_post.html:76
 #, fuzzy
 #| msgid "wrote a review of {item}"
 msgid "wrote a review"
 msgstr "escreveu uma resenha sobre {item}"
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:83
+#: journal/templates/article.html:106 social/templates/_event_post.html:78
 #, fuzzy
 #| msgid "wrote a note"
 msgid "wrote an article"
@@ -6474,9 +6425,7 @@ msgstr ""
 
 #: journal/templates/article.html:155
 msgid "The author has set it to be viewable only by logged-in users."
-msgstr ""
-"O autor definiu o conteúdo a visualizar apenas para utilizadores com sessão "
-"iniciada."
+msgstr "O autor definiu o conteúdo a visualizar apenas para utilizadores com sessão iniciada."
 
 #: journal/templates/article_edit.html:13
 #, fuzzy
@@ -6584,23 +6533,21 @@ msgstr "partilhar com a posição de reprodução"
 msgid "Mark"
 msgstr "Marcação"
 
-#: journal/templates/mark.html:50
+#: journal/templates/mark.html:54
 msgid "not rated"
 msgstr "sem avaliação"
 
-#: journal/templates/mark.html:70
+#: journal/templates/mark.html:74
 msgid "add a tag and press Enter"
 msgstr "adicione uma etiqueta e clique Enter"
 
-#: journal/templates/mark.html:122
+#: journal/templates/mark.html:126
 msgid "change mark date"
 msgstr "alterar data de marcação"
 
-#: journal/templates/mark.html:148
+#: journal/templates/mark.html:156
 msgid "Sure to delete mark, comment and tags for this item?"
-msgstr ""
-"Tem a certeza que pretende eliminar marcação, comentário e etiquetas deste "
-"item?"
+msgstr "Tem a certeza que pretende eliminar marcação, comentário e etiquetas deste item?"
 
 #: journal/templates/markdown_editor.html:9
 msgid "Markdown format references"
@@ -6641,12 +6588,11 @@ msgid ""
 "Content Cell  | Content Cell\n"
 "Content Cell  | Content Cell\n"
 "\n"
-"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/"
-"Wikipedia-logo-v2.svg)\n"
+"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 "\n"
 msgstr ""
 
-#: journal/templates/note.html:19 journal/views/note.py:23
+#: journal/templates/note.html:19 journal/views/note.py:22
 msgid "Note"
 msgstr "Nota"
 
@@ -6677,12 +6623,8 @@ msgid "Are you sure to delete this entire content?"
 msgstr "Tem a certeza que quer apagar todo este conteúdo?"
 
 #: journal/templates/piece_delete.html:24
-msgid ""
-"By deleting it, you will also lose track of others' comments and feedbacks "
-"to your content."
-msgstr ""
-"Ao eliminá-lo, perderá o acesso aos comentários e feedbacks de outros "
-"utilizadores ao seu conteúdo."
+msgid "By deleting it, you will also lose track of others' comments and feedbacks to your content."
+msgstr "Ao eliminá-lo, perderá o acesso aos comentários e feedbacks de outros utilizadores ao seu conteúdo."
 
 #: journal/templates/piece_delete.html:25
 #: journal/templates/piece_delete.html:32
@@ -6775,7 +6717,7 @@ msgstr "sumário anual"
 msgid "Articles"
 msgstr ""
 
-#: journal/templates/profile.html:166 journal/views/collection.py:427
+#: journal/templates/profile.html:166 journal/views/collection.py:409
 #: journal/views/profile.py:401
 msgid "collection"
 msgstr "coleção"
@@ -6811,13 +6753,8 @@ msgid "Personal"
 msgstr "Pessoal"
 
 #: journal/templates/tag_edit.html:52
-msgid ""
-"Personal tags are not included in public index. However, if you use this tag "
-"when marking an item publicly, it might still be visible to others."
-msgstr ""
-"As etiquetas pessoais não são incluídas no índice público. No entanto, se "
-"usar esta etiqueta para marcar um artigo público, é possível que fique "
-"visível a outros utilizadores."
+msgid "Personal tags are not included in public index. However, if you use this tag when marking an item publicly, it might still be visible to others."
+msgstr "As etiquetas pessoais não são incluídas no índice público. No entanto, se usar esta etiqueta para marcar um artigo público, é possível que fique visível a outros utilizadores."
 
 #: journal/templates/tag_edit.html:55
 msgid "Delete this tag"
@@ -6892,133 +6829,128 @@ msgstr "Resenhas de {0}"
 msgid "Link invalid"
 msgstr "Link inválido"
 
-#: journal/views/collection.py:58 journal/views/collection.py:96
+#: journal/views/collection.py:62 journal/views/collection.py:94
 #, python-brace-format
 msgid "Collection by {0}"
 msgstr "Coleção de {0}"
 
-#: journal/views/collection.py:432
+#: journal/views/collection.py:414
 msgid "shared my collection"
 msgstr "partilhou a minha coleção"
 
-#: journal/views/collection.py:435
+#: journal/views/collection.py:417
 #, python-brace-format
 msgid "shared {username}'s collection"
 msgstr "partilhou a coleção de {username}"
 
-#: journal/views/collection.py:502 journal/views/collection.py:541
-#: journal/views/collection.py:553 journal/views/collection.py:579
+#: journal/views/collection.py:484 journal/views/collection.py:523
+#: journal/views/collection.py:535 journal/views/collection.py:561
 msgid "Dynamic collection is not editable"
 msgstr ""
 
-#: journal/views/collection.py:518
+#: journal/views/collection.py:500
 #, fuzzy
 #| msgid "This username is already in use."
 msgid "The item is already in the collection."
 msgstr "Este nome de utilizador já está a ser usado."
 
-#: journal/views/collection.py:520
+#: journal/views/collection.py:502
 msgid "Unable to find the item, please use item url from this site."
-msgstr ""
-"Não foi possível encontrar o item. Por favor, insira um item de url deste "
-"site."
+msgstr "Não foi possível encontrar o item. Por favor, insira um item de url deste site."
 
-#: journal/views/collection.py:566
+#: journal/views/collection.py:548
 #, fuzzy
 #| msgid "Save"
 msgid "Saved."
 msgstr "Guardar"
 
-#: journal/views/common.py:119 journal/views/mark.py:225
-#: journal/views/mark.py:279 journal/views/note.py:175
+#: journal/views/common.py:126 journal/views/mark.py:273
+#: journal/views/mark.py:315 journal/views/note.py:167
 #: journal/views/profile.py:42 journal/views/review.py:59
 #: journal/views/review.py:79
 msgid "Content not found"
 msgstr "Conteúdo não encontrado"
 
-#: journal/views/common.py:174 journal/views/mark.py:159
+#: journal/views/common.py:184 journal/views/mark.py:210
 msgid "Data saved but unable to crosspost to Fediverse instance."
-msgstr ""
-"Dados guardados, porém, não é possível fazer crosspost para a instância do "
-"Fediverso."
+msgstr "Dados guardados, porém, não é possível fazer crosspost para a instância do Fediverso."
 
-#: journal/views/common.py:176
+#: journal/views/common.py:186
 msgid "Redirecting to your Fediverse instance now to re-authenticate."
-msgstr ""
-"Está a ser redirecionado para a sua instância do Fediverso de modo a fazer "
-"novamente a sua autenticação."
+msgstr "Está a ser redirecionado para a sua instância do Fediverso de modo a fazer novamente a sua autenticação."
 
-#: journal/views/common.py:183
+#: journal/views/common.py:193
 msgid "List not found."
 msgstr "Lista não encontrada."
 
-#: journal/views/mark.py:150
+#: journal/views/mark.py:206
 msgid "Content too long for your Fediverse instance."
 msgstr "Conteúdo demasiado longo para a sua instância do Fediverso."
 
-#: journal/views/mark.py:178 journal/views/mark.py:238
+#: journal/views/mark.py:224 journal/views/mark.py:226
+#: journal/views/mark.py:280
 #, fuzzy
 #| msgid "Invalid tag"
 msgid "Invalid input"
 msgstr "Etiqueta inválida"
 
-#: journal/views/note.py:23
+#: journal/views/note.py:22
 msgid "Progress"
 msgstr ""
 
-#: journal/views/note.py:28
+#: journal/views/note.py:27
 #, fuzzy
 #| msgid "Update note"
 msgid "Update progress"
 msgstr "Atualizar nota"
 
-#: journal/views/note.py:59
+#: journal/views/note.py:58
 msgid "Progress (optional)"
 msgstr "Progresso (opcional)"
 
-#: journal/views/note.py:61
+#: journal/views/note.py:60
 msgid "Note Content"
 msgstr "Conteúdo da nota"
 
-#: journal/views/note.py:63
+#: journal/views/note.py:62
 msgid "Content Warning (optional)"
 msgstr "Aviso de Conteúdo (opcional)"
 
-#: journal/views/note.py:85
+#: journal/views/note.py:84
 msgid "Progress Type (optional)"
 msgstr "Tipo de progresso (opcional)"
 
-#: journal/views/note.py:123 journal/views/note.py:183
+#: journal/views/note.py:115 journal/views/note.py:175
 msgid "Only in-progress items can have progress."
 msgstr ""
 
-#: journal/views/post.py:98 journal/views/post.py:392
+#: journal/views/post.py:100 journal/views/post.py:388
 msgid "Post not found"
 msgstr "Post não encontrado"
 
-#: journal/views/post.py:189
+#: journal/views/post.py:191
 msgid "Visibility too high for quoting this post"
 msgstr ""
 
-#: journal/views/post.py:337 journal/views/post.py:418
+#: journal/views/post.py:339 journal/views/post.py:414
 #, fuzzy
 #| msgid "Item cannot be deleted."
 msgid "Content cannot be empty."
 msgstr "Este item não pode ser apagado."
 
-#: journal/views/post.py:396
+#: journal/views/post.py:392
 #, fuzzy
 #| msgid "This operation cannot be undone. Sure to merge?"
 msgid "This post cannot be edited here"
 msgstr "Esta operação não pode ser desfeita. Tem certeza que deseja mesclar?"
 
-#: journal/views/post.py:541
+#: journal/views/post.py:531
 #, fuzzy
 #| msgid "Invalid file."
 msgid "Invalid choices"
 msgstr "Ficheiro inválido."
 
-#: journal/views/post.py:544
+#: journal/views/post.py:534
 #, fuzzy
 #| msgid "Invalid tag"
 msgid "Invalid post"
@@ -7038,64 +6970,59 @@ msgstr "{review_title} - uma análise de {item_title}"
 #, fuzzy
 #| msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgid "may contain spoiler or triggering content"
-msgstr ""
-"Relativamente a {item_title}, pode conter spoilers e conteúdo inapropriado"
+msgstr "Relativamente a {item_title}, pode conter spoilers e conteúdo inapropriado"
 
-#: journal/views/tag.py:47 journal/views/tag.py:61
+#: journal/views/tag.py:46 journal/views/tag.py:60
 msgid "Invalid tag"
 msgstr "Etiqueta inválida"
 
-#: journal/views/tag.py:50
+#: journal/views/tag.py:49
 msgid "Tag not found"
 msgstr "Etiqueta não encontrada"
 
-#: journal/views/tag.py:72
+#: journal/views/tag.py:65
 msgid "Tag deleted."
 msgstr "Etiqueta eliminada."
 
-#: journal/views/tag.py:82
+#: journal/views/tag.py:75
 msgid "Duplicated tag."
 msgstr "Etiqueta duplicada."
 
-#: journal/views/tag.py:96
+#: journal/views/tag.py:83
 msgid "Tag updated."
 msgstr "Etiqueta atualizada."
 
-#: journal/views/wrapped.py:160
+#: journal/views/wrapped.py:161
 msgid "Summary posted to timeline."
 msgstr "Sumário publicado na timeline."
 
-#: mastodon/models/common.py:29
+#: mastodon/models/common.py:31
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: mastodon/models/common.py:30 users/templates/users/login.html:120
+#: mastodon/models/common.py:32 users/templates/users/login.html:114
 msgid "Threads"
 msgstr "Threads"
 
-#: mastodon/models/common.py:31
+#: mastodon/models/common.py:33
 msgid "Bluesky"
 msgstr "Bluesky"
 
-#: mastodon/models/email.py:59
+#: mastodon/models/email.py:63
 msgid ""
 "\n"
 "\n"
-"If you did not mean to register or login, please ignore this email. If you "
-"are concerned with your account security, please change the email linked "
-"with your account, or contact us."
+"If you did not mean to register or login, please ignore this email. If you are concerned with your account security, please change the email linked with your account, or contact us."
 msgstr ""
 "\n"
 "\n"
-"Se não pretendia registar-se ou iniciar sessão, ignore este email. Se "
-"estiver preocupado com a segurança da sua conta, por favor altere o e-mail "
-"associado à sua conta ou contacte-nos."
+"Se não pretendia registar-se ou iniciar sessão, ignore este email. Se estiver preocupado com a segurança da sua conta, por favor altere o e-mail associado à sua conta ou contacte-nos."
 
-#: mastodon/models/email.py:64 mastodon/models/email.py:69
+#: mastodon/models/email.py:68 mastodon/models/email.py:73
 msgid "Verification Code"
 msgstr "Código de verificação"
 
-#: mastodon/models/email.py:66
+#: mastodon/models/email.py:70
 #, python-brace-format
 msgid ""
 "Use this code to verify your email address {email}\n"
@@ -7106,7 +7033,7 @@ msgstr ""
 "\n"
 "{code}"
 
-#: mastodon/models/email.py:70
+#: mastodon/models/email.py:74
 #, python-brace-format
 msgid ""
 "Use this code to login as {email}\n"
@@ -7117,30 +7044,27 @@ msgstr ""
 "\n"
 "{code}"
 
-#: mastodon/models/email.py:74 users/templates/users/captcha.html:13
+#: mastodon/models/email.py:78 users/templates/users/captcha.html:13
 #: users/templates/users/captcha_solved.html:9
 #: users/templates/users/login.html:20 users/templates/users/register.html:9
 #: users/templates/users/welcome.html:10
 msgid "Register"
 msgstr "Registar"
 
-#: mastodon/models/email.py:76
+#: mastodon/models/email.py:80
 #, python-brace-format
 msgid ""
 "There is no account registered with this email address yet: {email}\n"
 "\n"
-"If you already have an account with us, just login and add this email to you "
-"account.\n"
+"If you already have an account with us, just login and add this email to you account.\n"
 "\n"
-"If you prefer to register a new account with this email, please use this "
-"verification code: {code}"
+"If you prefer to register a new account with this email, please use this verification code: {code}"
 msgstr ""
 "Não existe ainda nenhuma conta com este endereço de email: {email}\n"
 "\n"
 "Se já tem conta connosco, inicie sessão e adicione este email à sua conta.\n"
 "\n"
-"Se preferir criar uma nova conta com este email, por favor use o seguinte "
-"código de verificação: {code}"
+"Se preferir criar uma nova conta com este email, por favor use o seguinte código de verificação: {code}"
 
 #: mastodon/models/mastodon.py:570
 msgid "site domain name"
@@ -7182,57 +7106,61 @@ msgstr "Tamanho máximo da postagem"
 msgid "New Post"
 msgstr "Novo Post"
 
-#: mastodon/views/bluesky.py:26 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:32 mastodon/views/bluesky.py:93
 #, fuzzy
 #| msgid "Bluesky Login ID"
 msgid "Bluesky login is disabled."
 msgstr "Iniciar sessão com ID de Bluesky"
 
-#: mastodon/views/bluesky.py:28 mastodon/views/email.py:35
-#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:29
-#: users/templates/users/login.html:6 users/views/webauthn.py:133
+#: mastodon/views/bluesky.py:47 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:65 mastodon/views/bluesky.py:98
+#: mastodon/views/bluesky.py:106 mastodon/views/bluesky.py:112
+#: mastodon/views/common.py:36 mastodon/views/mastodon.py:62
+#: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
+#: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
+#: mastodon/views/threads.py:57 mastodon/views/threads.py:65
+#: mastodon/views/threads.py:71 users/views/account.py:256
+#: users/views/account.py:375
+msgid "Authentication failed"
+msgstr "A autenticação falhou"
+
+#: mastodon/views/bluesky.py:47 mastodon/views/common.py:103
+msgid "Identity not found."
+msgstr "Identidade não encontrada."
+
+#: mastodon/views/bluesky.py:53 mastodon/views/email.py:35
+#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:31
+#: users/templates/users/login.html:6 users/views/webauthn.py:136
 #, fuzzy
 #| msgid "Export file expired. Please export again."
 msgid "Security check failed. Please try again."
 msgstr "O ficheiro de exportação expirou. Por favor, tente novamente."
 
-#: mastodon/views/bluesky.py:34 mastodon/views/bluesky.py:40
-#: mastodon/views/bluesky.py:64 mastodon/views/bluesky.py:72
-#: mastodon/views/bluesky.py:78 mastodon/views/common.py:36
-#: mastodon/views/mastodon.py:62 mastodon/views/mastodon.py:70
-#: mastodon/views/mastodon.py:77 mastodon/views/mastodon.py:87
-#: mastodon/views/mastodon.py:94 mastodon/views/threads.py:55
-#: mastodon/views/threads.py:63 mastodon/views/threads.py:69
-#: users/views/account.py:254 users/views/account.py:373
-msgid "Authentication failed"
-msgstr "A autenticação falhou"
-
-#: mastodon/views/bluesky.py:35 mastodon/views/email.py:66
+#: mastodon/views/bluesky.py:60 mastodon/views/email.py:66
 #, fuzzy
 #| msgid "System busy, please try again in a minute."
 msgid "Too many attempts, please try again later."
-msgstr ""
-"Sistema sobrecarregado. Por favor, tente novamente dentro de um minuto."
+msgstr "Sistema sobrecarregado. Por favor, tente novamente dentro de um minuto."
 
-#: mastodon/views/bluesky.py:40
+#: mastodon/views/bluesky.py:65
 #, fuzzy
 #| msgid "ATProto handle"
 msgid "ATProto handle is required."
 msgstr "handle do ATProto"
 
-#: mastodon/views/bluesky.py:50
+#: mastodon/views/bluesky.py:84
 #, fuzzy
 #| msgid "Error connecting to instance"
 msgid "Error connecting to your ATProto server"
 msgstr "Erro ao conectar-se com a instância"
 
-#: mastodon/views/bluesky.py:73
+#: mastodon/views/bluesky.py:107
 #, fuzzy
 #| msgid "Invalid response from Fediverse instance."
 msgid "Invalid response from ATProto authorization server."
 msgstr "Resposta inválida da instância do Fediverso."
 
-#: mastodon/views/bluesky.py:78
+#: mastodon/views/bluesky.py:112
 msgid "Invalid account data from Bluesky."
 msgstr "Dados de conta Bluesky inválidos."
 
@@ -7240,7 +7168,7 @@ msgstr "Dados de conta Bluesky inválidos."
 msgid "Invalid user."
 msgstr "Utilizador inválido."
 
-#: mastodon/views/common.py:52 users/views/account.py:414
+#: mastodon/views/common.py:52 users/views/account.py:416
 msgid "Registration failed"
 msgstr "Falha ao registar-se"
 
@@ -7272,10 +7200,6 @@ msgstr "Informação do Login foi atualizada como {handle}."
 msgid "Disconnect identity failed"
 msgstr "Falhou ao desconectar-se da identidade"
 
-#: mastodon/views/common.py:103
-msgid "Identity not found."
-msgstr "Identidade não encontrada."
-
 #: mastodon/views/common.py:117
 msgid "You cannot disconnect last login identity."
 msgstr "Não é possível desconectar a última identidade de início de sessão."
@@ -7295,8 +7219,7 @@ msgstr "Verificação"
 
 #: mastodon/views/email.py:48 users/templates/users/verify.html:20
 msgid "Verification email is being sent, please check your inbox."
-msgstr ""
-"Está a ser enviado um email de verificação. Por favor, verifique a sua inbox."
+msgstr "Está a ser enviado um email de verificação. Por favor, verifique a sua inbox."
 
 #: mastodon/views/email.py:80
 msgid "Invalid verification code"
@@ -7318,7 +7241,7 @@ msgstr "Erro ao conectar-se com a instância"
 msgid "Invalid response from Fediverse instance."
 msgstr "Resposta inválida da instância do Fediverso."
 
-#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:64
+#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:66
 msgid "Invalid OAuth state. Please try again."
 msgstr ""
 
@@ -7338,19 +7261,17 @@ msgstr "Token inválido da sua instância do Fediverso."
 msgid "Invalid account data from Fediverse instance."
 msgstr "Dados de conta de instância do Fediverso inválidos."
 
-#: mastodon/views/threads.py:69
+#: mastodon/views/threads.py:71
 msgid "Invalid account data from Threads."
 msgstr "Dados de conta do Threads inválidos."
 
-#: mastodon/views/threads.py:147
+#: mastodon/views/threads.py:149
 msgid "Data deletion completed"
 msgstr ""
 
-#: mastodon/views/threads.py:149
+#: mastodon/views/threads.py:151
 #, python-brace-format
-msgid ""
-"Data linked to your Threads account has been deleted. Confirmation code: "
-"{code}"
+msgid "Data linked to your Threads account has been deleted. Confirmation code: {code}"
 msgstr ""
 
 #: social/templates/_article_teaser.html:10
@@ -7389,15 +7310,11 @@ msgstr "impulsionado"
 msgid "play"
 msgstr "reproduzir"
 
-#: social/templates/_event_post.html:50
-msgid "mark"
-msgstr "marcação"
-
-#: social/templates/_event_post.html:79
+#: social/templates/_event_post.html:74
 msgid "wrote a note"
 msgstr "escreveu uma nota"
 
-#: social/templates/_event_post.html:88
+#: social/templates/_event_post.html:83
 #, fuzzy
 #| msgid "playing"
 msgid "replying to"
@@ -7412,7 +7329,7 @@ msgstr ""
 msgid "Untitled article"
 msgstr ""
 
-#: social/templates/event/boosted.html:3
+#: social/templates/event/boosted.html:2
 msgid "boosted your post"
 msgstr "Deu boost ao seu post"
 
@@ -7444,8 +7361,7 @@ msgid ""
 "boosted your comment on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"deu boost ao seu comentário em/no <a href=\"%(item_url)s\">%(item_title)s</"
-"a>\n"
+"deu boost ao seu comentário em/no <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/boosted_note.html:3
 #, python-format
@@ -7469,12 +7385,10 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"deu boost à sua crítica <a href=\"%(piece_url)s\">%(piece_title)s</a> em/"
-"no<a href=\"%(item_url)s\">%(item_title)s</a>\n"
+"deu boost à sua crítica <a href=\"%(piece_url)s\">%(piece_title)s</a> em/no<a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/boosted_shelfmember.html:3
 #, python-format
@@ -7493,7 +7407,7 @@ msgstr "pediu para o seguir"
 msgid "followed you"
 msgstr "seguiu-o"
 
-#: social/templates/event/liked.html:3
+#: social/templates/event/liked.html:2
 msgid "liked your post"
 msgstr "gostou da sua publicação"
 
@@ -7549,12 +7463,10 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"gostou da sua crítica <a href=\"%(piece_url)s\">%(piece_title)s</a> em/no <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"gostou da sua crítica <a href=\"%(piece_url)s\">%(piece_title)s</a> em/no <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/liked_shelfmember.html:3
 #, python-format
@@ -7565,7 +7477,7 @@ msgstr ""
 "\n"
 "gostou da sua marcação em/no <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
-#: social/templates/event/mentioned.html:3
+#: social/templates/event/mentioned.html:2
 msgid "mentioned you"
 msgstr "mencionou-o"
 
@@ -7597,8 +7509,7 @@ msgid ""
 "replied to your comment on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"respondeu ao seu comentário em/no <a href=\"%(item_url)s\">%(item_title)s</"
-"a>\n"
+"respondeu ao seu comentário em/no <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/mentioned_note.html:3
 #, python-format
@@ -7622,12 +7533,10 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"respondeu à sua crítica <a href=\"%(piece_url)s\">%(piece_title)s</a> em/no "
-"<a href=\"%(item_url)s\">%(item_title)s</a>\n"
+"respondeu à sua crítica <a href=\"%(piece_url)s\">%(piece_title)s</a> em/no <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/mentioned_shelfmember.html:3
 #, python-format
@@ -7638,33 +7547,46 @@ msgstr ""
 "\n"
 "respondeu à sua marcação em/no <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
-#: social/templates/feed.html:12 social/templates/feed.html:39
-#: social/templates/search_feed.html:12
-msgid "Activities from those you follow"
-msgstr "Atividades das pessoas que segue"
+#: social/templates/feed.html:39 users/templates/users/preferences.html:40
+msgid "Activities"
+msgstr "Atividades"
 
-#: social/templates/feed.html:42 social/templates/feed.html:44
+#: social/templates/feed.html:43 social/templates/feed.html:45
+msgid "world"
+msgstr ""
+
+#: social/templates/feed.html:51 social/templates/feed.html:53
+#, fuzzy
+#| msgid "locale"
+msgid "local"
+msgstr "localização"
+
+#: social/templates/feed.html:58 social/templates/feed.html:60
+#, fuzzy
+#| msgid "sure to follow?"
+msgid "those you follow"
+msgstr "De certeza que pretende seguir?"
+
+#: social/templates/feed.html:64 social/templates/feed.html:66
 #, fuzzy
 #| msgid "What they read/watch/..."
 msgid "what they read/watch/..."
 msgstr "O que andam a ler/ver/..."
 
-#: social/templates/feed_events.html:30
+#: social/templates/feed_events.html:29
 msgid "no matching activities."
 msgstr "sem atividades correspondentes."
 
-#: social/templates/feed_events.html:33
+#: social/templates/feed_events.html:31
+#, fuzzy
+#| msgid "no matching activities."
+msgid "no public activities yet."
+msgstr "sem atividades correspondentes."
+
+#: social/templates/feed_events.html:34
 #, python-format
-msgid ""
-"Find and mark some books/movies/podcasts/games, <a "
-"href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/"
-"Douban, follow some fellow %(site_name)s users on the fediverse, so their "
-"recent activities and yours will show up here."
-msgstr ""
-"Encontre e marque livros/filmes/podcasts/jogos, <a "
-"href=\"%(import_url)s\">importe os seus dados</a> do Goodreads/Letterboxd/"
-"Douban, siga %(site_name)s utilizadores no fediverso, para a que a sua "
-"atividade e as deles apareçam aqui."
+msgid "Find and mark some books/movies/podcasts/games, <a href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/Douban, follow some fellow %(site_name)s users on the fediverse, so their recent activities and yours will show up here."
+msgstr "Encontre e marque livros/filmes/podcasts/jogos, <a href=\"%(import_url)s\">importe os seus dados</a> do Goodreads/Letterboxd/Douban, siga %(site_name)s utilizadores no fediverso, para a que a sua atividade e as deles apareçam aqui."
 
 #: social/templates/notification.html:58
 msgid "mention"
@@ -7700,6 +7622,10 @@ msgstr ""
 msgid "Poll ending at %(end_time)s"
 msgstr ""
 
+#: social/templates/search_feed.html:12 social/views.py:57 social/views.py:58
+msgid "Activities from those you follow"
+msgstr "Atividades das pessoas que segue"
+
 #: social/templates/single_post.html:13 social/templates/single_post.html:32
 #, fuzzy
 #| msgid "Posts"
@@ -7714,61 +7640,69 @@ msgstr ""
 msgid "Poll"
 msgstr ""
 
-#: takahe/models.py:453
+#: social/views.py:59
+#, fuzzy
+#| msgid "Activities from those you follow"
+msgid "Activities on this site"
+msgstr "Atividades das pessoas que segue"
+
+#: social/views.py:60
+#, fuzzy
+#| msgid "Activities from those you follow"
+msgid "Activities from the fediverse"
+msgstr "Atividades das pessoas que segue"
+
+#: takahe/models.py:445
 msgid "Display Name"
 msgstr "Nome de apresentação"
 
-#: takahe/models.py:455
+#: takahe/models.py:447
 msgid "Bio"
 msgstr "Bio"
 
-#: takahe/models.py:457
+#: takahe/models.py:449
 msgid "Manually approve new followers"
 msgstr "Aprovar novos seguidores manualmente"
 
-#: takahe/models.py:461
+#: takahe/models.py:453
 #, fuzzy
 #| msgid "Include profile and posts in discovery"
 msgid "Include profile, marks and posts in discovery"
 msgstr "Incluir perfil e publicações em \"explorar\""
 
-#: takahe/models.py:464
+#: takahe/models.py:456
 msgid "Include posts in search results"
 msgstr "Incluir posts nos resultados de pesquisa"
 
-#: takahe/models.py:482
+#: takahe/models.py:474
 msgid "Profile picture"
 msgstr "Foto de perfil"
 
-#: takahe/models.py:489
+#: takahe/models.py:481
 msgid "Header picture"
 msgstr "Foto de cabeçalho"
 
-#: users/models/task.py:22
+#: users/models/task.py:24
 msgid "Started"
 msgstr "Iniciado"
 
-#: users/models/task.py:23
+#: users/models/task.py:25
 msgid "Complete"
 msgstr "Completo"
 
-#: users/models/user.py:69
-msgid ""
-"Enter a valid username. This value may contain only unaccented lowercase a-z "
-"and uppercase A-Z letters, numbers, and _ characters."
-msgstr ""
-"Introduza um nome de utilizador válido. Apenas pode conter letras minúsculas "
-"a-z e maiúsculas A-Z não acentuadas, números e _ caracteres."
+#: users/models/user.py:71
+msgid "Enter a valid username. This value may contain only unaccented lowercase a-z and uppercase A-Z letters, numbers, and _ characters."
+msgstr "Introduza um nome de utilizador válido. Apenas pode conter letras minúsculas a-z e maiúsculas A-Z não acentuadas, números e _ caracteres."
 
-#: users/models/user.py:130
+#: users/models/user.py:132
 msgid "username"
 msgstr "nome de utilizador"
 
-#: users/models/user.py:135
+#: users/models/user.py:137
 msgid "Required. 50 characters or fewer. Letters, digits and _ only."
 msgstr "Necessário. 50 caracteres ou menos. Letras, digitos e _ apenas."
 
-#: users/models/user.py:138
+#: users/models/user.py:140
 msgid "A user with that username already exists."
 msgstr "Já existe um utilizador com esse nome de utilizador."
 
@@ -7923,9 +7857,7 @@ msgid "Cancel import"
 msgstr "Cancelar"
 
 #: users/templates/users/_rym_section.html:29
-msgid ""
-"On RateYourMusic, go to your profile and use the <b>Export your music "
-"catalog</b> option to download your library as a CSV file."
+msgid "On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:31
@@ -7934,18 +7866,12 @@ msgid "Upload the downloaded CSV file below."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:33
-msgid ""
-"Albums are matched by title + artist (and year if present) — first against "
-"the local catalog, then MusicBrainz, then Spotify. After auto-matching, "
-"you'll preview the matches in a table, edit any link or shelf status, and "
-"confirm the import."
+msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:36
 #: users/templates/users/_storygraph_section.html:38
-msgid ""
-"You can also re-upload a previously-downloaded matched CSV — the existing "
-"<code>link</code> column will be honoured as the default match."
+msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:40
@@ -7976,18 +7902,11 @@ msgid "Cancel the StoryGraph import? Progress will be discarded."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:31
-msgid ""
-"On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to "
-"download your library as a CSV file."
+msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:35
-msgid ""
-"Books are matched by ISBN — first against the local catalog, then Google "
-"Books and OpenLibrary — with a title + author search as fallback. After auto-"
-"matching, you'll preview the matches in a table, edit any link or shelf "
-"status, and confirm the import."
+msgid "Books are matched by ISBN — first against the local catalog, then Google Books and OpenLibrary — with a title + author search as fallback. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/account.html:11
@@ -7999,13 +7918,8 @@ msgid "Display name, avatar and other information"
 msgstr "Nome a apresentar, avatar e outras informações"
 
 #: users/templates/users/account.html:23
-msgid ""
-"Updating profile information here will turn off automatic sync of display "
-"name, bio and avatar from your Mastodon instance. Sure to continue?"
-msgstr ""
-"Ao atualizar as informações de perfil aqui, irá desativar a sincronização "
-"automática do nome a apresentar, bio e avatar da sua instância de Mastodon. "
-"Pretende avançar?"
+msgid "Updating profile information here will turn off automatic sync of display name, bio and avatar from your Mastodon instance. Sure to continue?"
+msgstr "Ao atualizar as informações de perfil aqui, irá desativar a sincronização automática do nome a apresentar, bio e avatar da sua instância de Mastodon. Pretende avançar?"
 
 #: users/templates/users/account.html:26
 msgid "Username"
@@ -8017,22 +7931,12 @@ msgstr "Endereço de Email"
 
 #: users/templates/users/account.html:59 users/templates/users/register.html:47
 #, python-format
-msgid ""
-"Please click the confirmation link in the email sent to %(pending_email)s; "
-"if you haven't received it for more than a few minutes, please input and "
-"save again."
-msgstr ""
-"Por favor, clique no link de confirmação do email enviado para "
-"%(pending_email)s ; se não tiver recebido nada dentro de alguns minutos, "
-"introduza novamente e guarde-o."
+msgid "Please click the confirmation link in the email sent to %(pending_email)s; if you haven't received it for more than a few minutes, please input and save again."
+msgstr "Por favor, clique no link de confirmação do email enviado para %(pending_email)s ; se não tiver recebido nada dentro de alguns minutos, introduza novamente e guarde-o."
 
 #: users/templates/users/account.html:61 users/templates/users/register.html:50
-msgid ""
-"Email is recommended as a backup login method, if you log in via a Fediverse "
-"instance"
-msgstr ""
-"O email é recomendado como método de backup referente ao início de sessão, "
-"se iniciar sessão através de uma instância do Fediverso"
+msgid "Email is recommended as a backup login method, if you log in via a Fediverse instance"
+msgstr "O email é recomendado como método de backup referente ao início de sessão, se iniciar sessão através de uma instância do Fediverso"
 
 #: users/templates/users/account.html:73 users/templates/users/login.html:84
 msgid "Fediverse (Mastodon)"
@@ -8049,30 +7953,16 @@ msgid "Last updated"
 msgstr "Última atualização"
 
 #: users/templates/users/account.html:92
-msgid ""
-"If you have not yet registered with any Federated instance, you may <a "
-"href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an "
-"instance</a> and register."
-msgstr ""
-"Se ainda não se registou em nenhuma instância federada, pode sempre <a "
-"href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">escolher uma "
-"instância</a> e registar-se."
+msgid "If you have not yet registered with any Federated instance, you may <a href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an instance</a> and register."
+msgstr "Se ainda não se registou em nenhuma instância federada, pode sempre <a href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">escolher uma instância</a> e registar-se."
 
 #: users/templates/users/account.html:97
-msgid ""
-"To associate with another federated identity, please enter the domain name "
-"of the instance where the new identity is located."
-msgstr ""
-"Para se associar a outra identidade/conta federada, por favor, insira o nome "
-"do domínio da instância onde está localizada a sua nova identidade/conta."
+msgid "To associate with another federated identity, please enter the domain name of the instance where the new identity is located."
+msgstr "Para se associar a outra identidade/conta federada, por favor, insira o nome do domínio da instância onde está localizada a sua nova identidade/conta."
 
 #: users/templates/users/account.html:99
-msgid ""
-"If you have registered with a Federated instance, please enter the instance "
-"domain name."
-msgstr ""
-"Se resgistou-se através de uma instância do Fediverso, por favor, insira o "
-"nome do domínio da instância."
+msgid "If you have registered with a Federated instance, please enter the instance domain name."
+msgstr "Se resgistou-se através de uma instância do Fediverso, por favor, insira o nome do domínio da instância."
 
 #: users/templates/users/account.html:104
 #, fuzzy
@@ -8085,33 +7975,18 @@ msgid "Go to target instance and authorize with the identity"
 msgstr "Dirija-se à sua instância de destino para validar a autorização"
 
 #: users/templates/users/account.html:113
-msgid ""
-"After replacing the association, you may use the new Fediverse identity to "
-"log in and control data visibility. Existing data such as tags, comments, "
-"and collections will not be affected."
-msgstr ""
-"Após a substituição da conta associada, deve utilizar a sua nova identidade "
-"do Fediverso para iniciar sessão e controlar a visibilidade dos seus dados. "
-"Os dados existentes como etiquetas, comentários e colecções não serão "
-"afetados."
+msgid "After replacing the association, you may use the new Fediverse identity to log in and control data visibility. Existing data such as tags, comments, and collections will not be affected."
+msgstr "Após a substituição da conta associada, deve utilizar a sua nova identidade do Fediverso para iniciar sessão e controlar a visibilidade dos seus dados. Os dados existentes como etiquetas, comentários e colecções não serão afetados."
 
 #: users/templates/users/account.html:115
-msgid ""
-"Once associated with Fediverse identity, you can discover more users and use "
-"the full features of this site."
-msgstr ""
-"Quando associar-se à sua identidade do Fediverso, poderá descobrir mais "
-"utilizadores e usar, por completo, todas as funcionalidades do site."
+msgid "Once associated with Fediverse identity, you can discover more users and use the full features of this site."
+msgstr "Quando associar-se à sua identidade do Fediverso, poderá descobrir mais utilizadores e usar, por completo, todas as funcionalidades do site."
 
 #: users/templates/users/account.html:123
 #: users/templates/users/account.html:160
 #: users/templates/users/account.html:206
-msgid ""
-"Once disconnected, you will no longer be able login with this identity. Are "
-"you sure to continue?"
-msgstr ""
-"Uma vez desconectado, não será possível iniciar sessão novamente com esta "
-"identidade. Tem a certeza que pretende continuar?"
+msgid "Once disconnected, you will no longer be able login with this identity. Are you sure to continue?"
+msgstr "Uma vez desconectado, não será possível iniciar sessão novamente com esta identidade. Tem a certeza que pretende continuar?"
 
 #: users/templates/users/account.html:126
 msgid "Disconnect with this identity"
@@ -8137,7 +8012,7 @@ msgstr "Conectar com uma conta threads.net"
 msgid "Disconnect with Threads"
 msgstr "Desconectar com o Threads"
 
-#: users/templates/users/account.html:173 users/templates/users/login.html:112
+#: users/templates/users/account.html:173 users/templates/users/login.html:106
 msgid "Bluesky (ATProto)"
 msgstr "Bluesky (ATProto)"
 
@@ -8145,7 +8020,7 @@ msgstr "Bluesky (ATProto)"
 msgid "Verified ATProto identity"
 msgstr "Identidade ATProto verificada"
 
-#: users/templates/users/account.html:194 users/templates/users/login.html:216
+#: users/templates/users/account.html:194 users/templates/users/login.html:210
 msgid "ATProto handle"
 msgstr "handle do ATProto"
 
@@ -8170,7 +8045,7 @@ msgid "Name this passkey:"
 msgstr ""
 
 #: users/templates/users/account.html:227 users/templates/users/login.html:69
-#: users/templates/users/welcome.html:33 users/views/webauthn.py:106
+#: users/templates/users/welcome.html:33 users/views/webauthn.py:109
 msgid "Passkey"
 msgstr ""
 
@@ -8219,13 +8094,8 @@ msgid "Save sync settings"
 msgstr "Guardar definições de sincronização"
 
 #: users/templates/users/account.html:297
-msgid ""
-"New follow, mute and blocks in the associated identity may be automatically "
-"imported; removal has to be done manually."
-msgstr ""
-"As novas pessoas que segue, silenciados e bloqueados na identidade/conta "
-"associada, podem ser importadas automaticamente; a remoção tem de ser feita "
-"manualmente."
+msgid "New follow, mute and blocks in the associated identity may be automatically imported; removal has to be done manually."
+msgstr "As novas pessoas que segue, silenciados e bloqueados na identidade/conta associada, podem ser importadas automaticamente; a remoção tem de ser feita manualmente."
 
 #: users/templates/users/account.html:304
 msgid "Click button below to start sync now."
@@ -8261,15 +8131,11 @@ msgid "Log out everywhere"
 msgstr ""
 
 #: users/templates/users/account.html:365
-msgid ""
-"This will log you out of all browsers and devices (including the current "
-"one), and revoke all API tokens. Continue?"
+msgid "This will log you out of all browsers and devices (including the current one), and revoke all API tokens. Continue?"
 msgstr ""
 
 #: users/templates/users/account.html:368
-msgid ""
-"If you notice any suspicious activity or have logged in on a shared "
-"computer, you can log out of all sessions and revoke all API tokens."
+msgid "If you notice any suspicious activity or have logged in on a shared computer, you can log out of all sessions and revoke all API tokens."
 msgstr ""
 
 #: users/templates/users/account.html:378
@@ -8344,10 +8210,10 @@ msgstr "para ouvir"
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:74
-#: users/templates/users/data.html:126 users/templates/users/data.html:183
-#: users/templates/users/data.html:234 users/templates/users/data.html:298
-#: users/templates/users/data.html:358 users/templates/users/data.html:553
+#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/data.html:141 users/templates/users/data.html:198
+#: users/templates/users/data.html:249 users/templates/users/data.html:313
+#: users/templates/users/data.html:376 users/templates/users/data.html:553
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr "Importar"
@@ -8379,15 +8245,9 @@ msgstr "Migrar conta"
 
 #: users/templates/users/account.html:488
 #, fuzzy
-#| msgid ""
-#| "Link an email so that you can migrate followers from other Fediverse "
-#| "instances."
-msgid ""
-"Linking an email to your account is highly recommended before migrating from "
-"another Fediverse instance."
-msgstr ""
-"Vincular um email para que possa migrar seguidores de outras instâncias do "
-"Fediverso."
+#| msgid "Link an email so that you can migrate followers from other Fediverse instances."
+msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
+msgstr "Vincular um email para que possa migrar seguidores de outras instâncias do Fediverso."
 
 #: users/templates/users/account.html:491
 #, fuzzy
@@ -8407,16 +8267,11 @@ msgstr "Eliminar conta"
 
 #: users/templates/users/account.html:504
 msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
-msgstr ""
-"Após eliminada, a sua conta não pode ser recuperada. Deseja prosseguir?"
+msgstr "Após eliminada, a sua conta não pode ser recuperada. Deseja prosseguir?"
 
 #: users/templates/users/account.html:507
-msgid ""
-"Enter full <code>username@instance.social</code> or <code>email@domain.com</"
-"code> to confirm deletion."
-msgstr ""
-"Insira o nome de utilizador completo <code>username@instance.social</code> "
-"ou <code>email@domain.com</code> para confirmar a sua eliminação."
+msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
+msgstr "Insira o nome de utilizador completo <code>username@instance.social</code> ou <code>email@domain.com</code> para confirmar a sua eliminação."
 
 #: users/templates/users/account.html:517
 msgid "Once deleted, account data cannot be recovered."
@@ -8477,9 +8332,7 @@ msgid "Token Created"
 msgstr "sem avaliação"
 
 #: users/templates/users/authorized_app_created.html:22
-msgid ""
-"Your new personal access token has been created. Copy it now -- you will not "
-"be able to see it again."
+msgid "Your new personal access token has been created. Copy it now -- you will not be able to see it again."
 msgstr ""
 
 #: users/templates/users/authorized_app_created.html:25
@@ -8507,9 +8360,7 @@ msgid "One quick check"
 msgstr ""
 
 #: users/templates/users/captcha.html:28
-msgid ""
-"Put every cover into the row it belongs to. Drag it, or select a cover and "
-"then select a row."
+msgid "Put every cover into the row it belongs to. Drag it, or select a cover and then select a row."
 msgstr ""
 
 #: users/templates/users/captcha.html:41 users/templates/users/captcha.html:43
@@ -8544,7 +8395,7 @@ msgstr ""
 msgid "That is all we needed. Let's get you a username."
 msgstr ""
 
-#: users/templates/users/captcha_solved.html:34
+#: users/templates/users/captcha_solved.html:32
 #: users/templates/users/login.html:63
 #: users/templates/users/verify_email.html:25
 #: users/templates/users/welcome.html:51
@@ -8564,10 +8415,7 @@ msgid "Failed Crossposts"
 msgstr ""
 
 #: users/templates/users/crossposts.html:42
-msgid ""
-"These posts could not be crossposted to your linked social accounts. Re-"
-"authorize the account if needed, then retry. In rare cases retrying may "
-"create a duplicate post."
+msgid "These posts could not be crossposted to your linked social accounts. Re-authorize the account if needed, then retry. In rare cases retrying may create a duplicate post."
 msgstr ""
 
 #: users/templates/users/crossposts.html:48
@@ -8590,261 +8438,191 @@ msgstr ""
 msgid "Data Management"
 msgstr "Gestão de Dados"
 
-#: users/templates/users/data.html:27
+#: users/templates/users/data.html:39
 msgid "Import Marks and Reviews from Douban"
 msgstr "Importar Marcações e Críticas de Douban"
 
-#: users/templates/users/data.html:31
-msgid ""
-"Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
-"target=\"_blank\" rel=\"noopener\">Doufen</a>"
-msgstr ""
-"Selecionar<code>.xlsx</code> exportado de <a href=\"https://doufen.org\" "
-"target=\"_blank\" rel=\"noopener\">Doufen</a>"
+#: users/templates/users/data.html:43
+msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
+msgstr "Selecionar<code>.xlsx</code> exportado de <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 
 #: users/templates/users/data.html:45
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
-"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
-"NeoDB Archive</a> below."
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON format instead; upload it under <a href=\"#import-neodb-archive\">Import NeoDB Archive</a> below."
 msgstr ""
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:256
+#: users/templates/users/data.html:49 users/templates/users/data.html:271
 msgid "Import Method"
 msgstr "Método de importação"
 
-#: users/templates/users/data.html:37
-msgid ""
-"Merge: only update when status changes from wishlist to in-progress, or from "
-"in-progress to complete."
-msgstr ""
-"Mesclar: atualize apenas quando o estado mudar de lista de desejos para em "
-"andamento ou de em andamento para completo."
+#: users/templates/users/data.html:52
+msgid "Merge: only update when status changes from wishlist to in-progress, or from in-progress to complete."
+msgstr "Mesclar: atualize apenas quando o estado mudar de lista de desejos para em andamento ou de em andamento para completo."
 
-#: users/templates/users/data.html:41
+#: users/templates/users/data.html:56
 msgid "Overwrite: update all imported status."
 msgstr "Substituir: atualiza todos os estado importados."
 
-#: users/templates/users/data.html:74
-msgid ""
-"Another import is in progress, starting a new import may cause issues, sure "
-"to import?"
-msgstr ""
-"Tem uma importação em progresso. Realizar uma nova importação poderá causar "
-"erros. Tem a certeza que deseja continuar?"
+#: users/templates/users/data.html:89
+msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
+msgstr "Tem uma importação em progresso. Realizar uma nova importação poderá causar erros. Tem a certeza que deseja continuar?"
 
-#: users/templates/users/data.html:74
+#: users/templates/users/data.html:89 users/views/data.py:1130
 msgid "Import in progress, please wait"
 msgstr "Importação em progresso, por favor espere"
 
-#: users/templates/users/data.html:81
+#: users/templates/users/data.html:96
 #, fuzzy
 #| msgid "Import Shelf or List from Goodreads"
 msgid "Import from Goodreads"
 msgstr "Importar Lista ou Prateleira do Goodreads"
 
-#: users/templates/users/data.html:87
-msgid ""
-"On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download "
-"your library as a CSV file."
+#: users/templates/users/data.html:102
+msgid "On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download your library as a CSV file."
 msgstr ""
 
-#: users/templates/users/data.html:90
-msgid ""
-"Upload the downloaded <code>goodreads_library_export.csv</code> file below."
+#: users/templates/users/data.html:105
+msgid "Upload the downloaded <code>goodreads_library_export.csv</code> file below."
 msgstr ""
 
-#: users/templates/users/data.html:93
-msgid ""
-"want-to-read / currently-reading / read / did-not-finish books and their "
-"reviews will be imported."
-msgstr ""
-
-#: users/templates/users/data.html:134
-msgid "Import from Letterboxd"
-msgstr "Importar do Letterboxd"
-
-#: users/templates/users/data.html:140
-msgid ""
-"on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" "
-"target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap "
-"Advanced Settings in Settings, tap EXPORT YOUR DATA"
-msgstr ""
-
-#: users/templates/users/data.html:143
-msgid ""
-"download file with name like <code>letterboxd-username-2018-03-11-07-52-"
-"utc.zip</code>, do not unzip"
-msgstr ""
-
-#: users/templates/users/data.html:146
-msgid ""
-"the following files in the zip file will be processed: <code>reviews.csv</"
-"code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</"
-"code> <code>lists/*.csv</code>"
+#: users/templates/users/data.html:108
+msgid "want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported."
 msgstr ""
 
 #: users/templates/users/data.html:149
-msgid ""
-"exported file does not indicate whether a list is private, unlisted or "
-"public, so all imported marks, reviews and collections will be created with "
-"the visibility selected below"
+msgid "Import from Letterboxd"
+msgstr "Importar do Letterboxd"
+
+#: users/templates/users/data.html:155
+msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
 msgstr ""
 
-#: users/templates/users/data.html:184 users/templates/users/data.html:235
+#: users/templates/users/data.html:158
+msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
+msgstr ""
+
+#: users/templates/users/data.html:161
+msgid "the following files in the zip file will be processed: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
+msgstr ""
+
+#: users/templates/users/data.html:164
+msgid "exported file does not indicate whether a list is private, unlisted or public, so all imported marks, reviews and collections will be created with the visibility selected below"
+msgstr ""
+
+#: users/templates/users/data.html:199 users/templates/users/data.html:250
 msgid "Only forward changes(none->to-watch->watched) will be imported."
-msgstr ""
-"Apenas as alterações progressivas (nenhum -> para assistir -> assistido) "
-"serão importadas."
+msgstr "Apenas as alterações progressivas (nenhum -> para assistir -> assistido) serão importadas."
 
-#: users/templates/users/data.html:191
+#: users/templates/users/data.html:206
 #, fuzzy
 #| msgid "Import from Letterboxd"
 msgid "Import from Trakt"
 msgstr "Importar do Letterboxd"
 
-#: users/templates/users/data.html:197
-msgid ""
-"On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" "
-"rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait "
-"for the download link to appear."
+#: users/templates/users/data.html:212
+msgid "On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait for the download link to appear."
 msgstr ""
 
-#: users/templates/users/data.html:200
+#: users/templates/users/data.html:215
 msgid "Upload the downloaded <code>.zip</code> file below, do not unzip."
 msgstr ""
 
-#: users/templates/users/data.html:202
+#: users/templates/users/data.html:217
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:243
+#: users/templates/users/data.html:258
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr ""
 
-#: users/templates/users/data.html:246
+#: users/templates/users/data.html:261
 msgid "Login with Steam"
 msgstr ""
 
-#: users/templates/users/data.html:252
+#: users/templates/users/data.html:267
 msgid "Import Podcast Subscriptions"
 msgstr "Importar subscrições de Podcast(s)"
 
-#: users/templates/users/data.html:263
+#: users/templates/users/data.html:278
 msgid "Mark as listening"
 msgstr "Marcar como estando a ouvir"
 
-#: users/templates/users/data.html:267
+#: users/templates/users/data.html:282
 msgid "Import as a new collection"
 msgstr "Importar como nova coleção"
 
-#: users/templates/users/data.html:296
+#: users/templates/users/data.html:311
 msgid "Select OPML file"
 msgstr "Selecionar ficheiro OPML"
 
-#: users/templates/users/data.html:306
+#: users/templates/users/data.html:321
 msgid "Import NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:312
-msgid ""
-"Upload a <code>.zip</code> file containing <code>.csv</code> or "
-"<code>.ndjson</code> files exported from NeoDB."
+#: users/templates/users/data.html:327
+msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr ""
 
 #: users/templates/users/data.html:330
 #, fuzzy
-#| msgid ""
-#| "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
-#| "target=\"_blank\" rel=\"noopener\">Doufen</a>"
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
-"imported here."
-msgstr ""
-"Selecionar<code>.xlsx</code> exportado de <a href=\"https://doufen.org\" "
-"target=\"_blank\" rel=\"noopener\">Doufen</a>"
+#| msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is imported here."
+msgstr "Selecionar<code>.xlsx</code> exportado de <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 
-#: users/templates/users/data.html:314
+#: users/templates/users/data.html:332
 #, fuzzy
 #| msgid "Existing metadata might get overwritten, sure to proceed?"
 msgid "Existing data may be overwritten."
-msgstr ""
-"Metadados existentes podem ser substituídos, tem a certeza que quer "
-"continuar?"
+msgstr "Metadados existentes podem ser substituídos, tem a certeza que quer continuar?"
 
-#: users/templates/users/data.html:324
+#: users/templates/users/data.html:342
 msgid "Detected format"
 msgstr ""
 
-#: users/templates/users/data.html:385
+#: users/templates/users/data.html:403
 msgid "Detecting format..."
 msgstr ""
 
-#: users/templates/users/data.html:411
+#: users/templates/users/data.html:429
 #, fuzzy
 #| msgid "Unknown or Other"
 msgid "Unknown format"
 msgstr "Desconhecido ou Outro"
 
-#: users/templates/users/data.html:436
+#: users/templates/users/data.html:454
 #, fuzzy
 #| msgid "Error connecting to instance"
 msgid "Error detecting format"
 msgstr "Erro ao conectar-se com a instância"
 
-#: users/templates/users/data.html:460
+#: users/templates/users/data.html:478
 msgid "Export NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:464
+#: users/templates/users/data.html:482
 #, fuzzy
 #| msgid "Export marks and reviews"
 msgid "Export marks, reviews and notes in CSV"
 msgstr "Exportar marcações e críticas"
 
-#: users/templates/users/data.html:471
+#: users/templates/users/data.html:489
 msgid "Export everything in NDJSON"
 msgstr ""
-
-#: users/templates/users/data.html:479
-#, fuzzy
-#| msgid "Export marks and reviews"
-msgid "Export marks and reviews in XLSX (Doufen format)"
-msgstr "Exportar marcações e críticas"
-
-#: users/templates/users/data.html:482
-msgid "Last export"
-msgstr "Última exportação"
-
-#: users/templates/users/data.html:487
-msgid "Download"
-msgstr "Download"
 
 #: users/templates/users/data.html:496
 msgid "Import and Export Articles (WordPress)"
 msgstr ""
 
 #: users/templates/users/data.html:499
-msgid ""
-"Your articles are exchanged as WordPress posts in the WXR format, which "
-"WordPress and most blogging tools can read and write. Marks, reviews and "
-"notes are not included: use the NeoDB archive above for those."
+msgid "Your articles are exchanged as WordPress posts in the WXR format, which WordPress and most blogging tools can read and write. Marks, reviews and notes are not included: use the NeoDB archive above for those."
 msgstr ""
 
 #: users/templates/users/data.html:502
-msgid ""
-"Article title, body, excerpt, tags, dates and featured image are exchanged. "
-"Comments and custom fields are ignored."
+msgid "Article title, body, excerpt, tags, dates and featured image are exchanged. Comments and custom fields are ignored."
 msgstr ""
 
 #: users/templates/users/data.html:505
-msgid ""
-"The body is converted between Markdown and HTML, so formatting is kept but "
-"the text is not character-for-character identical."
+msgid "The body is converted between Markdown and HTML, so formatting is kept but the text is not character-for-character identical."
 msgstr ""
 
 #: users/templates/users/data.html:512
@@ -8854,16 +8632,11 @@ msgid "Export articles in WordPress format"
 msgstr "Exportar marcações e críticas"
 
 #: users/templates/users/data.html:519
-msgid ""
-"In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download "
-"an <code>.xml</code> file, then upload it below."
+msgid "In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download an <code>.xml</code> file, then upload it below."
 msgstr ""
 
 #: users/templates/users/data.html:522
-msgid ""
-"Only published posts use the visibility below. Drafts, pending, private and "
-"password-protected posts are always imported as mentioned-only, so nothing "
-"unpublished becomes public."
+msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
 #: users/templates/users/data.html:560
@@ -8871,13 +8644,8 @@ msgid "View Annual Summary"
 msgstr "Ver Relatório Anual"
 
 #: users/templates/users/fetch_identity_failed.html:4
-msgid ""
-"Unable to find the user, please check your spelling; or the server may be "
-"busy, please try again later."
-msgstr ""
-"Não foi possível encontrar utilizador. Por favor, verifique se escreveu de "
-"maneira correta; existe também a possibilidade do servidor estar "
-"sobrecarregado. Por favor, tente novamente mais tarde."
+msgid "Unable to find the user, please check your spelling; or the server may be busy, please try again later."
+msgstr "Não foi possível encontrar utilizador. Por favor, verifique se escreveu de maneira correta; existe também a possibilidade do servidor estar sobrecarregado. Por favor, tente novamente mais tarde."
 
 #: users/templates/users/fetch_identity_pending.html:13
 #: users/templates/users/fetch_identity_pending.html:22
@@ -8896,116 +8664,78 @@ msgstr "Login"
 msgid "logo"
 msgstr ""
 
-#: users/templates/users/login.html:127
-msgid ""
-"Sign in with a passkey saved on this device or in your password manager."
+#: users/templates/users/login.html:121
+msgid "Sign in with a passkey saved on this device or in your password manager."
 msgstr ""
 
-#: users/templates/users/login.html:132
+#: users/templates/users/login.html:126
 msgid "Sign in with Passkey"
 msgstr ""
 
-#: users/templates/users/login.html:148
+#: users/templates/users/login.html:142
 msgid "Enter your email address"
 msgstr "Insira o seu email"
 
-#: users/templates/users/login.html:152
+#: users/templates/users/login.html:146
 msgid "Send verification code"
 msgstr "Enviar código de verificação"
 
-#: users/templates/users/login.html:171
+#: users/templates/users/login.html:165
 msgid "Domain of your instance, e.g. mastodon.social"
 msgstr "Domínio da sua instância, p.e. mastodon.social"
 
-#: users/templates/users/login.html:177
-msgid ""
-"Please enter domain of your instance; e.g. if your id is "
-"<i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
-msgstr ""
-"Por favor, insira o domínio da sua instância; p.e. se o seu id é "
-"<i>@neodb@mastodon.social</i>, apenas necessita de colocar "
-"<i>mastodon.social</i>."
+#: users/templates/users/login.html:171
+msgid "Please enter domain of your instance; e.g. if your id is <i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
+msgstr "Por favor, insira o domínio da sua instância; p.e. se o seu id é <i>@neodb@mastodon.social</i>, apenas necessita de colocar <i>mastodon.social</i>."
 
-#: users/templates/users/login.html:182 users/templates/users/login.html:246
+#: users/templates/users/login.html:176 users/templates/users/login.html:240
 msgid "Authorize via Fediverse instance"
 msgstr "Autorizar via instância do Fediverso"
 
-#: users/templates/users/login.html:187
-msgid ""
-"If you don't have a <a href=\"https://joinmastodon.org/servers\" "
-"target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or "
-"login with Email first, and link it with Fediverse (Mastodon) later in "
-"account settings."
-msgstr ""
-"Se ainda não possui uma conta no <a href=\"https://joinmastodon.org/"
-"servers\" target=\"_blank\">Fediverso (Mastodon) </a> , pode registar-se ou "
-"iniciar sessão com Email e, mais tarde, conectar-se com o Fediverso "
-"(Mastodon) nas definições da sua conta."
+#: users/templates/users/login.html:181
+msgid "If you don't have a <a href=\"https://joinmastodon.org/servers\" target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or login with Email first, and link it with Fediverse (Mastodon) later in account settings."
+msgstr "Se ainda não possui uma conta no <a href=\"https://joinmastodon.org/servers\" target=\"_blank\">Fediverso (Mastodon) </a> , pode registar-se ou iniciar sessão com Email e, mais tarde, conectar-se com o Fediverso (Mastodon) nas definições da sua conta."
 
-#: users/templates/users/login.html:200
+#: users/templates/users/login.html:194
 msgid "Authorize via Threads"
 msgstr "Autorizar via Threads"
 
-#: users/templates/users/login.html:221
-msgid ""
-"Please input your ATProto handle (e.g. neodb.bsky.social, without the "
-"leading @), do not use email. If you changed handle recently, just use the "
-"latest one."
-msgstr ""
-"Insira o seu handle de ATProto (por exemplo, neodb.bsky.social, sem o @ "
-"inicial). Não utilize um endereço de email. Se alterou recentemente o seu "
-"handle, use o mais recente."
+#: users/templates/users/login.html:215
+msgid "Please input your ATProto handle (e.g. neodb.bsky.social, without the leading @), do not use email. If you changed handle recently, just use the latest one."
+msgstr "Insira o seu handle de ATProto (por exemplo, neodb.bsky.social, sem o @ inicial). Não utilize um endereço de email. Se alterou recentemente o seu handle, use o mais recente."
 
-#: users/templates/users/login.html:224
+#: users/templates/users/login.html:218
 #, fuzzy
 #| msgid "Authorize via Threads"
 msgid "Authorize via ATProto server"
 msgstr "Autorizar via Threads"
 
-#: users/templates/users/login.html:231
+#: users/templates/users/login.html:225
 #, python-format
-msgid ""
-"Please choose one to register or login %(site_name)s. Have more than one of "
-"these identities? Don't worry, you may link them in account settings once "
-"logged in."
-msgstr ""
-"Por favor, escolha uma destas opções para se registar ou iniciar sessão "
-"%(site_name)s. Tem mais do que uma destas identidades/contas? Não se "
-"preocupe, pode vincular uma destas suas identidades/contas nas definições da "
-"sua conta, quando iniciar sessão."
+msgid "Please choose one to register or login %(site_name)s. Have more than one of these identities? Don't worry, you may link them in account settings once logged in."
+msgstr "Por favor, escolha uma destas opções para se registar ou iniciar sessão %(site_name)s. Tem mais do que uma destas identidades/contas? Não se preocupe, pode vincular uma destas suas identidades/contas nas definições da sua conta, quando iniciar sessão."
 
-#: users/templates/users/login.html:255
+#: users/templates/users/login.html:249
 msgid "Valid invitation code, please login or register."
 msgstr "Código de convite válido. Por favor, registe-se ou inicie sessão."
 
-#: users/templates/users/login.html:257
-msgid ""
-"Please use invitation link to register a new account; existing user may "
-"login."
-msgstr ""
-"Por favor, utilize o link de convite para registar uma nova conta; "
-"utilizadores já inscritos podem iniciar sessão."
+#: users/templates/users/login.html:251
+msgid "Please use invitation link to register a new account; existing user may login."
+msgstr "Por favor, utilize o link de convite para registar uma nova conta; utilizadores já inscritos podem iniciar sessão."
 
-#: users/templates/users/login.html:259
+#: users/templates/users/login.html:253
 msgid "Invitation code invalid or expired."
 msgstr "Código do convite inválido ou expirou."
 
-#: users/templates/users/login.html:267
+#: users/templates/users/login.html:261
 msgid "Loading timed out, please check your network (VPN) settings."
-msgstr ""
-"O tempo de carregar expirou, por favor verifique a sua ligação à internet."
+msgstr "O tempo de carregar expirou, por favor verifique a sua ligação à internet."
 
-#: users/templates/users/login.html:273
-msgid ""
-"Continue using this site implies consent to our <a href=\"/pages/rules/"
-"\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using "
-"cookies to provide necessary functionality."
-msgstr ""
-"Ao continuar a usar este site implica que aceita as nossas <a href=\"/pages/"
-"rules/\">regras</a> e <a href=\"/pages/terms/\">termos</a>, incluindo o uso "
-"de cookies para fornecer funcionalidades necessárias."
+#: users/templates/users/login.html:267
+msgid "Continue using this site implies consent to our <a href=\"/pages/rules/\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using cookies to provide necessary functionality."
+msgstr "Ao continuar a usar este site implica que aceita as nossas <a href=\"/pages/rules/\">regras</a> e <a href=\"/pages/terms/\">termos</a>, incluindo o uso de cookies para fornecer funcionalidades necessárias."
 
-#: users/templates/users/login.html:287
+#: users/templates/users/login.html:281
 msgid "Domain of your instance (excl. @)"
 msgstr "Domínio da sua instância (excl. @)"
 
@@ -9015,9 +8745,7 @@ msgid "Migrate Here"
 msgstr ""
 
 #: users/templates/users/migrate_in.html:22
-msgid ""
-"To move another account to this one, first add it as an alias here, and then "
-"go to the server where it is hosted and initiate the move."
+msgid "To move another account to this one, first add it as an alias here, and then go to the server where it is hosted and initiate the move."
 msgstr ""
 
 #: users/templates/users/migrate_in.html:27
@@ -9073,16 +8801,11 @@ msgstr ""
 
 #: users/templates/users/migrate_out.html:46
 #, python-format
-msgid ""
-"To migrate to another account, first add <code>@%(handle)s</code> as an "
-"alias on the target server, and then type the target account below to start "
-"the migration."
+msgid "To migrate to another account, first add <code>@%(handle)s</code> as an alias on the target server, and then type the target account below to start the migration."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:50
-msgid ""
-"Are you sure you want to migrate your account? Your followers will be moved "
-"to the target account."
+msgid "Are you sure you want to migrate your account? Your followers will be moved to the target account."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:53
@@ -9100,10 +8823,6 @@ msgstr "começar a ler"
 #: users/templates/users/preferences.html:28
 msgid "Default view once logged in"
 msgstr "Visão padrão quando inicio sessão"
-
-#: users/templates/users/preferences.html:40
-msgid "Activities"
-msgstr "Atividades"
 
 #: users/templates/users/preferences.html:49
 msgid "Default visibility"
@@ -9132,9 +8851,7 @@ msgstr "Por padrão, ativar crosspost para outras redes sociais"
 
 #: users/templates/users/preferences.html:111
 #: users/templates/users/register.html:88
-msgid ""
-"If a Mastodon account is linked with this identity, boosting a post will "
-"also make the same post boosted with that Mastodon account."
+msgid "If a Mastodon account is linked with this identity, boosting a post will also make the same post boosted with that Mastodon account."
 msgstr ""
 
 #: users/templates/users/preferences.html:115
@@ -9150,18 +8867,12 @@ msgid "Create a new post"
 msgstr "Criar novo post"
 
 #: users/templates/users/preferences.html:130
-msgid ""
-"this method is less optimal, may generate duplicated posts and miss "
-"reactions."
-msgstr ""
-"Este método é menos prático e poderá provocar posts duplicados e falhas nas "
-"reações."
+msgid "this method is less optimal, may generate duplicated posts and miss reactions."
+msgstr "Este método é menos prático e poderá provocar posts duplicados e falhas nas reações."
 
 #: users/templates/users/preferences.html:140
 #: users/templates/users/register.html:97
-msgid ""
-"Always publish my public marks, reviews and articles as data records to my "
-"PDS."
+msgid "Always publish my public marks, reviews and articles as data records to my PDS."
 msgstr ""
 
 #: users/templates/users/preferences.html:145
@@ -9181,18 +8892,8 @@ msgid "Automatic bookmark for these categories"
 msgstr "Marcador automático para estas categorias"
 
 #: users/templates/users/preferences.html:175
-msgid ""
-"When start to read/watch/play/... an item in these categories, a bookmark "
-"will be created automatically. Bookmarks can be viewed and managed in most "
-"<a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon "
-"compatible apps</a>; your replies to these posts will automatically become "
-"notes for the item."
-msgstr ""
-"Quando começar a ler/ver/jogar/... um item destas categorias, será criado "
-"automaticamente um bookmark. Os bookmarks podem ser vistos e geridos na "
-"maioria das <a href=\"https://joinmastodon.org/apps\" "
-"target=\"_blank\">aplicações compatíveis com o Mastodon </a>; As suas "
-"respostas a estas mensagens tornar-se-ão automaticamente notas para o item."
+msgid "When start to read/watch/play/... an item in these categories, a bookmark will be created automatically. Bookmarks can be viewed and managed in most <a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon compatible apps</a>; your replies to these posts will automatically become notes for the item."
+msgstr "Quando começar a ler/ver/jogar/... um item destas categorias, será criado automaticamente um bookmark. Os bookmarks podem ser vistos e geridos na maioria das <a href=\"https://joinmastodon.org/apps\" target=\"_blank\">aplicações compatíveis com o Mastodon </a>; As suas respostas a estas mensagens tornar-se-ão automaticamente notas para o item."
 
 #: users/templates/users/preferences.html:183
 msgid "Turn replies to my own catalog item posts into notes for the item"
@@ -9208,16 +8909,11 @@ msgstr ""
 
 #: users/templates/users/preferences.html:216
 msgid "Profile visible to anonymous web visitors and search engines"
-msgstr ""
-"O perfil está visível para todos os visitantes anónimos e motores de pesquisa"
+msgstr "O perfil está visível para todos os visitantes anónimos e motores de pesquisa"
 
 #: users/templates/users/preferences.html:217
-msgid ""
-"this option limits web visits only; to limit fediverse visibility, choose "
-"followers only or mentioned only when posting"
-msgstr ""
-"Esta opção limita apenas as visitas à web; para limitar a visibilidade "
-"fediverso, escolha somente seguidores ou somente mencionados ao postar"
+msgid "this option limits web visits only; to limit fediverse visibility, choose followers only or mentioned only when posting"
+msgstr "Esta opção limita apenas as visitas à web; para limitar a visibilidade fediverso, escolha somente seguidores ou somente mencionados ao postar"
 
 #: users/templates/users/preferences.html:225
 msgid "Show your name on item page if you recently edited it"
@@ -9228,17 +8924,7 @@ msgid "Do not show me item recommendations"
 msgstr ""
 
 #: users/templates/users/preferences.html:237
-msgid ""
-"Recommendations are generated only from public marks, processed in batch on "
-"this server. Your private and follower-only marks are never used as a signal "
-"for anyone, and we never share your data with third parties for this "
-"feature. When you share marks publicly and keep your profile discoverable, "
-"your marks help others here and across the Fediverse find things they might "
-"enjoy -- that voluntary contribution is what makes the feature work for "
-"everyone. If you'd rather not contribute, uncheck \"Include profile, marks "
-"and posts in discovery\" on your account page; this setting is published "
-"over ActivityPub, so other servers will also stop including you in their "
-"discovery features."
+msgid "Recommendations are generated only from public marks, processed in batch on this server. Your private and follower-only marks are never used as a signal for anyone, and we never share your data with third parties for this feature. When you share marks publicly and keep your profile discoverable, your marks help others here and across the Fediverse find things they might enjoy -- that voluntary contribution is what makes the feature work for everyone. If you'd rather not contribute, uncheck \"Include profile, marks and posts in discovery\" on your account page; this setting is published over ActivityPub, so other servers will also stop including you in their discovery features."
 msgstr ""
 
 #: users/templates/users/profile_actions.html:12
@@ -9336,29 +9022,15 @@ msgstr "O seu nome de utilizador em %(site_name)s"
 
 #: users/templates/users/register.html:28
 msgid "2-30 alphabets, numbers or underscore, can't be changed once saved"
-msgstr ""
-"2-30 letras, números ou underscore ( _ ). Não poderá alterar após ser "
-"guardado"
+msgstr "2-30 letras, números ou underscore ( _ ). Não poderá alterar após ser guardado"
 
 #: users/templates/users/register.html:72
-msgid ""
-"Use display name, bio and avatar from the social network you authenticated "
-"with"
-msgstr ""
-"Utilizar o nome a apresentar, bio e avatar da rede social com a qual se "
-"autenticou"
+msgid "Use display name, bio and avatar from the social network you authenticated with"
+msgstr "Utilizar o nome a apresentar, bio e avatar da rede social com a qual se autenticou"
 
 #: users/templates/users/register.html:80
-msgid ""
-"Add follow, mute and block list from the social network you authenticated "
-"with"
-msgstr ""
-"Adicionar lista de pessoas que segue, silenciados e bloqueados da rede "
-"social com a qual se autenticou"
-
-#: users/templates/users/register.html:104
-msgid "Confirm and save"
-msgstr "Confirmar e guardar"
+msgid "Add follow, mute and block list from the social network you authenticated with"
+msgstr "Adicionar lista de pessoas que segue, silenciados e bloqueados da rede social com a qual se autenticou"
 
 #: users/templates/users/register.html:106
 msgid "Close"
@@ -9386,8 +9058,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"              Matched %(local)s locally, %(external)s externally, "
-"%(unmatched)s unmatched out of %(total)s rows.\n"
+"              Matched %(local)s locally, %(external)s externally, %(unmatched)s unmatched out of %(total)s rows.\n"
 "            "
 msgstr ""
 
@@ -9522,9 +9193,7 @@ msgid "Played"
 msgstr "jogado"
 
 #: users/templates/users/steam_import.html:90
-msgid ""
-"Games in wishlist; or purchased in library but never played, mark date will "
-"be set as today"
+msgid "Games in wishlist; or purchased in library but never played, mark date will be set as today"
 msgstr ""
 
 #: users/templates/users/steam_import.html:91
@@ -9568,15 +9237,11 @@ msgid "Comma-separated Steam AppIDs"
 msgstr ""
 
 #: users/templates/users/steam_import.html:121
-msgid ""
-"Allow reverse override of status (e.g. playing -> want to, or played -> "
-"playing)"
+msgid "Allow reverse override of status (e.g. playing -> want to, or played -> playing)"
 msgstr ""
 
 #: users/templates/users/steam_import.html:139
-msgid ""
-"To import from Steam, your game details must be visible to public in Steam "
-"privacy settings."
+msgid "To import from Steam, your game details must be visible to public in Steam privacy settings."
 msgstr ""
 
 #: users/templates/users/storygraph_import.html:9
@@ -9627,38 +9292,23 @@ msgstr "Bem-vindo"
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
-#| "              %(site_name)s is flourishing because of collaborations and "
-#| "contributions from users like you. Please read our <a href=\"/pages/"
-#| "terms\">term of service</a>, and feel free to <a "
-#| "href=\"%(support_link)s\">contact us</a> if you have any question or "
-#| "feedback.\n"
+#| "              %(site_name)s is flourishing because of collaborations and contributions from users like you. Please read our <a href=\"/pages/terms\">term of service</a>, and feel free to <a href=\"%(support_link)s\">contact us</a> if you have any question or feedback.\n"
 #| "        "
 msgid ""
 "\n"
-"              %(site_name)s is flourishing because of collaborations and "
-"contributions from users like you. Please read our <a href=\"/pages/"
-"rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</"
-"a> if you have any question or feedback.\n"
+"              %(site_name)s is flourishing because of collaborations and contributions from users like you. Please read our <a href=\"/pages/rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</a> if you have any question or feedback.\n"
 "        "
 msgstr ""
 "\n"
-"              %(site_name)s está a crescer e a florescer graças a "
-"colaborações e contribuições de utilizadores como tu. Por favor, leia os "
-"nossos <a href=\"/pages/terms\">Termos de serviço</a> e não hesite em <a "
-"href=\"%(support_link)s\">contactar-nos</a> se tiver alguma questão ou "
-"feedback.\n"
+"              %(site_name)s está a crescer e a florescer graças a colaborações e contribuições de utilizadores como tu. Por favor, leia os nossos <a href=\"/pages/terms\">Termos de serviço</a> e não hesite em <a href=\"%(support_link)s\">contactar-nos</a> se tiver alguma questão ou feedback.\n"
 "        "
 
 #: users/templates/users/welcome.html:37
-msgid ""
-"Set up a passkey to sign in quickly next time using your fingerprint, face, "
-"or screen lock."
+msgid "Set up a passkey to sign in quickly next time using your fingerprint, face, or screen lock."
 msgstr ""
 
 #: users/templates/users/welcome.html:39
-msgid ""
-"Creating a passkey is highly recommended, as the website or email you use to "
-"create this account may not be always available."
+msgid "Creating a passkey is highly recommended, as the website or email you use to create this account may not be always available."
 msgstr ""
 
 #: users/templates/users/welcome.html:43
@@ -9675,348 +9325,246 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:124
+#: users/views/account.py:126
 msgid "This username is already in use."
 msgstr "Este nome de utilizador já está a ser usado."
 
-#: users/views/account.py:135
+#: users/views/account.py:137
 msgid "This email address is already in use."
 msgstr "Este email já se encontra a ser usado."
 
-#: users/views/account.py:255 users/views/account.py:374
+#: users/views/account.py:257 users/views/account.py:376
 msgid "Registration is for invitation only"
 msgstr "O registo está apenas disponível através de convite"
 
-#: users/views/account.py:266 users/views/account.py:338
+#: users/views/account.py:268 users/views/account.py:340
 #, fuzzy
 #| msgid "Timestamp"
 msgid "Time is up"
 msgstr "Marca temporal"
 
-#: users/views/account.py:267 users/views/account.py:310
-#: users/views/account.py:339
+#: users/views/account.py:269 users/views/account.py:312
+#: users/views/account.py:341
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:313
+#: users/views/account.py:315
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:325
+#: users/views/account.py:327
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:326
+#: users/views/account.py:328
 #, fuzzy
 #| msgid "System busy, please try again in a minute."
 msgid "Please try again later."
-msgstr ""
-"Sistema sobrecarregado. Por favor, tente novamente dentro de um minuto."
+msgstr "Sistema sobrecarregado. Por favor, tente novamente dentro de um minuto."
 
-#: users/views/account.py:415
+#: users/views/account.py:417
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:445
+#: users/views/account.py:447
 msgid "Valid username required"
 msgstr "Requer um nome de utilizador válido"
 
-#: users/views/account.py:526
+#: users/views/account.py:518
 msgid "Account is being deleted."
 msgstr "A conta está a ser apagada."
 
-#: users/views/account.py:529
+#: users/views/account.py:521
 msgid "Account mismatch."
 msgstr "Conta incompatível."
 
-#: users/views/data.py:262 users/views/data.py:294
+#: users/views/data.py:264 users/views/data.py:296
 msgid "Export file not available."
 msgstr "O ficheiro de exportação não se encontra disponível."
 
-#: users/views/data.py:288
+#: users/views/data.py:290
 msgid "Generating exports."
 msgstr "A gerar exportações."
 
-#: users/views/data.py:306
+#: users/views/data.py:308
 msgid "Export file expired. Please export again."
 msgstr "O ficheiro de exportação expirou. Por favor, tente novamente."
 
-#: users/views/data.py:321 users/views/data.py:342 users/views/data.py:363
+#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
 #, fuzzy
 #| msgid "Import in progress."
 msgid "Recent export still in progress."
 msgstr "Importação em progresso."
 
-#: users/views/data.py:379 users/views/data.py:513 users/views/data.py:547
-#: users/views/data.py:772 users/views/data.py:989 users/views/data.py:1015
-#: users/views/data.py:1040 users/views/data.py:1065
+#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
+#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
+#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
 msgid "Invalid file."
 msgstr "Ficheiro inválido."
 
-#: users/views/data.py:403
+#: users/views/data.py:405
 msgid "Sync in progress."
 msgstr "Sincronização em progresso."
 
-#: users/views/data.py:417
+#: users/views/data.py:419
 msgid "Settings saved."
 msgstr "Definições guardadas."
 
-#: users/views/data.py:472
+#: users/views/data.py:474
 #, fuzzy
 #| msgid "Account is being deleted."
 msgid "Account no longer linked."
 msgstr "A conta está a ser apagada."
 
-#: users/views/data.py:475
+#: users/views/data.py:477
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:503
+#: users/views/data.py:505
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:583 users/views/data.py:808
+#: users/views/data.py:585 users/views/data.py:810
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:608 users/views/data.py:837
+#: users/views/data.py:610 users/views/data.py:839
 #, fuzzy
 #| msgid "Cancel"
 msgid "Cancelled."
 msgstr "Cancelar"
 
-#: users/views/data.py:628
+#: users/views/data.py:630
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:636 users/views/data.py:746 users/views/data.py:867
-#: users/views/data.py:972
+#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
+#: users/views/data.py:974
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:732 users/views/data.py:958
+#: users/views/data.py:734 users/views/data.py:960
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:742 users/views/data.py:968
+#: users/views/data.py:744 users/views/data.py:970
 #, fuzzy
 #| msgid "Export file not available."
 msgid "No matched file available."
 msgstr "O ficheiro de exportação não se encontra disponível."
 
-#: users/views/data.py:859
+#: users/views/data.py:861
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1188
+#: users/views/data.py:1226
 #, fuzzy
 #| msgid "Login required"
 msgid "Name is required."
 msgstr "Requer iniciar sessão"
 
-#: users/views/data.py:1210
+#: users/views/data.py:1248
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1264
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1231
+#: users/views/data.py:1269
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1241 users/views/data.py:1292
+#: users/views/data.py:1279 users/views/data.py:1330
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:1248
+#: users/views/data.py:1286
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:1253
+#: users/views/data.py:1291
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:1279
+#: users/views/data.py:1317
 #, fuzzy
 #| msgid "Registration failed"
 msgid "Migration cancelled."
 msgstr "Falha ao registar-se"
 
-#: users/views/data.py:1284
+#: users/views/data.py:1322
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:1297
+#: users/views/data.py:1335
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:1308
+#: users/views/data.py:1346
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:1314
+#: users/views/data.py:1352
 #, fuzzy, python-brace-format
 #| msgid "Continue login as {handle}."
 msgid "Start moving to {handle}."
 msgstr "Continuar início de sessão como {handle}."
 
-#: users/views/data.py:1372
+#: users/views/data.py:1410
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1388
+#: users/views/data.py:1426
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1392
+#: users/views/data.py:1430
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1402
+#: users/views/data.py:1440
 #, python-brace-format
-msgid ""
-"Import of {count} entries received. They will be processed in the background."
+msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""
 
-#: users/views/webauthn.py:103
+#: users/views/webauthn.py:106
 #, fuzzy
 #| msgid "Registration failed"
 msgid "Passkey registration failed"
 msgstr "Falha ao registar-se"
 
-#: users/views/webauthn.py:123
+#: users/views/webauthn.py:126
 msgid "Credential already registered"
 msgstr ""
 
-#: users/views/webauthn.py:165 users/views/webauthn.py:172
-#: users/views/webauthn.py:181
+#: users/views/webauthn.py:168 users/views/webauthn.py:175
+#: users/views/webauthn.py:184
 msgid "Passkey not recognized"
 msgstr ""
 
-#: users/views/webauthn.py:186
+#: users/views/webauthn.py:189
 #, fuzzy
 #| msgid "Account is being deleted."
 msgid "Account is inactive"
 msgstr "A conta está a ser apagada."
 
-#: users/views/webauthn.py:202
+#: users/views/webauthn.py:205
 #, fuzzy
 #| msgid "Send verification code"
 msgid "Passkey verification failed"
 msgstr "Enviar código de verificação"
 
-#: users/views/webauthn.py:228 users/views/webauthn.py:250
+#: users/views/webauthn.py:231 users/views/webauthn.py:253
 #, fuzzy
 #| msgid "User not found"
 msgid "Passkey not found"
 msgstr "Utilizador não encontrado"
 
-#: users/views/webauthn.py:244
+#: users/views/webauthn.py:247
 #, fuzzy
 #| msgid "Login required"
 msgid "Name is required"
 msgstr "Requer iniciar sessão"
-
-#~ msgid "Fanfic"
-#~ msgstr "Fanfic"
-
-#~ msgid "FanFic"
-#~ msgstr "FanFic"
-
-#~ msgid "year of publication"
-#~ msgstr "ano da publicação"
-
-#~ msgid "YYYY-MM-DD"
-#~ msgstr "AAAA-MM-DD"
-
-#~ msgid "region or event"
-#~ msgstr "região ou evento"
-
-#~ msgid "Germany or Toronto International Film Festival"
-#~ msgstr "ex.: Alemanha ou Festival de Cannes"
-
-#~ msgid "year"
-#~ msgstr "ano"
-
-#~ msgctxt "music"
-#~ msgid "genre"
-#~ msgstr "género"
-
-#~ msgid "my notes"
-#~ msgstr "minhas notas"
-
-#~ msgid "release year"
-#~ msgstr "ano de realização"
-
-#~ msgid "episode Length"
-#~ msgstr "Duração de episódio"
-
-#~ msgid "show time"
-#~ msgstr "mostrar horário"
-
-#~ msgid "Region or Event"
-#~ msgstr "Região ou evento"
-
-#~ msgid "boost"
-#~ msgstr "boost"
-
-#~ msgid "Invalid form data"
-#~ msgstr "Formato de dados inválido"
-
-#~ msgid "Username and app password is required."
-#~ msgstr "É necessário nome de utilizador e password da app."
-
-#~ msgid "All"
-#~ msgstr "Tudo"
-
-#~ msgid "Bluesky app password"
-#~ msgstr "Password da Bluesky app"
-
-#~ msgid ""
-#~ "App password can be created on <a href=\"https://bsky.app/settings/app-"
-#~ "passwords\" target=\"_blank\">bsky.app</a>."
-#~ msgstr ""
-#~ "A password da app pode ser criada em <a href=\"https://bsky.app/settings/"
-#~ "app-passwords\" target=\"_blank\">bsky.app</a>."
-
-#~ msgid "Link to Goodreads Profile / Shelf / List"
-#~ msgstr "Ligação para Perfil / Prateleira / Lista do Goodreads"
-
-#~ msgid "Last import started"
-#~ msgstr "A última importação já começou"
-
-#~ msgid "Shelf will be imported as a new collection."
-#~ msgstr "Shelf será importado como nova coleção."
-
-#~ msgid "List will be imported as a new collection."
-#~ msgstr "Lista será importada como uma nova coleção."
-
-#~ msgid ""
-#~ "Failed links, likely due to Letterboxd error, you may have to mark them "
-#~ "manually"
-#~ msgstr ""
-#~ "Links indisponíveis, provavelmente devido a um erro do Letterboxd. É "
-#~ "provável que tenha de as marcar manualmente"
-
-#, fuzzy
-#~ msgid "Export Data"
-#~ msgstr "Exportar Dados"
-
-#~ msgid "back to your home page."
-#~ msgstr "voltar à página inicial."
-
-#~ msgid "Turn on crosspost to timeline by default"
-#~ msgstr "Por padrão, ativar o crosspost para a cronologia"
-
-#~ msgid "Username in use"
-#~ msgstr "Este nome de utilizador encontra-se a ser usado"
-
-#~ msgid "Invalid URL."
-#~ msgstr "URL inválido."
-
-#~ msgid "File is uploaded and will be imported soon."
-#~ msgstr "O ficheiro foi carregado e a importação começará em breve."

--- a/neodb/locale/pt_BR/LC_MESSAGES/django.po
+++ b/neodb/locale/pt_BR/LC_MESSAGES/django.po
@@ -6,12 +6,11 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: dev@neodb.social.NOSPAM\n"
-"POT-Creation-Date: 2026-08-23 15:40-0400\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-06 20:04-0400\n"
 "PO-Revision-Date: 2026-09-02 01:51+0000\n"
 "Last-Translator: Havokdan <havokdan@yahoo.com.br>\n"
-"Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
-"neodb/neodb/pt_BR/>\n"
+"Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/neodb/neodb/pt_BR/>\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,159 +18,159 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: boofilsic/settings.py:472 common/models/lang.py:230
+#: boofilsic/settings.py:501 common/models/lang.py:232
 msgid "English"
 msgstr "Inglês"
 
-#: boofilsic/settings.py:473 common/models/lang.py:77
+#: boofilsic/settings.py:502 common/models/lang.py:79
 msgid "Danish"
 msgstr "Dinamarquês"
 
-#: boofilsic/settings.py:474 common/models/lang.py:78
+#: boofilsic/settings.py:503 common/models/lang.py:80
 msgid "German"
 msgstr "Alemão"
 
-#: boofilsic/settings.py:475 common/models/lang.py:183
+#: boofilsic/settings.py:504 common/models/lang.py:185
 msgid "Spanish"
 msgstr "Espanhol"
 
-#: boofilsic/settings.py:476 common/models/lang.py:87
+#: boofilsic/settings.py:505 common/models/lang.py:89
 msgid "French"
 msgstr "Francês"
 
-#: boofilsic/settings.py:477 common/models/lang.py:112
+#: boofilsic/settings.py:506 common/models/lang.py:114
 msgid "Italian"
 msgstr "Italiano"
 
-#: boofilsic/settings.py:478 common/models/lang.py:166
-#: common/models/lang.py:305
+#: boofilsic/settings.py:507 common/models/lang.py:168
+#: common/models/lang.py:307
 msgid "Portuguese"
 msgstr "Português"
 
-#: boofilsic/settings.py:479
+#: boofilsic/settings.py:508
 msgid "Brazilian Portuguese"
 msgstr "Português Brasileiro"
 
-#: boofilsic/settings.py:480 common/models/lang.py:316
+#: boofilsic/settings.py:509 common/models/lang.py:318
 msgid "Simplified Chinese"
 msgstr "Chinês Simplificado"
 
-#: boofilsic/settings.py:481 common/models/lang.py:317
+#: boofilsic/settings.py:510 common/models/lang.py:319
 msgid "Traditional Chinese"
 msgstr "Chinês Tradicional"
 
-#: catalog/forms.py:35 catalog/models/item.py:291
+#: catalog/forms.py:35 catalog/models/item.py:307
 msgid "Primary ID Type"
 msgstr "Tipo de ID Primário"
 
-#: catalog/forms.py:40 catalog/models/item.py:294
+#: catalog/forms.py:40 catalog/models/item.py:310
 msgid "Primary ID Value"
 msgstr "Valor do ID Primário"
 
-#: catalog/forms.py:181
+#: catalog/forms.py:176
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr "Data inválida, o formato esperado é AAAA, AAAA-MM ou AAAA-MM-DD."
 
-#: catalog/models/book.py:139 catalog/models/book.py:158
-#: catalog/models/common.py:280 catalog/models/common.py:298
+#: catalog/models/book.py:141 catalog/models/book.py:160
+#: catalog/models/common.py:279 catalog/models/common.py:297
 msgid "locale"
 msgstr "localidade"
 
-#: catalog/models/book.py:142 catalog/models/book.py:161
-#: catalog/models/common.py:283 catalog/models/common.py:303
+#: catalog/models/book.py:144 catalog/models/book.py:163
+#: catalog/models/common.py:282 catalog/models/common.py:302
 msgid "text content"
 msgstr "conteúdo de texto"
 
-#: catalog/models/book.py:177
+#: catalog/models/book.py:179
 msgid "Paperback"
 msgstr "Encadernado"
 
-#: catalog/models/book.py:178
+#: catalog/models/book.py:180
 msgid "Hardcover"
 msgstr "Capa Dura"
 
-#: catalog/models/book.py:179
+#: catalog/models/book.py:181
 msgid "eBook"
 msgstr "E-book"
 
-#: catalog/models/book.py:180
+#: catalog/models/book.py:182
 msgid "Audiobook"
 msgstr "Livro de áudio"
 
-#: catalog/models/book.py:182
+#: catalog/models/book.py:184
 msgid "Web Fiction"
 msgstr "Ficção na Web"
 
-#: catalog/models/book.py:183 catalog/models/game.py:38
+#: catalog/models/book.py:185 catalog/models/game.py:38
 msgid "Other"
 msgstr "Outro"
 
-#: catalog/models/book.py:260
+#: catalog/models/book.py:262
 msgid "subtitle"
 msgstr "legenda"
 
-#: catalog/models/book.py:270 catalog/models/movie.py:120
-#: catalog/models/performance.py:385 catalog/models/tv.py:211
-#: catalog/models/tv.py:437
+#: catalog/models/book.py:272 catalog/models/movie.py:120
+#: catalog/models/performance.py:385 catalog/models/tv.py:213
+#: catalog/models/tv.py:439
 msgid "original title"
 msgstr "título original"
 
-#: catalog/models/book.py:274
+#: catalog/models/book.py:276
 msgid "other title"
 msgstr "outro título"
 
-#: catalog/models/book.py:280 catalog/models/book.py:564
-#: catalog/models/item.py:123
+#: catalog/models/book.py:282 catalog/models/book.py:566
+#: catalog/models/item.py:119
 msgid "author"
 msgstr "autor"
 
-#: catalog/models/book.py:287 catalog/models/item.py:124
+#: catalog/models/book.py:289 catalog/models/item.py:120
 msgid "translator"
 msgstr "tradutor"
 
-#: catalog/models/book.py:294 catalog/templates/edition.html:26
+#: catalog/models/book.py:296 catalog/templates/edition.html:26
 msgid "book format"
 msgstr "formato do livro"
 
-#: catalog/models/book.py:301 catalog/models/game.py:135
-#: catalog/models/item.py:138 catalog/models/music.py:142
+#: catalog/models/book.py:303 catalog/models/game.py:135
+#: catalog/models/item.py:134 catalog/models/music.py:142
 msgid "publisher"
 msgstr "editora"
 
-#: catalog/models/book.py:308
+#: catalog/models/book.py:310
 msgid "publication year"
 msgstr "ano de publicação"
 
-#: catalog/models/book.py:314
+#: catalog/models/book.py:316
 msgid "publication month"
 msgstr "mês de publicação"
 
-#: catalog/models/book.py:319
+#: catalog/models/book.py:321
 msgid "binding"
 msgstr "encadernação"
 
-#: catalog/models/book.py:320
+#: catalog/models/book.py:322
 msgid "pages"
 msgstr "páginas"
 
-#: catalog/models/book.py:321 catalog/templates/edition.html:45
+#: catalog/models/book.py:323 catalog/templates/edition.html:45
 msgid "series"
 msgstr "séries"
 
-#: catalog/models/book.py:322 catalog/templates/edition.html:65
+#: catalog/models/book.py:324 catalog/templates/edition.html:65
 msgid "contents"
 msgstr "conteúdo"
 
-#: catalog/models/book.py:323 catalog/templates/edition.html:51
+#: catalog/models/book.py:325 catalog/templates/edition.html:51
 msgid "price"
 msgstr "preço"
 
-#: catalog/models/book.py:324 catalog/models/item.py:149
+#: catalog/models/book.py:326 catalog/models/item.py:145
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr "selo editorial"
 
-#: catalog/models/common.py:26 common/models/lang.py:256
+#: catalog/models/common.py:26 common/models/lang.py:258
 msgid "Unknown"
 msgstr "Desconhecido"
 
@@ -179,11 +178,11 @@ msgstr "Desconhecido"
 msgid "Douban"
 msgstr "Douban"
 
-#: catalog/models/common.py:28 catalog/models/common.py:79
+#: catalog/models/common.py:28 catalog/models/common.py:81
 msgid "Goodreads"
 msgstr "Goodreads"
 
-#: catalog/models/common.py:29 catalog/models/common.py:81
+#: catalog/models/common.py:29 catalog/models/common.py:83
 msgid "Google Books"
 msgstr "Google Livros"
 
@@ -191,16 +190,16 @@ msgstr "Google Livros"
 msgid "BooksTW"
 msgstr "BooksTW"
 
-#: catalog/models/common.py:31 catalog/models/common.py:91
-#: catalog/models/common.py:93
+#: catalog/models/common.py:31 catalog/models/common.py:93
+#: catalog/models/common.py:95
 msgid "Bibliotek.dk"
 msgstr "Bibliotek.dk"
 
-#: catalog/models/common.py:32 catalog/models/common.py:92
+#: catalog/models/common.py:32 catalog/models/common.py:94
 msgid "eReolen.dk"
 msgstr "eReolen.dk"
 
-#: catalog/models/common.py:33 catalog/models/common.py:74
+#: catalog/models/common.py:33 catalog/models/common.py:76
 #: catalog/templates/movie.html:41 catalog/templates/people.html:37
 #: catalog/templates/tvseason.html:58 catalog/templates/tvshow.html:53
 msgid "IMDb"
@@ -210,7 +209,7 @@ msgstr "IMDb"
 msgid "TMDB"
 msgstr "TMDB"
 
-#: catalog/models/common.py:35 catalog/models/common.py:94
+#: catalog/models/common.py:35 catalog/models/common.py:96
 msgid "Bandcamp"
 msgstr "Bandcamp"
 
@@ -226,11 +225,11 @@ msgstr "IGDB"
 msgid "Steam"
 msgstr "Steam"
 
-#: catalog/models/common.py:39 catalog/models/common.py:114
+#: catalog/models/common.py:39 catalog/models/common.py:116
 msgid "itch.io"
 msgstr "itch.io"
 
-#: catalog/models/common.py:40 catalog/models/common.py:115
+#: catalog/models/common.py:40 catalog/models/common.py:117
 msgid "Bangumi"
 msgstr "Bangumi"
 
@@ -238,7 +237,7 @@ msgstr "Bangumi"
 msgid "BGG"
 msgstr "BGG"
 
-#: catalog/models/common.py:42 catalog/models/common.py:116
+#: catalog/models/common.py:42 catalog/models/common.py:118
 msgid "Apple Podcast"
 msgstr "Apple Podcast"
 
@@ -250,35 +249,35 @@ msgstr "RSS"
 msgid "Discogs"
 msgstr "Discogs"
 
-#: catalog/models/common.py:45 catalog/models/common.py:117
+#: catalog/models/common.py:45 catalog/models/common.py:119
 msgid "Apple Music"
 msgstr "Apple Music"
 
-#: catalog/models/common.py:46 catalog/models/common.py:119
+#: catalog/models/common.py:46 catalog/models/common.py:121
 msgid "Fediverse"
 msgstr "Fediverso"
 
-#: catalog/models/common.py:47 catalog/models/common.py:120
+#: catalog/models/common.py:47 catalog/models/common.py:122
 msgid "Qidian"
 msgstr "Qidian"
 
-#: catalog/models/common.py:48 catalog/models/common.py:121
+#: catalog/models/common.py:48 catalog/models/common.py:123
 msgid "Ypshuo"
 msgstr "Ypshuo"
 
-#: catalog/models/common.py:49 catalog/models/common.py:122
+#: catalog/models/common.py:49 catalog/models/common.py:124
 msgid "Archive of Our Own"
 msgstr "Archive of Our Own"
 
-#: catalog/models/common.py:50 catalog/models/common.py:123
+#: catalog/models/common.py:50 catalog/models/common.py:125
 msgid "JinJiang"
 msgstr "JinJiang"
 
-#: catalog/models/common.py:51 catalog/models/common.py:64
+#: catalog/models/common.py:51 catalog/models/common.py:66
 msgid "WikiData"
 msgstr "WikiData"
 
-#: catalog/models/common.py:52 catalog/models/common.py:124
+#: catalog/models/common.py:52 catalog/models/common.py:126
 msgid "Open Library"
 msgstr "Open Library"
 
@@ -290,15 +289,15 @@ msgstr "MusicBrainz"
 msgid "WorldCat"
 msgstr "WorldCat"
 
-#: catalog/models/common.py:55 catalog/models/common.py:126
+#: catalog/models/common.py:55 catalog/models/common.py:128
 msgid "MobyGames"
 msgstr "MobyGames"
 
-#: catalog/models/common.py:56 catalog/models/common.py:127
+#: catalog/models/common.py:56 catalog/models/common.py:129
 msgid "StoryGraph"
 msgstr "StoryGraph"
 
-#: catalog/models/common.py:57 catalog/models/common.py:118
+#: catalog/models/common.py:57 catalog/models/common.py:120
 msgid "YouTube Music"
 msgstr "YouTube Music"
 
@@ -314,338 +313,350 @@ msgstr "AniList"
 msgid "Readmoo"
 msgstr "Readmoo"
 
-#: catalog/models/common.py:65
+#: catalog/models/common.py:61
+#, fuzzy
+#| msgid "MyAnimeList Anime"
+msgid "MyAnimeList"
+msgstr "MyAnimeList Anime"
+
+#: catalog/models/common.py:62 catalog/models/common.py:140
+#, fuzzy
+#| msgid "Update"
+msgid "MangaUpdates"
+msgstr "Atualizar"
+
+#: catalog/models/common.py:67
 msgid "ISBN10"
 msgstr "ISBN10"
 
-#: catalog/models/common.py:66 catalog/templates/edition.html:19
+#: catalog/models/common.py:68 catalog/templates/edition.html:19
 msgid "ISBN"
 msgstr "ISBN"
 
-#: catalog/models/common.py:67
+#: catalog/models/common.py:69
 msgid "ASIN"
 msgstr "ASIN"
 
-#: catalog/models/common.py:68
+#: catalog/models/common.py:70
 msgid "ISSN"
 msgstr "ISSN"
 
-#: catalog/models/common.py:69
+#: catalog/models/common.py:71
 msgid "CUBN"
 msgstr "CUBN"
 
-#: catalog/models/common.py:70
+#: catalog/models/common.py:72
 msgid "ISRC"
 msgstr "ISRC"
 
-#: catalog/models/common.py:71
+#: catalog/models/common.py:73
 msgid "GTIN UPC EAN"
 msgstr "GTIN UPC EAN"
 
-#: catalog/models/common.py:72
+#: catalog/models/common.py:74
 msgid "OCLC Number"
 msgstr "Número OCLC"
 
-#: catalog/models/common.py:73
+#: catalog/models/common.py:75
 msgid "RSS Feed URL"
 msgstr "URL do Feed RSS"
 
-#: catalog/models/common.py:75
+#: catalog/models/common.py:77
 msgid "TMDB TV Series"
 msgstr "Séries TV TMDB"
 
-#: catalog/models/common.py:76
+#: catalog/models/common.py:78
 msgid "TMDB TV Season"
 msgstr "Temporada de TV do TMDB"
 
-#: catalog/models/common.py:77
+#: catalog/models/common.py:79
 msgid "TMDB TV Episode"
 msgstr "Episódio de TV do TMDB"
 
-#: catalog/models/common.py:78
+#: catalog/models/common.py:80
 msgid "TMDB Movie"
 msgstr "Filme TMDB"
 
-#: catalog/models/common.py:80
+#: catalog/models/common.py:82
 msgid "Goodreads Work"
 msgstr "Obra Goodreads"
 
-#: catalog/models/common.py:82
+#: catalog/models/common.py:84
 msgid "Douban Book"
 msgstr "Livro do Douban"
 
-#: catalog/models/common.py:83
+#: catalog/models/common.py:85
 msgid "Douban Book Work"
 msgstr "Obra Literária Douban"
 
-#: catalog/models/common.py:84
+#: catalog/models/common.py:86
 msgid "Douban Movie"
 msgstr "Filme Douban"
 
-#: catalog/models/common.py:85
+#: catalog/models/common.py:87
 msgid "Douban Music"
 msgstr "Música Douban"
 
-#: catalog/models/common.py:86
+#: catalog/models/common.py:88
 msgid "Douban Game"
 msgstr "Jogo Douban"
 
-#: catalog/models/common.py:87
+#: catalog/models/common.py:89
 msgid "Douban Drama"
 msgstr "Drama Douban"
 
-#: catalog/models/common.py:88
+#: catalog/models/common.py:90
 msgid "Douban Drama Version"
 msgstr "Versão de Drama Douban"
 
-#: catalog/models/common.py:89
+#: catalog/models/common.py:91
 msgid "BooksTW Book"
 msgstr "Livro BooksTW"
 
-#: catalog/models/common.py:90
+#: catalog/models/common.py:92
 msgid "Readmoo Book"
 msgstr "Livro Readmoo"
 
-#: catalog/models/common.py:95
+#: catalog/models/common.py:97
 msgid "Spotify Album"
 msgstr "Álbum Spotify"
 
-#: catalog/models/common.py:96
+#: catalog/models/common.py:98
 msgid "Spotify Podcast"
 msgstr "Podcast Spotify"
 
-#: catalog/models/common.py:97
+#: catalog/models/common.py:99
 msgid "Discogs Release"
 msgstr "Lançamento Discogs"
 
-#: catalog/models/common.py:98
+#: catalog/models/common.py:100
 msgid "Discogs Master"
 msgstr "Discogs Master"
 
-#: catalog/models/common.py:101
+#: catalog/models/common.py:103
 msgid "MusicBrainz Release Group"
 msgstr "Grupo de Lançamento do MusicBrainz"
 
-#: catalog/models/common.py:103
+#: catalog/models/common.py:105
 msgid "MusicBrainz Release"
 msgstr "Lançamento do MusicBrainz"
 
-#: catalog/models/common.py:104
+#: catalog/models/common.py:106
 msgid "MusicBrainz Artist"
 msgstr "Artista do MusicBrainz"
 
-#: catalog/models/common.py:105
+#: catalog/models/common.py:107
 msgid "Douban Personage"
 msgstr "Personagem do Douban"
 
-#: catalog/models/common.py:106
+#: catalog/models/common.py:108
 msgid "Goodreads Author"
 msgstr "Autor do Goodreads"
 
-#: catalog/models/common.py:107
+#: catalog/models/common.py:109
 msgid "Spotify Artist"
 msgstr "Artista do Spotify"
 
-#: catalog/models/common.py:108
+#: catalog/models/common.py:110
 msgid "TMDB Person"
 msgstr "Pessoa TMDB"
 
-#: catalog/models/common.py:109
+#: catalog/models/common.py:111
 msgid "Open Library Author"
 msgstr "Autor da Open Library"
 
-#: catalog/models/common.py:110
+#: catalog/models/common.py:112
 msgid "IGDB Company"
 msgstr "Empresa IGDB"
 
-#: catalog/models/common.py:111
+#: catalog/models/common.py:113
 msgid "IGDB Game"
 msgstr "Jogo IGDB"
 
-#: catalog/models/common.py:112
+#: catalog/models/common.py:114
 msgid "BGG Boardgame"
 msgstr "Jogo de Tabuleiro BGG"
 
-#: catalog/models/common.py:113
+#: catalog/models/common.py:115
 msgid "Steam Game"
 msgstr "Jogo da Steam"
 
-#: catalog/models/common.py:125
+#: catalog/models/common.py:127
 msgid "Open Library Work"
 msgstr "Obra da Open Library"
 
-#: catalog/models/common.py:128
+#: catalog/models/common.py:130
 msgid "RateYourMusic Release"
 msgstr "Lançamento no RateYourMusic"
 
-#: catalog/models/common.py:132
+#: catalog/models/common.py:134
 msgid "AniList Anime"
 msgstr "AniList Anime"
 
-#: catalog/models/common.py:133
+#: catalog/models/common.py:135
 msgid "AniList Manga"
 msgstr "AniList Mangá"
 
-#: catalog/models/common.py:134
+#: catalog/models/common.py:136
 msgid "MyAnimeList Anime"
 msgstr "MyAnimeList Anime"
 
-#: catalog/models/common.py:135
+#: catalog/models/common.py:137
 msgid "MyAnimeList Manga"
 msgstr "MyAnimeList Mangá"
 
-#: catalog/models/common.py:156
+#: catalog/models/common.py:161
 msgid "Edition"
 msgstr "Edição"
 
-#: catalog/models/common.py:157 catalog/templates/_sidebar_edit.html:286
+#: catalog/models/common.py:162 catalog/templates/_sidebar_edit.html:289
 msgid "Work"
 msgstr "Obra"
 
-#: catalog/models/common.py:158
+#: catalog/models/common.py:163
 msgid "TV Series"
 msgstr "Série de TV"
 
-#: catalog/models/common.py:159 catalog/templates/_sidebar_edit.html:207
+#: catalog/models/common.py:164 catalog/templates/_sidebar_edit.html:202
+#: catalog/views/edit.py:385
 msgid "TV Season"
 msgstr "Temporada de TV"
 
-#: catalog/models/common.py:160
+#: catalog/models/common.py:165
 msgid "TV Episode"
 msgstr "Episódio de TV"
 
-#: catalog/models/common.py:161 catalog/models/common.py:177
-#: catalog/models/common.py:191 catalog/templates/_sidebar_edit.html:200
-#: journal/templates/_sidebar_user_mark_list.html:35
+#: catalog/models/common.py:166 catalog/models/common.py:182
+#: catalog/models/common.py:196 catalog/templates/_sidebar_edit.html:196
+#: catalog/views/edit.py:384 journal/templates/_sidebar_user_mark_list.html:35
 #: journal/templates/_sidebar_user_tag_filter.html:27
 msgid "Movie"
 msgstr "Filme"
 
-#: catalog/models/common.py:162
+#: catalog/models/common.py:167
 msgid "Album"
 msgstr "Álbum"
 
-#: catalog/models/common.py:163 catalog/models/common.py:180
-#: catalog/models/common.py:194 common/templates/_header.html:43
+#: catalog/models/common.py:168 catalog/models/common.py:185
+#: catalog/models/common.py:199 common/templates/_header.html:53
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
 msgstr "Jogo"
 
-#: catalog/models/common.py:164
+#: catalog/models/common.py:169
 msgid "Podcast Program"
 msgstr "Programa de Podcast"
 
-#: catalog/models/common.py:165
+#: catalog/models/common.py:170
 msgid "Podcast Episode"
 msgstr "Episódio de Podcast"
 
-#: catalog/models/common.py:166 catalog/models/common.py:182
-#: catalog/models/common.py:196 common/templates/_header.html:47
+#: catalog/models/common.py:171 catalog/models/common.py:187
+#: catalog/models/common.py:201 common/templates/_header.html:57
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
 msgstr "Apresentação"
 
-#: catalog/models/common.py:167
+#: catalog/models/common.py:172
 msgid "Production"
 msgstr "Produção"
 
-#: catalog/models/common.py:168
+#: catalog/models/common.py:173
 msgid "Exhibition"
 msgstr "Exibição"
 
-#: catalog/models/common.py:169 catalog/models/common.py:186
+#: catalog/models/common.py:174 catalog/models/common.py:191
 #: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr "Coleção"
 
-#: catalog/models/common.py:172 catalog/models/common.py:185
+#: catalog/models/common.py:177 catalog/models/common.py:190
 msgid "Person / Organization"
 msgstr "Pessoa / Organização"
 
-#: catalog/models/common.py:176 catalog/models/common.py:190
-#: common/templates/_header.html:27
+#: catalog/models/common.py:181 catalog/models/common.py:195
+#: common/templates/_header.html:37
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
 msgstr "Livro"
 
-#: catalog/models/common.py:178 catalog/models/common.py:192
+#: catalog/models/common.py:183 catalog/models/common.py:197
 #: journal/templates/_sidebar_user_mark_list.html:38
 #: journal/templates/_sidebar_user_tag_filter.html:30
 msgid "TV"
 msgstr "TV"
 
-#: catalog/models/common.py:179 catalog/models/common.py:193
-#: common/templates/_header.html:39
+#: catalog/models/common.py:184 catalog/models/common.py:198
+#: common/templates/_header.html:49
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr "Música"
 
-#: catalog/models/common.py:181 catalog/models/common.py:195
-#: catalog/templates/_sidebar_edit.html:219 common/templates/_header.html:35
+#: catalog/models/common.py:186 catalog/models/common.py:200
+#: catalog/templates/_sidebar_edit.html:213 common/templates/_header.html:45
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
 msgstr "Podcast"
 
-#: catalog/models/common.py:346 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:345 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr "gênero"
 
-#: catalog/models/common.py:384
+#: catalog/models/common.py:383
 msgid "origin country"
 msgstr "país de origem"
 
-#: catalog/models/common.py:413 catalog/templates/album.html:33
+#: catalog/models/common.py:412 catalog/templates/album.html:33
 msgid "album type"
 msgstr "tipo de álbum"
 
-#: catalog/models/common.py:417 catalog/templates/_platform_list.html:5
+#: catalog/models/common.py:416 catalog/templates/_platform_list.html:5
 msgid "platform"
 msgstr "plataforma"
 
-#: catalog/models/common.py:421
+#: catalog/models/common.py:420
 msgid "media format"
 msgstr "formato de mídia"
 
-#: catalog/models/common.py:426 catalog/templates/_language_list.html:5
-#: users/models/user.py:142
+#: catalog/models/common.py:425 catalog/templates/_language_list.html:5
+#: users/models/user.py:144
 msgid "language"
 msgstr "idioma"
 
-#: catalog/models/creator.py:24
+#: catalog/models/creator.py:26
 msgid "pending"
 msgstr "pendente"
 
-#: catalog/models/creator.py:25
+#: catalog/models/creator.py:27
 msgid "verified"
 msgstr "verificado"
 
-#: catalog/models/creator.py:26
+#: catalog/models/creator.py:28
 msgid "failed"
 msgstr "falhou"
 
-#: catalog/models/creator.py:29
+#: catalog/models/creator.py:31
 msgid "no feed url available for this item"
 msgstr "nenhuma URL de feed disponível para este item"
 
-#: catalog/models/creator.py:30
+#: catalog/models/creator.py:32
 msgid "unable to fetch or parse the feed"
 msgstr "não foi possível buscar ou processar o feed"
 
-#: catalog/models/creator.py:31
+#: catalog/models/creator.py:33
 msgid "no audio episode found in the feed"
 msgstr "nenhum episódio de áudio encontrado no feed"
 
-#: catalog/models/creator.py:34
+#: catalog/models/creator.py:36
 msgid "no matching identity found in the feed or its linked website"
-msgstr ""
-"nenhuma identidade correspondente encontrada no feed ou em seu site vinculado"
+msgstr "nenhuma identidade correspondente encontrada no feed ou em seu site vinculado"
 
 #: catalog/models/game.py:30
 msgid "Main Game"
@@ -679,16 +690,16 @@ msgstr "Remake"
 msgid "Special Edition"
 msgstr "Edição Especial"
 
-#: catalog/models/game.py:111 catalog/models/item.py:130
+#: catalog/models/game.py:111 catalog/models/item.py:126
 msgid "designer"
 msgstr "designer"
 
-#: catalog/models/game.py:119 catalog/models/item.py:129
+#: catalog/models/game.py:119 catalog/models/item.py:125
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr "artista"
 
-#: catalog/models/game.py:127 catalog/models/item.py:139
+#: catalog/models/game.py:127 catalog/models/item.py:135
 msgid "developer"
 msgstr "desenvolvedor"
 
@@ -697,8 +708,8 @@ msgid "date of publication"
 msgstr "data de publicação"
 
 #: catalog/models/game.py:147 catalog/models/movie.py:156
-#: catalog/models/music.py:128 catalog/models/tv.py:247
-#: catalog/models/tv.py:473
+#: catalog/models/music.py:128 catalog/models/tv.py:249
+#: catalog/models/tv.py:475
 msgid "YYYY, YYYY-MM or YYYY-MM-DD"
 msgstr "AAAA, AAAA-MM ou AAAA-MM-DD"
 
@@ -709,7 +720,7 @@ msgstr "tipo de lançamento"
 #: catalog/models/game.py:180 catalog/models/movie.py:158
 #: catalog/models/people.py:178 catalog/models/performance.py:258
 #: catalog/models/performance.py:465 catalog/models/podcast.py:89
-#: catalog/models/tv.py:249 catalog/models/tv.py:476
+#: catalog/models/tv.py:251 catalog/models/tv.py:478
 #: catalog/templates/game.html:33 catalog/templates/movie.html:48
 #: catalog/templates/people.html:44 catalog/templates/performance.html:35
 #: catalog/templates/performanceproduction.html:35
@@ -718,146 +729,146 @@ msgstr "tipo de lançamento"
 msgid "website"
 msgstr "site"
 
-#: catalog/models/item.py:125 catalog/models/movie.py:123
+#: catalog/models/item.py:121 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
-#: catalog/models/tv.py:214 catalog/models/tv.py:440
+#: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr "diretor"
 
-#: catalog/models/item.py:126 catalog/models/movie.py:130
+#: catalog/models/item.py:122 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
-#: catalog/models/tv.py:221 catalog/models/tv.py:447
+#: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr "dramaturgo"
 
-#: catalog/models/item.py:127 catalog/models/movie.py:137
+#: catalog/models/item.py:123 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
-#: catalog/models/tv.py:228 catalog/models/tv.py:454
+#: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr "ator"
 
-#: catalog/models/item.py:128 catalog/models/movie.py:144
-#: catalog/models/tv.py:235 catalog/models/tv.py:461
+#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/tv.py:237 catalog/models/tv.py:463
 msgid "producer"
 msgstr "produtor"
 
-#: catalog/models/item.py:131 catalog/models/performance.py:203
+#: catalog/models/item.py:127 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr "compositor"
 
-#: catalog/models/item.py:132 catalog/models/performance.py:210
+#: catalog/models/item.py:128 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr "coreógrafo"
 
-#: catalog/models/item.py:133 catalog/models/performance.py:224
+#: catalog/models/item.py:129 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr "artista"
 
-#: catalog/models/item.py:134 catalog/models/podcast.py:80
+#: catalog/models/item.py:130 catalog/models/podcast.py:80
 msgid "host"
 msgstr "host"
 
-#: catalog/models/item.py:135 catalog/models/performance.py:196
+#: catalog/models/item.py:131 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr "criador original"
 
-#: catalog/models/item.py:136 catalog/models/performance.py:238
+#: catalog/models/item.py:132 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr "equipe"
 
-#: catalog/models/item.py:140
+#: catalog/models/item.py:136
 msgid "production company"
 msgstr "produtora"
 
-#: catalog/models/item.py:141
+#: catalog/models/item.py:137
 msgid "record label"
 msgstr "gravadora"
 
-#: catalog/models/item.py:142
+#: catalog/models/item.py:138
 msgid "distributor"
 msgstr "distribuidora"
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:139
 msgid "studio"
 msgstr "estúdio"
 
-#: catalog/models/item.py:144 catalog/models/performance.py:231
+#: catalog/models/item.py:140 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr "trupe"
 
-#: catalog/models/item.py:147
+#: catalog/models/item.py:143
 msgid "voice actor"
 msgstr "dublador"
 
-#: catalog/models/item.py:148 catalog/templates/edition.html:30
+#: catalog/models/item.py:144 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr "casa editorial"
 
-#: catalog/models/item.py:173 catalog/models/people.py:476
+#: catalog/models/item.py:169 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr "papel"
 
-#: catalog/models/item.py:174 catalog/models/people.py:155
+#: catalog/models/item.py:170 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr "nome"
 
-#: catalog/models/item.py:176 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr "nome do personagem"
 
-#: catalog/models/item.py:288 catalog/models/item.py:320
-#: journal/models/collection.py:96
+#: catalog/models/item.py:304 catalog/models/item.py:336
+#: journal/models/collection.py:100
 msgid "title"
 msgstr "título"
 
-#: catalog/models/item.py:289 catalog/models/item.py:328
-#: journal/models/collection.py:97
+#: catalog/models/item.py:305 catalog/models/item.py:344
+#: journal/models/collection.py:101
 msgid "description"
 msgstr "descrição"
 
-#: catalog/models/item.py:300 catalog/models/people.py:484
+#: catalog/models/item.py:316 catalog/models/people.py:484
 msgid "metadata"
 msgstr "metadados"
 
-#: catalog/models/item.py:302 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
 msgid "cover"
 msgstr "capa"
 
-#: catalog/models/item.py:1485
+#: catalog/models/item.py:1526
 msgid "source site"
 msgstr "site de origem"
 
-#: catalog/models/item.py:1487
+#: catalog/models/item.py:1528
 msgid "ID on source site"
 msgstr "ID no site de origem"
 
-#: catalog/models/item.py:1489
+#: catalog/models/item.py:1530
 msgid "source url"
 msgstr "URL de origem"
 
-#: catalog/models/item.py:1505
+#: catalog/models/item.py:1546
 msgid "IdType of the source site"
 msgstr "Tipo de ID do site de origem"
 
-#: catalog/models/item.py:1511
+#: catalog/models/item.py:1552
 msgid "Primary Id on the source site"
 msgstr "ID primário no site de origem"
 
-#: catalog/models/item.py:1514
+#: catalog/models/item.py:1555
 msgid "url to the resource"
 msgstr "URL do recurso"
 
 #: catalog/models/movie.py:152 catalog/models/music.py:124
-#: catalog/models/tv.py:243 catalog/models/tv.py:469
+#: catalog/models/tv.py:245 catalog/models/tv.py:471
 #: catalog/templates/_item_card_metadata_album.html:16
 #: catalog/templates/album.html:17 catalog/templates/game.html:22
 #: catalog/templates/movie.html:36 catalog/templates/tvseason.html:53
@@ -872,7 +883,7 @@ msgid "length"
 msgstr "duração"
 
 #: catalog/models/movie.py:162 catalog/models/music.py:131
-#: catalog/models/tv.py:259 catalog/models/tv.py:486
+#: catalog/models/tv.py:261 catalog/models/tv.py:488
 msgid "seconds"
 msgstr "segundos"
 
@@ -1034,46 +1045,98 @@ msgstr "data de abertura"
 msgid "closing date"
 msgstr "data de encerramento"
 
-#: catalog/models/tv.py:186 catalog/templates/tvseason.html:38
+#: catalog/models/tv.py:188 catalog/templates/tvseason.html:38
 #: catalog/templates/tvshow.html:33
 msgid "number of seasons"
 msgstr "número de temporadas"
 
-#: catalog/models/tv.py:189 catalog/models/tv.py:415
+#: catalog/models/tv.py:191 catalog/models/tv.py:417
 #: catalog/templates/tvseason.html:43 catalog/templates/tvshow.html:38
 msgid "number of episodes"
 msgstr "número de episódios"
 
-#: catalog/models/tv.py:256 catalog/models/tv.py:483
+#: catalog/models/tv.py:258 catalog/models/tv.py:485
 msgid "episode length"
 msgstr "duração do episódio"
 
-#: catalog/models/tv.py:412 catalog/templates/tvseason.html:33
+#: catalog/models/tv.py:414 catalog/templates/tvseason.html:33
 msgid "season number"
 msgstr "número da temporada"
 
-#: catalog/models/tv.py:530
+#: catalog/models/tv.py:532
 #, python-brace-format
 msgid "{show_title} Season {season_number}"
 msgstr "{show_title} Temporada {season_number}"
 
-#: catalog/models/tv.py:684
+#: catalog/models/tv.py:686
 #, python-brace-format
 msgid "{season_title} E{episode_number}"
 msgstr "{season_title} E{episode_number}"
+
+#: catalog/templates/_catalog_confirm_item.html:7
+#: catalog/templates/catalog_edit.html:62
+msgid "Item has been deleted."
+msgstr "O item foi excluído."
+
+#: catalog/templates/_catalog_confirm_item.html:12
+#: catalog/templates/catalog_edit.html:65
+msgid "Item contains sub-items."
+msgstr "O item contém subitens."
+
+#: catalog/templates/_catalog_confirm_item.html:17
+msgid "Item has been merged to another item."
+msgstr "O item foi mesclado com outro item."
+
+#: catalog/templates/_catalog_confirm_item.html:22
+msgid "Item has been marked by users."
+msgstr "O item foi marcado por usuários."
+
+#: catalog/templates/_catalog_edit_preview.html:11
+#, fuzzy
+#| msgid "Confirm and save"
+msgid "Confirm changes"
+msgstr "Confirmar e salvar"
+
+#: catalog/templates/_catalog_edit_preview.html:16
+msgid "Please correct the errors below."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:24
+msgid "Field"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:25
+msgid "From"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:26
+msgid "To"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:45
+#, fuzzy
+#| msgid "Tag deleted."
+msgid "No changes detected."
+msgstr "Etiqueta excluída."
+
+#: catalog/templates/_catalog_edit_preview.html:54
+#: users/templates/users/register.html:104
+msgid "Confirm and save"
+msgstr "Confirmar e salvar"
+
+#: catalog/templates/_catalog_edit_preview.html:57
+#, fuzzy
+#| msgid "back to item"
+msgid "Back to editing"
+msgstr "voltar ao item"
 
 #: catalog/templates/_country_list.html:5
 msgid "region"
 msgstr "região"
 
 #: catalog/templates/_fetch_failed.html:4
-msgid ""
-"Unable to fetch from the link, please check again. Some sites may require "
-"login for certain links, please manually create them here."
-msgstr ""
-"Não foi possível buscar a partir do link. Por favor, verifique novamente. "
-"Alguns sites podem exigir login para determinados links; crie-os manualmente "
-"aqui."
+msgid "Unable to fetch from the link, please check again. Some sites may require login for certain links, please manually create them here."
+msgstr "Não foi possível buscar a partir do link. Por favor, verifique novamente. Alguns sites podem exigir login para determinados links; crie-os manualmente aqui."
 
 #: catalog/templates/_item_card_metadata_album.html:7
 #: catalog/templates/_item_card_metadata_edition.html:7
@@ -1128,7 +1191,7 @@ msgstr "mostrar mais"
 #: journal/templates/profile_posts.html:21
 #: journal/templates/user_follow_list_items.html:63
 #: journal/templates/user_post_list_items.html:24
-#: social/templates/events.html:43 social/templates/feed_events.html:28
+#: social/templates/events.html:43 social/templates/feed_events.html:27
 msgid "nothing more."
 msgstr "nada mais."
 
@@ -1215,7 +1278,7 @@ msgid "Add note"
 msgstr "Adicionar anotação"
 
 #: catalog/templates/_item_user_pieces.html:83
-#: common/templates/_sidebar.html:196 journal/templates/profile_items.html:46
+#: common/templates/_sidebar.html:195 journal/templates/profile_items.html:46
 msgid "Set progress"
 msgstr "Definir progresso"
 
@@ -1242,6 +1305,12 @@ msgstr "minha coleção"
 #: catalog/templates/_item_user_pieces.html:214
 msgid "mark history"
 msgstr "histórico de marcações"
+
+#: catalog/templates/_search_suggest.html:2
+#, fuzzy
+#| msgid "Suggest Edits"
+msgid "Suggestions"
+msgstr "Sugerir Edições"
 
 #: catalog/templates/_sidebar_edit.html:8
 msgid "edit"
@@ -1270,15 +1339,15 @@ msgid "Edit Options"
 msgstr "Editar Opções"
 
 #: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
-#: catalog/views/edit.py:82 catalog/views/edit.py:143 catalog/views/edit.py:197
-#: catalog/views/edit.py:218 catalog/views/edit.py:259
-#: catalog/views/edit.py:328 catalog/views/edit.py:332
-#: catalog/views/edit.py:351 catalog/views/edit.py:400
-#: catalog/views/edit.py:425 catalog/views/edit.py:440
-#: catalog/views/edit.py:480 catalog/views/edit.py:490
-#: catalog/views/edit.py:517 catalog/views/edit.py:582
-#: catalog/views/edit.py:637 catalog/views/edit.py:659
-#: catalog/views/search.py:367
+#: catalog/views/edit.py:160 catalog/views/edit.py:221
+#: catalog/views/edit.py:288 catalog/views/edit.py:309
+#: catalog/views/edit.py:364 catalog/views/edit.py:471
+#: catalog/views/edit.py:475 catalog/views/edit.py:509
+#: catalog/views/edit.py:576 catalog/views/edit.py:601
+#: catalog/views/edit.py:624 catalog/views/edit.py:664
+#: catalog/views/edit.py:674 catalog/views/edit.py:703
+#: catalog/views/edit.py:782 catalog/views/edit.py:837
+#: catalog/views/edit.py:859 catalog/views/search.py:418
 msgid "Editing this item is restricted."
 msgstr "A edição deste item é restrita."
 
@@ -1306,14 +1375,13 @@ msgstr "Este item foi sinalizado por usuários."
 msgid "The following items are merged into this item"
 msgstr "Os seguintes itens estão mesclados neste item"
 
-#: catalog/templates/_sidebar_edit.html:70
+#: catalog/templates/_sidebar_edit.html:70 catalog/views/edit.py:456
 msgid "External website"
 msgstr "Site externo"
 
 #: catalog/templates/_sidebar_edit.html:81
 msgid "Fetch films and TV shows for this person from this external source"
-msgstr ""
-"Buscar filmes e séries de TV para esta pessoa a partir desta fonte externa"
+msgstr "Buscar filmes e séries de TV para esta pessoa a partir desta fonte externa"
 
 #: catalog/templates/_sidebar_edit.html:82
 msgid "pull works"
@@ -1321,45 +1389,37 @@ msgstr "buscar obras"
 
 #: catalog/templates/_sidebar_edit.html:88
 msgid "Existing metadata might get overwritten, sure to proceed?"
-msgstr ""
-"Os metadados existentes podem ser substituídos. Tem certeza de que deseja "
-"continuar?"
+msgstr "Os metadados existentes podem ser substituídos. Tem certeza de que deseja continuar?"
 
 #: catalog/templates/_sidebar_edit.html:92
 msgid "Fetch again"
 msgstr "Buscar novamente"
 
-#: catalog/templates/_sidebar_edit.html:97
-msgid "You may not be able to undo this operation, sure to remove?"
-msgstr ""
-"Você pode não conseguir desfazer esta operação. Tem certeza de que deseja "
-"remover?"
-
-#: catalog/templates/_sidebar_edit.html:102
+#: catalog/templates/_sidebar_edit.html:100
 msgid "Remove link to site"
 msgstr "Remover link para o site"
 
-#: catalog/templates/_sidebar_edit.html:110
+#: catalog/templates/_sidebar_edit.html:108
 msgid "Choose cover"
 msgstr "Escolher capa"
 
-#: catalog/templates/_sidebar_edit.html:119
+#: catalog/templates/_sidebar_edit.html:117
+#: catalog/templates/_sidebar_edit.html:118
 #: catalog/templates/_sidebar_edit.html:120
-#: catalog/templates/_sidebar_edit.html:122
 msgid "Current cover"
 msgstr "Capa atual"
 
-#: catalog/templates/_sidebar_edit.html:139
+#: catalog/templates/_sidebar_edit.html:137
 msgid "Select an image to use as the cover of this item."
 msgstr "Selecione uma imagem para usar como capa deste item."
 
-#: catalog/templates/_sidebar_edit.html:140
-#: catalog/templates/catalog_edit.html:65
-#: common/templates/manage/settings.html:136
+#: catalog/templates/_sidebar_edit.html:138
+#: catalog/templates/catalog_edit.html:78
+#: common/templates/manage/settings.html:19
 #: journal/templates/add_to_collection.html:43
 #: journal/templates/article_edit.html:60
 #: journal/templates/collection_edit.html:39 journal/templates/comment.html:41
-#: journal/templates/mark.html:134 journal/templates/note.html:65
+#: journal/templates/mark.html:138 journal/templates/note.html:65
 #: journal/templates/post_compose.html:103
 #: journal/templates/review_edit.html:46 journal/templates/tag_edit.html:51
 #: users/templates/users/_pref_device.html:37
@@ -1368,199 +1428,160 @@ msgstr "Selecione uma imagem para usar como capa deste item."
 msgid "Save"
 msgstr "Salvar"
 
-#: catalog/templates/_sidebar_edit.html:147
+#: catalog/templates/_sidebar_edit.html:145
 msgid "Edit sub-items"
 msgstr "Editar subitens"
 
-#: catalog/templates/_sidebar_edit.html:160
+#: catalog/templates/_sidebar_edit.html:158
 msgid "create"
 msgstr "criar"
 
-#: catalog/templates/_sidebar_edit.html:166
+#: catalog/templates/_sidebar_edit.html:164
 msgid "Fetch all episodes"
 msgstr "Buscar todos os episódios"
 
-#: catalog/templates/_sidebar_edit.html:171
+#: catalog/templates/_sidebar_edit.html:169
 msgid "Fetch all"
 msgstr "Buscar tudo"
 
-#: catalog/templates/_sidebar_edit.html:172
-msgid ""
-"Due to differences in how Douban, IMDB, and TMDB handle season data, a small "
-"number of TV shows and animations may not return correct results. Please "
-"manually verify and clean up after updating."
-msgstr ""
-"Devido às diferenças na forma como Douban, IMDB e TMDB lidam com dados de "
-"temporada, um pequeno número de séries de TV e animações pode não retornar "
-"resultados corretos. Por favor, verifique e limpe manualmente após a "
-"atualização."
+#: catalog/templates/_sidebar_edit.html:170
+msgid "Due to differences in how Douban, IMDB, and TMDB handle season data, a small number of TV shows and animations may not return correct results. Please manually verify and clean up after updating."
+msgstr "Devido às diferenças na forma como Douban, IMDB e TMDB lidam com dados de temporada, um pequeno número de séries de TV e animações pode não retornar resultados corretos. Por favor, verifique e limpe manualmente após a atualização."
 
-#: catalog/templates/_sidebar_edit.html:173
+#: catalog/templates/_sidebar_edit.html:171
 msgid "Up to 250 episodes will be fetched for a season."
 msgstr "Até 250 episódios serão buscados para uma temporada."
 
-#: catalog/templates/_sidebar_edit.html:176
-msgid ""
-"To fetch all episodes, season numbers and IMDB information are required. If "
-"filling this out is inconvenient, you can also manually create sub-entries."
-msgstr ""
-"Para buscar todos os episódios, os números de temporada e as informações do "
-"IMDB são obrigatórios. Se for inconveniente preencher isso, você também pode "
-"criar subentradas manualmente."
+#: catalog/templates/_sidebar_edit.html:174
+msgid "To fetch all episodes, season numbers and IMDB information are required. If filling this out is inconvenient, you can also manually create sub-entries."
+msgstr "Para buscar todos os episódios, os números de temporada e as informações do IMDB são obrigatórios. Se for inconveniente preencher isso, você também pode criar subentradas manualmente."
 
-#: catalog/templates/_sidebar_edit.html:182
-#: catalog/templates/_sidebar_edit.html:194
-#: catalog/templates/_sidebar_edit.html:213
+#: catalog/templates/_sidebar_edit.html:180
+#: catalog/templates/_sidebar_edit.html:191
+#: catalog/templates/_sidebar_edit.html:208
 msgid "switch category"
 msgstr "alternar categoria"
 
-#: catalog/templates/_sidebar_edit.html:185
-msgid "Switching may remove some metadata. Sure to proceed?"
-msgstr ""
-"Alternar pode remover alguns metadados. Tem certeza de que deseja continuar?"
-
-#: catalog/templates/_sidebar_edit.html:188
+#: catalog/templates/_sidebar_edit.html:185 catalog/views/edit.py:383
 msgid "TV Show"
 msgstr "Séries"
 
-#: catalog/templates/_sidebar_edit.html:227
+#: catalog/templates/_sidebar_edit.html:221
 msgid "Link to parent item"
 msgstr "Vincular ao item pai"
 
 #: catalog/templates/_sidebar_edit.html:230
-msgid "Sure to link?"
-msgstr "Tem certeza de que deseja vincular?"
-
-#: catalog/templates/_sidebar_edit.html:237
 msgid "Update link"
 msgstr "Atualizar link"
 
-#: catalog/templates/_sidebar_edit.html:243
+#: catalog/templates/_sidebar_edit.html:236
 msgid "Cleanup seasons"
 msgstr "Limpar temporadas"
 
-#: catalog/templates/_sidebar_edit.html:246
-#: catalog/templates/catalog_delete.html:45
-msgid "This operation cannot be undone. Sure to delete?"
-msgstr ""
-"Esta operação não pode ser desfeita. Tem certeza de que deseja excluir?"
-
-#: catalog/templates/_sidebar_edit.html:250
+#: catalog/templates/_sidebar_edit.html:242
 msgid "remove seasons not marked"
 msgstr "remover temporadas não marcadas"
 
-#: catalog/templates/_sidebar_edit.html:256
-#: catalog/templates/catalog_merge.html:12
+#: catalog/templates/_sidebar_edit.html:248
 msgid "Merge"
 msgstr "Mesclar"
 
-#: catalog/templates/_sidebar_edit.html:262
+#: catalog/templates/_sidebar_edit.html:254
 msgid "URL of target item, or empty if undo merge"
 msgstr "URL do item de destino, ou vazio para desfazer mesclagem"
 
-#: catalog/templates/_sidebar_edit.html:268
-#: catalog/templates/_sidebar_edit.html:348
+#: catalog/templates/_sidebar_edit.html:260
+#: catalog/templates/_sidebar_edit.html:350
 msgid "merge to another item"
 msgstr "mesclar com outro item"
 
-#: catalog/templates/_sidebar_edit.html:273
-#: catalog/templates/_sidebar_edit.html:277
-#: catalog/templates/catalog_delete.html:12
+#: catalog/templates/_sidebar_edit.html:265
+#: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
 #: journal/templates/article.html:199 journal/templates/collection.html:188
-#: journal/templates/mark.html:149 journal/templates/note.html:82
+#: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
 #: users/templates/users/account.html:254
 msgid "Delete"
 msgstr "Excluir"
 
-#: catalog/templates/_sidebar_edit.html:287
+#: catalog/templates/_sidebar_edit.html:275
+#: catalog/templates/_sidebar_edit.html:279
+#, fuzzy
+#| msgid "Tag deleted."
+msgid "Undo delete"
+msgstr "Etiqueta excluída."
+
+#: catalog/templates/_sidebar_edit.html:280
+msgid "Links to external sites and parent item were removed on delete and will not be restored."
+msgstr ""
+
+#: catalog/templates/_sidebar_edit.html:290
 msgid "This edition belongs to the following work"
 msgstr "Esta edição pertence à seguinte obra"
 
-#: catalog/templates/_sidebar_edit.html:292
-msgid "Sure to unlink?"
-msgstr "Tem certeza de que deseja desvincular?"
-
-#: catalog/templates/_sidebar_edit.html:298
+#: catalog/templates/_sidebar_edit.html:300
 msgid "Unlink from work"
 msgstr "Desvincular da obra"
 
-#: catalog/templates/_sidebar_edit.html:304
+#: catalog/templates/_sidebar_edit.html:306
 msgid "Link"
 msgstr "Vincular"
 
-#: catalog/templates/_sidebar_edit.html:315
+#: catalog/templates/_sidebar_edit.html:317
 msgid "Link to another edition from same work"
 msgstr "Vincular a outra edição da mesma obra"
 
-#: catalog/templates/_sidebar_edit.html:324
+#: catalog/templates/_sidebar_edit.html:326
 msgid "Restriction"
 msgstr "Restrição"
 
-#: catalog/templates/_sidebar_edit.html:337
+#: catalog/templates/_sidebar_edit.html:339
 #: journal/templates/collection_update_item_note.html:4
 msgid "Update"
 msgstr "Atualizar"
 
-#: catalog/templates/_sidebar_edit.html:342
+#: catalog/templates/_sidebar_edit.html:344
 msgid "Suggest Edits"
 msgstr "Sugerir Edições"
 
-#: catalog/templates/_sidebar_edit.html:347
+#: catalog/templates/_sidebar_edit.html:349
 msgid "proposed action"
 msgstr "ação proposta"
 
-#: catalog/templates/_sidebar_edit.html:349
+#: catalog/templates/_sidebar_edit.html:351
 msgid "link to another item"
 msgstr "vincular a outro item"
 
-#: catalog/templates/_sidebar_edit.html:350
+#: catalog/templates/_sidebar_edit.html:352
 msgid "change item category"
 msgstr "alterar categoria do item"
 
-#: catalog/templates/_sidebar_edit.html:351
+#: catalog/templates/_sidebar_edit.html:353
 msgid "change item metadata"
 msgstr "alterar metadados do item"
 
-#: catalog/templates/_sidebar_edit.html:352
+#: catalog/templates/_sidebar_edit.html:354
 msgid "remove item"
 msgstr "remover item"
 
-#: catalog/templates/_sidebar_edit.html:353
+#: catalog/templates/_sidebar_edit.html:355
 msgid "other"
 msgstr "outro"
 
-#: catalog/templates/_sidebar_edit.html:357
-msgid ""
-"To suggest merging or association, please include the URL of the target item"
+#: catalog/templates/_sidebar_edit.html:359
+msgid "To suggest merging or association, please include the URL of the target item"
 msgstr "Para sugerir mesclagem ou associação, inclua a URL do item de destino"
 
-#: catalog/templates/_sidebar_edit.html:358
+#: catalog/templates/_sidebar_edit.html:360
 #: catalog/templates/catalog_verify.html:116
 msgid "submit"
 msgstr "enviar"
 
-#: catalog/templates/_sidebar_edit.html:359
-msgid ""
-"As a user of this community, you may edit some metadata of items on this "
-"site. If you are unsure whether your edits are appropriate or are unable to "
-"make a certain change, you can make suggestions here. Moderators will "
-"consider each suggestion, although there is no guarantee that they will "
-"always be fully adopted; suggestions may also be viewed or discussed by "
-"other community users. If you have suggestions that are not related to a "
-"specific item, please contact us. Thank you for your support and "
-"contribution."
-msgstr ""
-"Como usuário desta comunidade, você pode editar alguns metadados dos itens "
-"neste site. Se não tiver certeza se suas edições são adequadas ou não "
-"conseguir realizar determinada alteração, você pode fazer sugestões aqui. Os "
-"moderadores analisarão cada sugestão, embora não haja garantia de que serão "
-"sempre adotadas integralmente; as sugestões também podem ser visualizadas ou "
-"discutidas por outros usuários da comunidade. Se tiver sugestões não "
-"relacionadas a um item específico, entre em contato conosco. Obrigado pelo "
-"seu apoio e contribuição."
+#: catalog/templates/_sidebar_edit.html:361
+msgid "As a user of this community, you may edit some metadata of items on this site. If you are unsure whether your edits are appropriate or are unable to make a certain change, you can make suggestions here. Moderators will consider each suggestion, although there is no guarantee that they will always be fully adopted; suggestions may also be viewed or discussed by other community users. If you have suggestions that are not related to a specific item, please contact us. Thank you for your support and contribution."
+msgstr "Como usuário desta comunidade, você pode editar alguns metadados dos itens neste site. Se não tiver certeza se suas edições são adequadas ou não conseguir realizar determinada alteração, você pode fazer sugestões aqui. Os moderadores analisarão cada sugestão, embora não haja garantia de que serão sempre adotadas integralmente; as sugestões também podem ser visualizadas ou discutidas por outros usuários da comunidade. Se tiver sugestões não relacionadas a um item específico, entre em contato conosco. Obrigado pelo seu apoio e contribuição."
 
 #: catalog/templates/_sidebar_search.html:5
 #: journal/templates/_sidebar_search_journal.html:4
@@ -1657,18 +1678,14 @@ msgid "matched"
 msgstr "correspondido"
 
 #: catalog/templates/_verify_status.html:21
-msgid ""
-"Sure to remove your creator verification? Anyone will be able to edit this "
-"item again."
-msgstr ""
-"Tem certeza de que deseja remover sua verificação de criador? Qualquer "
-"pessoa poderá editar este item novamente."
+msgid "Sure to remove your creator verification? Anyone will be able to edit this item again."
+msgstr "Tem certeza de que deseja remover sua verificação de criador? Qualquer pessoa poderá editar este item novamente."
 
 #: catalog/templates/_verify_status.html:26
 msgid "Remove my verification"
 msgstr "Remover minha verificação"
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:309
+#: catalog/templates/_verify_status.html:31 users/views/account.py:311
 msgid "Verification failed"
 msgstr "Falha na verificação"
 
@@ -1705,43 +1722,11 @@ msgstr "código de barras"
 msgid "album media"
 msgstr "mídia de álbum"
 
-#: catalog/templates/catalog_delete.html:19
-msgid "Are you sure to delete?"
-msgstr "Tem certeza de que deseja excluir?"
-
-#: catalog/templates/catalog_delete.html:24
-#: catalog/templates/catalog_edit.html:52
-#: catalog/templates/catalog_merge.html:36
-#: catalog/templates/catalog_merge.html:64
-msgid "Item has been deleted."
-msgstr "O item foi excluído."
-
-#: catalog/templates/catalog_delete.html:29
-#: catalog/templates/catalog_edit.html:55
-#: catalog/templates/catalog_merge.html:41
-#: catalog/templates/catalog_merge.html:69
-msgid "Item contains sub-items."
-msgstr "O item contém subitens."
-
-#: catalog/templates/catalog_delete.html:34
-#: catalog/templates/catalog_merge.html:46
-#: catalog/templates/catalog_merge.html:74
-msgid "Item has been merged to another item."
-msgstr "O item foi mesclado com outro item."
-
-#: catalog/templates/catalog_delete.html:39
-#: catalog/templates/catalog_merge.html:51
-#: catalog/templates/catalog_merge.html:79
-msgid "Item has been marked by users."
-msgstr "O item foi marcado por usuários."
-
-#: catalog/templates/catalog_delete.html:48
-#: catalog/templates/catalog_merge.html:92 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:55 common/views_manage.py:139
 msgid "Yes"
 msgstr "Sim"
 
-#: catalog/templates/catalog_delete.html:49
-#: catalog/templates/catalog_merge.html:93 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:56 common/views_manage.py:139
 msgid "No"
 msgstr "Não"
 
@@ -1750,55 +1735,27 @@ msgstr "Não"
 msgid "Create"
 msgstr "Criar"
 
-#: catalog/templates/catalog_edit.html:68
+#: catalog/templates/catalog_edit.html:81
 #: journal/templates/collection_update_item_note.html:8
 #: journal/templates/piece_delete.html:38
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: catalog/templates/catalog_edit.html:104
+#: catalog/templates/catalog_edit.html:118
 msgid "open linked people page"
 msgstr "abrir página de pessoas vinculadas"
 
-#: catalog/templates/catalog_merge.html:22
-msgid "Are you sure to merge?"
-msgstr "Tem certeza de que deseja mesclar?"
-
-#: catalog/templates/catalog_merge.html:24
-msgid "Are you sure to cancel merge?"
-msgstr "Tem certeza de que deseja cancelar a mesclagem?"
-
-#: catalog/templates/catalog_merge.html:27
-msgid "Are you sure to link?"
-msgstr "Tem certeza de que deseja vincular?"
-
-#: catalog/templates/catalog_merge.html:86
-msgid "This operation cannot be undone. Sure to merge?"
-msgstr ""
-"Esta operação não pode ser desfeita. Tem certeza de que deseja mesclar?"
-
 #: catalog/templates/catalog_verify.html:21
-msgid ""
-"If you are a creator of this podcast, you may verify the ownership, so that "
-"only you (and other verified creators) can edit its metadata on this site."
-msgstr ""
-"Se você é um criador deste podcast, pode verificar a propriedade, de modo "
-"que apenas você (e outros criadores verificados) possa editar seus metadados "
-"neste site."
+msgid "If you are a creator of this podcast, you may verify the ownership, so that only you (and other verified creators) can edit its metadata on this site."
+msgstr "Se você é um criador deste podcast, pode verificar a propriedade, de modo que apenas você (e outros criadores verificados) possa editar seus metadados neste site."
 
 #: catalog/templates/catalog_verify.html:22
 msgid "Your recent episodes may also occasionally be featured in discovery."
-msgstr ""
-"Seus episódios recentes também podem ser eventualmente destacados na seção "
-"de descoberta."
+msgstr "Seus episódios recentes também podem ser eventualmente destacados na seção de descoberta."
 
 #: catalog/templates/catalog_verify.html:24
-msgid ""
-"To verify, prove you control one of the following identifiers of your "
-"account (click to copy):"
-msgstr ""
-"Para verificar, comprove que você controla um dos seguintes identificadores "
-"da sua conta (clique para copiar):"
+msgid "To verify, prove you control one of the following identifiers of your account (click to copy):"
+msgstr "Para verificar, comprove que você controla um dos seguintes identificadores da sua conta (clique para copiar):"
 
 #: catalog/templates/catalog_verify.html:30
 #: catalog/templates/catalog_verify.html:48
@@ -1808,53 +1765,28 @@ msgid "copied"
 msgstr "copiado"
 
 #: catalog/templates/catalog_verify.html:35
-msgid ""
-"You can prove this in a few ways, then start verification: add one of the "
-"identifiers above to the podcast feed's description; add a <code>rel=\"me\"</"
-"code> link back to one of them on the web page your feed links to (the link "
-"verification Mastodon uses); or point your feed's website at your Bluesky "
-"handle's own domain."
-msgstr ""
-"Você pode comprovar isso de algumas maneiras e, em seguida, iniciar a "
-"verificação: adicione um dos identificadores acima à descrição do feed do "
-"podcast; adicione um link <code>rel=\"me\"</code> apontando para um deles na "
-"página web vinculada ao seu feed (o método de verificação de link usado pelo "
-"Mastodon); ou aponte o site do seu feed para o domínio do seu identificador "
-"do Bluesky."
+msgid "You can prove this in a few ways, then start verification: add one of the identifiers above to the podcast feed's description; add a <code>rel=\"me\"</code> link back to one of them on the web page your feed links to (the link verification Mastodon uses); or point your feed's website at your Bluesky handle's own domain."
+msgstr "Você pode comprovar isso de algumas maneiras e, em seguida, iniciar a verificação: adicione um dos identificadores acima à descrição do feed do podcast; adicione um link <code>rel=\"me\"</code> apontando para um deles na página web vinculada ao seu feed (o método de verificação de link usado pelo Mastodon); ou aponte o site do seu feed para o domínio do seu identificador do Bluesky."
 
 #: catalog/templates/catalog_verify.html:44
-msgid ""
-"For example, add this rel=me link to the web page your feed links to (click "
-"to copy):"
-msgstr ""
-"Por exemplo, adicione este link rel=me à página web vinculada ao seu feed "
-"(clique para copiar):"
+msgid "For example, add this rel=me link to the web page your feed links to (click to copy):"
+msgstr "Por exemplo, adicione este link rel=me à página web vinculada ao seu feed (clique para copiar):"
 
 #: catalog/templates/catalog_verify.html:50
 msgid "or, in the page's head:"
 msgstr "ou, no cabeçalho da página:"
 
 #: catalog/templates/catalog_verify.html:57
-msgid ""
-"Can't edit the website? Just add a line like this to your feed's description "
-"instead (click to copy):"
-msgstr ""
-"Não pode editar o site? Basta adicionar uma linha como esta à descrição do "
-"seu feed (clique para copiar):"
+msgid "Can't edit the website? Just add a line like this to your feed's description instead (click to copy):"
+msgstr "Não pode editar o site? Basta adicionar uma linha como esta à descrição do seu feed (clique para copiar):"
 
 #: catalog/templates/catalog_verify.html:62
 msgid "Welcome to follow me on the Fediverse:"
 msgstr "Fique à vontade para me seguir no Fediverso:"
 
 #: catalog/templates/catalog_verify.html:66
-msgid ""
-"NeoDB does not re-check this periodically at the moment, but we recommend "
-"you keep it so that your audience can discover and connect with you in "
-"distributed social media."
-msgstr ""
-"No momento, o NeoDB não verifica isso periodicamente, mas recomendamos que "
-"você o mantenha, para que seu público possa te descobrir e se conectar com "
-"você nas redes sociais distribuídas."
+msgid "NeoDB does not re-check this periodically at the moment, but we recommend you keep it so that your audience can discover and connect with you in distributed social media."
+msgstr "No momento, o NeoDB não verifica isso periodicamente, mas recomendamos que você o mantenha, para que seu público possa te descobrir e se conectar com você nas redes sociais distribuídas."
 
 #: catalog/templates/catalog_verify.html:72
 msgid "Verified creators"
@@ -1881,14 +1813,11 @@ msgid "Send feedback"
 msgstr "Enviar feedback"
 
 #: catalog/templates/catalog_verify.html:115
-msgid ""
-"Questions or issues with creator verification? Let the site moderators know."
-msgstr ""
-"Dúvidas ou problemas com a verificação de criador? Avise os moderadores do "
-"site."
+msgid "Questions or issues with creator verification? Let the site moderators know."
+msgstr "Dúvidas ou problemas com a verificação de criador? Avise os moderadores do site."
 
-#: catalog/templates/discover.html:28 common/views_manage.py:145
-#: common/views_manage.py:353 users/templates/users/preferences.html:34
+#: catalog/templates/discover.html:28 common/views_manage.py:35
+#: common/views_manage.py:431 users/templates/users/preferences.html:34
 msgid "Discover"
 msgstr "Descobrir"
 
@@ -1926,17 +1855,17 @@ msgstr "mostrar"
 msgid "hide"
 msgstr "ocultar"
 
-#: catalog/templates/discover.html:206 common/templates/_sidebar.html:14
+#: catalog/templates/discover.html:206 common/templates/_sidebar.html:13
 msgid "Unread Announcements"
 msgstr "Anúncios Não Lidos"
 
-#: catalog/templates/discover.html:212 common/templates/_sidebar.html:20
+#: catalog/templates/discover.html:212 common/templates/_sidebar.html:19
 #: social/templates/notification.html:67
 msgid "mark all as read"
 msgstr "marcar todos como lidos"
 
 #: catalog/templates/discover.html:222
-#: common/templates/_sidebar_anonymous.html:55
+#: common/templates/_sidebar_anonymous.html:54
 msgid "Popular Tags"
 msgstr "Etiquetas Populares"
 
@@ -1947,9 +1876,9 @@ msgstr "Etiquetas Populares"
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
 #: catalog/templates/user_verified_works.html:23
-#: common/templates/_sidebar.html:127
-#: common/templates/_sidebar_anonymous.html:46
-#: common/templates/_sidebar_anonymous.html:62 journal/templates/posts.html:8
+#: common/templates/_sidebar.html:126
+#: common/templates/_sidebar_anonymous.html:45
+#: common/templates/_sidebar_anonymous.html:61 journal/templates/posts.html:7
 #: journal/templates/profile_articles.html:24
 #: journal/templates/profile_articles.html:26
 #: journal/templates/profile_items.html:65
@@ -1965,7 +1894,7 @@ msgstr "Etiquetas Populares"
 msgid "nothing so far."
 msgstr "nada até agora."
 
-#: catalog/templates/discover.html:239 common/templates/_sidebar.html:269
+#: catalog/templates/discover.html:239 common/templates/_sidebar.html:268
 msgid "Recent Posts"
 msgstr "Publicações Recentes"
 
@@ -1991,12 +1920,8 @@ msgid "Borrow or Buy"
 msgstr "Emprestar ou Comprar"
 
 #: catalog/templates/external_search_results.html:10
-msgid ""
-"Some items were found from other websites and instances, click their title "
-"to save them locally."
-msgstr ""
-"Alguns itens foram encontrados em outros sites e instâncias; clique no "
-"título deles para salvá-los localmente."
+msgid "Some items were found from other websites and instances, click their title to save them locally."
+msgstr "Alguns itens foram encontrados em outros sites e instâncias; clique no título deles para salvá-los localmente."
 
 #: catalog/templates/fetch_pending.html:13
 msgid "Search results"
@@ -2022,9 +1947,7 @@ msgstr "marcar, comentar e colecionar"
 
 #: catalog/templates/item_base.html:142
 msgid "Login or register to review or add this item to your collection."
-msgstr ""
-"Entre ou cadastre-se para escrever uma análise ou adicionar este item à sua "
-"coleção."
+msgstr "Entre ou cadastre-se para escrever uma análise ou adicionar este item à sua coleção."
 
 #: catalog/templates/item_base.html:151
 msgid "Related Collections"
@@ -2097,12 +2020,12 @@ msgstr "número de Temporadas"
 msgid "number of Episodes"
 msgstr "número de Episódios"
 
-#: catalog/templates/people.html:13 common/templates/_sidebar.html:77
-#: common/templates/_sidebar.html:84 journal/models/shelf.py:326
+#: catalog/templates/people.html:13 common/templates/_sidebar.html:76
+#: common/templates/_sidebar.html:83 journal/models/shelf.py:328
 msgid "following"
 msgstr "seguindo"
 
-#: catalog/templates/people.html:15 journal/models/shelf.py:324
+#: catalog/templates/people.html:15 journal/models/shelf.py:326
 #: social/templates/notification.html:60
 msgid "follow"
 msgstr "seguir"
@@ -2121,7 +2044,6 @@ msgstr "falecimento"
 #: journal/templates/_sidebar_collection_filter.html:14
 #: journal/templates/_sidebar_collection_filter.html:28
 #: journal/templates/_sidebar_user_mark_list.html:56
-#: social/templates/feed.html:42 social/templates/feed.html:44
 #: social/templates/notification.html:56
 msgid "all"
 msgstr "todas"
@@ -2145,7 +2067,7 @@ msgstr "concluído"
 msgid "production"
 msgstr "produção"
 
-#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:54
+#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:53
 msgid "verified creator"
 msgstr "criador verificado"
 
@@ -2226,14 +2148,8 @@ msgid "No items matching your search query."
 msgstr "Nenhum item corresponde à sua consulta de pesquisa."
 
 #: catalog/templates/search_results.html:34
-msgid ""
-"If you have URL from one of these sites, please put the full URL (e.g. "
-"<code>https://www.imdb.com/title/tt2513074/</code>) to the search box and "
-"press Enter."
-msgstr ""
-"Se você tiver a URL de um desses sites, insira a URL completa (ex.: "
-"<code>https://www.imdb.com/title/tt2513074/</code>) na caixa de pesquisa e "
-"pressione Enter."
+msgid "If you have URL from one of these sites, please put the full URL (e.g. <code>https://www.imdb.com/title/tt2513074/</code>) to the search box and press Enter."
+msgstr "Se você tiver a URL de um desses sites, insira a URL completa (ex.: <code>https://www.imdb.com/title/tt2513074/</code>) na caixa de pesquisa e pressione Enter."
 
 #: catalog/templates/search_results.html:48
 msgid "Searching from other sites"
@@ -2269,106 +2185,198 @@ msgstr "Obras verificadas"
 msgid "Editions"
 msgstr "Edições"
 
-#: catalog/views/edit.py:202 catalog/views/edit.py:205
-#: catalog/views/edit.py:306 catalog/views/edit.py:309
-#: catalog/views/verify.py:197 journal/views/collection.py:77
-#: journal/views/collection.py:102 journal/views/collection.py:556
-#: journal/views/collection.py:651 journal/views/common.py:221
-#: journal/views/mark.py:196 journal/views/post.py:117
-#: journal/views/post.py:119 journal/views/post.py:166
-#: journal/views/post.py:185 journal/views/post.py:187
-#: journal/views/post.py:228 journal/views/post.py:241
+#: catalog/views/edit.py:293 catalog/views/edit.py:296
+#: catalog/views/edit.py:440 catalog/views/edit.py:443
+#: catalog/views/verify.py:197 journal/views/collection.py:75
+#: journal/views/collection.py:100 journal/views/collection.py:538
+#: journal/views/collection.py:634 journal/views/common.py:231
+#: journal/views/mark.py:244 journal/views/post.py:119
+#: journal/views/post.py:121 journal/views/post.py:168
+#: journal/views/post.py:187 journal/views/post.py:189
+#: journal/views/post.py:230 journal/views/post.py:243
 #: journal/views/review.py:154 journal/views/review.py:158
-#: users/views/actions.py:179
+#: users/views/actions.py:178
 msgid "Invalid parameter"
 msgstr "Parâmetro inválido"
 
-#: catalog/views/edit.py:220
+#: catalog/views/edit.py:313
 msgid "Item in use."
 msgstr "Item em uso."
 
-#: catalog/views/edit.py:222
+#: catalog/views/edit.py:315
 msgid "Item cannot be deleted."
 msgstr "O item não pode ser excluído."
 
-#: catalog/views/edit.py:247 catalog/views/edit.py:303
-#: catalog/views/edit.py:427 catalog/views/edit.py:519
-#: catalog/views/edit.py:552 catalog/views/verify.py:158
+#: catalog/views/edit.py:319 catalog/views/edit.py:515
+msgid "Are you sure to delete?"
+msgstr "Tem certeza de que deseja excluir?"
+
+#: catalog/views/edit.py:323 catalog/views/edit.py:518
+#: catalog/views/edit.py:617
+#, fuzzy
+#| msgid "This operation cannot be undone. Sure to merge?"
+msgid "This operation cannot be undone."
+msgstr "Esta operação não pode ser desfeita. Tem certeza de que deseja mesclar?"
+
+#: catalog/views/edit.py:344 catalog/views/edit.py:437
+#: catalog/views/edit.py:603 catalog/views/edit.py:705
+#: catalog/views/edit.py:752 catalog/views/verify.py:158
 #: catalog/views/verify.py:206 journal/views/article.py:44
 #: journal/views/article.py:133 journal/views/article.py:153
 #: journal/views/collection.py:248 journal/views/collection.py:341
-#: journal/views/collection.py:360 journal/views/collection.py:384
-#: journal/views/collection.py:457 journal/views/collection.py:500
-#: journal/views/collection.py:539 journal/views/collection.py:551
-#: journal/views/collection.py:576 journal/views/collection.py:613
-#: journal/views/common.py:300 journal/views/mark.py:281
-#: journal/views/post.py:58 journal/views/post.py:78 journal/views/post.py:100
-#: journal/views/post.py:170 journal/views/post.py:199
-#: journal/views/post.py:272 journal/views/post.py:287
-#: journal/views/post.py:394 journal/views/post.py:549
+#: journal/views/collection.py:354 journal/views/collection.py:372
+#: journal/views/collection.py:439 journal/views/collection.py:482
+#: journal/views/collection.py:521 journal/views/collection.py:533
+#: journal/views/collection.py:558 journal/views/collection.py:595
+#: journal/views/common.py:304 journal/views/mark.py:317
+#: journal/views/post.py:60 journal/views/post.py:80 journal/views/post.py:102
+#: journal/views/post.py:172 journal/views/post.py:201
+#: journal/views/post.py:274 journal/views/post.py:289
+#: journal/views/post.py:390 journal/views/post.py:539
 #: journal/views/review.py:64 journal/views/review.py:81
 #: journal/views/review.py:106
 msgid "Insufficient permission"
 msgstr "Permissão insuficiente"
 
-#: catalog/views/edit.py:374
+#: catalog/views/edit.py:346
+#, fuzzy
+#| msgid "Item has been deleted."
+msgid "Item is not deleted"
+msgstr "O item foi excluído."
+
+#: catalog/views/edit.py:389
+#, fuzzy
+#| msgid "Switching may remove some metadata. Sure to proceed?"
+msgid "Switching may remove some metadata."
+msgstr "Alternar pode remover alguns metadados. Tem certeza de que deseja continuar?"
+
+#: catalog/views/edit.py:395
+#, fuzzy
+#| msgid "The following items are merged into this item"
+msgid "The following seasons will be detached from this show"
+msgstr "Os seguintes itens estão mesclados neste item"
+
+#: catalog/views/edit.py:400
+#, fuzzy
+#| msgid "Alias to {handle} removed."
+msgid "Links to IMDB and TMDB will be removed."
+msgstr "Alias para {handle} removido."
+
+#: catalog/views/edit.py:403
+#, fuzzy
+#| msgid "Are you sure to merge?"
+msgid "Are you sure to switch category?"
+msgstr "Tem certeza de que deseja mesclar?"
+
+#: catalog/views/edit.py:451
+#, fuzzy
+#| msgid "Are you sure to delete this post?"
+msgid "Are you sure to remove the link to this site?"
+msgstr "Tem certeza de que deseja excluir esta publicação?"
+
+#: catalog/views/edit.py:457
+#, fuzzy
+#| msgid "You may not be able to undo this operation, sure to remove?"
+msgid "You may not be able to undo this operation."
+msgstr "Você pode não conseguir desfazer esta operação. Tem certeza de que deseja remover?"
+
+#: catalog/views/edit.py:483
+#, fuzzy
+#| msgid "Link to parent item"
+msgid "Current parent item"
+msgstr "Vincular ao item pai"
+
+#: catalog/views/edit.py:487
+msgid "The link to the parent item will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:490 catalog/views/edit.py:680
+msgid "Are you sure to link?"
+msgstr "Tem certeza de que deseja vincular?"
+
+#: catalog/views/edit.py:521
+msgid "The following seasons will be deleted"
+msgstr ""
+
+#: catalog/views/edit.py:525
+msgid "The following seasons will be kept"
+msgstr ""
+
+#: catalog/views/edit.py:550
 msgid "TV Season with IMDB id and season number required."
 msgstr "Temporada de TV com ID IMDB e número de temporada obrigatórios."
 
-#: catalog/views/edit.py:380
+#: catalog/views/edit.py:556
 msgid "Updating episodes"
 msgstr "Atualizando episódios"
 
-#: catalog/views/edit.py:405
+#: catalog/views/edit.py:581
 msgid "This person has no supported source to fetch works from."
 msgstr "Esta pessoa não tem nenhuma fonte compatível para buscar obras."
 
-#: catalog/views/edit.py:412
+#: catalog/views/edit.py:588
 msgid "Already pulling works for this person, try again later."
-msgstr ""
-"Já está em andamento a busca de obras para esta pessoa; tente novamente mais "
-"tarde."
+msgstr "Já está em andamento a busca de obras para esta pessoa; tente novamente mais tarde."
 
-#: catalog/views/edit.py:416
+#: catalog/views/edit.py:592
 msgid "Pulling works in background."
 msgstr "Buscando obras em segundo plano."
 
-#: catalog/views/edit.py:438
+#: catalog/views/edit.py:609
+msgid "Are you sure to merge?"
+msgstr "Tem certeza de que deseja mesclar?"
+
+#: catalog/views/edit.py:611
+msgid "Are you sure to cancel merge?"
+msgstr "Tem certeza de que deseja cancelar a mesclagem?"
+
+#: catalog/views/edit.py:622
 msgid "Cannot be merged to an item already deleted or merged"
 msgstr "Não é possível mesclar com um item já excluído ou mesclado"
 
-#: catalog/views/edit.py:443
+#: catalog/views/edit.py:627
 msgid "Cannot merge items in different categories"
 msgstr "Não é possível mesclar itens de categorias diferentes"
 
-#: catalog/views/edit.py:447
+#: catalog/views/edit.py:631
 msgid "Cannot merge an item to itself"
 msgstr "Não é possível mesclar um item com ele mesmo"
 
-#: catalog/views/edit.py:488
+#: catalog/views/edit.py:672
 msgid "Cannot be linked to an item already deleted or merged"
 msgstr "Não é possível vincular a um item já excluído ou mesclado"
 
-#: catalog/views/edit.py:492
+#: catalog/views/edit.py:676
 msgid "Cannot link items other than editions"
 msgstr "Não é possível vincular itens que não sejam edições"
 
-#: catalog/views/search.py:96
+#: catalog/views/edit.py:710
+#, fuzzy
+#| msgid "Are you sure to link?"
+msgid "Are you sure to unlink?"
+msgstr "Tem certeza de que deseja vincular?"
+
+#: catalog/views/edit.py:715
+#, fuzzy
+#| msgid "This edition belongs to the following work"
+msgid "This edition will be unlinked from the following work"
+msgstr "Esta edição pertence à seguinte obra"
+
+#: catalog/views/search.py:113
 msgid "the internet"
 msgstr "a internet"
 
-#: catalog/views/search.py:359
+#: catalog/views/search.py:410
 msgid "Invalid URL"
 msgstr "URL Inválida"
 
-#: catalog/views/search.py:362
+#: catalog/views/search.py:413
 msgid "Unsupported URL"
 msgstr "URL Não Suportada"
 
 #: catalog/views/verify.py:42
 msgid "Creator verification is only available for podcasts for now."
-msgstr ""
-"No momento, a verificação de criador está disponível apenas para podcasts."
+msgstr "No momento, a verificação de criador está disponível apenas para podcasts."
 
 #: catalog/views/verify.py:110
 msgid "No feed url available for this item."
@@ -2386,9 +2394,9 @@ msgstr "A verificação já está em andamento."
 msgid "Please wait a moment before trying again."
 msgstr "Aguarde um instante antes de tentar novamente."
 
-#: catalog/views/verify.py:164 common/utils.py:122 common/utils.py:163
+#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
 #: journal/views/article.py:186 journal/views/review.py:182
-#: users/views/actions.py:45 users/views/actions.py:131
+#: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
 msgstr "Usuário não encontrado"
 
@@ -2400,15 +2408,15 @@ msgstr "Criador verificado."
 msgid "Creator verification removed."
 msgstr "Verificação de criador removida."
 
-#: catalog/views/view.py:74 catalog/views/view.py:99
+#: catalog/views/view.py:77 catalog/views/view.py:102
 msgid "Item not found"
 msgstr "Item não encontrado"
 
-#: catalog/views/view.py:78 catalog/views/view.py:107 catalog/views/view.py:190
+#: catalog/views/view.py:81 catalog/views/view.py:110 catalog/views/view.py:193
 msgid "Item no longer exists"
 msgstr "O item não existe mais"
 
-#: catalog/views/view.py:187
+#: catalog/views/view.py:190
 msgid "Invalid role"
 msgstr "Função inválida"
 
@@ -2892,759 +2900,759 @@ msgctxt "genre"
 msgid "Health"
 msgstr "Saúde"
 
-#: common/models/lang.py:54
+#: common/models/lang.py:56
 msgid "Afar"
 msgstr "Afar"
 
-#: common/models/lang.py:55
+#: common/models/lang.py:57
 msgid "Afrikaans"
 msgstr "Africânderes"
 
-#: common/models/lang.py:56
+#: common/models/lang.py:58
 msgid "Akan"
 msgstr "Acã"
 
-#: common/models/lang.py:57
+#: common/models/lang.py:59
 msgid "Aragonese"
 msgstr "Aragonês"
 
-#: common/models/lang.py:58
+#: common/models/lang.py:60
 msgid "Assamese"
 msgstr "Assamês"
 
-#: common/models/lang.py:59
+#: common/models/lang.py:61
 msgid "Avaric"
 msgstr "Ávaro"
 
-#: common/models/lang.py:60
+#: common/models/lang.py:62
 msgid "Avestan"
 msgstr "Avéstico"
 
-#: common/models/lang.py:61
+#: common/models/lang.py:63
 msgid "Aymara"
 msgstr "Aimará"
 
-#: common/models/lang.py:62
+#: common/models/lang.py:64
 msgid "Azerbaijani"
 msgstr "Azerbaijano"
 
-#: common/models/lang.py:63
+#: common/models/lang.py:65
 msgid "Bashkir"
 msgstr "Basquir"
 
-#: common/models/lang.py:64
+#: common/models/lang.py:66
 msgid "Bambara"
 msgstr "Bambara"
 
-#: common/models/lang.py:65
+#: common/models/lang.py:67
 msgid "Bislama"
 msgstr "Bislamá"
 
-#: common/models/lang.py:66
+#: common/models/lang.py:68
 msgid "Tibetan"
 msgstr "Tibetano"
 
-#: common/models/lang.py:67
+#: common/models/lang.py:69
 msgid "Breton"
 msgstr "Bretão"
 
-#: common/models/lang.py:68
+#: common/models/lang.py:70
 msgid "Catalan"
 msgstr "Catalão"
 
-#: common/models/lang.py:69
+#: common/models/lang.py:71
 msgid "Czech"
 msgstr "Tcheco"
 
-#: common/models/lang.py:70
+#: common/models/lang.py:72
 msgid "Chechen"
 msgstr "Checheno"
 
-#: common/models/lang.py:71
+#: common/models/lang.py:73
 msgid "Slavic"
 msgstr "Eslavo"
 
-#: common/models/lang.py:72
+#: common/models/lang.py:74
 msgid "Chuvash"
 msgstr "Tchuvache"
 
-#: common/models/lang.py:73
+#: common/models/lang.py:75
 msgid "Cornish"
 msgstr "Córnico"
 
-#: common/models/lang.py:74
+#: common/models/lang.py:76
 msgid "Corsican"
 msgstr "Corso"
 
-#: common/models/lang.py:75
+#: common/models/lang.py:77
 msgid "Cree"
 msgstr "Cri"
 
-#: common/models/lang.py:76
+#: common/models/lang.py:78
 msgid "Welsh"
 msgstr "Galês"
 
-#: common/models/lang.py:79
+#: common/models/lang.py:81
 msgid "Divehi"
 msgstr "Diveí"
 
-#: common/models/lang.py:80
+#: common/models/lang.py:82
 msgid "Dzongkha"
 msgstr "Butanês"
 
-#: common/models/lang.py:81
+#: common/models/lang.py:83
 msgid "Esperanto"
 msgstr "Esperanto"
 
-#: common/models/lang.py:82
+#: common/models/lang.py:84
 msgid "Estonian"
 msgstr "Estoniano"
 
-#: common/models/lang.py:83
+#: common/models/lang.py:85
 msgid "Basque"
 msgstr "Basco"
 
-#: common/models/lang.py:84
+#: common/models/lang.py:86
 msgid "Faroese"
 msgstr "Feroesa"
 
-#: common/models/lang.py:85
+#: common/models/lang.py:87
 msgid "Fijian"
 msgstr "Fijiana"
 
-#: common/models/lang.py:86
+#: common/models/lang.py:88
 msgid "Finnish"
 msgstr "Finlandês"
 
-#: common/models/lang.py:88
+#: common/models/lang.py:90
 msgid "Frisian"
 msgstr "Frísio"
 
-#: common/models/lang.py:89
+#: common/models/lang.py:91
 msgid "Fulah"
 msgstr "Fulas"
 
-#: common/models/lang.py:90
+#: common/models/lang.py:92
 msgid "Gaelic"
 msgstr "Gaélico"
 
-#: common/models/lang.py:91
+#: common/models/lang.py:93
 msgid "Irish"
 msgstr "Irlandês"
 
-#: common/models/lang.py:92
+#: common/models/lang.py:94
 msgid "Galician"
 msgstr "Galego"
 
-#: common/models/lang.py:93
+#: common/models/lang.py:95
 msgid "Manx"
 msgstr "Manês"
 
-#: common/models/lang.py:94
+#: common/models/lang.py:96
 msgid "Guarani"
 msgstr "Guarani"
 
-#: common/models/lang.py:95
+#: common/models/lang.py:97
 msgid "Gujarati"
 msgstr "Guzerate"
 
-#: common/models/lang.py:96
+#: common/models/lang.py:98
 msgid "Haitian; Haitian Creole"
 msgstr "Haitiano"
 
-#: common/models/lang.py:97
+#: common/models/lang.py:99
 msgid "Hausa"
 msgstr "Haúça"
 
-#: common/models/lang.py:98
+#: common/models/lang.py:100
 msgid "Serbo-Croatian"
 msgstr "Servo-croata"
 
-#: common/models/lang.py:99
+#: common/models/lang.py:101
 msgid "Herero"
 msgstr "Herero"
 
-#: common/models/lang.py:100
+#: common/models/lang.py:102
 msgid "Hiri Motu"
 msgstr "Hiri Motu"
 
-#: common/models/lang.py:101
+#: common/models/lang.py:103
 msgid "Croatian"
 msgstr "Croata"
 
-#: common/models/lang.py:102
+#: common/models/lang.py:104
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: common/models/lang.py:103
+#: common/models/lang.py:105
 msgid "Igbo"
 msgstr "Ibo"
 
-#: common/models/lang.py:104
+#: common/models/lang.py:106
 msgid "Ido"
 msgstr "Ido"
 
-#: common/models/lang.py:105
+#: common/models/lang.py:107
 msgid "Yi"
 msgstr "Yi"
 
-#: common/models/lang.py:106
+#: common/models/lang.py:108
 msgid "Inuktitut"
 msgstr "Inuctitutes"
 
-#: common/models/lang.py:107
+#: common/models/lang.py:109
 msgid "Interlingue"
 msgstr "Interlingue"
 
-#: common/models/lang.py:108
+#: common/models/lang.py:110
 msgid "Interlingua"
 msgstr "Interlíngua"
 
-#: common/models/lang.py:109
+#: common/models/lang.py:111
 msgid "Indonesian"
 msgstr "Indonésio"
 
-#: common/models/lang.py:110
+#: common/models/lang.py:112
 msgid "Inupiaq"
 msgstr "Inupiate"
 
-#: common/models/lang.py:111
+#: common/models/lang.py:113
 msgid "Icelandic"
 msgstr "Islandês"
 
-#: common/models/lang.py:113
+#: common/models/lang.py:115
 msgid "Javanese"
 msgstr "Javanês"
 
-#: common/models/lang.py:114
+#: common/models/lang.py:116
 msgid "Japanese"
 msgstr "Japonês"
 
-#: common/models/lang.py:115
+#: common/models/lang.py:117
 msgid "Kalaallisut"
 msgstr "Groenlandês"
 
-#: common/models/lang.py:116
+#: common/models/lang.py:118
 msgid "Kannada"
 msgstr "Canarês"
 
-#: common/models/lang.py:117
+#: common/models/lang.py:119
 msgid "Kashmiri"
 msgstr "Caxemiriano"
 
-#: common/models/lang.py:118
+#: common/models/lang.py:120
 msgid "Kanuri"
 msgstr "Canúri"
 
-#: common/models/lang.py:119
+#: common/models/lang.py:121
 msgid "Kazakh"
 msgstr "Cazaque"
 
-#: common/models/lang.py:120
+#: common/models/lang.py:122
 msgid "Khmer"
 msgstr "Quemer"
 
-#: common/models/lang.py:121
+#: common/models/lang.py:123
 msgid "Kikuyu"
 msgstr "Quicuia"
 
-#: common/models/lang.py:122
+#: common/models/lang.py:124
 msgid "Kinyarwanda"
 msgstr "Quiniaruanda"
 
-#: common/models/lang.py:123
+#: common/models/lang.py:125
 msgid "Kirghiz"
 msgstr "Quirguiz"
 
-#: common/models/lang.py:124
+#: common/models/lang.py:126
 msgid "Komi"
 msgstr "Cómi"
 
-#: common/models/lang.py:125
+#: common/models/lang.py:127
 msgid "Kongo"
 msgstr "Conga"
 
-#: common/models/lang.py:126
+#: common/models/lang.py:128
 msgid "Korean"
 msgstr "Coreano"
 
-#: common/models/lang.py:127
+#: common/models/lang.py:129
 msgid "Kuanyama"
 msgstr "Cuanhama"
 
-#: common/models/lang.py:128
+#: common/models/lang.py:130
 msgid "Kurdish"
 msgstr "Curdo"
 
-#: common/models/lang.py:129
+#: common/models/lang.py:131
 msgid "Lao"
 msgstr "Lao"
 
-#: common/models/lang.py:130
+#: common/models/lang.py:132
 msgid "Latin"
 msgstr "Latim"
 
-#: common/models/lang.py:131
+#: common/models/lang.py:133
 msgid "Latvian"
 msgstr "Letão"
 
-#: common/models/lang.py:132
+#: common/models/lang.py:134
 msgid "Limburgish"
 msgstr "Limburguês"
 
-#: common/models/lang.py:133
+#: common/models/lang.py:135
 msgid "Lingala"
 msgstr "Lingala"
 
-#: common/models/lang.py:134
+#: common/models/lang.py:136
 msgid "Lithuanian"
 msgstr "Lituano"
 
-#: common/models/lang.py:135
+#: common/models/lang.py:137
 msgid "Letzeburgesch"
 msgstr "Luxemburguês"
 
-#: common/models/lang.py:136
+#: common/models/lang.py:138
 msgid "Luba-Katanga"
 msgstr "Luba-Katanga"
 
-#: common/models/lang.py:137
+#: common/models/lang.py:139
 msgid "Ganda"
 msgstr "Ganda"
 
-#: common/models/lang.py:138
+#: common/models/lang.py:140
 msgid "Marshall"
 msgstr "Marshallês"
 
-#: common/models/lang.py:139
+#: common/models/lang.py:141
 msgid "Malayalam"
 msgstr "Malaiala"
 
-#: common/models/lang.py:140
+#: common/models/lang.py:142
 msgid "Marathi"
 msgstr "Marata"
 
-#: common/models/lang.py:141
+#: common/models/lang.py:143
 msgid "Malagasy"
 msgstr "Malgaxe"
 
-#: common/models/lang.py:142
+#: common/models/lang.py:144
 msgid "Maltese"
 msgstr "Maltesa"
 
-#: common/models/lang.py:143
+#: common/models/lang.py:145
 msgid "Moldavian"
 msgstr "Moldávio"
 
-#: common/models/lang.py:144
+#: common/models/lang.py:146
 msgid "Mongolian"
 msgstr "Mongol"
 
-#: common/models/lang.py:145
+#: common/models/lang.py:147
 msgid "Maori"
 msgstr "Maori"
 
-#: common/models/lang.py:146
+#: common/models/lang.py:148
 msgid "Malay"
 msgstr "Malaio"
 
-#: common/models/lang.py:147
+#: common/models/lang.py:149
 msgid "Burmese"
 msgstr "Birmanês"
 
-#: common/models/lang.py:148
+#: common/models/lang.py:150
 msgid "Nauru"
 msgstr "Nauruano"
 
-#: common/models/lang.py:149
+#: common/models/lang.py:151
 msgid "Navajo"
 msgstr "Navajo"
 
-#: common/models/lang.py:150 common/models/lang.py:151
+#: common/models/lang.py:152 common/models/lang.py:153
 msgid "Ndebele"
 msgstr "Andebele"
 
-#: common/models/lang.py:152
+#: common/models/lang.py:154
 msgid "Ndonga"
 msgstr "Xindonga"
 
-#: common/models/lang.py:153
+#: common/models/lang.py:155
 msgid "Nepali"
 msgstr "Nepalês"
 
-#: common/models/lang.py:154
+#: common/models/lang.py:156
 msgid "Dutch"
 msgstr "Holandês"
 
-#: common/models/lang.py:155
+#: common/models/lang.py:157
 msgid "Norwegian Nynorsk"
 msgstr "Norueguês"
 
-#: common/models/lang.py:156
+#: common/models/lang.py:158
 msgid "Norwegian Bokmål"
 msgstr "Bokmål Norueguês"
 
-#: common/models/lang.py:157
+#: common/models/lang.py:159
 msgid "Norwegian"
 msgstr "Norueguês"
 
-#: common/models/lang.py:158
+#: common/models/lang.py:160
 msgid "Chichewa; Nyanja"
 msgstr "Cinianja ;Nianja"
 
-#: common/models/lang.py:159
+#: common/models/lang.py:161
 msgid "Occitan"
 msgstr "Occitana"
 
-#: common/models/lang.py:160
+#: common/models/lang.py:162
 msgid "Ojibwa"
 msgstr "Ojibwe"
 
-#: common/models/lang.py:161
+#: common/models/lang.py:163
 msgid "Oriya"
 msgstr "Oriá"
 
-#: common/models/lang.py:162
+#: common/models/lang.py:164
 msgid "Oromo"
 msgstr "Oromo"
 
-#: common/models/lang.py:163
+#: common/models/lang.py:165
 msgid "Ossetian; Ossetic"
 msgstr "Osseto"
 
-#: common/models/lang.py:164
+#: common/models/lang.py:166
 msgid "Pali"
 msgstr "Páli"
 
-#: common/models/lang.py:165
+#: common/models/lang.py:167
 msgid "Polish"
 msgstr "Polonês"
 
-#: common/models/lang.py:167
+#: common/models/lang.py:169
 msgid "Quechua"
 msgstr "Quíchua"
 
-#: common/models/lang.py:168
+#: common/models/lang.py:170
 msgid "Raeto-Romance"
 msgstr "Romanche"
 
-#: common/models/lang.py:169
+#: common/models/lang.py:171
 msgid "Romanian"
 msgstr "Romeno"
 
-#: common/models/lang.py:170
+#: common/models/lang.py:172
 msgid "Rundi"
 msgstr "Rundi"
 
-#: common/models/lang.py:171
+#: common/models/lang.py:173
 msgid "Russian"
 msgstr "Russo"
 
-#: common/models/lang.py:172
+#: common/models/lang.py:174
 msgid "Sango"
 msgstr "Sango"
 
-#: common/models/lang.py:173
+#: common/models/lang.py:175
 msgid "Sanskrit"
 msgstr "Sânscrito"
 
-#: common/models/lang.py:174
+#: common/models/lang.py:176
 msgid "Sinhalese"
 msgstr "Cingalês"
 
-#: common/models/lang.py:175
+#: common/models/lang.py:177
 msgid "Slovak"
 msgstr "Eslovaco"
 
-#: common/models/lang.py:176
+#: common/models/lang.py:178
 msgid "Slovenian"
 msgstr "Esloveno"
 
-#: common/models/lang.py:177
+#: common/models/lang.py:179
 msgid "Northern Sami"
 msgstr "Sámi Setentrional"
 
-#: common/models/lang.py:178
+#: common/models/lang.py:180
 msgid "Samoan"
 msgstr "Samoano"
 
-#: common/models/lang.py:179
+#: common/models/lang.py:181
 msgid "Shona"
 msgstr "Xona"
 
-#: common/models/lang.py:180
+#: common/models/lang.py:182
 msgid "Sindhi"
 msgstr "Sindi"
 
-#: common/models/lang.py:181
+#: common/models/lang.py:183
 msgid "Somali"
 msgstr "Somali"
 
-#: common/models/lang.py:182
+#: common/models/lang.py:184
 msgid "Sotho"
 msgstr "Sepedi"
 
-#: common/models/lang.py:184
+#: common/models/lang.py:186
 msgid "Albanian"
 msgstr "Albanês"
 
-#: common/models/lang.py:185
+#: common/models/lang.py:187
 msgid "Sardinian"
 msgstr "Sardo"
 
-#: common/models/lang.py:186
+#: common/models/lang.py:188
 msgid "Serbian"
 msgstr "Sérvio"
 
-#: common/models/lang.py:187
+#: common/models/lang.py:189
 msgid "Swati"
 msgstr "Suázi"
 
-#: common/models/lang.py:188
+#: common/models/lang.py:190
 msgid "Sundanese"
 msgstr "Sundanês"
 
-#: common/models/lang.py:189
+#: common/models/lang.py:191
 msgid "Swahili"
 msgstr "Suaíli"
 
-#: common/models/lang.py:190
+#: common/models/lang.py:192
 msgid "Swedish"
 msgstr "Sueco"
 
-#: common/models/lang.py:191
+#: common/models/lang.py:193
 msgid "Tahitian"
 msgstr "Taitiano"
 
-#: common/models/lang.py:192
+#: common/models/lang.py:194
 msgid "Tamil"
 msgstr "Tâmil"
 
-#: common/models/lang.py:193
+#: common/models/lang.py:195
 msgid "Tatar"
 msgstr "Tártaros"
 
-#: common/models/lang.py:194
+#: common/models/lang.py:196
 msgid "Telugu"
 msgstr "Telugo"
 
-#: common/models/lang.py:195
+#: common/models/lang.py:197
 msgid "Tajik"
 msgstr "Tajiques"
 
-#: common/models/lang.py:196
+#: common/models/lang.py:198
 msgid "Tagalog"
 msgstr "Tagalo"
 
-#: common/models/lang.py:197
+#: common/models/lang.py:199
 msgid "Thai"
 msgstr "Tailandês"
 
-#: common/models/lang.py:198
+#: common/models/lang.py:200
 msgid "Tigrinya"
 msgstr "Tigrínia"
 
-#: common/models/lang.py:199
+#: common/models/lang.py:201
 msgid "Tonga"
 msgstr "Tonganês"
 
-#: common/models/lang.py:200
+#: common/models/lang.py:202
 msgid "Tswana"
 msgstr "Tswana"
 
-#: common/models/lang.py:201
+#: common/models/lang.py:203
 msgid "Tsonga"
 msgstr "Tsonga"
 
-#: common/models/lang.py:202
+#: common/models/lang.py:204
 msgid "Turkmen"
 msgstr "Turquemeno"
 
-#: common/models/lang.py:203
+#: common/models/lang.py:205
 msgid "Turkish"
 msgstr "Turco"
 
-#: common/models/lang.py:204
+#: common/models/lang.py:206
 msgid "Twi"
 msgstr "Twi"
 
-#: common/models/lang.py:205
+#: common/models/lang.py:207
 msgid "Uighur"
 msgstr "Uigur"
 
-#: common/models/lang.py:206
+#: common/models/lang.py:208
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: common/models/lang.py:207
+#: common/models/lang.py:209
 msgid "Urdu"
 msgstr "Urdu"
 
-#: common/models/lang.py:208
+#: common/models/lang.py:210
 msgid "Uzbek"
 msgstr "Uzbeque"
 
-#: common/models/lang.py:209
+#: common/models/lang.py:211
 msgid "Venda"
 msgstr "Venda"
 
-#: common/models/lang.py:210
+#: common/models/lang.py:212
 msgid "Vietnamese"
 msgstr "Vietnamita"
 
-#: common/models/lang.py:211
+#: common/models/lang.py:213
 msgid "Volapük"
 msgstr "Volapük"
 
-#: common/models/lang.py:212
+#: common/models/lang.py:214
 msgid "Walloon"
 msgstr "Valão"
 
-#: common/models/lang.py:213
+#: common/models/lang.py:215
 msgid "Wolof"
 msgstr "Uolofe"
 
-#: common/models/lang.py:214
+#: common/models/lang.py:216
 msgid "Xhosa"
 msgstr "Xhosa"
 
-#: common/models/lang.py:215
+#: common/models/lang.py:217
 msgid "Yiddish"
 msgstr "Lídiche"
 
-#: common/models/lang.py:216
+#: common/models/lang.py:218
 msgid "Zhuang"
 msgstr "Xuém"
 
-#: common/models/lang.py:217
+#: common/models/lang.py:219
 msgid "Zulu"
 msgstr "Zulu"
 
-#: common/models/lang.py:218
+#: common/models/lang.py:220
 msgid "Abkhazian"
 msgstr "Abcázio"
 
-#: common/models/lang.py:219
+#: common/models/lang.py:221
 msgid "Chinese"
 msgstr "Chinês"
 
-#: common/models/lang.py:220
+#: common/models/lang.py:222
 msgid "Pushto"
 msgstr "Pashto"
 
-#: common/models/lang.py:221
+#: common/models/lang.py:223
 msgid "Amharic"
 msgstr "Amárico"
 
-#: common/models/lang.py:222
+#: common/models/lang.py:224
 msgid "Arabic"
 msgstr "Árabe"
 
-#: common/models/lang.py:223
+#: common/models/lang.py:225
 msgid "Bulgarian"
 msgstr "Búlgaro"
 
-#: common/models/lang.py:224
+#: common/models/lang.py:226
 msgid "Macedonian"
 msgstr "Macedónio"
 
-#: common/models/lang.py:225
+#: common/models/lang.py:227
 msgid "Greek"
 msgstr "Grego"
 
-#: common/models/lang.py:226
+#: common/models/lang.py:228
 msgid "Persian"
 msgstr "Persa"
 
-#: common/models/lang.py:227
+#: common/models/lang.py:229
 msgid "Hebrew"
 msgstr "Hebraico"
 
-#: common/models/lang.py:228
+#: common/models/lang.py:230
 msgid "Hindi"
 msgstr "Hindi"
 
-#: common/models/lang.py:229
+#: common/models/lang.py:231
 msgid "Armenian"
 msgstr "Armênio"
 
-#: common/models/lang.py:231
+#: common/models/lang.py:233
 msgid "Ewe"
 msgstr "Ewe"
 
-#: common/models/lang.py:232
+#: common/models/lang.py:234
 msgid "Georgian"
 msgstr "Georgiano"
 
-#: common/models/lang.py:233
+#: common/models/lang.py:235
 msgid "Punjabi"
 msgstr "Panjabi"
 
-#: common/models/lang.py:234
+#: common/models/lang.py:236
 msgid "Bengali"
 msgstr "Bengalês"
 
-#: common/models/lang.py:235
+#: common/models/lang.py:237
 msgid "Bosnian"
 msgstr "Bósnio"
 
-#: common/models/lang.py:236
+#: common/models/lang.py:238
 msgid "Chamorro"
 msgstr "Chamorro"
 
-#: common/models/lang.py:237
+#: common/models/lang.py:239
 msgid "Belarusian"
 msgstr "Bielo-russo"
 
-#: common/models/lang.py:238
+#: common/models/lang.py:240
 msgid "Yoruba"
 msgstr "Iorubá"
 
-#: common/models/lang.py:300
+#: common/models/lang.py:302
 msgid "Simplified Chinese (Mainland)"
 msgstr "Chinês Simplificado (Continente)"
 
-#: common/models/lang.py:301
+#: common/models/lang.py:303
 msgid "Traditional Chinese (Taiwan)"
 msgstr "Chinês tradicional (Taiwan)"
 
-#: common/models/lang.py:302
+#: common/models/lang.py:304
 msgid "Traditional Chinese (Hongkong)"
 msgstr "Chinês tradicional (Hong Kong)"
 
-#: common/models/lang.py:310
+#: common/models/lang.py:312
 msgid "Portuguese (Brazil)"
 msgstr "Português (Brasil)"
 
-#: common/models/lang.py:313
+#: common/models/lang.py:315
 msgid "Simplified Chinese (Singapore)"
 msgstr "Chinês Simplificado (Cingapura)"
 
-#: common/models/lang.py:314
+#: common/models/lang.py:316
 msgid "Simplified Chinese (Malaysia)"
 msgstr "Chinês Simplificado (Malásia)"
 
-#: common/models/lang.py:315
+#: common/models/lang.py:317
 msgid "Traditional Chinese (Macau)"
 msgstr "Chinês Tradicional (Macau)"
 
-#: common/models/lang.py:323
+#: common/models/lang.py:325
 msgid "Mandarin Chinese"
 msgstr "Mandarim"
 
-#: common/models/lang.py:324
+#: common/models/lang.py:326
 msgid "Yue Chinese"
 msgstr "Yue chinês"
 
-#: common/models/lang.py:328
+#: common/models/lang.py:330
 msgid "Min Nan Chinese"
 msgstr "Min Nan chinês"
 
-#: common/models/lang.py:329
+#: common/models/lang.py:331
 msgid "Wu Chinese"
 msgstr "Wu chinês"
 
-#: common/models/lang.py:330
+#: common/models/lang.py:332
 msgid "Hakka Chinese"
 msgstr "Hacá"
 
@@ -3774,61 +3782,37 @@ msgid "VCD"
 msgstr "VCD"
 
 #: common/templates/400.html:23
-msgid ""
-"You may have submitted invalid data, or the content may have been deleted by "
-"the author."
-msgstr ""
-"Você pode ter enviado dados inválidos, ou o conteúdo pode ter sido excluído "
-"pelo autor."
+msgid "You may have submitted invalid data, or the content may have been deleted by the author."
+msgstr "Você pode ter enviado dados inválidos, ou o conteúdo pode ter sido excluído pelo autor."
 
 #: common/templates/400.html:25 common/templates/403.html:24
 #: common/templates/404.html:24
-msgid ""
-"If you believe this is our mistake, please contact us through the link at "
-"the bottom of the page."
-msgstr ""
-"Se você acredita que isso é um erro nosso, entre em contato conosco pelo "
-"link no rodapé da página."
+msgid "If you believe this is our mistake, please contact us through the link at the bottom of the page."
+msgstr "Se você acredita que isso é um erro nosso, entre em contato conosco pelo link no rodapé da página."
 
 #: common/templates/403.html:22
-msgid ""
-"Author may require you to log in before accessing this content, or you do "
-"not have permission to view it."
-msgstr ""
-"O autor pode exigir que você esteja conectado antes de acessar este "
-"conteúdo, ou você não tem permissão para visualizá-lo."
+msgid "Author may require you to log in before accessing this content, or you do not have permission to view it."
+msgstr "O autor pode exigir que você esteja conectado antes de acessar este conteúdo, ou você não tem permissão para visualizá-lo."
 
 #: common/templates/404.html:20
 msgid "Something is missing"
 msgstr "Algo está faltando"
 
 #: common/templates/404.html:22
-msgid ""
-"You may have visited an incorrect URL, or the content you are looking for "
-"has been deleted by the author."
-msgstr ""
-"Você pode ter acessado uma URL incorreta, ou o conteúdo que você procura foi "
-"excluído pelo autor."
+msgid "You may have visited an incorrect URL, or the content you are looking for has been deleted by the author."
+msgstr "Você pode ter acessado uma URL incorreta, ou o conteúdo que você procura foi excluído pelo autor."
 
 #: common/templates/404.html:26
 msgid "Go to Home"
 msgstr "Ir para o Início"
 
 #: common/templates/500.html:22
-msgid ""
-"An internal error occurred. If this error occurs repeatedly, it will be "
-"recorded and handled by a human."
-msgstr ""
-"Ocorreu um erro interno. Se este erro ocorrer repetidamente, será registrado "
-"e tratado por uma pessoa."
+msgid "An internal error occurred. If this error occurs repeatedly, it will be recorded and handled by a human."
+msgstr "Ocorreu um erro interno. Se este erro ocorrer repetidamente, será registrado e tratado por uma pessoa."
 
 #: common/templates/500.html:24
-msgid ""
-"If you have an urgent situation or any questions, please contact us through "
-"the link at the bottom of the page."
-msgstr ""
-"Se você tiver uma situação urgente ou alguma dúvida, entre em contato "
-"conosco pelo link no rodapé da página."
+msgid "If you have an urgent situation or any questions, please contact us through the link at the bottom of the page."
+msgstr "Se você tiver uma situação urgente ou alguma dúvida, entre em contato conosco pelo link no rodapé da página."
 
 #: common/templates/_footer.html:6
 msgid "Rules"
@@ -3842,252 +3826,205 @@ msgstr "Termos"
 msgid "About"
 msgstr "Sobre"
 
-#: common/templates/_footer.html:12 users/templates/users/login.html:265
+#: common/templates/_footer.html:12 users/templates/users/login.html:259
 #, python-format
-msgid ""
-"You are visiting an alternative domain for %(site_name)s, please always use "
-"<a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if "
-"possible."
-msgstr ""
-"Você está visitando um domínio alternativo do %(site_name)s. Por favor, use "
-"sempre a <a href=\"%(site_url)s%(request.get_full_path)s\">versão original</"
-"a> sempre que possível."
+msgid "You are visiting an alternative domain for %(site_name)s, please always use <a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if possible."
+msgstr "Você está visitando um domínio alternativo do %(site_name)s. Por favor, use sempre a <a href=\"%(site_url)s%(request.get_full_path)s\">versão original</a> sempre que possível."
 
-#: common/templates/_header.html:19 common/templates/_header.html:164
+#: common/templates/_header.html:19 common/templates/_header.html:177
 msgid "title, creator, ISBN, item url, @user, @user@instance"
 msgstr "título, criador, ISBN, URL do item, @usuário, @usuário@instância"
 
-#: common/templates/_header.html:24
+#: common/templates/_header.html:34
 msgid "All Items"
 msgstr "Todos os itens"
 
-#: common/templates/_header.html:31
+#: common/templates/_header.html:41
 msgid "Movie & TV"
 msgstr "Filme & TV"
 
-#: common/templates/_header.html:50
+#: common/templates/_header.html:60
 msgid "People & Organizations"
 msgstr "Pessoas & Organizações"
 
-#: common/templates/_header.html:52
+#: common/templates/_header.html:62
 msgid "Journal"
 msgstr "Diário"
 
-#: common/templates/_header.html:54 journal/templates/user_post_list.html:10
+#: common/templates/_header.html:64 journal/templates/user_post_list.html:10
 #: journal/templates/user_post_list.html:23
 msgid "Posts"
 msgstr "Publicações"
 
-#: common/templates/_header.html:89
+#: common/templates/_header.html:102
 msgid "Explore"
 msgstr "Explorar"
 
-#: common/templates/_header.html:93
+#: common/templates/_header.html:106 common/views_manage.py:36
 msgid "Feed"
 msgstr "Feed"
 
-#: common/templates/_header.html:98 journal/templates/profile.html:13
+#: common/templates/_header.html:111 journal/templates/profile.html:13
 #: users/templates/users/preferences.html:46
 msgid "Home"
 msgstr "Página Inicial"
 
-#: common/templates/_header.html:114 common/templates/common/scan.html:9
+#: common/templates/_header.html:127 common/templates/common/scan.html:9
 #: common/templates/common/scan.html:42
 msgid "Scan Barcode"
 msgstr "Escanear Código de Barras"
 
-#: common/templates/_header.html:118 social/templates/notification.html:12
+#: common/templates/_header.html:131 social/templates/notification.html:12
 #: social/templates/notification.html:53
 msgid "Notification"
 msgstr "Notificação"
 
-#: common/templates/_header.html:122 users/models/task.py:21
+#: common/templates/_header.html:135 users/models/task.py:23
 #: users/templates/users/account.html:219
 #: users/templates/users/crossposts.html:9
 msgid "Pending"
 msgstr "Pendente"
 
-#: common/templates/_header.html:125
+#: common/templates/_header.html:138
 msgid "Data"
 msgstr "Dados"
 
-#: common/templates/_header.html:128 common/templates/_header.html:146
+#: common/templates/_header.html:141 common/templates/_header.html:159
 #: users/templates/users/preferences.html:12
 #: users/templates/users/preferences.html:23
 #: users/templates/users/preferences_anonymous.html:13
 msgid "Preferences"
 msgstr "Preferências"
 
-#: common/templates/_header.html:131
+#: common/templates/_header.html:144
 msgid "Account"
 msgstr "Conta"
 
-#: common/templates/_header.html:135
+#: common/templates/_header.html:148
 msgid "Manage"
 msgstr "Gerenciar"
 
-#: common/templates/_header.html:139
+#: common/templates/_header.html:152
 msgid "Logout"
 msgstr "Sair"
 
-#: common/templates/_header.html:143
+#: common/templates/_header.html:156
 msgid "Sign up or Login"
 msgstr "Cadastre-se ou Entre"
 
-#: common/templates/_header.html:160
-msgid ""
-"title or content  category:tv  status:complete  rating:8..10  "
-"date:2021-09-11..2022-02"
-msgstr ""
-"título ou conteúdo  categoria:tv  status:concluído  avaliação:8..10  "
-"data:2021-09-11..2022-02"
+#: common/templates/_header.html:173
+msgid "title or content  category:tv  status:complete  rating:8..10  date:2021-09-11..2022-02"
+msgstr "título ou conteúdo  categoria:tv  status:concluído  avaliação:8..10  data:2021-09-11..2022-02"
 
-#: common/templates/_header.html:162
+#: common/templates/_header.html:175
 msgid "name of a person or company"
 msgstr "nome de uma pessoa ou empresa"
 
-#: common/templates/_header.html:179
+#: common/templates/_header.html:192
 msgid "Open"
 msgstr "Abrir"
 
-#: common/templates/_sidebar.html:62
+#: common/templates/_sidebar.html:61
 #: users/templates/users/profile_actions.html:36
 msgid "approving followers manually"
 msgstr "aprovando seguidores manualmente"
 
-#: common/templates/_sidebar.html:81 common/templates/_sidebar.html:86
+#: common/templates/_sidebar.html:80 common/templates/_sidebar.html:85
 msgid "followers"
 msgstr "seguidores"
 
-#: common/templates/_sidebar.html:112
+#: common/templates/_sidebar.html:111
 msgid "Current Targets"
 msgstr "Destinos Atuais"
 
-#: common/templates/_sidebar.html:125
+#: common/templates/_sidebar.html:124
 msgid "Set a collection as target, its progress will show up here."
 msgstr "Defina uma coleção como destino; seu progresso aparecerá aqui."
 
-#: common/templates/_sidebar.html:138
+#: common/templates/_sidebar.html:137
 msgid "Recent podcast episodes"
 msgstr "Episódios recentes de podcast"
 
-#: common/templates/_sidebar.html:173
+#: common/templates/_sidebar.html:172
 msgid "Currently reading"
 msgstr "Lendo atualmente"
 
-#: common/templates/_sidebar.html:215
+#: common/templates/_sidebar.html:214
 msgid "Currently watching"
 msgstr "Assistindo atualmente"
 
-#: common/templates/_sidebar.html:238 journal/forms.py:217
+#: common/templates/_sidebar.html:237 journal/forms.py:217
 #: journal/templates/user_tag_list.html:13
 #: journal/templates/user_tagmember_list.html:4
 msgid "Tags"
 msgstr "Etiquetas"
 
-#: common/templates/_sidebar.html:244 journal/templates/user_tag_list.html:28
+#: common/templates/_sidebar.html:243 journal/templates/user_tag_list.html:28
 #: journal/templates/user_tagmember_list.html:10
 msgid "featured tag"
 msgstr "etiqueta em destaque"
 
-#: common/templates/_sidebar.html:247 journal/templates/user_tag_list.html:31
+#: common/templates/_sidebar.html:246 journal/templates/user_tag_list.html:31
 #: journal/templates/user_tagmember_list.html:15
 msgid "personal tag"
 msgstr "etiqueta pessoal"
 
-#: common/templates/_sidebar.html:254 journal/templates/user_tag_list.html:39
+#: common/templates/_sidebar.html:253 journal/templates/user_tag_list.html:39
 msgid "no tags so far."
 msgstr "nenhuma etiqueta até agora."
 
-#: common/templates/_sidebar.html:258 common/templates/_sidebar.html:271
+#: common/templates/_sidebar.html:257 common/templates/_sidebar.html:270
 msgid "show all"
 msgstr "mostrar todas"
 
-#: common/templates/_sidebar_anonymous.html:16
+#: common/templates/_sidebar_anonymous.html:15
 #, python-format
 msgid ""
 "\n"
 "        <h3>Welcome 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is "
-"committed to creating a free, open, and interconnected space for collecting "
-"and reviewing books, movies, music, games, and podcasts. Here, you can "
-"manage your collections, share your thoughts, discover new content, and "
-"connect with others.\n"
+"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is committed to creating a free, open, and interconnected space for collecting and reviewing books, movies, music, games, and podcasts. Here, you can manage your collections, share your thoughts, discover new content, and connect with others.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in "
-"to %(site_name)s is through a Fediverse (a distributed social network, "
-"including Mastodon/Pleroma/etc) instance account. If you haven’t registered "
-"yet, you can <a href=\"https://joinmastodon.org/en/servers\" "
-"target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
+"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in to %(site_name)s is through a Fediverse (a distributed social network, including Mastodon/Pleroma/etc) instance account. If you haven’t registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log "
-"in is through a Bluesky (another distributed social network, also called "
-"ATProto) account. If you haven’t registered yet, you may <a href=\"https://"
-"bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
+"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log in is through a Bluesky (another distributed social network, also called ATProto) account. If you haven’t registered yet, you may <a href=\"https://bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready "
-"to join either Fediverse or Bluesky, that’s perfectly fine. You can create "
-"an account here using your email address, and link it to the Fediverse and "
-"Bluesky in settings whenever you’re ready.\n"
+"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready to join either Fediverse or Bluesky, that’s perfectly fine. You can create an account here using your email address, and link it to the Fediverse and Bluesky in settings whenever you’re ready.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have "
-"any questions or suggestions, please feel free to contact us via <a "
-"href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://"
-"discord.gg/uprvcH8gqD\">Discord</a>.\n"
+"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have any questions or suggestions, please feel free to contact us via <a href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-"href=\"%(login_url)s\">Click here</a> to register or log in.\n"
+"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Click here</a> to register or log in.\n"
 "        </p>\n"
 "        "
 msgstr ""
 "\n"
 "        <h3>Bem-vindo(a) 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s "
-"tem o compromisso de criar um espaço livre, aberto e interconectado para "
-"catalogar e avaliar livros, filmes, músicas, jogos e podcasts. Aqui, você "
-"pode gerenciar suas coleções, compartilhar suas opiniões, descobrir novos "
-"conteúdos e se conectar com outras pessoas.\n"
+"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s tem o compromisso de criar um espaço livre, aberto e interconectado para catalogar e avaliar livros, filmes, músicas, jogos e podcasts. Aqui, você pode gerenciar suas coleções, compartilhar suas opiniões, descobrir novos conteúdos e se conectar com outras pessoas.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-globe\"></i> &nbsp; A melhor forma de "
-"entrar no %(site_name)s é por meio de uma conta em uma instância do "
-"Fediverse (uma rede social distribuída, incluindo Mastodon/Pleroma/etc). Se "
-"você ainda não se registrou, pode <a href=\"https://joinmastodon.org/en/"
-"servers\" target=\"_blank\">escolher uma instância do Fediverse e se "
-"cadastrar</a>.\n"
+"          <i class=\"fa-solid fa-globe\"></i> &nbsp; A melhor forma de entrar no %(site_name)s é por meio de uma conta em uma instância do Fediverse (uma rede social distribuída, incluindo Mastodon/Pleroma/etc). Se você ainda não se registrou, pode <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">escolher uma instância do Fediverse e se cadastrar</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Outra forma de "
-"entrar é por meio de uma conta no Bluesky (outra rede social distribuída, "
-"também chamada de ATProto). Se você ainda não se registrou, pode <a "
-"href=\"https://bsky.app\" target=\"_blank\">se cadastrar pelo bsky.app</a>.\n"
+"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Outra forma de entrar é por meio de uma conta no Bluesky (outra rede social distribuída, também chamada de ATProto). Se você ainda não se registrou, pode <a href=\"https://bsky.app\" target=\"_blank\">se cadastrar pelo bsky.app</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; Se você ainda não "
-"está pronto(a) para entrar no Fediverse ou no Bluesky, não tem problema. "
-"Você pode criar uma conta aqui usando seu endereço de e-mail e vinculá-la ao "
-"Fediverse e ao Bluesky nas configurações quando quiser.\n"
+"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; Se você ainda não está pronto(a) para entrar no Fediverse ou no Bluesky, não tem problema. Você pode criar uma conta aqui usando seu endereço de e-mail e vinculá-la ao Fediverse e ao Bluesky nas configurações quando quiser.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; Se você tiver "
-"alguma dúvida ou sugestão, sinta-se à vontade para entrar em contato conosco "
-"pelo <a href=\"https://mastodon.social/@neodb\">Fediverse</a> ou pelo <a "
-"href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
+"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; Se você tiver alguma dúvida ou sugestão, sinta-se à vontade para entrar em contato conosco pelo <a href=\"https://mastodon.social/@neodb\">Fediverse</a> ou pelo <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-"href=\"%(login_url)s\">Clique aqui</a> para se registrar ou entrar.\n"
+"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Clique aqui</a> para se registrar ou entrar.\n"
 "        </p>\n"
 "        "
 
-#: common/templates/_sidebar_anonymous.html:43
+#: common/templates/_sidebar_anonymous.html:42
 #: users/templates/users/announcements.html:12
 #: users/templates/users/announcements.html:39
 msgid "Announcements"
@@ -4109,7 +4046,7 @@ msgstr "Código-Fonte"
 msgid "Registration"
 msgstr "Registro"
 
-#: common/templates/common/about.html:35 common/views_manage.py:493
+#: common/templates/common/about.html:35 common/views_manage.py:594
 msgid "Invite Only"
 msgstr "Somente por Convite"
 
@@ -4117,7 +4054,7 @@ msgstr "Somente por Convite"
 msgid "Open Registration"
 msgstr "Registro Aberto"
 
-#: common/templates/common/about.html:40 common/views_manage.py:556
+#: common/templates/common/about.html:40 common/views_manage.py:657
 msgid "Preferred Languages"
 msgstr "Idiomas Preferidos"
 
@@ -4147,8 +4084,7 @@ msgstr "Instâncias Conhecidas do NeoDB"
 
 #: common/templates/common/about.html:88
 msgid "Statistics are being calculated. Please check back in a few minutes."
-msgstr ""
-"As estatísticas estão sendo calculadas. Volte a verificar em alguns minutos."
+msgstr "As estatísticas estão sendo calculadas. Volte a verificar em alguns minutos."
 
 #: common/templates/common/about.html:96
 msgid "Site Administrators"
@@ -4163,13 +4099,8 @@ msgid "Error"
 msgstr "Erro"
 
 #: common/templates/common/scan.html:45
-msgid ""
-"Point the camera at a book ISBN or product barcode (EAN / UPC). You will be "
-"redirected to the search once a code is detected."
-msgstr ""
-"Aponte a câmera para o ISBN de um livro ou código de barras do produto "
-"(EAN / UPC). Você será redirecionado(a) para a busca assim que um código for "
-"detectado."
+msgid "Point the camera at a book ISBN or product barcode (EAN / UPC). You will be redirected to the search once a code is detected."
+msgstr "Aponte a câmera para o ISBN de um livro ou código de barras do produto (EAN / UPC). Você será redirecionado(a) para a busca assim que um código for detectado."
 
 #: common/templates/common/scan.html:50
 msgid "Requesting camera access..."
@@ -4179,7 +4110,7 @@ msgstr "Solicitando acesso à câmera..."
 msgid "Or type barcode / ISBN manually"
 msgstr "Ou digite o código de barras / ISBN manualmente"
 
-#: common/templates/common/scan.html:60 common/views_manage.py:628
+#: common/templates/common/scan.html:60 common/views_manage.py:738
 msgid "Search"
 msgstr "Buscar"
 
@@ -4211,17 +4142,29 @@ msgstr "Nenhuma câmera encontrada. Use a entrada manual abaixo."
 msgid "Camera unavailable. Use manual entry below."
 msgstr "Câmera indisponível. Use a entrada manual abaixo."
 
-#: common/templates/manage/settings.html:9
+#: common/templates/manage/base.html:9
 msgid "Site Settings"
 msgstr "Configurações do Site"
 
-#: common/templates/manage/settings.html:109
+#: common/templates/manage/base.html:127
 msgid "Takahe Admin"
 msgstr "Administração do Takahe"
 
-#: common/templates/manage/settings.html:112
+#: common/templates/manage/base.html:130
 msgid "Database Admin"
 msgstr "Administração do Banco de Dados"
+
+#: common/templates/manage/environment.html:6
+msgid "These settings come from environment variables and cannot be changed here. Edit .env and restart the server to change them. Passwords and keys are hidden."
+msgstr ""
+
+#: common/templates/manage/environment.html:23
+msgid "(empty)"
+msgstr ""
+
+#: common/templates/manage/environment.html:26
+msgid "default"
+msgstr ""
 
 #: common/templatetags/duration.py:59
 msgid "just now"
@@ -4239,7 +4182,7 @@ msgstr "seguido"
 msgid "following you"
 msgstr "seguindo você"
 
-#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:95
+#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:90
 msgid "you"
 msgstr "você"
 
@@ -4247,879 +4190,819 @@ msgstr "você"
 msgid "unavailable"
 msgstr "indisponível"
 
-#: common/utils.py:126 common/utils.py:167 users/views/actions.py:134
+#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr "Usuário não existe mais"
 
-#: common/utils.py:133 common/utils.py:135 common/utils.py:138
-#: common/utils.py:174 common/utils.py:178 journal/views/profile.py:499
+#: common/utils.py:135 common/utils.py:137 common/utils.py:140
+#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
 msgid "Access denied"
 msgstr "Acesso negado"
 
-#: common/utils.py:141 common/utils.py:143 journal/views/article.py:204
+#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr "Login obrigatório"
 
-#: common/views_manage.py:144 common/views_manage.py:295
+#: common/views_manage.py:34 common/views_manage.py:373
 msgid "Branding"
 msgstr "Identidade Visual"
 
-#: common/views_manage.py:146
+#: common/views_manage.py:37
 msgid "Recommendations"
 msgstr "Recomendações"
 
-#: common/views_manage.py:147
+#: common/views_manage.py:38
 msgid "Access"
 msgstr "Acesso"
 
-#: common/views_manage.py:148 common/views_manage.py:623
+#: common/views_manage.py:39 common/views_manage.py:733
 msgid "Federation"
 msgstr "Federação"
 
-#: common/views_manage.py:149
+#: common/views_manage.py:40
 msgid "Catalog"
 msgstr "Catálogo"
 
-#: common/views_manage.py:150
+#: common/views_manage.py:41
 msgid "API Keys"
 msgstr "Chaves de API"
 
-#: common/views_manage.py:151
+#: common/views_manage.py:42
 msgid "Downloader"
 msgstr "Downloader"
 
-#: common/views_manage.py:152 common/views_manage.py:303
+#: common/views_manage.py:43 common/views_manage.py:381
 #: users/templates/users/steam_import.html:113
 msgid "Advanced"
 msgstr "Avançado"
 
-#: common/views_manage.py:202
+#: common/views_manage.py:44
+msgid "Environment"
+msgstr ""
+
+#: common/views_manage.py:280
 msgid "Invalid value."
 msgstr "Valor inválido."
 
-#: common/views_manage.py:206
+#: common/views_manage.py:284
 msgid "Invalid configuration. Please check your input."
 msgstr "Configuração inválida. Verifique sua entrada."
 
-#: common/views_manage.py:211
+#: common/views_manage.py:289
 msgid "Settings have been saved."
 msgstr "As configurações foram salvas."
 
-#: common/views_manage.py:231
+#: common/views_manage.py:309
 msgid "Site Name"
 msgstr "Nome do Site"
 
-#: common/views_manage.py:234
+#: common/views_manage.py:312
 msgid "Site Description"
 msgstr "Descrição do Site"
 
-#: common/views_manage.py:235
+#: common/views_manage.py:313
 msgid "Short description shown in metadata and about page."
 msgstr "Breve descrição exibida nos metadados e na página sobre."
 
-#: common/views_manage.py:238
+#: common/views_manage.py:316
 msgid "Site Logo URL"
 msgstr "URL do Logotipo do Site"
 
-#: common/views_manage.py:239
+#: common/views_manage.py:317
 msgid "URL path to the site logo image."
 msgstr "Caminho de URL para a imagem do logotipo do site."
 
-#: common/views_manage.py:242
+#: common/views_manage.py:320
 msgid "Site Icon URL"
 msgstr "URL do Ícone do Site"
 
-#: common/views_manage.py:243
+#: common/views_manage.py:321
 msgid "URL path to the site icon/favicon."
 msgstr "Caminho de URL para o ícone/favicon do site."
 
-#: common/views_manage.py:246
+#: common/views_manage.py:324
 msgid "Default User Avatar URL"
 msgstr "URL do Avatar Padrão do Usuário"
 
-#: common/views_manage.py:247
+#: common/views_manage.py:325
 msgid "URL path to the default user avatar."
 msgstr "Caminho de URL para o avatar padrão do usuário."
 
-#: common/views_manage.py:250
+#: common/views_manage.py:328
 msgid "Site Color Theme"
 msgstr "Tema de Cores do Site"
 
-#: common/views_manage.py:251
+#: common/views_manage.py:329
 msgid "PicoCSS color theme."
 msgstr "Tema de cores do PicoCSS."
 
-#: common/views_manage.py:276
+#: common/views_manage.py:354
 msgid "Site Introduction"
 msgstr "Introdução do Site"
 
-#: common/views_manage.py:277
+#: common/views_manage.py:355
 msgid "URL path for the intro/welcome sidebar page."
 msgstr "Caminho de URL para a página lateral de introdução/boas-vindas."
 
-#: common/views_manage.py:280
+#: common/views_manage.py:358
 msgid "Custom HTML Head"
 msgstr "HTML Personalizado do Cabeçalho"
 
-#: common/views_manage.py:281
+#: common/views_manage.py:359
 msgid "Extra HTML injected into the <head> of all pages."
 msgstr "HTML extra injetado no <head> de todas as páginas."
 
-#: common/views_manage.py:285
+#: common/views_manage.py:363
 msgid "Footer Links"
 msgstr "Links do Rodapé"
 
-#: common/views_manage.py:286
+#: common/views_manage.py:364
 msgid "Link title mapped to URL."
 msgstr "Título do link mapeado para a URL."
 
-#: common/views_manage.py:315
+#: common/views_manage.py:393
 msgid "Minimum Marks for Discover"
 msgstr "Marcações Mínimas para Descoberta"
 
-#: common/views_manage.py:317
+#: common/views_manage.py:395
 msgid "Number of marks required for an item to appear in discover."
-msgstr ""
-"Número de marcações necessárias para que um item apareça na descoberta."
+msgstr "Número de marcações necessárias para que um item apareça na descoberta."
 
-#: common/views_manage.py:322
+#: common/views_manage.py:400
 msgid "Update Interval (minutes)"
 msgstr "Intervalo de Atualização (minutos)"
 
-#: common/views_manage.py:323
+#: common/views_manage.py:401
 msgid "How often to refresh the popular items list."
 msgstr "Com que frequência atualizar a lista de itens populares."
 
-#: common/views_manage.py:327
+#: common/views_manage.py:405
 msgid "Filter by Preferred Languages"
 msgstr "Filtrar por Idiomas Preferidos"
 
-#: common/views_manage.py:328
+#: common/views_manage.py:406
 msgid "Only show items with titles in the preferred languages."
 msgstr "Mostrar apenas itens com títulos nos idiomas preferidos."
 
-#: common/views_manage.py:331
+#: common/views_manage.py:409
 msgid "Show Local Only"
 msgstr "Mostrar Apenas Local"
 
-#: common/views_manage.py:333
+#: common/views_manage.py:411
 msgid "Only show items marked by local users, not the entire network."
-msgstr ""
-"Mostrar apenas itens marcados por usuários locais, e não por toda a rede."
+msgstr "Mostrar apenas itens marcados por usuários locais, e não por toda a rede."
 
-#: common/views_manage.py:337
+#: common/views_manage.py:415
 msgid "Show Popular Posts"
 msgstr "Mostrar Publicações Populares"
 
-#: common/views_manage.py:338
+#: common/views_manage.py:416
 msgid "Show popular public posts instead of recent ones."
 msgstr "Mostrar publicações públicas populares em vez das mais recentes."
 
-#: common/views_manage.py:341
+#: common/views_manage.py:419
 msgid "Show Popular Tags"
 msgstr "Mostrar Etiquetas Populares"
 
-#: common/views_manage.py:342
+#: common/views_manage.py:420
 msgid "Show popular public tags on the discover page."
 msgstr "Mostrar etiquetas públicas populares na página de descoberta."
 
-#: common/views_manage.py:345
+#: common/views_manage.py:423
 msgid "Show Verified Podcasts"
 msgstr "Mostrar Podcasts Verificados"
 
-#: common/views_manage.py:347
-msgid ""
-"Show a shelf of recent episodes from podcasts with a verified creator on the "
-"discover page."
-msgstr ""
-"Mostrar uma prateleira com episódios recentes de podcasts com criador "
-"verificado na página de descoberta."
+#: common/views_manage.py:425
+msgid "Show a shelf of recent episodes from podcasts with a verified creator on the discover page."
+msgstr "Mostrar uma prateleira com episódios recentes de podcasts com criador verificado na página de descoberta."
 
-#: common/views_manage.py:386
+#: common/views_manage.py:447
+#, fuzzy
+#| msgid "your timeline"
+msgid "Show World Timeline"
+msgstr "sua linha do tempo"
+
+#: common/views_manage.py:449
+msgid "Offer a tab with public posts from this site and every server it federates with."
+msgstr ""
+
+#: common/views_manage.py:454
+#, fuzzy
+#| msgid "Show Local Only"
+msgid "Show Local Timeline"
+msgstr "Mostrar Apenas Local"
+
+#: common/views_manage.py:455
+msgid "Offer a tab with public posts from this site only."
+msgstr ""
+
+#: common/views_manage.py:459
+#, fuzzy
+#| msgid "your timeline"
+msgid "Timelines"
+msgstr "sua linha do tempo"
+
+#: common/views_manage.py:487
 msgid "Enable Recommendations"
 msgstr "Ativar Recomendações"
 
-#: common/views_manage.py:388
-msgid ""
-"Master switch. When off, all recommendation surfaces are hidden and the cron "
-"jobs are not scheduled."
-msgstr ""
-"Interruptor principal. Quando desativado, todas as seções de recomendação "
-"ficam ocultas e as tarefas agendadas (cron jobs) não são executadas."
+#: common/views_manage.py:489
+msgid "Master switch. When off, all recommendation surfaces are hidden and the cron jobs are not scheduled."
+msgstr "Interruptor principal. Quando desativado, todas as seções de recomendação ficam ocultas e as tarefas agendadas (cron jobs) não são executadas."
 
-#: common/views_manage.py:393
+#: common/views_manage.py:494
 msgid "Source Item Mark Threshold"
 msgstr "Limite de Marcações do Item de Origem"
 
-#: common/views_manage.py:395
-msgid ""
-"Minimum public marks an item needs before similarity rows are built for it."
-msgstr ""
-"Número mínimo de marcações públicas que um item precisa ter antes que as "
-"linhas de similaridade sejam geradas para ele."
+#: common/views_manage.py:496
+msgid "Minimum public marks an item needs before similarity rows are built for it."
+msgstr "Número mínimo de marcações públicas que um item precisa ter antes que as linhas de similaridade sejam geradas para ele."
 
-#: common/views_manage.py:401
+#: common/views_manage.py:502
 msgid "Target Item Mark Threshold"
 msgstr "Limite de Marcações do Item de Destino"
 
-#: common/views_manage.py:403
-msgid ""
-"Minimum public marks an item needs to be eligible as a recommendation target."
-msgstr ""
-"Número mínimo de marcações públicas que um item precisa ter para ser "
-"elegível como alvo de recomendação."
+#: common/views_manage.py:504
+msgid "Minimum public marks an item needs to be eligible as a recommendation target."
+msgstr "Número mínimo de marcações públicas que um item precisa ter para ser elegível como alvo de recomendação."
 
-#: common/views_manage.py:409
+#: common/views_manage.py:510
 msgid "Top-K Similar Items per Source"
 msgstr "Top-K Itens Semelhantes por Origem"
 
-#: common/views_manage.py:410
+#: common/views_manage.py:511
 msgid "Number of similar items stored per source item."
 msgstr "Número de itens semelhantes armazenados por item de origem."
 
-#: common/views_manage.py:414
+#: common/views_manage.py:515
 msgid "Top-N Recommendations per User"
 msgstr "Top-N Recomendações por Usuário"
 
-#: common/views_manage.py:415
+#: common/views_manage.py:516
 msgid "Number of personalised rows stored per user."
 msgstr "Número de linhas personalizadas armazenadas por usuário."
 
-#: common/views_manage.py:419
+#: common/views_manage.py:520
 msgid "Dampen Heavy Shelvers"
 msgstr "Atenuar Usuários com Muitas Marcações"
 
-#: common/views_manage.py:421
-msgid ""
-"Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-"
-"shelvers in similarity scoring."
-msgstr ""
-"Pondera a contribuição de cada usuário por 1/sqrt(n_marcações) para "
-"neutralizar o efeito de usuários com um volume muito alto de marcações no "
-"cálculo de similaridade."
+#: common/views_manage.py:522
+msgid "Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-shelvers in similarity scoring."
+msgstr "Pondera a contribuição de cada usuário por 1/sqrt(n_marcações) para neutralizar o efeito de usuários com um volume muito alto de marcações no cálculo de similaridade."
 
-#: common/views_manage.py:426
+#: common/views_manage.py:527
 msgid "Per-User Mark Cap (training)"
 msgstr "Limite de Marcações por Usuário (treinamento)"
 
-#: common/views_manage.py:428
-msgid ""
-"Truncate each user's contribution to their N most recent marks when building "
-"the similarity matrix."
-msgstr ""
-"Trunca a contribuição de cada usuário para suas N marcações mais recentes ao "
-"construir a matriz de similaridade."
+#: common/views_manage.py:529
+msgid "Truncate each user's contribution to their N most recent marks when building the similarity matrix."
+msgstr "Trunca a contribuição de cada usuário para suas N marcações mais recentes ao construir a matriz de similaridade."
 
-#: common/views_manage.py:434
+#: common/views_manage.py:535
 msgid "Active-User Window (days)"
 msgstr "Janela de Usuário Ativo (dias)"
 
-#: common/views_manage.py:436
-msgid ""
-"Refresh personalised recommendations for users with at least one public mark "
-"in the last N days."
-msgstr ""
-"Atualiza as recomendações personalizadas para usuários com pelo menos uma "
-"marcação pública nos últimos N dias."
+#: common/views_manage.py:537
+msgid "Refresh personalised recommendations for users with at least one public mark in the last N days."
+msgstr "Atualiza as recomendações personalizadas para usuários com pelo menos uma marcação pública nos últimos N dias."
 
-#: common/views_manage.py:442
+#: common/views_manage.py:543
 msgid "Per-User Seed Cap (serving)"
 msgstr "Limite de Itens-Semente por Usuário (exibição)"
 
-#: common/views_manage.py:444
-msgid ""
-"Number of recent marks used as seeds when scoring personalised "
-"recommendations for one user."
-msgstr ""
-"Número de marcações recentes usadas como sementes ao pontuar recomendações "
-"personalizadas para um usuário."
+#: common/views_manage.py:545
+msgid "Number of recent marks used as seeds when scoring personalised recommendations for one user."
+msgstr "Número de marcações recentes usadas como sementes ao pontuar recomendações personalizadas para um usuário."
 
-#: common/views_manage.py:450
+#: common/views_manage.py:551
 msgid "Lazy Refresh TTL (days)"
 msgstr "TTL de Atualização Sob Demanda (dias)"
 
-#: common/views_manage.py:452
-msgid ""
-"How long cached on-demand recommendations are valid before the next request "
-"triggers a refresh."
-msgstr ""
-"Por quanto tempo as recomendações em cache geradas sob demanda permanecem "
-"válidas antes que a próxima solicitação acione uma atualização."
+#: common/views_manage.py:553
+msgid "How long cached on-demand recommendations are valid before the next request triggers a refresh."
+msgstr "Por quanto tempo as recomendações em cache geradas sob demanda permanecem válidas antes que a próxima solicitação acione uma atualização."
 
-#: common/views_manage.py:458
+#: common/views_manage.py:559
 msgid "Circles Window (days)"
 msgstr "Janela de Círculos (dias)"
 
-#: common/views_manage.py:460
-msgid ""
-"Look back N days when finding items recently marked by people the viewer "
-"follows."
-msgstr ""
-"Retroceder N dias ao buscar itens marcados recentemente por pessoas que o "
-"usuário segue."
+#: common/views_manage.py:561
+msgid "Look back N days when finding items recently marked by people the viewer follows."
+msgstr "Retroceder N dias ao buscar itens marcados recentemente por pessoas que o usuário segue."
 
-#: common/views_manage.py:467
+#: common/views_manage.py:568
 msgid "Master Switch"
 msgstr "Interruptor Principal"
 
-#: common/views_manage.py:470
+#: common/views_manage.py:571
 msgid "Similarity Builder"
 msgstr "Construtor de Similaridade"
 
-#: common/views_manage.py:477
+#: common/views_manage.py:578
 msgid "Personalisation"
 msgstr "Personalização"
 
-#: common/views_manage.py:495
-msgid ""
-"Require an invite token to register. Invite tokens can be generated with "
-"neodb-manage invite --create."
-msgstr ""
-"Exigir um token de convite para se registrar. Tokens de convite podem ser "
-"gerados com neodb-manage invite --create."
+#: common/views_manage.py:596
+msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
+msgstr "Exigir um token de convite para se registrar. Tokens de convite podem ser gerados com neodb-manage invite --create."
 
-#: common/views_manage.py:500
+#: common/views_manage.py:601
 msgid "Enable Local-Only Posting"
 msgstr "Ativar Publicação Somente Local"
 
-#: common/views_manage.py:501
+#: common/views_manage.py:602
 msgid "Allow users to create posts visible only to local users."
-msgstr ""
-"Permitir que os usuários criem publicações visíveis apenas para usuários "
-"locais."
+msgstr "Permitir que os usuários criem publicações visíveis apenas para usuários locais."
 
-#: common/views_manage.py:504
+#: common/views_manage.py:605
 msgid "Mastodon Login Whitelist"
 msgstr "Lista de Permissões de Login via Mastodon"
 
-#: common/views_manage.py:505
+#: common/views_manage.py:606
 msgid "One domain per line. Leave empty to allow any instance."
-msgstr ""
-"Um domínio por linha. Deixe em branco para permitir qualquer instância."
+msgstr "Um domínio por linha. Deixe em branco para permitir qualquer instância."
 
-#: common/views_manage.py:508
+#: common/views_manage.py:609
 msgid "Registration Captcha Items"
 msgstr "Registro de itens de Captcha"
 
-#: common/views_manage.py:512
-msgid ""
-"Number of item covers a new user must sort into two category rows before "
-"choosing a username. 0 disables the captcha; 5-6 is recommended. The covers "
-"carry no title text, so this cannot be solved with a screen reader: if you "
-"enable it, keep another way in, such as an invite link."
-msgstr ""
-"Número de capas de item que um novo usuário deve classificar em duas linhas "
-"de categoria antes de escolher um nome de usuário. 0 desativa o captcha; 5-6 "
-"é recomendado. As capas não possuem texto de título, então isso não pode ser "
-"resolvido com um leitor de tela: se você ativá-lo, mantenha outra maneira de "
-"acesso, como um link de convite."
+#: common/views_manage.py:613
+msgid "Number of item covers a new user must sort into two category rows before choosing a username. 0 disables the captcha; 5-6 is recommended. The covers carry no title text, so this cannot be solved with a screen reader: if you enable it, keep another way in, such as an invite link."
+msgstr "Número de capas de item que um novo usuário deve classificar em duas linhas de categoria antes de escolher um nome de usuário. 0 desativa o captcha; 5-6 é recomendado. As capas não possuem texto de título, então isso não pode ser resolvido com um leitor de tela: se você ativá-lo, mantenha outra maneira de acesso, como um link de convite."
 
-#: common/views_manage.py:520
+#: common/views_manage.py:621
 msgid "Registration Captcha Minimum Marks"
 msgstr "Mínimo de Marcas de Captcha de Registro"
 
-#: common/views_manage.py:523
-msgid ""
-"Marks an item needs before the captcha treats it as well known enough to be "
-"recognizable. Categories with too few such items fall back to any item."
-msgstr ""
-"Marca um item como necessário antes que o captcha o trate como "
-"suficientemente conhecido para ser reconhecível. Categorias com muito poucos "
-"desses itens recorrem a qualquer item."
+#: common/views_manage.py:624
+msgid "Marks an item needs before the captcha treats it as well known enough to be recognizable. Categories with too few such items fall back to any item."
+msgstr "Marca um item como necessário antes que o captcha o trate como suficientemente conhecido para ser reconhecível. Categorias com muito poucos desses itens recorrem a qualquer item."
 
-#: common/views_manage.py:529
+#: common/views_manage.py:630
 msgid "Enable Mastodon Login"
 msgstr "Ativar Login via Mastodon"
 
-#: common/views_manage.py:532
+#: common/views_manage.py:633
 msgid "Enable Bluesky Login"
 msgstr "Ativar Login via Bluesky"
 
-#: common/views_manage.py:535
+#: common/views_manage.py:636
 msgid "Enable Threads Login"
 msgstr "Ativar Login via Threads"
 
-#: common/views_manage.py:538
+#: common/views_manage.py:639
 msgid "Email URL"
 msgstr "URL de E-mail"
 
-#: common/views_manage.py:540
+#: common/views_manage.py:641
 msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
-msgstr ""
-"URL do backend de e-mail para códigos de login, como uma URL SMTP ou Anymail."
+msgstr "URL do backend de e-mail para códigos de login, como uma URL SMTP ou Anymail."
 
-#: common/views_manage.py:544
+#: common/views_manage.py:645
 msgid "Email From"
 msgstr "E-mail do Remetente"
 
-#: common/views_manage.py:545
+#: common/views_manage.py:646
 msgid "Sender name and address for outgoing email."
 msgstr "Nome e endereço do remetente para e-mails enviados."
 
-#: common/views_manage.py:548
+#: common/views_manage.py:649
 msgid "Default Language"
 msgstr "Idioma Padrão"
 
-#: common/views_manage.py:551
-msgid ""
-"Interface language for visitors and for users who have not chosen one "
-"themselves."
-msgstr ""
-"Idioma da interface para visitantes e para usuários que ainda não escolheram "
-"um idioma próprio."
+#: common/views_manage.py:652
+msgid "Interface language for visitors and for users who have not chosen one themselves."
+msgstr "Idioma da interface para visitantes e para usuários que ainda não escolheram um idioma próprio."
 
-#: common/views_manage.py:558
-msgid ""
-"Language codes, one per line (e.g. en, zh, ja). First language is the "
-"default."
-msgstr ""
-"Códigos de idioma, um por linha (por exemplo, en, zh, ja). O primeiro idioma "
-"é o padrão."
+#: common/views_manage.py:659
+msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
+msgstr "Códigos de idioma, um por linha (por exemplo, en, zh, ja). O primeiro idioma é o padrão."
 
-#: common/views_manage.py:564
+#: common/views_manage.py:665
 msgid "Access Control"
 msgstr "Controle de Acesso"
 
-#: common/views_manage.py:571
+#: common/views_manage.py:672
 msgid "Login Methods"
 msgstr "Métodos de Login"
 
-#: common/views_manage.py:576 mastodon/models/common.py:28
+#: common/views_manage.py:677 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr "Email"
 
-#: common/views_manage.py:580
+#: common/views_manage.py:681
 msgid "Localization"
 msgstr "Localização"
 
-#: common/views_manage.py:591
+#: common/views_manage.py:692
 msgid "Disable Default Relay"
 msgstr "Desativar Relay Padrão"
 
-#: common/views_manage.py:593
-msgid ""
-"Disable relay.neodb.net federation for sharing public ratings across "
-"instances."
-msgstr ""
-"Desativar a federação relay.neodb.net usada para compartilhar avaliações "
-"públicas entre instâncias."
+#: common/views_manage.py:694
+msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
+msgstr "Desativar a federação relay.neodb.net usada para compartilhar avaliações públicas entre instâncias."
 
-#: common/views_manage.py:598
+#: common/views_manage.py:699
 msgid "Fanout Limit (days)"
 msgstr "Limite de Distribuição (dias)"
 
-#: common/views_manage.py:599
+#: common/views_manage.py:700
 msgid "Posts older than this many days will not be fanned out."
-msgstr ""
-"Publicações mais antigas que este número de dias não serão distribuídas."
+msgstr "Publicações mais antigas que este número de dias não serão distribuídas."
 
-#: common/views_manage.py:603
+#: common/views_manage.py:704
 msgid "Remote Prune Horizon (days)"
 msgstr "Horizonte de Remoção Remota (dias)"
 
-#: common/views_manage.py:605
+#: common/views_manage.py:706
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr "Perfis remotos inativos por esse número de dias serão removidos."
 
-#: common/views_manage.py:610
+#: common/views_manage.py:711
 msgid "Search Sites"
 msgstr "Sites de Busca"
 
-#: common/views_manage.py:611
+#: common/views_manage.py:712
 msgid "External search sites to include, one per line."
 msgstr "Sites de busca externos a incluir, um por linha."
 
-#: common/views_manage.py:614
+#: common/views_manage.py:715
 msgid "Federated Search Peers"
 msgstr "Pares de Busca Federada"
 
-#: common/views_manage.py:615
+#: common/views_manage.py:716
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr "Instâncias parceiras do NeoDB para busca federada, uma por linha."
 
-#: common/views_manage.py:618
+#: common/views_manage.py:719
 msgid "Hidden Categories"
 msgstr "Categorias Ocultas"
 
-#: common/views_manage.py:619
+#: common/views_manage.py:720
 msgid "Category values to hide from the catalog, one per line."
 msgstr "Valores de categoria a ocultar do catálogo, um por linha."
 
-#: common/views_manage.py:640
+#: common/views_manage.py:723
+msgid "Guest Search Page Limit"
+msgstr ""
+
+#: common/views_manage.py:725
+msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
+msgstr ""
+
+#: common/views_manage.py:751
 msgid "Spotify API Key"
 msgstr "Chave de API do Spotify"
 
-#: common/views_manage.py:641
+#: common/views_manage.py:752
 msgid "https://developer.spotify.com/"
 msgstr "https://developer.spotify.com/"
 
-#: common/views_manage.py:644
+#: common/views_manage.py:755
 msgid "TMDB API Key"
 msgstr "Chave de API do TMDB"
 
-#: common/views_manage.py:645
+#: common/views_manage.py:756
 msgid "https://developer.themoviedb.org/"
 msgstr "https://developer.themoviedb.org/"
 
-#: common/views_manage.py:648
+#: common/views_manage.py:759
 msgid "Google Books API Key"
 msgstr "Chave de API do Google Books"
 
-#: common/views_manage.py:649
+#: common/views_manage.py:760
 msgid "https://developers.google.com/books/"
 msgstr "https://developers.google.com/books/"
 
-#: common/views_manage.py:652
+#: common/views_manage.py:763
 msgid "Discogs API Key"
 msgstr "Chave de API do Discogs"
 
-#: common/views_manage.py:654
+#: common/views_manage.py:765
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr "Token de acesso pessoal em https://www.discogs.com/settings/developers"
 
-#: common/views_manage.py:658
+#: common/views_manage.py:769
 msgid "IGDB Client ID"
 msgstr "ID do Cliente IGDB"
 
-#: common/views_manage.py:659
+#: common/views_manage.py:770
 msgid "https://api-docs.igdb.com/"
 msgstr "https://api-docs.igdb.com/"
 
-#: common/views_manage.py:662
+#: common/views_manage.py:773
 msgid "IGDB Client Secret"
 msgstr "Segredo do Cliente IGDB"
 
-#: common/views_manage.py:665
+#: common/views_manage.py:776
 msgid "BoardGameGeek API Token"
 msgstr "Token de API do BoardGameGeek"
 
-#: common/views_manage.py:667
-msgid ""
-"Bearer token from https://boardgamegeek.com/applications (see https://"
-"boardgamegeek.com/using_the_xml_api#toc9)."
-msgstr ""
-"Token de portador (bearer token) obtido em https://boardgamegeek.com/"
-"applications (consulte https://boardgamegeek.com/using_the_xml_api#toc9)."
+#: common/views_manage.py:778
+msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
+msgstr "Token de portador (bearer token) obtido em https://boardgamegeek.com/applications (consulte https://boardgamegeek.com/using_the_xml_api#toc9)."
 
-#: common/views_manage.py:672 users/templates/users/steam_import.html:26
+#: common/views_manage.py:783
+#, fuzzy
+#| msgid "MyAnimeList Anime"
+msgid "MyAnimeList Client ID"
+msgstr "MyAnimeList Anime"
+
+#: common/views_manage.py:785
+msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
+msgstr ""
+
+#: common/views_manage.py:790 users/templates/users/steam_import.html:26
 msgid "Steam API Key"
 msgstr "Chave de API da Steam"
 
-#: common/views_manage.py:674
-msgid ""
-"https://steamcommunity.com/dev - fallback key for Steam importer. Users can "
-"provide their own key when importing."
-msgstr ""
-"https://steamcommunity.com/dev - chave alternativa (fallback) para o "
-"importador da Steam. Os usuários podem fornecer sua própria chave ao "
-"importar."
+#: common/views_manage.py:792
+msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
+msgstr "https://steamcommunity.com/dev - chave alternativa (fallback) para o importador da Steam. Os usuários podem fornecer sua própria chave ao importar."
 
-#: common/views_manage.py:679
+#: common/views_manage.py:797
 msgid "DeepL API Key"
 msgstr "Chave de API do DeepL"
 
-#: common/views_manage.py:680
+#: common/views_manage.py:798
 msgid "For translation features."
 msgstr "Para os recursos de tradução."
 
-#: common/views_manage.py:683
+#: common/views_manage.py:801
 msgid "LibreTranslate API URL"
 msgstr "URL da API do LibreTranslate"
 
-#: common/views_manage.py:686
+#: common/views_manage.py:804
 msgid "LibreTranslate API Key"
 msgstr "Chave de API do LibreTranslate"
 
-#: common/views_manage.py:689
+#: common/views_manage.py:807
 msgid "Threads App ID"
 msgstr "ID do Aplicativo Threads"
 
-#: common/views_manage.py:690
+#: common/views_manage.py:808
 msgid "OAuth app ID for Threads login."
 msgstr "ID do aplicativo OAuth para login via Threads."
 
-#: common/views_manage.py:693
+#: common/views_manage.py:811
 msgid "Threads App Secret"
 msgstr "Segredo do Aplicativo Threads"
 
-#: common/views_manage.py:696
+#: common/views_manage.py:814
 msgid "Discord Webhooks"
 msgstr "Webhooks do Discord"
 
-#: common/views_manage.py:698
-msgid ""
-"Webhook URLs keyed by channel (default, report, audit, suggest, system). All "
-"channels must be Discord forum or media channels (thread mode) because "
-"notifications are posted as threads."
-msgstr ""
-"URLs de webhook definidas por canal (default, report, audit, suggest, "
-"system). Todos os canais devem ser fóruns do Discord ou canais de mídia "
-"(modo de tópicos), pois as notificações são publicadas como tópicos."
+#: common/views_manage.py:816
+msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
+msgstr "URLs de webhook definidas por canal (default, report, audit, suggest, system). Todos os canais devem ser fóruns do Discord ou canais de mídia (modo de tópicos), pois as notificações são publicadas como tópicos."
 
-#: common/views_manage.py:715
+#: common/views_manage.py:833
 msgid "Catalog APIs"
 msgstr "APIs de Catálogo"
 
-#: common/views_manage.py:725
+#: common/views_manage.py:844
 msgid "Translation"
 msgstr "Tradução"
 
-#: common/views_manage.py:730
+#: common/views_manage.py:849
 msgid "Third-Party Login"
 msgstr "Login com Terceiros"
 
-#: common/views_manage.py:734 social/templates/feed.html:27
+#: common/views_manage.py:853 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr "Notificações"
 
-#: common/views_manage.py:744
+#: common/views_manage.py:863
 msgid "Scraping Providers"
 msgstr "Provedores de Coleta de Dados"
 
-#: common/views_manage.py:745
+#: common/views_manage.py:864
 msgid "Comma-separated list of providers to try in order."
-msgstr ""
-"Lista de provedores separados por vírgula, a serem tentados na ordem "
-"indicada."
+msgstr "Lista de provedores separados por vírgula, a serem tentados na ordem indicada."
 
-#: common/views_manage.py:748
+#: common/views_manage.py:867
 msgid "Proxy List"
 msgstr "Lista de Proxies"
 
-#: common/views_manage.py:749
+#: common/views_manage.py:868
 msgid "One per line, format: http://server?url=__URL__"
 msgstr "Um por linha, no formato: http://server?url=__URL__"
 
-#: common/views_manage.py:752
+#: common/views_manage.py:871
 msgid "Backup Proxy"
 msgstr "Proxy de Backup"
 
-#: common/views_manage.py:755
+#: common/views_manage.py:874
 msgid "Scrapfly API Key"
 msgstr "Chave de API do Scrapfly"
 
-#: common/views_manage.py:758
+#: common/views_manage.py:877
 msgid "Decodo Base64 Auth Token"
 msgstr "Token de Autenticação Base64 do Decodo"
 
-#: common/views_manage.py:761
+#: common/views_manage.py:880
 msgid "ScraperAPI Key"
 msgstr "Chave de API do ScraperAPI"
 
-#: common/views_manage.py:764
+#: common/views_manage.py:883
 msgid "ScrapingBee API Key"
 msgstr "Chave de API do ScrapingBee"
 
-#: common/views_manage.py:767
+#: common/views_manage.py:886
 msgid "Custom Scraper URL"
 msgstr "URL de Coletor Personalizado"
 
-#: common/views_manage.py:768
+#: common/views_manage.py:887
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr "URL com os marcadores __URL__ e __SELECTOR__."
 
-#: common/views_manage.py:771
+#: common/views_manage.py:890
 msgid "Request Timeout (seconds)"
 msgstr "Tempo Limite de Requisição (segundos)"
 
-#: common/views_manage.py:775
+#: common/views_manage.py:894
 msgid "Cache Timeout (seconds)"
 msgstr "Tempo Limite de Cache (segundos)"
 
-#: common/views_manage.py:779
+#: common/views_manage.py:898
 msgid "Retries"
 msgstr "Tentativas"
 
-#: common/views_manage.py:784
+#: common/views_manage.py:903
 msgid "Providers"
 msgstr "Provedores"
 
-#: common/views_manage.py:789
+#: common/views_manage.py:908
 msgid "Provider Keys"
 msgstr "Chaves de Provedor"
 
-#: common/views_manage.py:796
+#: common/views_manage.py:915
 msgid "Timeouts"
 msgstr "Tempos Limite"
 
-#: common/views_manage.py:808
+#: common/views_manage.py:927
 msgid "Alternative Domains"
 msgstr "Domínios Alternativos"
 
-#: common/views_manage.py:809
+#: common/views_manage.py:928
 msgid "One domain per line."
 msgstr "Um domínio por linha."
 
-#: common/views_manage.py:812
+#: common/views_manage.py:931
 msgid "Mastodon Client Scope"
 msgstr "Escopo do Cliente Mastodon"
 
-#: common/views_manage.py:813
+#: common/views_manage.py:932
 msgid "OAuth scope when creating Mastodon apps."
 msgstr "Escopo OAuth ao criar aplicativos Mastodon."
 
-#: common/views_manage.py:816
+#: common/views_manage.py:935
 msgid "Mastodon API Timeout (seconds)"
 msgstr "Tempo Limite da API do Mastodon (segundos)"
 
-#: common/views_manage.py:818
-msgid ""
-"Timeout for requests to Mastodon instances and remote fediverse servers."
-msgstr ""
-"Tempo limite para requisições a instâncias do Mastodon e servidores remotos "
-"do fediverse."
+#: common/views_manage.py:937
+msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
+msgstr "Tempo limite para requisições a instâncias do Mastodon e servidores remotos do fediverse."
 
-#: common/views_manage.py:824
+#: common/views_manage.py:943
 msgid "Disable Cron Jobs"
 msgstr "Desativar Tarefas Agendadas (Cron Jobs)"
 
-#: common/views_manage.py:825
+#: common/views_manage.py:944
 msgid "Job names to disable, one per line. Use * to disable all."
-msgstr ""
-"Nomes das tarefas a desativar, um por linha. Use * para desativar todas."
+msgstr "Nomes das tarefas a desativar, um por linha. Use * para desativar todas."
 
-#: common/views_manage.py:828
+#: common/views_manage.py:947
 msgid "Index Aliases"
 msgstr "Aliases de Índice"
 
-#: common/views_manage.py:829
+#: common/views_manage.py:948
 msgid "Map index names to their aliases."
 msgstr "Mapear nomes de índices para seus aliases."
 
-#: common/views_manage.py:839
+#: common/views_manage.py:958
 msgid "Task Cleanup (days)"
 msgstr "Limpeza de Tarefas (dias)"
 
-#: common/views_manage.py:841
-msgid ""
-"Delete import/export tasks and their files after this many days. Set to 0 to "
-"disable cleanup."
-msgstr ""
-"Excluir tarefas de importação/exportação e seus arquivos após este número de "
-"dias. Defina como 0 para desativar a limpeza."
+#: common/views_manage.py:960
+msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
+msgstr "Excluir tarefas de importação/exportação e seus arquivos após este número de dias. Defina como 0 para desativar a limpeza."
 
-#: common/views_manage.py:847
+#: common/views_manage.py:966
 msgid "Skip Migration Jobs"
 msgstr "Ignorar Tarefas de Migração"
 
-#: common/views_manage.py:849
-msgid ""
-"Post-migration job keys to skip, one per line (e.g. normalize_genre). "
-"Checked by the worker at dequeue time; skipped jobs log a warning and notify "
-"the Discord system channel."
-msgstr ""
-"Chaves de tarefas pós-migração a ignorar, uma por linha (por exemplo, "
-"normalize_genre). Verificado pelo worker no momento da retirada da fila; "
-"tarefas ignoradas registram um aviso e notificam o canal system do Discord."
+#: common/views_manage.py:968
+msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
+msgstr "Chaves de tarefas pós-migração a ignorar, uma por linha (por exemplo, normalize_genre). Verificado pelo worker no momento da retirada da fila; tarefas ignoradas registram um aviso e notificam o canal system do Discord."
 
-#: common/views_manage.py:855
+#: common/views_manage.py:974
 msgid "ATProto OAuth Client Key"
 msgstr "Chave do Cliente OAuth ATProto"
 
-#: common/views_manage.py:857
-msgid ""
-"Private key (JWK) identifying this site to ATProto authorization servers. "
-"Auto-generated on first Bluesky login; clear to regenerate."
-msgstr ""
-"Chave privada (JWK) que identifica este site aos servidores de autorização "
-"ATProto. Gerada automaticamente no primeiro login via Bluesky; apague para "
-"gerar novamente."
+#: common/views_manage.py:976
+msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
+msgstr "Chave privada (JWK) que identifica este site aos servidores de autorização ATProto. Gerada automaticamente no primeiro login via Bluesky; apague para gerar novamente."
 
-#: common/views_manage.py:864
+#: common/views_manage.py:983
 msgid "Domains"
 msgstr "Domínios"
 
-#: common/views_manage.py:867
+#: common/views_manage.py:986
 msgid "Operational"
 msgstr "Operacional"
 
-#: common/views_manage.py:883
+#: common/views_manage.py:1002
 msgid "Movie Genres"
 msgstr "Gêneros de Filmes"
 
-#: common/views_manage.py:885
-msgid ""
-"Genre codes offered in the Movie edit dropdown, one per line. Leave empty to "
-"use the built-in default."
-msgstr ""
-"Códigos de gênero oferecidos no menu suspenso de edição de Filme, um por "
-"linha. Deixe em branco para usar o padrão integrado."
+#: common/views_manage.py:1004
+msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
+msgstr "Códigos de gênero oferecidos no menu suspenso de edição de Filme, um por linha. Deixe em branco para usar o padrão integrado."
 
-#: common/views_manage.py:890
+#: common/views_manage.py:1009
 msgid "TV Genres"
 msgstr "Gêneros de TV"
 
-#: common/views_manage.py:892
-msgid ""
-"Genre codes offered in the TV edit dropdown, one per line. Leave empty to "
-"use the built-in default."
-msgstr ""
-"Códigos de gênero oferecidos no menu suspenso de edição de TV, um por linha. "
-"Deixe em branco para usar o padrão integrado."
+#: common/views_manage.py:1011
+msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
+msgstr "Códigos de gênero oferecidos no menu suspenso de edição de TV, um por linha. Deixe em branco para usar o padrão integrado."
 
-#: common/views_manage.py:897
+#: common/views_manage.py:1016
 msgid "Music Genres"
 msgstr "Gêneros Musicais"
 
-#: common/views_manage.py:899
-msgid ""
-"Genre codes offered in the Music edit dropdown, one per line. Leave empty to "
-"use the built-in default."
-msgstr ""
-"Códigos de gênero oferecidos no menu suspenso de edição de Música, um por "
-"linha. Deixe em branco para usar o padrão integrado."
+#: common/views_manage.py:1018
+msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
+msgstr "Códigos de gênero oferecidos no menu suspenso de edição de Música, um por linha. Deixe em branco para usar o padrão integrado."
 
-#: common/views_manage.py:904
+#: common/views_manage.py:1023
 msgid "Game Genres"
 msgstr "Gêneros de Jogos"
 
-#: common/views_manage.py:906
-msgid ""
-"Genre codes offered in the Game edit dropdown, one per line. Leave empty to "
-"use the built-in default."
-msgstr ""
-"Códigos de gênero oferecidos no menu suspenso de edição de Jogo, um por "
-"linha. Deixe em branco para usar o padrão integrado."
+#: common/views_manage.py:1025
+msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
+msgstr "Códigos de gênero oferecidos no menu suspenso de edição de Jogo, um por linha. Deixe em branco para usar o padrão integrado."
 
-#: common/views_manage.py:911
+#: common/views_manage.py:1030
 msgid "Podcast Genres"
 msgstr "Gêneros de Podcast"
 
-#: common/views_manage.py:913
-msgid ""
-"Genre codes offered in the Podcast edit dropdown, one per line. Leave empty "
-"to use the built-in default."
-msgstr ""
-"Códigos de gênero oferecidos no menu suspenso de edição de Podcast, um por "
-"linha. Deixe em branco para usar o padrão integrado."
+#: common/views_manage.py:1032
+msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
+msgstr "Códigos de gênero oferecidos no menu suspenso de edição de Podcast, um por linha. Deixe em branco para usar o padrão integrado."
 
-#: common/views_manage.py:918
+#: common/views_manage.py:1037
 msgid "Performance Genres"
 msgstr "Gêneros de Espetáculo"
 
-#: common/views_manage.py:920
-msgid ""
-"Genre codes offered in the Performance edit dropdown, one per line. Leave "
-"empty to use the built-in default."
-msgstr ""
-"Códigos de gênero oferecidos no menu suspenso de edição de Espetáculo, um "
-"por linha. Deixe em branco para usar o padrão integrado."
+#: common/views_manage.py:1039
+msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
+msgstr "Códigos de gênero oferecidos no menu suspenso de edição de Espetáculo, um por linha. Deixe em branco para usar o padrão integrado."
 
-#: common/views_manage.py:926
+#: common/views_manage.py:1045
 msgid "Genres by Category"
 msgstr "Gêneros por Categoria"
 
-#: journal/forms.py:12
-msgid ""
-"Tips: use >!text!< for spoilers; some instances may not be able to show "
-"posts longer than 360 charactors."
+#: common/views_manage.py:1069
+#, fuzzy
+#| msgid "Site Name"
+msgid "Site"
+msgstr "Nome do Site"
+
+#: common/views_manage.py:1079
+#, fuzzy
+#| msgid "Database Admin"
+msgid "Database and Services"
+msgstr "Administração do Banco de Dados"
+
+#: common/views_manage.py:1089
+msgid "Media and Files"
 msgstr ""
-"Dicas: use &gt;!text!&lt; para spoilers; algumas instâncias podem não "
-"conseguir exibir publicações com mais de 360 caracteres."
+
+#: common/views_manage.py:1098
+msgid "Monitoring"
+msgstr ""
+
+#: common/views_manage.py:1102
+msgid "Security"
+msgstr ""
+
+#: common/views_manage.py:1111
+msgid "Other Environment Variables"
+msgstr ""
+
+#: common/views_manage.py:1113
+msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
+msgstr ""
+
+#: journal/forms.py:12
+msgid "Tips: use >!text!< for spoilers; some instances may not be able to show posts longer than 360 charactors."
+msgstr "Dicas: use &gt;!text!&lt; para spoilers; algumas instâncias podem não conseguir exibir publicações com mais de 360 caracteres."
 
 #: journal/forms.py:29 journal/forms.py:31 journal/forms.py:80
 #: journal/forms.py:83 journal/forms.py:153
@@ -5133,12 +5016,12 @@ msgid "Content (Markdown)"
 msgstr "Conteúdo (Markdown)"
 
 #: journal/forms.py:46 journal/forms.py:124 journal/forms.py:226
-#: journal/forms.py:288 journal/views/note.py:38
+#: journal/forms.py:288 journal/views/note.py:37
 msgid "Crosspost"
 msgstr "Republicação Cruzada"
 
 #: journal/forms.py:47 journal/forms.py:125 journal/forms.py:227
-#: journal/forms.py:289 journal/views/note.py:39
+#: journal/forms.py:289 journal/views/note.py:38
 msgid "Crosspost to your connected social networks"
 msgstr "Republicar automaticamente em suas redes sociais conectadas"
 
@@ -5153,10 +5036,10 @@ msgstr "Ao salvar, substituir espaços iniciais por espaços de largura total"
 #: journal/forms.py:59 journal/forms.py:137 journal/forms.py:162
 #: journal/forms.py:219 journal/forms.py:281
 #: journal/templates/collection_share.html:24
-#: journal/templates/wrapped_share.html:36 journal/views/note.py:31
-#: users/templates/users/data.html:45 users/templates/users/data.html:98
-#: users/templates/users/data.html:155 users/templates/users/data.html:206
-#: users/templates/users/data.html:269 users/templates/users/data.html:328
+#: journal/templates/wrapped_share.html:36 journal/views/note.py:30
+#: users/templates/users/data.html:60 users/templates/users/data.html:113
+#: users/templates/users/data.html:170 users/templates/users/data.html:221
+#: users/templates/users/data.html:284 users/templates/users/data.html:346
 #: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
@@ -5193,7 +5076,6 @@ msgid "Collaborative editing"
 msgstr "Edição colaborativa"
 
 #: journal/forms.py:204 users/templates/users/crossposts.html:51
-#: users/templates/users/data.html:483
 msgid "Status"
 msgstr "Estado"
 
@@ -5205,56 +5087,46 @@ msgstr "Comentário"
 msgid "Rating"
 msgstr "Avaliação"
 
-#: journal/importers/goodreads.py:196 journal/importers/letterboxd.py:144
-#: journal/importers/rym.py:442 journal/importers/storygraph.py:500
+#: journal/importers/goodreads.py:198 journal/importers/letterboxd.py:147
+#: journal/importers/rym.py:444 journal/importers/storygraph.py:504
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr "uma análise de {item_title}"
 
-#: journal/importers/opml.py:45
+#: journal/importers/opml.py:49
 #, python-brace-format
 msgid "{username}'s podcast subscriptions"
 msgstr "assinaturas de podcast de {username}"
 
-#: journal/importers/rym.py:168 journal/importers/storygraph.py:128
+#: journal/importers/rym.py:170 journal/importers/storygraph.py:132
 #, python-brace-format
-msgid ""
-"Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
-msgstr ""
-"Correspondência: {done}/{total} — {local} local, {ext} externo, {none} sem "
-"correspondência"
+msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
+msgstr "Correspondência: {done}/{total} — {local} local, {ext} externo, {none} sem correspondência"
 
-#: journal/importers/rym.py:178 journal/importers/storygraph.py:138
+#: journal/importers/rym.py:180 journal/importers/storygraph.py:142
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
-msgstr ""
-"Importando: {imported} importado(s), {skipped} ignorado(s), {failed} com "
-"falha"
+msgstr "Importando: {imported} importado(s), {skipped} ignorado(s), {failed} com falha"
 
-#: journal/importers/rym.py:233 journal/importers/storygraph.py:184
+#: journal/importers/rym.py:235 journal/importers/storygraph.py:188
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
-msgstr ""
-"Correspondência concluída: {local} local, {ext} externo, {none} sem "
-"correspondência"
+msgstr "Correspondência concluída: {local} local, {ext} externo, {none} sem correspondência"
 
-#: journal/importers/rym.py:348 journal/importers/storygraph.py:389
+#: journal/importers/rym.py:350 journal/importers/storygraph.py:393
 msgid "Matched file missing; cannot import."
 msgstr "Arquivo correspondido ausente; não é possível importar."
 
-#: journal/importers/rym.py:376 journal/importers/storygraph.py:412
+#: journal/importers/rym.py:378 journal/importers/storygraph.py:416
 #, python-brace-format
-msgid ""
-"Import complete: {imported} imported, {skipped} skipped, {failed} failed"
-msgstr ""
-"Importação concluída: {imported} importado(s), {skipped} ignorado(s), "
-"{failed} com falha"
+msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
+msgstr "Importação concluída: {imported} importado(s), {skipped} ignorado(s), {failed} com falha"
 
-#: journal/models/article.py:212 journal/views/article.py:218
+#: journal/models/article.py:215 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr "(pode conter conteúdo sensível)"
 
-#: journal/models/collection.py:44 journal/templates/add_to_collection.html:39
+#: journal/models/collection.py:48 journal/templates/add_to_collection.html:39
 #: journal/templates/collection_edit.html:64
 #: journal/templates/collection_share.html:63
 #: journal/templates/collection_update_item_note.html:3
@@ -5262,73 +5134,73 @@ msgstr "(pode conter conteúdo sensível)"
 msgid "note"
 msgstr "nota"
 
-#: journal/models/collection.py:111
+#: journal/models/collection.py:115
 msgid "search query for dynamic collection"
 msgstr "consulta de pesquisa para coleção dinâmica"
 
-#: journal/models/collection.py:524 journal/templatetags/collection.py:35
+#: journal/models/collection.py:566 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] "%(count)d livro"
 msgstr[1] "%(count)d livros"
 
-#: journal/models/collection.py:529 journal/templatetags/collection.py:43
+#: journal/models/collection.py:571 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] "%(count)d filme"
 msgstr[1] "%(count)d filmes"
 
-#: journal/models/collection.py:534 journal/templatetags/collection.py:51
+#: journal/models/collection.py:576 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] "%(count)d série"
 msgstr[1] "%(count)d séries"
 
-#: journal/models/collection.py:539 journal/templatetags/collection.py:59
+#: journal/models/collection.py:581 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] "%(count)d álbum"
 msgstr[1] "%(count)d álbuns"
 
-#: journal/models/collection.py:544 journal/templatetags/collection.py:67
+#: journal/models/collection.py:586 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] "%(count)d jogo"
 msgstr[1] "%(count)d jogos"
 
-#: journal/models/collection.py:549 journal/templatetags/collection.py:75
+#: journal/models/collection.py:591 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] "%(count)d podcast"
 msgstr[1] "%(count)d podcasts"
 
-#: journal/models/collection.py:555 journal/templatetags/collection.py:83
+#: journal/models/collection.py:597 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] "%(count)d apresentação"
 msgstr[1] "%(count)d apresentações"
 
-#: journal/models/collection.py:563 journal/templatetags/collection.py:91
+#: journal/models/collection.py:605 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] "%(count)d item"
 msgstr[1] "%(count)d itens"
 
-#: journal/models/common.py:50 journal/templates/action_open_post.html:15
-#: journal/templates/collection_share.html:35 journal/templates/mark.html:84
+#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
-#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:54
-#: users/templates/users/data.html:107 users/templates/users/data.html:164
-#: users/templates/users/data.html:215 users/templates/users/data.html:277
-#: users/templates/users/data.html:337 users/templates/users/data.html:534
+#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
+#: users/templates/users/data.html:122 users/templates/users/data.html:179
+#: users/templates/users/data.html:230 users/templates/users/data.html:292
+#: users/templates/users/data.html:355 users/templates/users/data.html:534
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5336,13 +5208,13 @@ msgstr[1] "%(count)d itens"
 msgid "Public"
 msgstr "Público"
 
-#: journal/models/common.py:51 journal/templates/action_open_post.html:9
-#: journal/templates/collection_share.html:46 journal/templates/mark.html:91
+#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
-#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
-#: users/templates/users/data.html:115 users/templates/users/data.html:172
-#: users/templates/users/data.html:223 users/templates/users/data.html:285
-#: users/templates/users/data.html:345 users/templates/users/data.html:542
+#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
+#: users/templates/users/data.html:130 users/templates/users/data.html:187
+#: users/templates/users/data.html:238 users/templates/users/data.html:300
+#: users/templates/users/data.html:363 users/templates/users/data.html:542
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5350,12 +5222,12 @@ msgstr "Público"
 msgid "Followers Only"
 msgstr "Apenas Seguidores"
 
-#: journal/models/common.py:52 journal/templates/collection_share.html:57
-#: journal/templates/mark.html:98 journal/templates/post_compose.html:72
-#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
-#: users/templates/users/data.html:123 users/templates/users/data.html:180
-#: users/templates/users/data.html:231 users/templates/users/data.html:293
-#: users/templates/users/data.html:353 users/templates/users/data.html:550
+#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/templates/mark.html:102 journal/templates/post_compose.html:72
+#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
+#: users/templates/users/data.html:138 users/templates/users/data.html:195
+#: users/templates/users/data.html:246 users/templates/users/data.html:308
+#: users/templates/users/data.html:371 users/templates/users/data.html:550
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5363,32 +5235,27 @@ msgstr "Apenas Seguidores"
 msgid "Mentioned Only"
 msgstr "Apenas Mencionados"
 
-#: journal/models/common.py:790
-msgid ""
-"A recent post was not posted to Bluesky, please login NeoDB using ATProto "
-"again to re-authorize."
-msgstr ""
-"Uma publicação recente não foi enviada ao Bluesky. Por favor, faça login no "
-"NeoDB usando ATProto novamente para reautorizar."
+#: journal/models/common.py:806
+msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
+msgstr "Uma publicação recente não foi enviada ao Bluesky. Por favor, faça login no NeoDB usando ATProto novamente para reautorizar."
 
-#: journal/models/common.py:987
+#: journal/models/common.py:1003
 msgid "A recent post was not posted to Threads."
 msgstr "Uma publicação recente não foi enviada ao Threads."
 
-#: journal/models/common.py:1020
+#: journal/models/common.py:1036
 msgid "A recent post was not boosted on Mastodon."
 msgstr "Uma publicação recente não foi impulsionada no Mastodon."
 
-#: journal/models/common.py:1030
+#: journal/models/common.py:1046
 msgid "Original post no longer exists."
 msgstr "A publicação original não existe mais."
 
-#: journal/models/common.py:1044
+#: journal/models/common.py:1060
 msgid "A recent post was not posted to Mastodon, please re-authorize."
-msgstr ""
-"Uma publicação recente não foi enviada ao Mastodon. Por favor, reautorize."
+msgstr "Uma publicação recente não foi enviada ao Mastodon. Por favor, reautorize."
 
-#: journal/models/common.py:1053
+#: journal/models/common.py:1069
 msgid "A recent post was not posted to Mastodon."
 msgstr "Uma publicação recente não foi enviada ao Mastodon."
 
@@ -5396,7 +5263,7 @@ msgstr "Uma publicação recente não foi enviada ao Mastodon."
 msgid "Authorization expired"
 msgstr "Autorização expirada"
 
-#: journal/models/crosspost.py:17 users/models/task.py:24
+#: journal/models/crosspost.py:17 users/models/task.py:26
 msgid "Failed"
 msgstr "Falhou"
 
@@ -5404,81 +5271,81 @@ msgstr "Falhou"
 msgid "Retrying"
 msgstr "Repetindo"
 
-#: journal/models/mark.py:469
+#: journal/models/mark.py:475
 msgid "Please mark the item before setting progress."
 msgstr "Marque o item antes de definir o progresso."
 
-#: journal/models/mark.py:473
+#: journal/models/mark.py:479
 msgid "Progress must be 500 characters or fewer."
 msgstr "O progresso deve ter no máximo 500 caracteres."
 
-#: journal/models/mark.py:480
+#: journal/models/mark.py:486
 msgid "Invalid progress type."
 msgstr "Tipo de progresso inválido."
 
-#: journal/models/mark.py:482
+#: journal/models/mark.py:488
 msgid "Invalid progress type for this item."
 msgstr "Tipo de progresso inválido para este item."
 
-#: journal/models/note.py:34 users/templates/users/rym_import.html:73
+#: journal/models/note.py:47 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr "Página"
 
-#: journal/models/note.py:35
+#: journal/models/note.py:48
 msgid "Chapter"
 msgstr "Capítulo"
 
-#: journal/models/note.py:38
+#: journal/models/note.py:51
 msgid "Part"
 msgstr "Parte"
 
-#: journal/models/note.py:39
+#: journal/models/note.py:52
 msgid "Episode"
 msgstr "Episódio"
 
-#: journal/models/note.py:40
+#: journal/models/note.py:53
 msgid "Track"
 msgstr "Faixa"
 
-#: journal/models/note.py:41
+#: journal/models/note.py:54
 msgid "Cycle"
 msgstr "Ciclo"
 
-#: journal/models/note.py:42
+#: journal/models/note.py:55
 msgid "Timestamp"
 msgstr "Marcação de tempo"
 
-#: journal/models/note.py:43
+#: journal/models/note.py:56
 msgid "Percentage"
 msgstr "Porcentagem"
 
-#: journal/models/note.py:60
+#: journal/models/note.py:77
 #, python-brace-format
 msgid "Page {value}"
 msgstr "Página {value}"
 
-#: journal/models/note.py:61
+#: journal/models/note.py:78
 #, python-brace-format
 msgid "Chapter {value}"
 msgstr "Capítulo {value}"
 
-#: journal/models/note.py:64
+#: journal/models/note.py:81
 #, python-brace-format
 msgid "Part {value}"
 msgstr "Parte {value}"
 
-#: journal/models/note.py:65
+#: journal/models/note.py:82
 #, python-brace-format
 msgid "Episode {value}"
 msgstr "Episódio {value}"
 
-#: journal/models/note.py:66
+#: journal/models/note.py:83
 #, python-brace-format
 msgid "Track {value}"
 msgstr "Faixa {value}"
 
-#: journal/models/note.py:67
+#: journal/models/note.py:84
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr "Ciclo {value}"
@@ -5488,439 +5355,439 @@ msgstr "Ciclo {value}"
 msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr "sobre {item_title}, pode conter spoilers ou conteúdo sensível"
 
-#: journal/models/review.py:78
+#: journal/models/review.py:79
 #, python-brace-format
 msgid "a review of {title}"
 msgstr "uma análise de {title}"
 
-#: journal/models/review.py:80
+#: journal/models/review.py:81
 msgid "(may contain spoilers)"
 msgstr "(pode conter spoilers)"
 
-#: journal/models/shelf.py:37
+#: journal/models/shelf.py:39
 msgid "WISHLIST"
 msgstr "LISTA DE DESEJOS"
 
-#: journal/models/shelf.py:38
+#: journal/models/shelf.py:40
 msgid "PROGRESS"
 msgstr "ANDAMENTO"
 
-#: journal/models/shelf.py:39
+#: journal/models/shelf.py:41
 msgid "COMPLETE"
 msgstr "CONCLUÍDO"
 
-#: journal/models/shelf.py:40
+#: journal/models/shelf.py:42
 msgid "DROPPED"
 msgstr "ABANDONADO"
 
-#: journal/models/shelf.py:49
+#: journal/models/shelf.py:51
 msgid "books to read"
 msgstr "livros a ler"
 
-#: journal/models/shelf.py:50
+#: journal/models/shelf.py:52
 msgid "want to read"
 msgstr "quer ler"
 
-#: journal/models/shelf.py:51
+#: journal/models/shelf.py:53
 #, python-brace-format
 msgid "wants to read {item}"
 msgstr "quer ler {item}"
 
-#: journal/models/shelf.py:52
+#: journal/models/shelf.py:54
 msgid "to read"
 msgstr "a ler"
 
-#: journal/models/shelf.py:57
+#: journal/models/shelf.py:59
 msgid "books reading"
 msgstr "livros sendo lidos"
 
-#: journal/models/shelf.py:58
+#: journal/models/shelf.py:60
 msgid "start reading"
 msgstr "começar a ler"
 
-#: journal/models/shelf.py:59
+#: journal/models/shelf.py:61
 #, python-brace-format
 msgid "started reading {item}"
 msgstr "começou a ler {item}"
 
-#: journal/models/shelf.py:60
+#: journal/models/shelf.py:62
 msgid "reading"
 msgstr "lendo"
 
-#: journal/models/shelf.py:65
+#: journal/models/shelf.py:67
 msgid "books completed"
 msgstr "livros concluídos"
 
-#: journal/models/shelf.py:66
+#: journal/models/shelf.py:68
 msgid "finish reading"
 msgstr "terminar de ler"
 
-#: journal/models/shelf.py:67
+#: journal/models/shelf.py:69
 #, python-brace-format
 msgid "finished reading {item}"
 msgstr "terminou de ler {item}"
 
-#: journal/models/shelf.py:68
+#: journal/models/shelf.py:70
 msgid "read"
 msgstr "lido"
 
-#: journal/models/shelf.py:73
+#: journal/models/shelf.py:75
 msgid "books dropped"
 msgstr "livros abadonados"
 
-#: journal/models/shelf.py:74
+#: journal/models/shelf.py:76
 msgid "stop reading"
 msgstr "parar de ler"
 
-#: journal/models/shelf.py:75
+#: journal/models/shelf.py:77
 #, python-brace-format
 msgid "stopped reading {item}"
 msgstr "parou de ler {item}"
 
-#: journal/models/shelf.py:76
+#: journal/models/shelf.py:78
 msgid "stopped reading"
 msgstr "parou de ler"
 
-#: journal/models/shelf.py:81
+#: journal/models/shelf.py:83
 msgid "books reviewed"
 msgstr "livros analisados"
 
-#: journal/models/shelf.py:82 journal/models/shelf.py:122
-#: journal/models/shelf.py:162 journal/models/shelf.py:202
-#: journal/models/shelf.py:242 journal/models/shelf.py:282
-#: journal/models/shelf.py:316
+#: journal/models/shelf.py:84 journal/models/shelf.py:124
+#: journal/models/shelf.py:164 journal/models/shelf.py:204
+#: journal/models/shelf.py:244 journal/models/shelf.py:284
+#: journal/models/shelf.py:318
 msgid "review"
 msgstr "análise"
 
-#: journal/models/shelf.py:83 journal/models/shelf.py:123
-#: journal/models/shelf.py:163 journal/models/shelf.py:203
-#: journal/models/shelf.py:243 journal/models/shelf.py:283
-#: journal/models/shelf.py:317
+#: journal/models/shelf.py:85 journal/models/shelf.py:125
+#: journal/models/shelf.py:165 journal/models/shelf.py:205
+#: journal/models/shelf.py:245 journal/models/shelf.py:285
+#: journal/models/shelf.py:319
 #, python-brace-format
 msgid "wrote a review of {item}"
 msgstr "escreveu uma análise de {item}"
 
-#: journal/models/shelf.py:89
+#: journal/models/shelf.py:91
 msgid "movies to watch"
 msgstr "filmes a assistir"
 
-#: journal/models/shelf.py:90 journal/models/shelf.py:130
+#: journal/models/shelf.py:92 journal/models/shelf.py:132
 msgid "want to watch"
 msgstr "quer assistir"
 
-#: journal/models/shelf.py:91 journal/models/shelf.py:131
+#: journal/models/shelf.py:93 journal/models/shelf.py:133
 #, python-brace-format
 msgid "wants to watch {item}"
 msgstr "quer assistir {item}"
 
-#: journal/models/shelf.py:92 journal/models/shelf.py:132
+#: journal/models/shelf.py:94 journal/models/shelf.py:134
 msgid "to watch"
 msgstr "a assistir"
 
-#: journal/models/shelf.py:97
+#: journal/models/shelf.py:99
 msgid "movies watching"
 msgstr "filmes sendo assistidos"
 
-#: journal/models/shelf.py:98 journal/models/shelf.py:138
+#: journal/models/shelf.py:100 journal/models/shelf.py:140
 msgid "start watching"
 msgstr "começar a assistir"
 
-#: journal/models/shelf.py:99 journal/models/shelf.py:139
+#: journal/models/shelf.py:101 journal/models/shelf.py:141
 #, python-brace-format
 msgid "started watching {item}"
 msgstr "começou a assistir {item}"
 
-#: journal/models/shelf.py:100 journal/models/shelf.py:140
+#: journal/models/shelf.py:102 journal/models/shelf.py:142
 msgid "watching"
 msgstr "assistindo"
 
-#: journal/models/shelf.py:105
+#: journal/models/shelf.py:107
 msgid "movies watched"
 msgstr "filmes assistidos"
 
-#: journal/models/shelf.py:106 journal/models/shelf.py:146
+#: journal/models/shelf.py:108 journal/models/shelf.py:148
 msgid "finish watching"
 msgstr "terminar de assistir"
 
-#: journal/models/shelf.py:107 journal/models/shelf.py:147
+#: journal/models/shelf.py:109 journal/models/shelf.py:149
 #, python-brace-format
 msgid "finished watching {item}"
 msgstr "terminou de assistir {item}"
 
-#: journal/models/shelf.py:108 journal/models/shelf.py:148
+#: journal/models/shelf.py:110 journal/models/shelf.py:150
 msgid "watched"
 msgstr "assistido"
 
-#: journal/models/shelf.py:113
+#: journal/models/shelf.py:115
 msgid "movies dropped"
 msgstr "filmes abadonados"
 
-#: journal/models/shelf.py:114 journal/models/shelf.py:154
+#: journal/models/shelf.py:116 journal/models/shelf.py:156
 msgid "stop watching"
 msgstr "parar de assistir"
 
-#: journal/models/shelf.py:115 journal/models/shelf.py:155
+#: journal/models/shelf.py:117 journal/models/shelf.py:157
 #, python-brace-format
 msgid "stopped watching {item}"
 msgstr "parou de assistir {item}"
 
-#: journal/models/shelf.py:116 journal/models/shelf.py:156
+#: journal/models/shelf.py:118 journal/models/shelf.py:158
 msgid "stopped watching"
 msgstr "parou de assistir"
 
-#: journal/models/shelf.py:121
+#: journal/models/shelf.py:123
 msgid "movies reviewed"
 msgstr "filmes analisados"
 
-#: journal/models/shelf.py:129
+#: journal/models/shelf.py:131
 msgid "TV shows to watch"
 msgstr "séries a assistir"
 
-#: journal/models/shelf.py:137
+#: journal/models/shelf.py:139
 msgid "TV shows watching"
 msgstr "séries sendo assistidas"
 
-#: journal/models/shelf.py:145
+#: journal/models/shelf.py:147
 msgid "TV shows watched"
 msgstr "séries assistidas"
 
-#: journal/models/shelf.py:153
+#: journal/models/shelf.py:155
 msgid "TV shows dropped"
 msgstr "séries abandonadas"
 
-#: journal/models/shelf.py:161
+#: journal/models/shelf.py:163
 msgid "TV shows reviewed"
 msgstr "séries analisadas"
 
-#: journal/models/shelf.py:169
+#: journal/models/shelf.py:171
 msgid "albums to listen"
 msgstr "álbuns a ouvir"
 
-#: journal/models/shelf.py:170 journal/models/shelf.py:250
+#: journal/models/shelf.py:172 journal/models/shelf.py:252
 msgid "want to listen"
 msgstr "quer ouvir"
 
-#: journal/models/shelf.py:171 journal/models/shelf.py:251
+#: journal/models/shelf.py:173 journal/models/shelf.py:253
 #, python-brace-format
 msgid "wants to listen {item}"
 msgstr "quer ouvir {item}"
 
-#: journal/models/shelf.py:172 journal/models/shelf.py:252
+#: journal/models/shelf.py:174 journal/models/shelf.py:254
 msgid "to listen"
 msgstr "a ouvir"
 
-#: journal/models/shelf.py:177
+#: journal/models/shelf.py:179
 msgid "albums listening"
 msgstr "álbuns sendo ouvidos"
 
-#: journal/models/shelf.py:178 journal/models/shelf.py:258
+#: journal/models/shelf.py:180 journal/models/shelf.py:260
 msgid "start listening"
 msgstr "começar a ouvir"
 
-#: journal/models/shelf.py:179 journal/models/shelf.py:259
+#: journal/models/shelf.py:181 journal/models/shelf.py:261
 #, python-brace-format
 msgid "started listening {item}"
 msgstr "começou a ouvir {item}"
 
-#: journal/models/shelf.py:180 journal/models/shelf.py:260
+#: journal/models/shelf.py:182 journal/models/shelf.py:262
 msgid "listening"
 msgstr "ouvindo"
 
-#: journal/models/shelf.py:185
+#: journal/models/shelf.py:187
 msgid "albums listened"
 msgstr "álbuns ouvidos"
 
-#: journal/models/shelf.py:186 journal/models/shelf.py:266
+#: journal/models/shelf.py:188 journal/models/shelf.py:268
 msgid "finish listening"
 msgstr "terminar de ouvir"
 
-#: journal/models/shelf.py:187 journal/models/shelf.py:267
+#: journal/models/shelf.py:189 journal/models/shelf.py:269
 #, python-brace-format
 msgid "finished listening {item}"
 msgstr "terminou de ouvir {item}"
 
-#: journal/models/shelf.py:188 journal/models/shelf.py:268
+#: journal/models/shelf.py:190 journal/models/shelf.py:270
 msgid "listened"
 msgstr "ouvido"
 
-#: journal/models/shelf.py:193
+#: journal/models/shelf.py:195
 msgid "albums dropped"
 msgstr "álbuns abadonados"
 
-#: journal/models/shelf.py:194 journal/models/shelf.py:274
+#: journal/models/shelf.py:196 journal/models/shelf.py:276
 msgid "stop listening"
 msgstr "parar de ouvir"
 
-#: journal/models/shelf.py:195 journal/models/shelf.py:275
+#: journal/models/shelf.py:197 journal/models/shelf.py:277
 #, python-brace-format
 msgid "stopped listening {item}"
 msgstr "parou de ouvir {item}"
 
-#: journal/models/shelf.py:196 journal/models/shelf.py:276
+#: journal/models/shelf.py:198 journal/models/shelf.py:278
 msgid "stopped listening"
 msgstr "parou de ouvir"
 
-#: journal/models/shelf.py:201
+#: journal/models/shelf.py:203
 msgid "albums reviewed"
 msgstr "álbuns analisados"
 
-#: journal/models/shelf.py:209
+#: journal/models/shelf.py:211
 msgid "games to play"
 msgstr "jogos a jogar"
 
-#: journal/models/shelf.py:210
+#: journal/models/shelf.py:212
 msgid "want to play"
 msgstr "quer jogar"
 
-#: journal/models/shelf.py:211
+#: journal/models/shelf.py:213
 #, python-brace-format
 msgid "wants to play {item}"
 msgstr "quer jogar {item}"
 
-#: journal/models/shelf.py:212
+#: journal/models/shelf.py:214
 msgid "to play"
 msgstr "a jogar"
 
-#: journal/models/shelf.py:217
+#: journal/models/shelf.py:219
 msgid "games playing"
 msgstr "jogos sendo jogados"
 
-#: journal/models/shelf.py:218
+#: journal/models/shelf.py:220
 msgid "start playing"
 msgstr "começar a jogar"
 
-#: journal/models/shelf.py:219
+#: journal/models/shelf.py:221
 #, python-brace-format
 msgid "started playing {item}"
 msgstr "começou a jogar {item}"
 
-#: journal/models/shelf.py:220
+#: journal/models/shelf.py:222
 msgid "playing"
 msgstr "jogando"
 
-#: journal/models/shelf.py:225
+#: journal/models/shelf.py:227
 msgid "games played"
 msgstr "jogos jogados"
 
-#: journal/models/shelf.py:226
+#: journal/models/shelf.py:228
 msgid "finish playing"
 msgstr "terminar de jogar"
 
-#: journal/models/shelf.py:227
+#: journal/models/shelf.py:229
 #, python-brace-format
 msgid "finished playing {item}"
 msgstr "terminou de jogar {item}"
 
-#: journal/models/shelf.py:228
+#: journal/models/shelf.py:230
 msgid "played"
 msgstr "jogado"
 
-#: journal/models/shelf.py:233
+#: journal/models/shelf.py:235
 msgid "games dropped"
 msgstr "jogos abadonados"
 
-#: journal/models/shelf.py:234
+#: journal/models/shelf.py:236
 msgid "stop playing"
 msgstr "parar de jogar"
 
-#: journal/models/shelf.py:235
+#: journal/models/shelf.py:237
 #, python-brace-format
 msgid "stopped playing {item}"
 msgstr "parou de jogar {item}"
 
-#: journal/models/shelf.py:236
+#: journal/models/shelf.py:238
 msgid "stopped playing"
 msgstr "parou de jogar"
 
-#: journal/models/shelf.py:241
+#: journal/models/shelf.py:243
 msgid "games reviewed"
 msgstr "jogos analisados"
 
-#: journal/models/shelf.py:249
+#: journal/models/shelf.py:251
 msgid "podcasts to listen"
 msgstr "podcasts a ouvir"
 
-#: journal/models/shelf.py:257
+#: journal/models/shelf.py:259
 msgid "podcasts listening"
 msgstr "podcasts sendo ouvidos"
 
-#: journal/models/shelf.py:265
+#: journal/models/shelf.py:267
 msgid "podcasts listened"
 msgstr "podcasts ouvidos"
 
-#: journal/models/shelf.py:273
+#: journal/models/shelf.py:275
 msgid "podcasts dropped"
 msgstr "podcasts abadonados"
 
-#: journal/models/shelf.py:281
+#: journal/models/shelf.py:283
 msgid "podcasts reviewed"
 msgstr "podcasts analisados"
 
-#: journal/models/shelf.py:289
+#: journal/models/shelf.py:291
 msgid "performances to see"
 msgstr "apresentações a assistir"
 
-#: journal/models/shelf.py:290
+#: journal/models/shelf.py:292
 msgid "want to see"
 msgstr "quer assistir"
 
-#: journal/models/shelf.py:291
+#: journal/models/shelf.py:293
 #, python-brace-format
 msgid "wants to see {item}"
 msgstr "quer assistir {item}"
 
-#: journal/models/shelf.py:292
+#: journal/models/shelf.py:294
 msgid "to see"
 msgstr "a assistir"
 
-#: journal/models/shelf.py:299
+#: journal/models/shelf.py:301
 msgid "performances saw"
 msgstr "apresentações assistidas"
 
-#: journal/models/shelf.py:300
+#: journal/models/shelf.py:302
 msgid "finish seeing"
 msgstr "terminar de assistir"
 
-#: journal/models/shelf.py:301
+#: journal/models/shelf.py:303
 #, python-brace-format
 msgid "finished seeing {item}"
 msgstr "terminou de assistir {item}"
 
-#: journal/models/shelf.py:302
+#: journal/models/shelf.py:304
 msgid "seen"
 msgstr "assistido"
 
-#: journal/models/shelf.py:307
+#: journal/models/shelf.py:309
 msgid "performances dropped"
 msgstr "apresentações abandonadas"
 
-#: journal/models/shelf.py:308
+#: journal/models/shelf.py:310
 msgid "stop seeing"
 msgstr "parar de assistir"
 
-#: journal/models/shelf.py:309
+#: journal/models/shelf.py:311
 #, python-brace-format
 msgid "stopped seeing {item}"
 msgstr "parou de assistir {item}"
 
-#: journal/models/shelf.py:310
+#: journal/models/shelf.py:312
 msgid "stopped seeing"
 msgstr "parou de assistir"
 
-#: journal/models/shelf.py:315
+#: journal/models/shelf.py:317
 msgid "performances reviewed"
 msgstr "apresentações analisadas"
 
-#: journal/models/shelf.py:323
+#: journal/models/shelf.py:325
 msgid "people following"
 msgstr "pessoas seguidas"
 
-#: journal/models/shelf.py:325
+#: journal/models/shelf.py:327
 #, python-brace-format
 msgid "started following {item}"
 msgstr "começou a seguir {item}"
 
-#: journal/models/shelf.py:921
+#: journal/models/shelf.py:923
 msgid "removed mark"
 msgstr "marcação removida"
 
@@ -5948,33 +5815,21 @@ msgstr "Mover para o final"
 msgid "Remove from collection"
 msgstr "Remover da coleção"
 
-#: journal/templates/_list_item.html:34
-msgid "add mark"
-msgstr "adicionar marcação"
-
-#: journal/templates/_list_item.html:42
-msgid "update mark"
-msgstr "atualizar marcação"
-
-#: journal/templates/_list_item.html:60
+#: journal/templates/_list_item.html:43
 #: journal/templates/collection_update_item_note_ok.html:3
 msgid "Update note"
 msgstr "Atualizar nota"
 
-#: journal/templates/_list_item.html:100 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:123
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
 msgstr "Análise"
 
-#: journal/templates/_list_item.html:133
+#: journal/templates/_list_item.html:91
 #, python-format
-msgid ""
-"%(dups)s item(s) are from the same work or have the same identifier, click "
-"here to display:"
-msgstr ""
-"%(dups)s item(s) são da mesma obra ou possuem o mesmo identificador; clique "
-"aqui para exibir:"
+msgid "%(dups)s item(s) are from the same work or have the same identifier, click here to display:"
+msgstr "%(dups)s item(s) são da mesma obra ou possuem o mesmo identificador; clique aqui para exibir:"
 
 #: journal/templates/_sidebar_collection_filter.html:32
 msgid "dropped"
@@ -6054,9 +5909,7 @@ msgstr "Impulsionar"
 
 #: journal/templates/action_delete_post.html:7
 msgid "Are you sure to delete this post and the mark or note related with it?"
-msgstr ""
-"Tem certeza de que deseja excluir esta publicação e a marcação ou nota "
-"relacionada a ela?"
+msgstr "Tem certeza de que deseja excluir esta publicação e a marcação ou nota relacionada a ela?"
 
 #: journal/templates/action_delete_post.html:7
 msgid "Are you sure to delete this reply?"
@@ -6082,6 +5935,14 @@ msgstr "Curtido"
 #: journal/templates/action_like_post.html:16
 msgid "Like"
 msgstr "Curtir"
+
+#: journal/templates/action_mark_item.html:10
+msgid "add mark"
+msgstr "adicionar marcação"
+
+#: journal/templates/action_mark_item.html:18
+msgid "update mark"
+msgstr "atualizar marcação"
 
 #: journal/templates/action_open_post.html:7
 msgid "Quiet Public"
@@ -6135,11 +5996,11 @@ msgstr "Adicionar à coleção"
 msgid "Create a new collection"
 msgstr "Criar uma nova coleção"
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:81
+#: journal/templates/article.html:104 social/templates/_event_post.html:76
 msgid "wrote a review"
 msgstr "escreveu uma análise"
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:83
+#: journal/templates/article.html:106 social/templates/_event_post.html:78
 msgid "wrote an article"
 msgstr "escreveu um artigo"
 
@@ -6241,9 +6102,7 @@ msgstr "Arraste e solte para alterar a ordem e clique aqui para salvar"
 
 #: journal/templates/collection_share.html:24
 msgid "for the sharing post only, not visibility of the collection"
-msgstr ""
-"apenas para a publicação de compartilhamento, não para a visibilidade da "
-"coleção"
+msgstr "apenas para a publicação de compartilhamento, não para a visibilidade da coleção"
 
 #: journal/templates/comment.html:47
 msgid "share with playback position"
@@ -6253,23 +6112,21 @@ msgstr "compartilhar com posição de reprodução"
 msgid "Mark"
 msgstr "Marcação"
 
-#: journal/templates/mark.html:50
+#: journal/templates/mark.html:54
 msgid "not rated"
 msgstr "não avaliado"
 
-#: journal/templates/mark.html:70
+#: journal/templates/mark.html:74
 msgid "add a tag and press Enter"
 msgstr "adicione uma etiqueta e pressione Enter"
 
-#: journal/templates/mark.html:122
+#: journal/templates/mark.html:126
 msgid "change mark date"
 msgstr "alterar data da marcação"
 
-#: journal/templates/mark.html:148
+#: journal/templates/mark.html:156
 msgid "Sure to delete mark, comment and tags for this item?"
-msgstr ""
-"Tem certeza de que deseja excluir a marcação, o comentário e as etiquetas "
-"deste item?"
+msgstr "Tem certeza de que deseja excluir a marcação, o comentário e as etiquetas deste item?"
 
 #: journal/templates/markdown_editor.html:9
 msgid "Markdown format references"
@@ -6310,8 +6167,7 @@ msgid ""
 "Content Cell  | Content Cell\n"
 "Content Cell  | Content Cell\n"
 "\n"
-"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/"
-"Wikipedia-logo-v2.svg)\n"
+"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 "\n"
 msgstr ""
 "\n"
@@ -6347,11 +6203,10 @@ msgstr ""
 "Célula de Conteúdo | Célula de Conteúdo\n"
 "Célula de Conteúdo | Célula de Conteúdo\n"
 "\n"
-"Cole ou envie uma imagem ![](https://upload.wikimedia.org/wikipedia/en/8/80/"
-"Wikipedia-logo-v2.svg)\n"
+"Cole ou envie uma imagem ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 "\n"
 
-#: journal/templates/note.html:19 journal/views/note.py:23
+#: journal/templates/note.html:19 journal/views/note.py:22
 msgid "Note"
 msgstr "Nota"
 
@@ -6361,9 +6216,7 @@ msgstr "Anotação e progresso"
 
 #: journal/templates/note.html:29
 msgid "Note with empty content will be deleted, sure to continue?"
-msgstr ""
-"Uma nota com conteúdo vazio será excluída. Tem certeza de que deseja "
-"continuar?"
+msgstr "Uma nota com conteúdo vazio será excluída. Tem certeza de que deseja continuar?"
 
 #: journal/templates/note.html:72 journal/templates/note.html:73
 msgid "Clear progress"
@@ -6378,12 +6231,8 @@ msgid "Are you sure to delete this entire content?"
 msgstr "Tem certeza de que deseja excluir todo este conteúdo?"
 
 #: journal/templates/piece_delete.html:24
-msgid ""
-"By deleting it, you will also lose track of others' comments and feedbacks "
-"to your content."
-msgstr ""
-"Ao excluir, você também perderá o registro dos comentários e feedbacks de "
-"outros usuários sobre seu conteúdo."
+msgid "By deleting it, you will also lose track of others' comments and feedbacks to your content."
+msgstr "Ao excluir, você também perderá o registro dos comentários e feedbacks de outros usuários sobre seu conteúdo."
 
 #: journal/templates/piece_delete.html:25
 #: journal/templates/piece_delete.html:32
@@ -6462,7 +6311,7 @@ msgstr "resumo anual"
 msgid "Articles"
 msgstr "Artigos"
 
-#: journal/templates/profile.html:166 journal/views/collection.py:427
+#: journal/templates/profile.html:166 journal/views/collection.py:409
 #: journal/views/profile.py:401
 msgid "collection"
 msgstr "coleção"
@@ -6496,13 +6345,8 @@ msgid "Personal"
 msgstr "Pessoal"
 
 #: journal/templates/tag_edit.html:52
-msgid ""
-"Personal tags are not included in public index. However, if you use this tag "
-"when marking an item publicly, it might still be visible to others."
-msgstr ""
-"As etiquetas pessoais não estão incluídas no índice público. No entanto, se "
-"você usar esta etiqueta ao marcar um item publicamente, ela ainda poderá ser "
-"visível para outros."
+msgid "Personal tags are not included in public index. However, if you use this tag when marking an item publicly, it might still be visible to others."
+msgstr "As etiquetas pessoais não estão incluídas no índice público. No entanto, se você usar esta etiqueta ao marcar um item publicamente, ela ainda poderá ser visível para outros."
 
 #: journal/templates/tag_edit.html:55
 msgid "Delete this tag"
@@ -6570,117 +6414,114 @@ msgstr "Artigos de {0}"
 msgid "Link invalid"
 msgstr "Link inválido"
 
-#: journal/views/collection.py:58 journal/views/collection.py:96
+#: journal/views/collection.py:62 journal/views/collection.py:94
 #, python-brace-format
 msgid "Collection by {0}"
 msgstr "Coleção de {0}"
 
-#: journal/views/collection.py:432
+#: journal/views/collection.py:414
 msgid "shared my collection"
 msgstr "compartilhou minha coleção"
 
-#: journal/views/collection.py:435
+#: journal/views/collection.py:417
 #, python-brace-format
 msgid "shared {username}'s collection"
 msgstr "compartilhou a coleção de {username}"
 
-#: journal/views/collection.py:502 journal/views/collection.py:541
-#: journal/views/collection.py:553 journal/views/collection.py:579
+#: journal/views/collection.py:484 journal/views/collection.py:523
+#: journal/views/collection.py:535 journal/views/collection.py:561
 msgid "Dynamic collection is not editable"
 msgstr "Coleção dinâmica não é editável"
 
-#: journal/views/collection.py:518
+#: journal/views/collection.py:500
 msgid "The item is already in the collection."
 msgstr "O item já está na coleção."
 
-#: journal/views/collection.py:520
+#: journal/views/collection.py:502
 msgid "Unable to find the item, please use item url from this site."
-msgstr ""
-"Não foi possível encontrar o item. Por favor, use a URL do item deste site."
+msgstr "Não foi possível encontrar o item. Por favor, use a URL do item deste site."
 
-#: journal/views/collection.py:566
+#: journal/views/collection.py:548
 msgid "Saved."
 msgstr "Salvo."
 
-#: journal/views/common.py:119 journal/views/mark.py:225
-#: journal/views/mark.py:279 journal/views/note.py:175
+#: journal/views/common.py:126 journal/views/mark.py:273
+#: journal/views/mark.py:315 journal/views/note.py:167
 #: journal/views/profile.py:42 journal/views/review.py:59
 #: journal/views/review.py:79
 msgid "Content not found"
 msgstr "Conteúdo não encontrado"
 
-#: journal/views/common.py:174 journal/views/mark.py:159
+#: journal/views/common.py:184 journal/views/mark.py:210
 msgid "Data saved but unable to crosspost to Fediverse instance."
-msgstr ""
-"Dados salvos, mas não foi possível publicar de forma cruzada na instância do "
-"Fediverso."
+msgstr "Dados salvos, mas não foi possível publicar de forma cruzada na instância do Fediverso."
 
-#: journal/views/common.py:176
+#: journal/views/common.py:186
 msgid "Redirecting to your Fediverse instance now to re-authenticate."
-msgstr ""
-"Redirecionando para sua instância do Fediverso agora para reautenticar."
+msgstr "Redirecionando para sua instância do Fediverso agora para reautenticar."
 
-#: journal/views/common.py:183
+#: journal/views/common.py:193
 msgid "List not found."
 msgstr "Lista não encontrada."
 
-#: journal/views/mark.py:150
+#: journal/views/mark.py:206
 msgid "Content too long for your Fediverse instance."
 msgstr "Conteúdo muito longo para sua instância do Fediverso."
 
-#: journal/views/mark.py:178 journal/views/mark.py:238
+#: journal/views/mark.py:224 journal/views/mark.py:226
+#: journal/views/mark.py:280
 msgid "Invalid input"
 msgstr "Entrada inválida"
 
-#: journal/views/note.py:23
+#: journal/views/note.py:22
 msgid "Progress"
 msgstr "Progresso"
 
-#: journal/views/note.py:28
+#: journal/views/note.py:27
 msgid "Update progress"
 msgstr "Atualizar progresso"
 
-#: journal/views/note.py:59
+#: journal/views/note.py:58
 msgid "Progress (optional)"
 msgstr "Progresso (opcional)"
 
-#: journal/views/note.py:61
+#: journal/views/note.py:60
 msgid "Note Content"
 msgstr "Conteúdo da Nota"
 
-#: journal/views/note.py:63
+#: journal/views/note.py:62
 msgid "Content Warning (optional)"
 msgstr "Aviso de Conteúdo (opcional)"
 
-#: journal/views/note.py:85
+#: journal/views/note.py:84
 msgid "Progress Type (optional)"
 msgstr "Tipo de Progresso (opcional)"
 
-#: journal/views/note.py:123 journal/views/note.py:183
+#: journal/views/note.py:115 journal/views/note.py:175
 msgid "Only in-progress items can have progress."
 msgstr "Somente itens em andamento podem ter progresso."
 
-#: journal/views/post.py:98 journal/views/post.py:392
+#: journal/views/post.py:100 journal/views/post.py:388
 msgid "Post not found"
 msgstr "Publicação não encontrada"
 
-#: journal/views/post.py:189
+#: journal/views/post.py:191
 msgid "Visibility too high for quoting this post"
 msgstr "Visibilidade muito alta para citar esta publicação"
 
-#: journal/views/post.py:337 journal/views/post.py:418
+#: journal/views/post.py:339 journal/views/post.py:414
 msgid "Content cannot be empty."
 msgstr "O conteúdo não pode estar vazio."
 
-#: journal/views/post.py:396
+#: journal/views/post.py:392
 msgid "This post cannot be edited here"
 msgstr "Esta publicação não pode ser editada aqui"
 
-#: journal/views/post.py:541
+#: journal/views/post.py:531
 msgid "Invalid choices"
 msgstr "Escolhas inválidas"
 
-#: journal/views/post.py:544
+#: journal/views/post.py:534
 msgid "Invalid post"
 msgstr "Publicação inválida"
 
@@ -6698,61 +6539,57 @@ msgstr "{review_title} - uma análise de {item_title}"
 msgid "may contain spoiler or triggering content"
 msgstr "pode conter spoilers ou conteúdo sensível"
 
-#: journal/views/tag.py:47 journal/views/tag.py:61
+#: journal/views/tag.py:46 journal/views/tag.py:60
 msgid "Invalid tag"
 msgstr "Etiqueta inválida"
 
-#: journal/views/tag.py:50
+#: journal/views/tag.py:49
 msgid "Tag not found"
 msgstr "Etiqueta não encontrada"
 
-#: journal/views/tag.py:72
+#: journal/views/tag.py:65
 msgid "Tag deleted."
 msgstr "Etiqueta excluída."
 
-#: journal/views/tag.py:82
+#: journal/views/tag.py:75
 msgid "Duplicated tag."
 msgstr "Etiqueta duplicada."
 
-#: journal/views/tag.py:96
+#: journal/views/tag.py:83
 msgid "Tag updated."
 msgstr "Etiqueta atualizada."
 
-#: journal/views/wrapped.py:160
+#: journal/views/wrapped.py:161
 msgid "Summary posted to timeline."
 msgstr "Resumo publicado na linha do tempo."
 
-#: mastodon/models/common.py:29
+#: mastodon/models/common.py:31
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: mastodon/models/common.py:30 users/templates/users/login.html:120
+#: mastodon/models/common.py:32 users/templates/users/login.html:114
 msgid "Threads"
 msgstr "Threads"
 
-#: mastodon/models/common.py:31
+#: mastodon/models/common.py:33
 msgid "Bluesky"
 msgstr "Bluesky"
 
-#: mastodon/models/email.py:59
+#: mastodon/models/email.py:63
 msgid ""
 "\n"
 "\n"
-"If you did not mean to register or login, please ignore this email. If you "
-"are concerned with your account security, please change the email linked "
-"with your account, or contact us."
+"If you did not mean to register or login, please ignore this email. If you are concerned with your account security, please change the email linked with your account, or contact us."
 msgstr ""
 "\n"
 "\n"
-"Se você não pretendia se cadastrar ou entrar, ignore este e-mail. Se estiver "
-"preocupado com a segurança da sua conta, altere o e-mail vinculado à sua "
-"conta ou entre em contato conosco."
+"Se você não pretendia se cadastrar ou entrar, ignore este e-mail. Se estiver preocupado com a segurança da sua conta, altere o e-mail vinculado à sua conta ou entre em contato conosco."
 
-#: mastodon/models/email.py:64 mastodon/models/email.py:69
+#: mastodon/models/email.py:68 mastodon/models/email.py:73
 msgid "Verification Code"
 msgstr "Código de Verificação"
 
-#: mastodon/models/email.py:66
+#: mastodon/models/email.py:70
 #, python-brace-format
 msgid ""
 "Use this code to verify your email address {email}\n"
@@ -6763,7 +6600,7 @@ msgstr ""
 "\n"
 "{code}"
 
-#: mastodon/models/email.py:70
+#: mastodon/models/email.py:74
 #, python-brace-format
 msgid ""
 "Use this code to login as {email}\n"
@@ -6774,31 +6611,27 @@ msgstr ""
 "\n"
 "{code}"
 
-#: mastodon/models/email.py:74 users/templates/users/captcha.html:13
+#: mastodon/models/email.py:78 users/templates/users/captcha.html:13
 #: users/templates/users/captcha_solved.html:9
 #: users/templates/users/login.html:20 users/templates/users/register.html:9
 #: users/templates/users/welcome.html:10
 msgid "Register"
 msgstr "Cadastrar"
 
-#: mastodon/models/email.py:76
+#: mastodon/models/email.py:80
 #, python-brace-format
 msgid ""
 "There is no account registered with this email address yet: {email}\n"
 "\n"
-"If you already have an account with us, just login and add this email to you "
-"account.\n"
+"If you already have an account with us, just login and add this email to you account.\n"
 "\n"
-"If you prefer to register a new account with this email, please use this "
-"verification code: {code}"
+"If you prefer to register a new account with this email, please use this verification code: {code}"
 msgstr ""
 "Ainda não há nenhuma conta registrada com este endereço de e-mail: {email} \n"
 "\n"
-"Se você já possui uma conta conosco, basta entrar e adicionar este e-mail à "
-"sua conta. \n"
+"Se você já possui uma conta conosco, basta entrar e adicionar este e-mail à sua conta. \n"
 "\n"
-"Se preferir registrar uma nova conta com este e-mail, use este código de "
-"verificação: {code}"
+"Se preferir registrar uma nova conta com este e-mail, use este código de verificação: {code}"
 
 #: mastodon/models/mastodon.py:570
 msgid "site domain name"
@@ -6840,44 +6673,49 @@ msgstr "comprimento máximo do toot"
 msgid "New Post"
 msgstr "Nova Publicação"
 
-#: mastodon/views/bluesky.py:26 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:32 mastodon/views/bluesky.py:93
 msgid "Bluesky login is disabled."
 msgstr "O login via Bluesky está desativado."
 
-#: mastodon/views/bluesky.py:28 mastodon/views/email.py:35
-#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:29
-#: users/templates/users/login.html:6 users/views/webauthn.py:133
-msgid "Security check failed. Please try again."
-msgstr "Falha na verificação de segurança. Tente novamente."
-
-#: mastodon/views/bluesky.py:34 mastodon/views/bluesky.py:40
-#: mastodon/views/bluesky.py:64 mastodon/views/bluesky.py:72
-#: mastodon/views/bluesky.py:78 mastodon/views/common.py:36
-#: mastodon/views/mastodon.py:62 mastodon/views/mastodon.py:70
-#: mastodon/views/mastodon.py:77 mastodon/views/mastodon.py:87
-#: mastodon/views/mastodon.py:94 mastodon/views/threads.py:55
-#: mastodon/views/threads.py:63 mastodon/views/threads.py:69
-#: users/views/account.py:254 users/views/account.py:373
+#: mastodon/views/bluesky.py:47 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:65 mastodon/views/bluesky.py:98
+#: mastodon/views/bluesky.py:106 mastodon/views/bluesky.py:112
+#: mastodon/views/common.py:36 mastodon/views/mastodon.py:62
+#: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
+#: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
+#: mastodon/views/threads.py:57 mastodon/views/threads.py:65
+#: mastodon/views/threads.py:71 users/views/account.py:256
+#: users/views/account.py:375
 msgid "Authentication failed"
 msgstr "Falha na autenticação"
 
-#: mastodon/views/bluesky.py:35 mastodon/views/email.py:66
+#: mastodon/views/bluesky.py:47 mastodon/views/common.py:103
+msgid "Identity not found."
+msgstr "Identidade não encontrada."
+
+#: mastodon/views/bluesky.py:53 mastodon/views/email.py:35
+#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:31
+#: users/templates/users/login.html:6 users/views/webauthn.py:136
+msgid "Security check failed. Please try again."
+msgstr "Falha na verificação de segurança. Tente novamente."
+
+#: mastodon/views/bluesky.py:60 mastodon/views/email.py:66
 msgid "Too many attempts, please try again later."
 msgstr "Muitas tentativas, tente novamente mais tarde."
 
-#: mastodon/views/bluesky.py:40
+#: mastodon/views/bluesky.py:65
 msgid "ATProto handle is required."
 msgstr "O identificador ATProto é obrigatório."
 
-#: mastodon/views/bluesky.py:50
+#: mastodon/views/bluesky.py:84
 msgid "Error connecting to your ATProto server"
 msgstr "Erro ao conectar ao seu servidor ATProto"
 
-#: mastodon/views/bluesky.py:73
+#: mastodon/views/bluesky.py:107
 msgid "Invalid response from ATProto authorization server."
 msgstr "Resposta inválida do servidor de autorização ATProto."
 
-#: mastodon/views/bluesky.py:78
+#: mastodon/views/bluesky.py:112
 msgid "Invalid account data from Bluesky."
 msgstr "Dados de conta inválidos do Bluesky."
 
@@ -6885,7 +6723,7 @@ msgstr "Dados de conta inválidos do Bluesky."
 msgid "Invalid user."
 msgstr "Usuário inválido."
 
-#: mastodon/views/common.py:52 users/views/account.py:414
+#: mastodon/views/common.py:52 users/views/account.py:416
 msgid "Registration failed"
 msgstr "Falha no cadastro"
 
@@ -6917,10 +6755,6 @@ msgstr "Informações de login atualizadas como {handle}."
 msgid "Disconnect identity failed"
 msgstr "Falha ao desconectar a identidade"
 
-#: mastodon/views/common.py:103
-msgid "Identity not found."
-msgstr "Identidade não encontrada."
-
 #: mastodon/views/common.py:117
 msgid "You cannot disconnect last login identity."
 msgstr "Você não pode desconectar a última identidade de login."
@@ -6940,9 +6774,7 @@ msgstr "Verificação"
 
 #: mastodon/views/email.py:48 users/templates/users/verify.html:20
 msgid "Verification email is being sent, please check your inbox."
-msgstr ""
-"O e-mail de verificação está sendo enviado. Por favor, verifique sua caixa "
-"de entrada."
+msgstr "O e-mail de verificação está sendo enviado. Por favor, verifique sua caixa de entrada."
 
 #: mastodon/views/email.py:80
 msgid "Invalid verification code"
@@ -6964,7 +6796,7 @@ msgstr "Erro ao conectar à instância"
 msgid "Invalid response from Fediverse instance."
 msgstr "Resposta inválida da instância do Fediverso."
 
-#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:64
+#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:66
 msgid "Invalid OAuth state. Please try again."
 msgstr "Estado OAuth inválido. Tente novamente."
 
@@ -6984,22 +6816,18 @@ msgstr "Token inválido da instância do Fediverso."
 msgid "Invalid account data from Fediverse instance."
 msgstr "Dados de conta inválidos da instância do Fediverso."
 
-#: mastodon/views/threads.py:69
+#: mastodon/views/threads.py:71
 msgid "Invalid account data from Threads."
 msgstr "Dados de conta inválidos do Threads."
 
-#: mastodon/views/threads.py:147
+#: mastodon/views/threads.py:149
 msgid "Data deletion completed"
 msgstr "Exclusão de dados concluída"
 
-#: mastodon/views/threads.py:149
+#: mastodon/views/threads.py:151
 #, python-brace-format
-msgid ""
-"Data linked to your Threads account has been deleted. Confirmation code: "
-"{code}"
-msgstr ""
-"Os dados vinculados à sua conta do Threads foram excluídos. Código de "
-"confirmação: {code}"
+msgid "Data linked to your Threads account has been deleted. Confirmation code: {code}"
+msgstr "Os dados vinculados à sua conta do Threads foram excluídos. Código de confirmação: {code}"
 
 #: social/templates/_article_teaser.html:10
 #, python-format
@@ -7031,15 +6859,11 @@ msgstr "impulsionou"
 msgid "play"
 msgstr "reproduzir"
 
-#: social/templates/_event_post.html:50
-msgid "mark"
-msgstr "marcação"
-
-#: social/templates/_event_post.html:79
+#: social/templates/_event_post.html:74
 msgid "wrote a note"
 msgstr "escreveu uma nota"
 
-#: social/templates/_event_post.html:88
+#: social/templates/_event_post.html:83
 msgid "replying to"
 msgstr "respondendo a"
 
@@ -7052,7 +6876,7 @@ msgstr "Mais"
 msgid "Untitled article"
 msgstr "Artigo sem título"
 
-#: social/templates/event/boosted.html:3
+#: social/templates/event/boosted.html:2
 msgid "boosted your post"
 msgstr "impulsionou sua publicação"
 
@@ -7105,12 +6929,10 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"impulsionou sua análise <a href=\"%(piece_url)s\">%(piece_title)s</a> em <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"impulsionou sua análise <a href=\"%(piece_url)s\">%(piece_title)s</a> em <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/boosted_shelfmember.html:3
 #, python-format
@@ -7129,7 +6951,7 @@ msgstr "solicitou seguir você"
 msgid "followed you"
 msgstr "passou a te seguir"
 
-#: social/templates/event/liked.html:3
+#: social/templates/event/liked.html:2
 msgid "liked your post"
 msgstr "curtiu sua publicação"
 
@@ -7182,12 +7004,10 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"curtiu sua análise <a href=\"%(piece_url)s\">%(piece_title)s</a> em <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"curtiu sua análise <a href=\"%(piece_url)s\">%(piece_title)s</a> em <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/liked_shelfmember.html:3
 #, python-format
@@ -7198,7 +7018,7 @@ msgstr ""
 "\n"
 "curtiu sua marcação em <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
-#: social/templates/event/mentioned.html:3
+#: social/templates/event/mentioned.html:2
 msgid "mentioned you"
 msgstr "mencionou você"
 
@@ -7251,12 +7071,10 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"respondeu à sua análise <a href=\"%(piece_url)s\">%(piece_title)s</a> em <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"respondeu à sua análise <a href=\"%(piece_url)s\">%(piece_title)s</a> em <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
 #: social/templates/event/mentioned_shelfmember.html:3
 #, python-format
@@ -7267,31 +7085,46 @@ msgstr ""
 "\n"
 "respondeu à sua marcação em <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 
-#: social/templates/feed.html:12 social/templates/feed.html:39
-#: social/templates/search_feed.html:12
-msgid "Activities from those you follow"
-msgstr "Atividades de quem você segue"
+#: social/templates/feed.html:39 users/templates/users/preferences.html:40
+msgid "Activities"
+msgstr "Atividades"
 
-#: social/templates/feed.html:42 social/templates/feed.html:44
+#: social/templates/feed.html:43 social/templates/feed.html:45
+#, fuzzy
+#| msgid "WorldCat"
+msgid "world"
+msgstr "WorldCat"
+
+#: social/templates/feed.html:51 social/templates/feed.html:53
+#, fuzzy
+#| msgid "locale"
+msgid "local"
+msgstr "localidade"
+
+#: social/templates/feed.html:58 social/templates/feed.html:60
+#, fuzzy
+#| msgid "sure to follow?"
+msgid "those you follow"
+msgstr "Tem certeza de que deseja seguir?"
+
+#: social/templates/feed.html:64 social/templates/feed.html:66
 msgid "what they read/watch/..."
 msgstr "o que eles leem/assistem/..."
 
-#: social/templates/feed_events.html:30
+#: social/templates/feed_events.html:29
 msgid "no matching activities."
 msgstr "nenhuma atividade correspondente."
 
-#: social/templates/feed_events.html:33
+#: social/templates/feed_events.html:31
+#, fuzzy
+#| msgid "no matching activities."
+msgid "no public activities yet."
+msgstr "nenhuma atividade correspondente."
+
+#: social/templates/feed_events.html:34
 #, python-format
-msgid ""
-"Find and mark some books/movies/podcasts/games, <a "
-"href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/"
-"Douban, follow some fellow %(site_name)s users on the fediverse, so their "
-"recent activities and yours will show up here."
-msgstr ""
-"Encontre e marque alguns livros/filmes/podcasts/jogos, <a "
-"href=\"%(import_url)s\">importe seus dados</a> do Goodreads/Letterboxd/"
-"Douban, siga outros usuários do %(site_name)s no Fediverso — as atividades "
-"recentes deles e as suas aparecerão aqui."
+msgid "Find and mark some books/movies/podcasts/games, <a href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/Douban, follow some fellow %(site_name)s users on the fediverse, so their recent activities and yours will show up here."
+msgstr "Encontre e marque alguns livros/filmes/podcasts/jogos, <a href=\"%(import_url)s\">importe seus dados</a> do Goodreads/Letterboxd/Douban, siga outros usuários do %(site_name)s no Fediverso — as atividades recentes deles e as suas aparecerão aqui."
 
 #: social/templates/notification.html:58
 msgid "mention"
@@ -7323,6 +7156,10 @@ msgstr "Enquete encerrada em %(end_time)s"
 msgid "Poll ending at %(end_time)s"
 msgstr "Enquete encerra em %(end_time)s"
 
+#: social/templates/search_feed.html:12 social/views.py:57 social/views.py:58
+msgid "Activities from those you follow"
+msgstr "Atividades de quem você segue"
+
 #: social/templates/single_post.html:13 social/templates/single_post.html:32
 msgid "Post"
 msgstr "Publicação"
@@ -7335,60 +7172,67 @@ msgstr "Artigo"
 msgid "Poll"
 msgstr "Enquete"
 
-#: takahe/models.py:453
+#: social/views.py:59
+#, fuzzy
+#| msgid "Activities from those you follow"
+msgid "Activities on this site"
+msgstr "Atividades de quem você segue"
+
+#: social/views.py:60
+#, fuzzy
+#| msgid "Activities from those you follow"
+msgid "Activities from the fediverse"
+msgstr "Atividades de quem você segue"
+
+#: takahe/models.py:445
 msgid "Display Name"
 msgstr "Nome de Exibição"
 
-#: takahe/models.py:455
+#: takahe/models.py:447
 msgid "Bio"
 msgstr "Bio"
 
-#: takahe/models.py:457
+#: takahe/models.py:449
 msgid "Manually approve new followers"
 msgstr "Aprovar manualmente novos seguidores"
 
-#: takahe/models.py:461
+#: takahe/models.py:453
 msgid "Include profile, marks and posts in discovery"
 msgstr "Incluir perfil, marcações e publicações na descoberta"
 
-#: takahe/models.py:464
+#: takahe/models.py:456
 msgid "Include posts in search results"
 msgstr "Incluir publicações nos resultados de pesquisa"
 
-#: takahe/models.py:482
+#: takahe/models.py:474
 msgid "Profile picture"
 msgstr "Foto de perfil"
 
-#: takahe/models.py:489
+#: takahe/models.py:481
 msgid "Header picture"
 msgstr "Imagem de cabeçalho"
 
-#: users/models/task.py:22
+#: users/models/task.py:24
 msgid "Started"
 msgstr "Iniciado"
 
-#: users/models/task.py:23
+#: users/models/task.py:25
 msgid "Complete"
 msgstr "Completo"
 
-#: users/models/user.py:69
-msgid ""
-"Enter a valid username. This value may contain only unaccented lowercase a-z "
-"and uppercase A-Z letters, numbers, and _ characters."
-msgstr ""
-"Insira um nome de usuário válido. Este valor pode conter apenas letras "
-"minúsculas sem acentuação de a-z e maiúsculas de A-Z, números e o caractere "
-"_."
+#: users/models/user.py:71
+msgid "Enter a valid username. This value may contain only unaccented lowercase a-z and uppercase A-Z letters, numbers, and _ characters."
+msgstr "Insira um nome de usuário válido. Este valor pode conter apenas letras minúsculas sem acentuação de a-z e maiúsculas de A-Z, números e o caractere _."
 
-#: users/models/user.py:130
+#: users/models/user.py:132
 msgid "username"
 msgstr "nome de usuário"
 
-#: users/models/user.py:135
+#: users/models/user.py:137
 msgid "Required. 50 characters or fewer. Letters, digits and _ only."
 msgstr "Obrigatório. 50 caracteres ou menos. Apenas letras, dígitos e _."
 
-#: users/models/user.py:138
+#: users/models/user.py:140
 msgid "A user with that username already exists."
 msgstr "Já existe um usuário com esse nome de usuário."
 
@@ -7519,12 +7363,8 @@ msgid "Cancel import"
 msgstr "Cancelar importação"
 
 #: users/templates/users/_rym_section.html:29
-msgid ""
-"On RateYourMusic, go to your profile and use the <b>Export your music "
-"catalog</b> option to download your library as a CSV file."
-msgstr ""
-"No RateYourMusic, acesse seu perfil e use a opção <b>Exportar seu catálogo "
-"musical</b> para baixar sua biblioteca em formato CSV."
+msgid "On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file."
+msgstr "No RateYourMusic, acesse seu perfil e use a opção <b>Exportar seu catálogo musical</b> para baixar sua biblioteca em formato CSV."
 
 #: users/templates/users/_rym_section.html:31
 #: users/templates/users/_storygraph_section.html:33
@@ -7532,27 +7372,13 @@ msgid "Upload the downloaded CSV file below."
 msgstr "Envie abaixo o arquivo CSV baixado."
 
 #: users/templates/users/_rym_section.html:33
-msgid ""
-"Albums are matched by title + artist (and year if present) — first against "
-"the local catalog, then MusicBrainz, then Spotify. After auto-matching, "
-"you'll preview the matches in a table, edit any link or shelf status, and "
-"confirm the import."
-msgstr ""
-"Os álbuns são correspondidos por título + artista (e ano, se disponível) — "
-"primeiro com o catálogo local, depois com o MusicBrainz e, por fim, com o "
-"Spotify. Após a correspondência automática, você poderá revisar as "
-"correspondências em uma tabela, editar qualquer link ou status de prateleira "
-"e confirmar a importação."
+msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
+msgstr "Os álbuns são correspondidos por título + artista (e ano, se disponível) — primeiro com o catálogo local, depois com o MusicBrainz e, por fim, com o Spotify. Após a correspondência automática, você poderá revisar as correspondências em uma tabela, editar qualquer link ou status de prateleira e confirmar a importação."
 
 #: users/templates/users/_rym_section.html:36
 #: users/templates/users/_storygraph_section.html:38
-msgid ""
-"You can also re-upload a previously-downloaded matched CSV — the existing "
-"<code>link</code> column will be honoured as the default match."
-msgstr ""
-"Você também pode reenviar um arquivo CSV correspondido baixado anteriormente "
-"— a coluna <code>link</code> existente será respeitada como a "
-"correspondência padrão."
+msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
+msgstr "Você também pode reenviar um arquivo CSV correspondido baixado anteriormente — a coluna <code>link</code> existente será respeitada como a correspondência padrão."
 
 #: users/templates/users/_rym_section.html:40
 #: users/templates/users/_storygraph_section.html:42
@@ -7578,27 +7404,12 @@ msgid "Cancel the StoryGraph import? Progress will be discarded."
 msgstr "Cancelar a importação do StoryGraph? O progresso será descartado."
 
 #: users/templates/users/_storygraph_section.html:31
-msgid ""
-"On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to "
-"download your library as a CSV file."
-msgstr ""
-"No StoryGraph, clique em <a href=\"https://app.thestorygraph.com/user-"
-"export\" target=\"_blank\" rel=\"noopener\"><b>Exportar sua biblioteca</b></"
-"a> para baixar sua biblioteca em formato CSV."
+msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
+msgstr "No StoryGraph, clique em <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Exportar sua biblioteca</b></a> para baixar sua biblioteca em formato CSV."
 
 #: users/templates/users/_storygraph_section.html:35
-msgid ""
-"Books are matched by ISBN — first against the local catalog, then Google "
-"Books and OpenLibrary — with a title + author search as fallback. After auto-"
-"matching, you'll preview the matches in a table, edit any link or shelf "
-"status, and confirm the import."
-msgstr ""
-"Os livros são correspondidos por ISBN — primeiro com o catálogo local, "
-"depois com o Google Books e o OpenLibrary — com uma busca por título + autor "
-"como alternativa (fallback). Após a correspondência automática, você poderá "
-"revisar as correspondências em uma tabela, editar qualquer link ou status de "
-"prateleira e confirmar a importação."
+msgid "Books are matched by ISBN — first against the local catalog, then Google Books and OpenLibrary — with a title + author search as fallback. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
+msgstr "Os livros são correspondidos por ISBN — primeiro com o catálogo local, depois com o Google Books e o OpenLibrary — com uma busca por título + autor como alternativa (fallback). Após a correspondência automática, você poderá revisar as correspondências em uma tabela, editar qualquer link ou status de prateleira e confirmar a importação."
 
 #: users/templates/users/account.html:11
 msgid "Account Information"
@@ -7609,13 +7420,8 @@ msgid "Display name, avatar and other information"
 msgstr "Nome de exibição, avatar e outras informações"
 
 #: users/templates/users/account.html:23
-msgid ""
-"Updating profile information here will turn off automatic sync of display "
-"name, bio and avatar from your Mastodon instance. Sure to continue?"
-msgstr ""
-"Atualizar as informações de perfil aqui desativará a sincronização "
-"automática do nome de exibição, biografia e avatar da sua instância do "
-"Mastodon. Tem certeza de que deseja continuar?"
+msgid "Updating profile information here will turn off automatic sync of display name, bio and avatar from your Mastodon instance. Sure to continue?"
+msgstr "Atualizar as informações de perfil aqui desativará a sincronização automática do nome de exibição, biografia e avatar da sua instância do Mastodon. Tem certeza de que deseja continuar?"
 
 #: users/templates/users/account.html:26
 msgid "Username"
@@ -7627,22 +7433,12 @@ msgstr "Endereço de email"
 
 #: users/templates/users/account.html:59 users/templates/users/register.html:47
 #, python-format
-msgid ""
-"Please click the confirmation link in the email sent to %(pending_email)s; "
-"if you haven't received it for more than a few minutes, please input and "
-"save again."
-msgstr ""
-"Por favor, clique no link de confirmação no e-mail enviado para "
-"%(pending_email)s; caso não o tenha recebido após alguns minutos, insira e "
-"salve novamente."
+msgid "Please click the confirmation link in the email sent to %(pending_email)s; if you haven't received it for more than a few minutes, please input and save again."
+msgstr "Por favor, clique no link de confirmação no e-mail enviado para %(pending_email)s; caso não o tenha recebido após alguns minutos, insira e salve novamente."
 
 #: users/templates/users/account.html:61 users/templates/users/register.html:50
-msgid ""
-"Email is recommended as a backup login method, if you log in via a Fediverse "
-"instance"
-msgstr ""
-"O e-mail é recomendado como método de login de backup, caso você entre via "
-"uma instância do Fediverso"
+msgid "Email is recommended as a backup login method, if you log in via a Fediverse instance"
+msgstr "O e-mail é recomendado como método de login de backup, caso você entre via uma instância do Fediverso"
 
 #: users/templates/users/account.html:73 users/templates/users/login.html:84
 msgid "Fediverse (Mastodon)"
@@ -7659,30 +7455,16 @@ msgid "Last updated"
 msgstr "Última atualização"
 
 #: users/templates/users/account.html:92
-msgid ""
-"If you have not yet registered with any Federated instance, you may <a "
-"href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an "
-"instance</a> and register."
-msgstr ""
-"Se você ainda não se cadastrou em nenhuma instância federada, pode <a "
-"href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">escolher uma "
-"instância</a> e se registrar."
+msgid "If you have not yet registered with any Federated instance, you may <a href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an instance</a> and register."
+msgstr "Se você ainda não se cadastrou em nenhuma instância federada, pode <a href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">escolher uma instância</a> e se registrar."
 
 #: users/templates/users/account.html:97
-msgid ""
-"To associate with another federated identity, please enter the domain name "
-"of the instance where the new identity is located."
-msgstr ""
-"Para associar a outra identidade federada, insira o nome de domínio da "
-"instância onde a nova identidade está localizada."
+msgid "To associate with another federated identity, please enter the domain name of the instance where the new identity is located."
+msgstr "Para associar a outra identidade federada, insira o nome de domínio da instância onde a nova identidade está localizada."
 
 #: users/templates/users/account.html:99
-msgid ""
-"If you have registered with a Federated instance, please enter the instance "
-"domain name."
-msgstr ""
-"Se você se cadastrou em uma instância federada, insira o nome de domínio da "
-"instância."
+msgid "If you have registered with a Federated instance, please enter the instance domain name."
+msgstr "Se você se cadastrou em uma instância federada, insira o nome de domínio da instância."
 
 #: users/templates/users/account.html:104
 msgid "e.g. mastodon.online"
@@ -7693,32 +7475,18 @@ msgid "Go to target instance and authorize with the identity"
 msgstr "Vá para a instância de destino e autorize com a identidade"
 
 #: users/templates/users/account.html:113
-msgid ""
-"After replacing the association, you may use the new Fediverse identity to "
-"log in and control data visibility. Existing data such as tags, comments, "
-"and collections will not be affected."
-msgstr ""
-"Após substituir a associação, você poderá usar a nova identidade do "
-"Fediverso para entrar e controlar a visibilidade dos dados. Os dados "
-"existentes, como etiquetas, comentários e coleções, não serão afetados."
+msgid "After replacing the association, you may use the new Fediverse identity to log in and control data visibility. Existing data such as tags, comments, and collections will not be affected."
+msgstr "Após substituir a associação, você poderá usar a nova identidade do Fediverso para entrar e controlar a visibilidade dos dados. Os dados existentes, como etiquetas, comentários e coleções, não serão afetados."
 
 #: users/templates/users/account.html:115
-msgid ""
-"Once associated with Fediverse identity, you can discover more users and use "
-"the full features of this site."
-msgstr ""
-"Ao associar-se a uma identidade do Fediverso, você poderá descobrir mais "
-"usuários e utilizar todos os recursos deste site."
+msgid "Once associated with Fediverse identity, you can discover more users and use the full features of this site."
+msgstr "Ao associar-se a uma identidade do Fediverso, você poderá descobrir mais usuários e utilizar todos os recursos deste site."
 
 #: users/templates/users/account.html:123
 #: users/templates/users/account.html:160
 #: users/templates/users/account.html:206
-msgid ""
-"Once disconnected, you will no longer be able login with this identity. Are "
-"you sure to continue?"
-msgstr ""
-"Após a desconexão, você não poderá mais entrar com esta identidade. Tem "
-"certeza de que deseja continuar?"
+msgid "Once disconnected, you will no longer be able login with this identity. Are you sure to continue?"
+msgstr "Após a desconexão, você não poderá mais entrar com esta identidade. Tem certeza de que deseja continuar?"
 
 #: users/templates/users/account.html:126
 msgid "Disconnect with this identity"
@@ -7744,7 +7512,7 @@ msgstr "Vincular a uma conta threads.net"
 msgid "Disconnect with Threads"
 msgstr "Desconectar do Threads"
 
-#: users/templates/users/account.html:173 users/templates/users/login.html:112
+#: users/templates/users/account.html:173 users/templates/users/login.html:106
 msgid "Bluesky (ATProto)"
 msgstr "Bluesky (ATProto)"
 
@@ -7752,7 +7520,7 @@ msgstr "Bluesky (ATProto)"
 msgid "Verified ATProto identity"
 msgstr "Identidade ATProto verificada"
 
-#: users/templates/users/account.html:194 users/templates/users/login.html:216
+#: users/templates/users/account.html:194 users/templates/users/login.html:210
 msgid "ATProto handle"
 msgstr "Identificador ATProto"
 
@@ -7777,7 +7545,7 @@ msgid "Name this passkey:"
 msgstr "Nomeie esta chave de acesso:"
 
 #: users/templates/users/account.html:227 users/templates/users/login.html:69
-#: users/templates/users/welcome.html:33 users/views/webauthn.py:106
+#: users/templates/users/welcome.html:33 users/views/webauthn.py:109
 msgid "Passkey"
 msgstr "Chave de Acesso"
 
@@ -7820,12 +7588,8 @@ msgid "Save sync settings"
 msgstr "Salvar configurações de sincronização"
 
 #: users/templates/users/account.html:297
-msgid ""
-"New follow, mute and blocks in the associated identity may be automatically "
-"imported; removal has to be done manually."
-msgstr ""
-"Novos seguimentos, silenciamentos e bloqueios na identidade associada podem "
-"ser importados automaticamente; a remoção deve ser feita manualmente."
+msgid "New follow, mute and blocks in the associated identity may be automatically imported; removal has to be done manually."
+msgstr "Novos seguimentos, silenciamentos e bloqueios na identidade associada podem ser importados automaticamente; a remoção deve ser feita manualmente."
 
 #: users/templates/users/account.html:304
 msgid "Click button below to start sync now."
@@ -7861,21 +7625,12 @@ msgid "Log out everywhere"
 msgstr "Sair de todos os dispositivos"
 
 #: users/templates/users/account.html:365
-msgid ""
-"This will log you out of all browsers and devices (including the current "
-"one), and revoke all API tokens. Continue?"
-msgstr ""
-"Isso encerrará sua sessão em todos os navegadores e dispositivos (incluindo "
-"o atual) e revogará todos os tokens de API. Deseja continuar?"
+msgid "This will log you out of all browsers and devices (including the current one), and revoke all API tokens. Continue?"
+msgstr "Isso encerrará sua sessão em todos os navegadores e dispositivos (incluindo o atual) e revogará todos os tokens de API. Deseja continuar?"
 
 #: users/templates/users/account.html:368
-msgid ""
-"If you notice any suspicious activity or have logged in on a shared "
-"computer, you can log out of all sessions and revoke all API tokens."
-msgstr ""
-"Se você notar qualquer atividade suspeita ou tiver feito login em um "
-"computador compartilhado, pode encerrar todas as sessões e revogar todos os "
-"tokens de API."
+msgid "If you notice any suspicious activity or have logged in on a shared computer, you can log out of all sessions and revoke all API tokens."
+msgstr "Se você notar qualquer atividade suspeita ou tiver feito login em um computador compartilhado, pode encerrar todas as sessões e revogar todos os tokens de API."
 
 #: users/templates/users/account.html:378
 msgid "Authorized Apps"
@@ -7935,10 +7690,10 @@ msgstr "Lista de Silenciados"
 msgid "CSV file"
 msgstr "Arquivo CSV"
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:74
-#: users/templates/users/data.html:126 users/templates/users/data.html:183
-#: users/templates/users/data.html:234 users/templates/users/data.html:298
-#: users/templates/users/data.html:358 users/templates/users/data.html:553
+#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/data.html:141 users/templates/users/data.html:198
+#: users/templates/users/data.html:249 users/templates/users/data.html:313
+#: users/templates/users/data.html:376 users/templates/users/data.html:553
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr "Importar"
@@ -7963,12 +7718,8 @@ msgid "Migrate Account"
 msgstr "Migrar Conta"
 
 #: users/templates/users/account.html:488
-msgid ""
-"Linking an email to your account is highly recommended before migrating from "
-"another Fediverse instance."
-msgstr ""
-"É altamente recomendável vincular um e-mail à sua conta antes de migrar de "
-"outra instância do Fediverso."
+msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
+msgstr "É altamente recomendável vincular um e-mail à sua conta antes de migrar de outra instância do Fediverso."
 
 #: users/templates/users/account.html:491
 msgid "Migrate another account here"
@@ -7984,17 +7735,11 @@ msgstr "Excluir Conta"
 
 #: users/templates/users/account.html:504
 msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
-msgstr ""
-"Uma vez excluídos, os dados da conta não poderão ser recuperados. Tem "
-"certeza de que deseja prosseguir?"
+msgstr "Uma vez excluídos, os dados da conta não poderão ser recuperados. Tem certeza de que deseja prosseguir?"
 
 #: users/templates/users/account.html:507
-msgid ""
-"Enter full <code>username@instance.social</code> or <code>email@domain.com</"
-"code> to confirm deletion."
-msgstr ""
-"Insira o <code>nome_de_usuário@instância.social</code> ou "
-"<code>email@domínio.com</code> completo para confirmar a exclusão."
+msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
+msgstr "Insira o <code>nome_de_usuário@instância.social</code> ou <code>email@domínio.com</code> completo para confirmar a exclusão."
 
 #: users/templates/users/account.html:517
 msgid "Once deleted, account data cannot be recovered."
@@ -8045,12 +7790,8 @@ msgid "Token Created"
 msgstr "Token Criado"
 
 #: users/templates/users/authorized_app_created.html:22
-msgid ""
-"Your new personal access token has been created. Copy it now -- you will not "
-"be able to see it again."
-msgstr ""
-"Seu novo token de acesso pessoal foi criado. Copie-o agora — você não poderá "
-"vê-lo novamente."
+msgid "Your new personal access token has been created. Copy it now -- you will not be able to see it again."
+msgstr "Seu novo token de acesso pessoal foi criado. Copie-o agora — você não poderá vê-lo novamente."
 
 #: users/templates/users/authorized_app_created.html:25
 msgid "Token"
@@ -8077,12 +7818,8 @@ msgid "One quick check"
 msgstr "Uma verificação rápida"
 
 #: users/templates/users/captcha.html:28
-msgid ""
-"Put every cover into the row it belongs to. Drag it, or select a cover and "
-"then select a row."
-msgstr ""
-"Coloque cada capa na linha a que pertence. Arraste-a ou selecione uma capa e "
-"depois selecione uma linha."
+msgid "Put every cover into the row it belongs to. Drag it, or select a cover and then select a row."
+msgstr "Coloque cada capa na linha a que pertence. Arraste-a ou selecione uma capa e depois selecione uma linha."
 
 #: users/templates/users/captcha.html:41 users/templates/users/captcha.html:43
 msgid "Item cover"
@@ -8110,10 +7847,9 @@ msgstr "Bem organizado"
 
 #: users/templates/users/captcha_solved.html:31
 msgid "That is all we needed. Let's get you a username."
-msgstr ""
-"Isso é tudo o que precisávamos. Vamos arrumar um nome de usuário para você."
+msgstr "Isso é tudo o que precisávamos. Vamos arrumar um nome de usuário para você."
 
-#: users/templates/users/captcha_solved.html:34
+#: users/templates/users/captcha_solved.html:32
 #: users/templates/users/login.html:63
 #: users/templates/users/verify_email.html:25
 #: users/templates/users/welcome.html:51
@@ -8122,8 +7858,7 @@ msgstr "Continuar"
 
 #: users/templates/users/crossposts.html:19
 msgid "Secure your account with a passkey for quick sign-in."
-msgstr ""
-"Proteja sua conta com uma chave de acesso para entrar mais rapidamente."
+msgstr "Proteja sua conta com uma chave de acesso para entrar mais rapidamente."
 
 #: users/templates/users/crossposts.html:20
 msgid "Set up"
@@ -8134,15 +7869,8 @@ msgid "Failed Crossposts"
 msgstr "Publicações Cruzadas com Falha"
 
 #: users/templates/users/crossposts.html:42
-msgid ""
-"These posts could not be crossposted to your linked social accounts. Re-"
-"authorize the account if needed, then retry. In rare cases retrying may "
-"create a duplicate post."
-msgstr ""
-"Estas publicações não puderam ser publicadas de forma cruzada nas suas "
-"contas sociais vinculadas. Reautorize a conta, se necessário, e tente "
-"novamente. Em casos raros, tentar novamente pode criar uma publicação "
-"duplicada."
+msgid "These posts could not be crossposted to your linked social accounts. Re-authorize the account if needed, then retry. In rare cases retrying may create a duplicate post."
+msgstr "Estas publicações não puderam ser publicadas de forma cruzada nas suas contas sociais vinculadas. Reautorize a conta, se necessário, e tente novamente. Em casos raros, tentar novamente pode criar uma publicação duplicada."
 
 #: users/templates/users/crossposts.html:48
 msgid "Time"
@@ -8160,313 +7888,198 @@ msgstr "Nenhuma publicação cruzada com falha."
 msgid "Data Management"
 msgstr "Gerenciamento de Dados"
 
-#: users/templates/users/data.html:27
+#: users/templates/users/data.html:39
 msgid "Import Marks and Reviews from Douban"
 msgstr "Importar Marcações e Análises do Douban"
 
-#: users/templates/users/data.html:31
-msgid ""
-"Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
-"target=\"_blank\" rel=\"noopener\">Doufen</a>"
-msgstr ""
-"Selecione o arquivo <code>.xlsx</code> exportado do <a href=\"https://"
-"doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
+#: users/templates/users/data.html:43
+msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
+msgstr "Selecione o arquivo <code>.xlsx</code> exportado do <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 
 #: users/templates/users/data.html:45
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
-"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
-"NeoDB Archive</a> below."
-msgstr ""
-"Um arquivo Douban exportado por <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> está no formato NDJSON do "
-"próprio NeoDB; carregue-o em <a href=\"#import-neodb-archive\">Importar "
-"arquivo NeoDB</a> abaixo."
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON format instead; upload it under <a href=\"#import-neodb-archive\">Import NeoDB Archive</a> below."
+msgstr "Um arquivo Douban exportado por <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> está no formato NDJSON do próprio NeoDB; carregue-o em <a href=\"#import-neodb-archive\">Importar arquivo NeoDB</a> abaixo."
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:256
+#: users/templates/users/data.html:49 users/templates/users/data.html:271
 msgid "Import Method"
 msgstr "Método de Importação"
 
-#: users/templates/users/data.html:37
-msgid ""
-"Merge: only update when status changes from wishlist to in-progress, or from "
-"in-progress to complete."
-msgstr ""
-"Mesclar: atualizar apenas quando o status mudar de lista de desejos para em "
-"andamento, ou de em andamento para concluído."
+#: users/templates/users/data.html:52
+msgid "Merge: only update when status changes from wishlist to in-progress, or from in-progress to complete."
+msgstr "Mesclar: atualizar apenas quando o status mudar de lista de desejos para em andamento, ou de em andamento para concluído."
 
-#: users/templates/users/data.html:41
+#: users/templates/users/data.html:56
 msgid "Overwrite: update all imported status."
 msgstr "Substituir: atualizar todos os status importados."
 
-#: users/templates/users/data.html:74
-msgid ""
-"Another import is in progress, starting a new import may cause issues, sure "
-"to import?"
-msgstr ""
-"Outra importação está em andamento. Iniciar uma nova importação pode causar "
-"problemas. Tem certeza de que deseja importar?"
+#: users/templates/users/data.html:89
+msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
+msgstr "Outra importação está em andamento. Iniciar uma nova importação pode causar problemas. Tem certeza de que deseja importar?"
 
-#: users/templates/users/data.html:74
+#: users/templates/users/data.html:89 users/views/data.py:1130
 msgid "Import in progress, please wait"
 msgstr "Importação em andamento, aguarde"
 
-#: users/templates/users/data.html:81
+#: users/templates/users/data.html:96
 msgid "Import from Goodreads"
 msgstr "Importar do Goodreads"
 
-#: users/templates/users/data.html:87
-msgid ""
-"On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download "
-"your library as a CSV file."
-msgstr ""
-"No Goodreads, clique em <a href=\"https://www.goodreads.com/review/import\" "
-"target=\"_blank\" rel=\"noopener\"><b>Exportar Biblioteca</b></a> para "
-"baixar sua biblioteca em formato CSV."
+#: users/templates/users/data.html:102
+msgid "On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download your library as a CSV file."
+msgstr "No Goodreads, clique em <a href=\"https://www.goodreads.com/review/import\" target=\"_blank\" rel=\"noopener\"><b>Exportar Biblioteca</b></a> para baixar sua biblioteca em formato CSV."
 
-#: users/templates/users/data.html:90
-msgid ""
-"Upload the downloaded <code>goodreads_library_export.csv</code> file below."
-msgstr ""
-"Envie abaixo o arquivo <code>goodreads_library_export.csv</code> baixado."
+#: users/templates/users/data.html:105
+msgid "Upload the downloaded <code>goodreads_library_export.csv</code> file below."
+msgstr "Envie abaixo o arquivo <code>goodreads_library_export.csv</code> baixado."
 
-#: users/templates/users/data.html:93
-msgid ""
-"want-to-read / currently-reading / read / did-not-finish books and their "
-"reviews will be imported."
-msgstr ""
-"Livros marcados como quero-ler / lendo-atualmente / lido / não-terminei, "
-"junto com suas respectivas avaliações, serão importados."
+#: users/templates/users/data.html:108
+msgid "want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported."
+msgstr "Livros marcados como quero-ler / lendo-atualmente / lido / não-terminei, junto com suas respectivas avaliações, serão importados."
 
-#: users/templates/users/data.html:134
+#: users/templates/users/data.html:149
 msgid "Import from Letterboxd"
 msgstr "Importar do Letterboxd"
 
-#: users/templates/users/data.html:140
-msgid ""
-"on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" "
-"target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap "
-"Advanced Settings in Settings, tap EXPORT YOUR DATA"
-msgstr ""
-"No letterboxd.com, clique em <a href=\"https://letterboxd.com/settings/data/"
-"\" target=\"_blank\" rel=\"noopener\">DATA em Configurações</a>; ou, no "
-"aplicativo, toque em Configurações Avançadas em Configurações e, em seguida, "
-"toque em EXPORTAR SEUS DADOS"
+#: users/templates/users/data.html:155
+msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
+msgstr "No letterboxd.com, clique em <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA em Configurações</a>; ou, no aplicativo, toque em Configurações Avançadas em Configurações e, em seguida, toque em EXPORTAR SEUS DADOS"
 
-#: users/templates/users/data.html:143
-msgid ""
-"download file with name like <code>letterboxd-username-2018-03-11-07-52-"
-"utc.zip</code>, do not unzip"
-msgstr ""
-"baixe o arquivo com um nome semelhante a <code>letterboxd-"
-"username-2018-03-11-07-52-utc.zip</code>, sem descompactá-lo"
+#: users/templates/users/data.html:158
+msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
+msgstr "baixe o arquivo com um nome semelhante a <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, sem descompactá-lo"
 
-#: users/templates/users/data.html:146
-msgid ""
-"the following files in the zip file will be processed: <code>reviews.csv</"
-"code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</"
-"code> <code>lists/*.csv</code>"
-msgstr ""
-"os seguintes arquivos dentro do arquivo zip serão processados: "
-"<code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> "
-"<code>watchlist.csv</code> <code>lists/*.csv</code>"
+#: users/templates/users/data.html:161
+msgid "the following files in the zip file will be processed: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
+msgstr "os seguintes arquivos dentro do arquivo zip serão processados: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
 
-#: users/templates/users/data.html:149
-msgid ""
-"exported file does not indicate whether a list is private, unlisted or "
-"public, so all imported marks, reviews and collections will be created with "
-"the visibility selected below"
-msgstr ""
-"o arquivo exportado não indica se uma lista é privada, não listada ou "
-"pública; portanto, todas as marcações, avaliações e coleções importadas "
-"serão criadas com a visibilidade selecionada abaixo"
+#: users/templates/users/data.html:164
+msgid "exported file does not indicate whether a list is private, unlisted or public, so all imported marks, reviews and collections will be created with the visibility selected below"
+msgstr "o arquivo exportado não indica se uma lista é privada, não listada ou pública; portanto, todas as marcações, avaliações e coleções importadas serão criadas com a visibilidade selecionada abaixo"
 
-#: users/templates/users/data.html:184 users/templates/users/data.html:235
+#: users/templates/users/data.html:199 users/templates/users/data.html:250
 msgid "Only forward changes(none->to-watch->watched) will be imported."
-msgstr ""
-"Somente mudanças progressivas (nenhum → a assistir → assistido) serão "
-"importadas."
+msgstr "Somente mudanças progressivas (nenhum → a assistir → assistido) serão importadas."
 
-#: users/templates/users/data.html:191
+#: users/templates/users/data.html:206
 msgid "Import from Trakt"
 msgstr "Importar do Trakt"
 
-#: users/templates/users/data.html:197
-msgid ""
-"On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" "
-"rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait "
-"for the download link to appear."
-msgstr ""
-"Em <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" "
-"rel=\"noopener\">Configurações do Trakt - Dados</a>, clique em <b>Exportar "
-"agora</b> e aguarde o link de download aparecer."
+#: users/templates/users/data.html:212
+msgid "On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait for the download link to appear."
+msgstr "Em <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Configurações do Trakt - Dados</a>, clique em <b>Exportar agora</b> e aguarde o link de download aparecer."
 
-#: users/templates/users/data.html:200
+#: users/templates/users/data.html:215
 msgid "Upload the downloaded <code>.zip</code> file below, do not unzip."
 msgstr "Envie abaixo o arquivo <code>.zip</code> baixado, sem descompactá-lo."
 
-#: users/templates/users/data.html:202
+#: users/templates/users/data.html:217
 msgid "Ratings, watched movies/shows and watchlist will be imported."
-msgstr ""
-"As avaliações, filmes/séries assistidos e a lista de observação serão "
-"importados."
+msgstr "As avaliações, filmes/séries assistidos e a lista de observação serão importados."
 
-#: users/templates/users/data.html:243
+#: users/templates/users/data.html:258
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr "Importar da Lista de Desejos / Biblioteca da Steam"
 
-#: users/templates/users/data.html:246
+#: users/templates/users/data.html:261
 msgid "Login with Steam"
 msgstr "Entrar com a Steam"
 
-#: users/templates/users/data.html:252
+#: users/templates/users/data.html:267
 msgid "Import Podcast Subscriptions"
 msgstr "Importar Assinaturas de Podcast"
 
-#: users/templates/users/data.html:263
+#: users/templates/users/data.html:278
 msgid "Mark as listening"
 msgstr "Marcar como ouvindo"
 
-#: users/templates/users/data.html:267
+#: users/templates/users/data.html:282
 msgid "Import as a new collection"
 msgstr "Importar como nova coleção"
 
-#: users/templates/users/data.html:296
+#: users/templates/users/data.html:311
 msgid "Select OPML file"
 msgstr "Selecionar arquivo OPML"
 
-#: users/templates/users/data.html:306
+#: users/templates/users/data.html:321
 msgid "Import NeoDB Archive"
 msgstr "Importar Arquivo do NeoDB"
 
-#: users/templates/users/data.html:312
-msgid ""
-"Upload a <code>.zip</code> file containing <code>.csv</code> or "
-"<code>.ndjson</code> files exported from NeoDB."
-msgstr ""
-"Envie um arquivo <code>.zip</code> contendo arquivos <code>.csv</code> ou "
-"<code>.ndjson</code> exportados do NeoDB."
+#: users/templates/users/data.html:327
+msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
+msgstr "Envie um arquivo <code>.zip</code> contendo arquivos <code>.csv</code> ou <code>.ndjson</code> exportados do NeoDB."
 
 #: users/templates/users/data.html:330
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
-"imported here."
-msgstr ""
-"Um arquivo Douban exportado por <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> está no mesmo formato e é "
-"importado aqui."
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is imported here."
+msgstr "Um arquivo Douban exportado por <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> está no mesmo formato e é importado aqui."
 
-#: users/templates/users/data.html:314
+#: users/templates/users/data.html:332
 msgid "Existing data may be overwritten."
 msgstr "Os dados existentes podem ser substituídos."
 
-#: users/templates/users/data.html:324
+#: users/templates/users/data.html:342
 msgid "Detected format"
 msgstr "Formato detectado"
 
-#: users/templates/users/data.html:385
+#: users/templates/users/data.html:403
 msgid "Detecting format..."
 msgstr "Detectando formato..."
 
-#: users/templates/users/data.html:411
+#: users/templates/users/data.html:429
 msgid "Unknown format"
 msgstr "Formato desconhecido"
 
-#: users/templates/users/data.html:436
+#: users/templates/users/data.html:454
 msgid "Error detecting format"
 msgstr "Erro ao detectar o formato"
 
-#: users/templates/users/data.html:460
+#: users/templates/users/data.html:478
 msgid "Export NeoDB Archive"
 msgstr "Exportar Arquivo do NeoDB"
 
-#: users/templates/users/data.html:464
+#: users/templates/users/data.html:482
 msgid "Export marks, reviews and notes in CSV"
 msgstr "Exportar marcações, análise e notas em CSV"
 
-#: users/templates/users/data.html:471
+#: users/templates/users/data.html:489
 msgid "Export everything in NDJSON"
 msgstr "Exportar tudo em NDJSON"
-
-#: users/templates/users/data.html:479
-msgid "Export marks and reviews in XLSX (Doufen format)"
-msgstr "Exportar marcações e análises em XLSX (formato Doufen)"
-
-#: users/templates/users/data.html:482
-msgid "Last export"
-msgstr "Última exportação"
-
-#: users/templates/users/data.html:487
-msgid "Download"
-msgstr "Download"
 
 #: users/templates/users/data.html:496
 msgid "Import and Export Articles (WordPress)"
 msgstr "Importar e Exportar Artigos (WordPress)"
 
 #: users/templates/users/data.html:499
-msgid ""
-"Your articles are exchanged as WordPress posts in the WXR format, which "
-"WordPress and most blogging tools can read and write. Marks, reviews and "
-"notes are not included: use the NeoDB archive above for those."
-msgstr ""
-"Seus artigos são trocados como posts do WordPress no formato WXR, que o "
-"WordPress e a maioria das ferramentas de blogs podem ler e escrever. Marcas, "
-"avaliações e notas não estão incluídas: use o arquivo NeoDB acima para esses."
+msgid "Your articles are exchanged as WordPress posts in the WXR format, which WordPress and most blogging tools can read and write. Marks, reviews and notes are not included: use the NeoDB archive above for those."
+msgstr "Seus artigos são trocados como posts do WordPress no formato WXR, que o WordPress e a maioria das ferramentas de blogs podem ler e escrever. Marcas, avaliações e notas não estão incluídas: use o arquivo NeoDB acima para esses."
 
 #: users/templates/users/data.html:502
-msgid ""
-"Article title, body, excerpt, tags, dates and featured image are exchanged. "
-"Comments and custom fields are ignored."
-msgstr ""
-"Título do artigo, corpo, trecho, etiquetas, datas e imagem em destaque são "
-"trocados. Comentários e campos personalizados são ignorados."
+msgid "Article title, body, excerpt, tags, dates and featured image are exchanged. Comments and custom fields are ignored."
+msgstr "Título do artigo, corpo, trecho, etiquetas, datas e imagem em destaque são trocados. Comentários e campos personalizados são ignorados."
 
 #: users/templates/users/data.html:505
-msgid ""
-"The body is converted between Markdown and HTML, so formatting is kept but "
-"the text is not character-for-character identical."
-msgstr ""
-"O corpo é convertido entre Markdown e HTML, então a formatação é mantida, "
-"mas o texto não é idêntico caractere por caractere."
+msgid "The body is converted between Markdown and HTML, so formatting is kept but the text is not character-for-character identical."
+msgstr "O corpo é convertido entre Markdown e HTML, então a formatação é mantida, mas o texto não é idêntico caractere por caractere."
 
 #: users/templates/users/data.html:512
 msgid "Export articles in WordPress format"
 msgstr "Exportar artigos no formato WordPress"
 
 #: users/templates/users/data.html:519
-msgid ""
-"In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download "
-"an <code>.xml</code> file, then upload it below."
-msgstr ""
-"No WordPress, vá em <b>Ferramentas</b> - <b>Exportar</b> - <b>Publicações</"
-"b> para baixar um arquivo <code>.xml</code>, depois envie-o abaixo."
+msgid "In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download an <code>.xml</code> file, then upload it below."
+msgstr "No WordPress, vá em <b>Ferramentas</b> - <b>Exportar</b> - <b>Publicações</b> para baixar um arquivo <code>.xml</code>, depois envie-o abaixo."
 
 #: users/templates/users/data.html:522
-msgid ""
-"Only published posts use the visibility below. Drafts, pending, private and "
-"password-protected posts are always imported as mentioned-only, so nothing "
-"unpublished becomes public."
-msgstr ""
-"Apenas publicações publicadas usam a visibilidade abaixo. Rascunhos, "
-"pendentes, privados e publicações protegidas por senha são sempre importados "
-"como somente mencionados, portanto nada não publicado se torna público."
+msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
+msgstr "Apenas publicações publicadas usam a visibilidade abaixo. Rascunhos, pendentes, privados e publicações protegidas por senha são sempre importados como somente mencionados, portanto nada não publicado se torna público."
 
 #: users/templates/users/data.html:560
 msgid "View Annual Summary"
 msgstr "Ver Resumo Anual"
 
 #: users/templates/users/fetch_identity_failed.html:4
-msgid ""
-"Unable to find the user, please check your spelling; or the server may be "
-"busy, please try again later."
-msgstr ""
-"Não foi possível encontrar o usuário. Verifique a ortografia; ou o servidor "
-"pode estar ocupado — tente novamente mais tarde."
+msgid "Unable to find the user, please check your spelling; or the server may be busy, please try again later."
+msgstr "Não foi possível encontrar o usuário. Verifique a ortografia; ou o servidor pode estar ocupado — tente novamente mais tarde."
 
 #: users/templates/users/fetch_identity_pending.html:13
 #: users/templates/users/fetch_identity_pending.html:22
@@ -8485,113 +8098,76 @@ msgstr "Entrar"
 msgid "logo"
 msgstr "logo"
 
-#: users/templates/users/login.html:127
-msgid ""
-"Sign in with a passkey saved on this device or in your password manager."
-msgstr ""
-"Entre com uma chave de acesso salva neste dispositivo ou no seu gerenciador "
-"de senhas."
+#: users/templates/users/login.html:121
+msgid "Sign in with a passkey saved on this device or in your password manager."
+msgstr "Entre com uma chave de acesso salva neste dispositivo ou no seu gerenciador de senhas."
 
-#: users/templates/users/login.html:132
+#: users/templates/users/login.html:126
 msgid "Sign in with Passkey"
 msgstr "Entrar com Chave de Acesso"
 
-#: users/templates/users/login.html:148
+#: users/templates/users/login.html:142
 msgid "Enter your email address"
 msgstr "Insira seu endereço de e-mail"
 
-#: users/templates/users/login.html:152
+#: users/templates/users/login.html:146
 msgid "Send verification code"
 msgstr "Enviar código de verificação"
 
-#: users/templates/users/login.html:171
+#: users/templates/users/login.html:165
 msgid "Domain of your instance, e.g. mastodon.social"
 msgstr "Domínio da sua instância, ex.: mastodon.social"
 
-#: users/templates/users/login.html:177
-msgid ""
-"Please enter domain of your instance; e.g. if your id is "
-"<i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
-msgstr ""
-"Por favor, insira o domínio da sua instância; ex.: se o seu ID é "
-"<i>@neodb@mastodon.social</i>, insira apenas <i>mastodon.social</i>."
+#: users/templates/users/login.html:171
+msgid "Please enter domain of your instance; e.g. if your id is <i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
+msgstr "Por favor, insira o domínio da sua instância; ex.: se o seu ID é <i>@neodb@mastodon.social</i>, insira apenas <i>mastodon.social</i>."
 
-#: users/templates/users/login.html:182 users/templates/users/login.html:246
+#: users/templates/users/login.html:176 users/templates/users/login.html:240
 msgid "Authorize via Fediverse instance"
 msgstr "Autorizar via instância do Fediverso"
 
-#: users/templates/users/login.html:187
-msgid ""
-"If you don't have a <a href=\"https://joinmastodon.org/servers\" "
-"target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or "
-"login with Email first, and link it with Fediverse (Mastodon) later in "
-"account settings."
-msgstr ""
-"Se você ainda não tem uma <a href=\"https://joinmastodon.org/servers\" "
-"target=\"_blank\">Fediverse (Mastodon) account</a>, pode se registrar ou "
-"entrar com e-mail primeiro e vinculá-la ao Fediverso (Mastodon) "
-"posteriormente nas configurações da conta."
+#: users/templates/users/login.html:181
+msgid "If you don't have a <a href=\"https://joinmastodon.org/servers\" target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or login with Email first, and link it with Fediverse (Mastodon) later in account settings."
+msgstr "Se você ainda não tem uma <a href=\"https://joinmastodon.org/servers\" target=\"_blank\">Fediverse (Mastodon) account</a>, pode se registrar ou entrar com e-mail primeiro e vinculá-la ao Fediverso (Mastodon) posteriormente nas configurações da conta."
 
-#: users/templates/users/login.html:200
+#: users/templates/users/login.html:194
 msgid "Authorize via Threads"
 msgstr "Autorizar via Threads"
 
-#: users/templates/users/login.html:221
-msgid ""
-"Please input your ATProto handle (e.g. neodb.bsky.social, without the "
-"leading @), do not use email. If you changed handle recently, just use the "
-"latest one."
-msgstr ""
-"Por favor, insira seu identificador ATProto (ex.: neodb.bsky.social, sem o @ "
-"inicial). Não use e-mail. Se você alterou seu identificador recentemente, "
-"use apenas o mais recente."
+#: users/templates/users/login.html:215
+msgid "Please input your ATProto handle (e.g. neodb.bsky.social, without the leading @), do not use email. If you changed handle recently, just use the latest one."
+msgstr "Por favor, insira seu identificador ATProto (ex.: neodb.bsky.social, sem o @ inicial). Não use e-mail. Se você alterou seu identificador recentemente, use apenas o mais recente."
 
-#: users/templates/users/login.html:224
+#: users/templates/users/login.html:218
 msgid "Authorize via ATProto server"
 msgstr "Autorizar via servidor ATProto"
 
-#: users/templates/users/login.html:231
+#: users/templates/users/login.html:225
 #, python-format
-msgid ""
-"Please choose one to register or login %(site_name)s. Have more than one of "
-"these identities? Don't worry, you may link them in account settings once "
-"logged in."
-msgstr ""
-"Por favor, escolha uma opção para registrar-se ou entrar no %(site_name)s. "
-"Possui mais de uma dessas identidades? Não se preocupe, você poderá vinculá-"
-"las nas configurações da conta após o login."
+msgid "Please choose one to register or login %(site_name)s. Have more than one of these identities? Don't worry, you may link them in account settings once logged in."
+msgstr "Por favor, escolha uma opção para registrar-se ou entrar no %(site_name)s. Possui mais de uma dessas identidades? Não se preocupe, você poderá vinculá-las nas configurações da conta após o login."
 
-#: users/templates/users/login.html:255
+#: users/templates/users/login.html:249
 msgid "Valid invitation code, please login or register."
 msgstr "Código de convite válido. Por favor, entre ou registre-se."
 
-#: users/templates/users/login.html:257
-msgid ""
-"Please use invitation link to register a new account; existing user may "
-"login."
-msgstr ""
-"Por favor, use o link de convite para registrar uma nova conta; usuários "
-"existentes podem entrar normalmente."
+#: users/templates/users/login.html:251
+msgid "Please use invitation link to register a new account; existing user may login."
+msgstr "Por favor, use o link de convite para registrar uma nova conta; usuários existentes podem entrar normalmente."
 
-#: users/templates/users/login.html:259
+#: users/templates/users/login.html:253
 msgid "Invitation code invalid or expired."
 msgstr "Código de convite inválido ou expirado."
 
-#: users/templates/users/login.html:267
+#: users/templates/users/login.html:261
 msgid "Loading timed out, please check your network (VPN) settings."
 msgstr "O carregamento expirou, verifique suas configurações de rede (VPN)."
 
-#: users/templates/users/login.html:273
-msgid ""
-"Continue using this site implies consent to our <a href=\"/pages/rules/"
-"\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using "
-"cookies to provide necessary functionality."
-msgstr ""
-"Continuar usando este site implica consentimento com nossas <a href=\"/pages/"
-"rules/\">regras</a> e <a href=\"/pages/terms/\">termos</a>, incluindo o uso "
-"de cookies para fornecer as funcionalidades necessárias."
+#: users/templates/users/login.html:267
+msgid "Continue using this site implies consent to our <a href=\"/pages/rules/\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using cookies to provide necessary functionality."
+msgstr "Continuar usando este site implica consentimento com nossas <a href=\"/pages/rules/\">regras</a> e <a href=\"/pages/terms/\">termos</a>, incluindo o uso de cookies para fornecer as funcionalidades necessárias."
 
-#: users/templates/users/login.html:287
+#: users/templates/users/login.html:281
 msgid "Domain of your instance (excl. @)"
 msgstr "Domínio da sua instância (sem o @)"
 
@@ -8601,13 +8177,8 @@ msgid "Migrate Here"
 msgstr "Migrar para Cá"
 
 #: users/templates/users/migrate_in.html:22
-msgid ""
-"To move another account to this one, first add it as an alias here, and then "
-"go to the server where it is hosted and initiate the move."
-msgstr ""
-"Para mover outra conta para esta, primeiro adicione-a como um alias aqui e, "
-"em seguida, vá até o servidor onde ela está hospedada e inicie a "
-"movimentação."
+msgid "To move another account to this one, first add it as an alias here, and then go to the server where it is hosted and initiate the move."
+msgstr "Para mover outra conta para esta, primeiro adicione-a como um alias aqui e, em seguida, vá até o servidor onde ela está hospedada e inicie a movimentação."
 
 #: users/templates/users/migrate_in.html:27
 msgid "Account to alias"
@@ -8648,22 +8219,12 @@ msgstr "Cancelar Migração"
 
 #: users/templates/users/migrate_out.html:46
 #, python-format
-msgid ""
-"To migrate to another account, first add <code>@%(handle)s</code> as an "
-"alias on the target server, and then type the target account below to start "
-"the migration."
-msgstr ""
-"Para migrar para outra conta, primeiro adicione <code>@%(handle)s</code> "
-"como um alias no servidor de destino e, em seguida, digite a conta de "
-"destino abaixo para iniciar a migração."
+msgid "To migrate to another account, first add <code>@%(handle)s</code> as an alias on the target server, and then type the target account below to start the migration."
+msgstr "Para migrar para outra conta, primeiro adicione <code>@%(handle)s</code> como um alias no servidor de destino e, em seguida, digite a conta de destino abaixo para iniciar a migração."
 
 #: users/templates/users/migrate_out.html:50
-msgid ""
-"Are you sure you want to migrate your account? Your followers will be moved "
-"to the target account."
-msgstr ""
-"Tem certeza de que deseja migrar sua conta? Seus seguidores serão movidos "
-"para a conta de destino."
+msgid "Are you sure you want to migrate your account? Your followers will be moved to the target account."
+msgstr "Tem certeza de que deseja migrar sua conta? Seus seguidores serão movidos para a conta de destino."
 
 #: users/templates/users/migrate_out.html:53
 msgid "Target account"
@@ -8676,10 +8237,6 @@ msgstr "Iniciar Migração"
 #: users/templates/users/preferences.html:28
 msgid "Default view once logged in"
 msgstr "Visualização padrão após o login"
-
-#: users/templates/users/preferences.html:40
-msgid "Activities"
-msgstr "Atividades"
 
 #: users/templates/users/preferences.html:49
 msgid "Default visibility"
@@ -8708,13 +8265,8 @@ msgstr "Ativar publicação cruzada em outras redes sociais por padrão"
 
 #: users/templates/users/preferences.html:111
 #: users/templates/users/register.html:88
-msgid ""
-"If a Mastodon account is linked with this identity, boosting a post will "
-"also make the same post boosted with that Mastodon account."
-msgstr ""
-"Se uma conta do Mastodon estiver vinculada a esta identidade, impulsionar "
-"uma publicação também fará com que a mesma publicação seja impulsionada com "
-"essa conta do Mastodon."
+msgid "If a Mastodon account is linked with this identity, boosting a post will also make the same post boosted with that Mastodon account."
+msgstr "Se uma conta do Mastodon estiver vinculada a esta identidade, impulsionar uma publicação também fará com que a mesma publicação seja impulsionada com essa conta do Mastodon."
 
 #: users/templates/users/preferences.html:115
 msgid "Method for crossposting to timeline"
@@ -8729,21 +8281,13 @@ msgid "Create a new post"
 msgstr "Criar uma nova publicação"
 
 #: users/templates/users/preferences.html:130
-msgid ""
-"this method is less optimal, may generate duplicated posts and miss "
-"reactions."
-msgstr ""
-"este método é menos eficiente, pode gerar publicações duplicadas e perder "
-"reações."
+msgid "this method is less optimal, may generate duplicated posts and miss reactions."
+msgstr "este método é menos eficiente, pode gerar publicações duplicadas e perder reações."
 
 #: users/templates/users/preferences.html:140
 #: users/templates/users/register.html:97
-msgid ""
-"Always publish my public marks, reviews and articles as data records to my "
-"PDS."
-msgstr ""
-"Sempre publicar minhas marcações, avaliações e artigos públicos como "
-"registros de dados no meu PDS."
+msgid "Always publish my public marks, reviews and articles as data records to my PDS."
+msgstr "Sempre publicar minhas marcações, avaliações e artigos públicos como registros de dados no meu PDS."
 
 #: users/templates/users/preferences.html:145
 msgid "Append tags when posting to timeline"
@@ -8762,24 +8306,12 @@ msgid "Automatic bookmark for these categories"
 msgstr "Marcador automático para estas categorias"
 
 #: users/templates/users/preferences.html:175
-msgid ""
-"When start to read/watch/play/... an item in these categories, a bookmark "
-"will be created automatically. Bookmarks can be viewed and managed in most "
-"<a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon "
-"compatible apps</a>; your replies to these posts will automatically become "
-"notes for the item."
-msgstr ""
-"Ao começar a ler/assistir/jogar/... um item nestas categorias, um marcador "
-"será criado automaticamente. Os marcadores podem ser visualizados e "
-"gerenciados na maioria dos <a href=\"https://joinmastodon.org/apps\" "
-"target=\"_blank\">aplicativos compatíveis com o Mastodon</a>; suas respostas "
-"a essas publicações se tornarão automaticamente notas para o item."
+msgid "When start to read/watch/play/... an item in these categories, a bookmark will be created automatically. Bookmarks can be viewed and managed in most <a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon compatible apps</a>; your replies to these posts will automatically become notes for the item."
+msgstr "Ao começar a ler/assistir/jogar/... um item nestas categorias, um marcador será criado automaticamente. Os marcadores podem ser visualizados e gerenciados na maioria dos <a href=\"https://joinmastodon.org/apps\" target=\"_blank\">aplicativos compatíveis com o Mastodon</a>; suas respostas a essas publicações se tornarão automaticamente notas para o item."
 
 #: users/templates/users/preferences.html:183
 msgid "Turn replies to my own catalog item posts into notes for the item"
-msgstr ""
-"Transformar respostas às minhas próprias publicações de itens do catálogo em "
-"anotações para o item"
+msgstr "Transformar respostas às minhas próprias publicações de itens do catálogo em anotações para o item"
 
 #: users/templates/users/preferences.html:187
 msgid "Hide these categories in search results"
@@ -8794,46 +8326,20 @@ msgid "Profile visible to anonymous web visitors and search engines"
 msgstr "Perfil visível para visitantes anônimos da web e mecanismos de busca"
 
 #: users/templates/users/preferences.html:217
-msgid ""
-"this option limits web visits only; to limit fediverse visibility, choose "
-"followers only or mentioned only when posting"
-msgstr ""
-"esta opção limita apenas as visitas pela web; para limitar a visibilidade no "
-"Fediverso, escolha apenas seguidores ou apenas mencionados ao publicar"
+msgid "this option limits web visits only; to limit fediverse visibility, choose followers only or mentioned only when posting"
+msgstr "esta opção limita apenas as visitas pela web; para limitar a visibilidade no Fediverso, escolha apenas seguidores ou apenas mencionados ao publicar"
 
 #: users/templates/users/preferences.html:225
 msgid "Show your name on item page if you recently edited it"
-msgstr ""
-"Exibir seu nome na página do item caso você o tenha editado recentemente"
+msgstr "Exibir seu nome na página do item caso você o tenha editado recentemente"
 
 #: users/templates/users/preferences.html:234
 msgid "Do not show me item recommendations"
 msgstr "Não me mostrar recomendações de itens"
 
 #: users/templates/users/preferences.html:237
-msgid ""
-"Recommendations are generated only from public marks, processed in batch on "
-"this server. Your private and follower-only marks are never used as a signal "
-"for anyone, and we never share your data with third parties for this "
-"feature. When you share marks publicly and keep your profile discoverable, "
-"your marks help others here and across the Fediverse find things they might "
-"enjoy -- that voluntary contribution is what makes the feature work for "
-"everyone. If you'd rather not contribute, uncheck \"Include profile, marks "
-"and posts in discovery\" on your account page; this setting is published "
-"over ActivityPub, so other servers will also stop including you in their "
-"discovery features."
-msgstr ""
-"As recomendações são geradas apenas a partir de marcações públicas, "
-"processadas em lote neste servidor. Suas marcações privadas e restritas a "
-"seguidores nunca são usadas como sinal para ninguém, e nunca compartilhamos "
-"seus dados com terceiros para este recurso. Ao compartilhar suas marcações "
-"publicamente e manter seu perfil detectável, suas marcações ajudam outras "
-"pessoas aqui e em todo o Fediverse a encontrar coisas que possam gostar -- "
-"essa contribuição voluntária é o que faz o recurso funcionar para todos. Se "
-"preferir não contribuir, desmarque \"Incluir perfil, marcações e publicações "
-"na descoberta\" na página da sua conta; essa configuração é publicada via "
-"ActivityPub, portanto outros servidores também deixarão de incluí-lo(a) em "
-"seus próprios recursos de descoberta."
+msgid "Recommendations are generated only from public marks, processed in batch on this server. Your private and follower-only marks are never used as a signal for anyone, and we never share your data with third parties for this feature. When you share marks publicly and keep your profile discoverable, your marks help others here and across the Fediverse find things they might enjoy -- that voluntary contribution is what makes the feature work for everyone. If you'd rather not contribute, uncheck \"Include profile, marks and posts in discovery\" on your account page; this setting is published over ActivityPub, so other servers will also stop including you in their discovery features."
+msgstr "As recomendações são geradas apenas a partir de marcações públicas, processadas em lote neste servidor. Suas marcações privadas e restritas a seguidores nunca são usadas como sinal para ninguém, e nunca compartilhamos seus dados com terceiros para este recurso. Ao compartilhar suas marcações publicamente e manter seu perfil detectável, suas marcações ajudam outras pessoas aqui e em todo o Fediverse a encontrar coisas que possam gostar -- essa contribuição voluntária é o que faz o recurso funcionar para todos. Se preferir não contribuir, desmarque \"Incluir perfil, marcações e publicações na descoberta\" na página da sua conta; essa configuração é publicada via ActivityPub, portanto outros servidores também deixarão de incluí-lo(a) em seus próprios recursos de descoberta."
 
 #: users/templates/users/profile_actions.html:12
 msgid "click to unblock"
@@ -8930,29 +8436,15 @@ msgstr "Seu nome de usuário no %(site_name)s"
 
 #: users/templates/users/register.html:28
 msgid "2-30 alphabets, numbers or underscore, can't be changed once saved"
-msgstr ""
-"2 a 30 caracteres alfanuméricos ou sublinhado, não pode ser alterado após "
-"salvo"
+msgstr "2 a 30 caracteres alfanuméricos ou sublinhado, não pode ser alterado após salvo"
 
 #: users/templates/users/register.html:72
-msgid ""
-"Use display name, bio and avatar from the social network you authenticated "
-"with"
-msgstr ""
-"Usar nome de exibição, biografia e avatar da rede social com a qual você se "
-"autenticou"
+msgid "Use display name, bio and avatar from the social network you authenticated with"
+msgstr "Usar nome de exibição, biografia e avatar da rede social com a qual você se autenticou"
 
 #: users/templates/users/register.html:80
-msgid ""
-"Add follow, mute and block list from the social network you authenticated "
-"with"
-msgstr ""
-"Adicionar lista de seguidos, silenciados e bloqueados da rede social com a "
-"qual você se autenticou"
-
-#: users/templates/users/register.html:104
-msgid "Confirm and save"
-msgstr "Confirmar e salvar"
+msgid "Add follow, mute and block list from the social network you authenticated with"
+msgstr "Adicionar lista de seguidos, silenciados e bloqueados da rede social com a qual você se autenticou"
 
 #: users/templates/users/register.html:106
 msgid "Close"
@@ -8980,14 +8472,11 @@ msgstr "Revisar Correspondências do RateYourMusic"
 #, python-format
 msgid ""
 "\n"
-"              Matched %(local)s locally, %(external)s externally, "
-"%(unmatched)s unmatched out of %(total)s rows.\n"
+"              Matched %(local)s locally, %(external)s externally, %(unmatched)s unmatched out of %(total)s rows.\n"
 "            "
 msgstr ""
 "\n"
-"              Correspondidos %(local)s localmente, %(external)s "
-"externamente, %(unmatched)s sem correspondência de um total de %(total)s "
-"linhas.\n"
+"              Correspondidos %(local)s localmente, %(external)s externamente, %(unmatched)s sem correspondência de um total de %(total)s linhas.\n"
 "            "
 
 #: users/templates/users/rym_import.html:45
@@ -9052,8 +8541,7 @@ msgstr "Obtenha uma chave gratuita em"
 
 #: users/templates/users/steam_import.html:37
 msgid "You can revoke or regenerate the key after the import is complete."
-msgstr ""
-"Você pode revogar ou gerar uma nova chave após a conclusão da importação."
+msgstr "Você pode revogar ou gerar uma nova chave após a conclusão da importação."
 
 #: users/templates/users/steam_import.html:42
 msgid "Import Sources"
@@ -9104,12 +8592,8 @@ msgid "Played"
 msgstr "Jogado"
 
 #: users/templates/users/steam_import.html:90
-msgid ""
-"Games in wishlist; or purchased in library but never played, mark date will "
-"be set as today"
-msgstr ""
-"Jogos na lista de desejos; ou adquiridos na biblioteca, mas nunca jogados — "
-"a data de marcação será definida como hoje"
+msgid "Games in wishlist; or purchased in library but never played, mark date will be set as today"
+msgstr "Jogos na lista de desejos; ou adquiridos na biblioteca, mas nunca jogados — a data de marcação será definida como hoje"
 
 #: users/templates/users/steam_import.html:91
 msgid "To play"
@@ -9148,20 +8632,12 @@ msgid "Comma-separated Steam AppIDs"
 msgstr "IDs de aplicativo da Steam (AppIDs) separados por vírgula"
 
 #: users/templates/users/steam_import.html:121
-msgid ""
-"Allow reverse override of status (e.g. playing -> want to, or played -> "
-"playing)"
-msgstr ""
-"Permitir substituição reversa de status (por exemplo, jogando -> quero "
-"jogar, ou jogado -> jogando)"
+msgid "Allow reverse override of status (e.g. playing -> want to, or played -> playing)"
+msgstr "Permitir substituição reversa de status (por exemplo, jogando -> quero jogar, ou jogado -> jogando)"
 
 #: users/templates/users/steam_import.html:139
-msgid ""
-"To import from Steam, your game details must be visible to public in Steam "
-"privacy settings."
-msgstr ""
-"Para importar da Steam, os detalhes dos seus jogos devem estar visíveis "
-"publicamente nas configurações de privacidade da Steam."
+msgid "To import from Steam, your game details must be visible to public in Steam privacy settings."
+msgstr "Para importar da Steam, os detalhes dos seus jogos devem estar visíveis publicamente nas configurações de privacidade da Steam."
 
 #: users/templates/users/storygraph_import.html:9
 #: users/templates/users/storygraph_import.html:37
@@ -9205,35 +8681,20 @@ msgstr "Bem-vindo"
 #, python-format
 msgid ""
 "\n"
-"              %(site_name)s is flourishing because of collaborations and "
-"contributions from users like you. Please read our <a href=\"/pages/"
-"rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</"
-"a> if you have any question or feedback.\n"
+"              %(site_name)s is flourishing because of collaborations and contributions from users like you. Please read our <a href=\"/pages/rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</a> if you have any question or feedback.\n"
 "        "
 msgstr ""
 "\n"
-"              O %(site_name)s prospera graças às colaborações e "
-"contribuições de usuários como você. Por favor, leia nossas <a href=\"/pages/"
-"rules\">regras</a> e fique à vontade para <a "
-"href=\"%(support_link)s\">entrar em contato conosco</a> caso tenha alguma "
-"dúvida ou sugestão.\n"
+"              O %(site_name)s prospera graças às colaborações e contribuições de usuários como você. Por favor, leia nossas <a href=\"/pages/rules\">regras</a> e fique à vontade para <a href=\"%(support_link)s\">entrar em contato conosco</a> caso tenha alguma dúvida ou sugestão.\n"
 "        "
 
 #: users/templates/users/welcome.html:37
-msgid ""
-"Set up a passkey to sign in quickly next time using your fingerprint, face, "
-"or screen lock."
-msgstr ""
-"Configure uma chave de acesso para entrar rapidamente na próxima vez, usando "
-"sua impressão digital, reconhecimento facial ou bloqueio de tela."
+msgid "Set up a passkey to sign in quickly next time using your fingerprint, face, or screen lock."
+msgstr "Configure uma chave de acesso para entrar rapidamente na próxima vez, usando sua impressão digital, reconhecimento facial ou bloqueio de tela."
 
 #: users/templates/users/welcome.html:39
-msgid ""
-"Creating a passkey is highly recommended, as the website or email you use to "
-"create this account may not be always available."
-msgstr ""
-"É altamente recomendável criar uma chave de acesso, pois o site ou e-mail "
-"usado para criar esta conta pode nem sempre estar disponível."
+msgid "Creating a passkey is highly recommended, as the website or email you use to create this account may not be always available."
+msgstr "É altamente recomendável criar uma chave de acesso, pois o site ou e-mail usado para criar esta conta pode nem sempre estar disponível."
 
 #: users/templates/users/welcome.html:43
 msgid "Create Passkey"
@@ -9247,308 +8708,219 @@ msgstr "Talvez mais tarde"
 msgid "Passkey created"
 msgstr "Chave de acesso criada"
 
-#: users/views/account.py:124
+#: users/views/account.py:126
 msgid "This username is already in use."
 msgstr "Este nome de usuário já está em uso."
 
-#: users/views/account.py:135
+#: users/views/account.py:137
 msgid "This email address is already in use."
 msgstr "Este endereço de e-mail já está em uso."
 
-#: users/views/account.py:255 users/views/account.py:374
+#: users/views/account.py:257 users/views/account.py:376
 msgid "Registration is for invitation only"
 msgstr "O cadastro é apenas por convite"
 
-#: users/views/account.py:266 users/views/account.py:338
+#: users/views/account.py:268 users/views/account.py:340
 msgid "Time is up"
 msgstr "O tempo acabou"
 
-#: users/views/account.py:267 users/views/account.py:310
-#: users/views/account.py:339
+#: users/views/account.py:269 users/views/account.py:312
+#: users/views/account.py:341
 msgid "Please log in again to continue registration."
 msgstr "Por favor, faça login novamente para continuar o registro."
 
-#: users/views/account.py:313
+#: users/views/account.py:315
 msgid "That is not quite right. Here is a new set."
 msgstr "Isso não está exatamente certo. Aqui está um novo conjunto."
 
-#: users/views/account.py:325
+#: users/views/account.py:327
 msgid "Too many attempts"
 msgstr "Muitas tentativas"
 
-#: users/views/account.py:326
+#: users/views/account.py:328
 msgid "Please try again later."
 msgstr "Por favor, tente novamente mais tarde."
 
-#: users/views/account.py:415
+#: users/views/account.py:417
 msgid "Username already taken. Please try again."
 msgstr "Nome de usuário já está em uso. Tente novamente."
 
-#: users/views/account.py:445
+#: users/views/account.py:447
 msgid "Valid username required"
 msgstr "Nome de usuário válido obrigatório"
 
-#: users/views/account.py:526
+#: users/views/account.py:518
 msgid "Account is being deleted."
 msgstr "A conta está sendo excluída."
 
-#: users/views/account.py:529
+#: users/views/account.py:521
 msgid "Account mismatch."
 msgstr "Incompatibilidade de conta."
 
-#: users/views/data.py:262 users/views/data.py:294
+#: users/views/data.py:264 users/views/data.py:296
 msgid "Export file not available."
 msgstr "Arquivo de exportação não disponível."
 
-#: users/views/data.py:288
+#: users/views/data.py:290
 msgid "Generating exports."
 msgstr "Gerando exportações."
 
-#: users/views/data.py:306
+#: users/views/data.py:308
 msgid "Export file expired. Please export again."
 msgstr "Arquivo de exportação expirado. Por favor, exporte novamente."
 
-#: users/views/data.py:321 users/views/data.py:342 users/views/data.py:363
+#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
 msgid "Recent export still in progress."
 msgstr "Exportação recente ainda em andamento."
 
-#: users/views/data.py:379 users/views/data.py:513 users/views/data.py:547
-#: users/views/data.py:772 users/views/data.py:989 users/views/data.py:1015
-#: users/views/data.py:1040 users/views/data.py:1065
+#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
+#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
+#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
 msgid "Invalid file."
 msgstr "Arquivo inválido."
 
-#: users/views/data.py:403
+#: users/views/data.py:405
 msgid "Sync in progress."
 msgstr "Sincronização em andamento."
 
-#: users/views/data.py:417
+#: users/views/data.py:419
 msgid "Settings saved."
 msgstr "Configurações salvas."
 
-#: users/views/data.py:472
+#: users/views/data.py:474
 msgid "Account no longer linked."
 msgstr "Conta não está mais vinculada."
 
-#: users/views/data.py:475
+#: users/views/data.py:477
 msgid "Content is no longer public."
 msgstr "O conteúdo não está mais público."
 
-#: users/views/data.py:503
+#: users/views/data.py:505
 msgid "Retry did not complete, please try again."
 msgstr "A repetição não foi concluída; tente novamente."
 
-#: users/views/data.py:583 users/views/data.py:808
+#: users/views/data.py:585 users/views/data.py:810
 msgid "Loaded from uploaded matched file."
 msgstr "Carregado a partir do arquivo correspondido enviado."
 
-#: users/views/data.py:608 users/views/data.py:837
+#: users/views/data.py:610 users/views/data.py:839
 msgid "Cancelled."
 msgstr "Cancelado."
 
-#: users/views/data.py:628
+#: users/views/data.py:630
 msgid "No RateYourMusic import to preview."
 msgstr "Nenhuma importação do RateYourMusic para pré-visualizar."
 
-#: users/views/data.py:636 users/views/data.py:746 users/views/data.py:867
-#: users/views/data.py:972
+#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
+#: users/views/data.py:974
 msgid "Matched file missing."
 msgstr "Arquivo correspondido ausente."
 
-#: users/views/data.py:732 users/views/data.py:958
+#: users/views/data.py:734 users/views/data.py:960
 msgid "Starting import..."
 msgstr "Iniciando importação..."
 
-#: users/views/data.py:742 users/views/data.py:968
+#: users/views/data.py:744 users/views/data.py:970
 msgid "No matched file available."
 msgstr "Nenhum arquivo correspondido disponível."
 
-#: users/views/data.py:859
+#: users/views/data.py:861
 msgid "No StoryGraph import to preview."
 msgstr "Nenhuma importação do StoryGraph para pré-visualizar."
 
-#: users/views/data.py:1188
+#: users/views/data.py:1226
 msgid "Name is required."
 msgstr "O nome é obrigatório."
 
-#: users/views/data.py:1210
+#: users/views/data.py:1248
 msgid "Application access has been revoked."
 msgstr "O acesso do aplicativo foi revogado."
 
-#: users/views/data.py:1226
+#: users/views/data.py:1264
 msgid "Alias update not allowed for a moved account."
 msgstr "Não é permitido atualizar o alias de uma conta que já foi movida."
 
-#: users/views/data.py:1231
+#: users/views/data.py:1269
 msgid "No alias specified."
 msgstr "Nenhum alias especificado."
 
-#: users/views/data.py:1241 users/views/data.py:1292
+#: users/views/data.py:1279 users/views/data.py:1330
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr "Consultando a conta. Tente novamente em alguns segundos."
 
-#: users/views/data.py:1248
+#: users/views/data.py:1286
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr "Alias para {handle} removido."
 
-#: users/views/data.py:1253
+#: users/views/data.py:1291
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr "Alias para {handle} adicionado."
 
-#: users/views/data.py:1279
+#: users/views/data.py:1317
 msgid "Migration cancelled."
 msgstr "Migração cancelada."
 
-#: users/views/data.py:1284
+#: users/views/data.py:1322
 msgid "No target account specified."
 msgstr "Nenhuma conta de destino especificada."
 
-#: users/views/data.py:1297
+#: users/views/data.py:1335
 msgid "Cannot migrate to a local account."
 msgstr "Não é possível migrar para uma conta local."
 
-#: users/views/data.py:1308
+#: users/views/data.py:1346
 msgid "You must set up an alias in the target account first."
 msgstr "Você deve primeiro configurar um alias na conta de destino."
 
-#: users/views/data.py:1314
+#: users/views/data.py:1352
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr "Iniciando a mudança para {handle}."
 
-#: users/views/data.py:1372
+#: users/views/data.py:1410
 msgid "No file uploaded."
 msgstr "Nenhum arquivo enviado."
 
-#: users/views/data.py:1388
+#: users/views/data.py:1426
 msgid "The uploaded file is not a valid CSV."
 msgstr "O arquivo enviado não é um CSV válido."
 
-#: users/views/data.py:1392
+#: users/views/data.py:1430
 msgid "No valid entries found in the CSV file."
 msgstr "Nenhuma entrada válida encontrada no arquivo CSV."
 
-#: users/views/data.py:1402
+#: users/views/data.py:1440
 #, python-brace-format
-msgid ""
-"Import of {count} entries received. They will be processed in the background."
-msgstr ""
-"Recebidas {count} entradas para importação. Elas serão processadas em "
-"segundo plano."
+msgid "Import of {count} entries received. They will be processed in the background."
+msgstr "Recebidas {count} entradas para importação. Elas serão processadas em segundo plano."
 
-#: users/views/webauthn.py:103
+#: users/views/webauthn.py:106
 msgid "Passkey registration failed"
 msgstr "Falha no registro da chave de acesso"
 
-#: users/views/webauthn.py:123
+#: users/views/webauthn.py:126
 msgid "Credential already registered"
 msgstr "Credencial já registrada"
 
-#: users/views/webauthn.py:165 users/views/webauthn.py:172
-#: users/views/webauthn.py:181
+#: users/views/webauthn.py:168 users/views/webauthn.py:175
+#: users/views/webauthn.py:184
 msgid "Passkey not recognized"
 msgstr "Chave de acesso não reconhecida"
 
-#: users/views/webauthn.py:186
+#: users/views/webauthn.py:189
 msgid "Account is inactive"
 msgstr "Conta está inativa"
 
-#: users/views/webauthn.py:202
+#: users/views/webauthn.py:205
 msgid "Passkey verification failed"
 msgstr "Falha na verificação da chave de acesso"
 
-#: users/views/webauthn.py:228 users/views/webauthn.py:250
+#: users/views/webauthn.py:231 users/views/webauthn.py:253
 msgid "Passkey not found"
 msgstr "Chave de acesso não encontrada"
 
-#: users/views/webauthn.py:244
+#: users/views/webauthn.py:247
 msgid "Name is required"
 msgstr "O nome é obrigatório"
-
-#~ msgid "FanFic"
-#~ msgstr "FanFic"
-
-#~ msgid "year of publication"
-#~ msgstr "ano de publicação"
-
-#~ msgid "YYYY-MM-DD"
-#~ msgstr "AAAA-MM-DD"
-
-#~ msgid "region or event"
-#~ msgstr "região ou evento"
-
-#~ msgid "Germany or Toronto International Film Festival"
-#~ msgstr "Alemanha ou Festival Internacional de Cinema de Toronto"
-
-#~ msgid "year"
-#~ msgstr "ano"
-
-#~ msgctxt "music"
-#~ msgid "genre"
-#~ msgstr "gênero"
-
-#~ msgid "media type"
-#~ msgstr "tipo de mídia"
-
-#~ msgid "my notes"
-#~ msgstr "minhas notas"
-
-#~ msgid "release year"
-#~ msgstr "ano de lançamento"
-
-#~ msgid "episode Length"
-#~ msgstr "Duração do episódio"
-
-#~ msgid "show time"
-#~ msgstr "mostrar horário"
-
-#~ msgid "Region or Event"
-#~ msgstr "Região ou Evento"
-
-#~ msgid "Unknown or Other"
-#~ msgstr "Desconhecido ou Outro"
-
-#~ msgid "boost"
-#~ msgstr "impulsionar"
-
-#~ msgid "dynamic collection"
-#~ msgstr "coleção dinâmica"
-
-#~ msgid "Invalid form data"
-#~ msgstr "Dados de formulário inválidos"
-
-#~ msgid "Username and app password is required."
-#~ msgstr "Nome de usuário e senha do aplicativo são obrigatórios."
-
-#~ msgid "All"
-#~ msgstr "Todos"
-
-#~ msgid "Bluesky app password"
-#~ msgstr "Senha do aplicativo Bluesky"
-
-#~ msgid ""
-#~ "App password can be created on <a href=\"https://bsky.app/settings/app-"
-#~ "passwords\" target=\"_blank\">bsky.app</a>."
-#~ msgstr ""
-#~ "A senha do aplicativo pode ser criada em <a href=\"https://bsky.app/"
-#~ "settings/app-passwords\" target=\"_blank\">bsky.app</a>."
-
-#~ msgid "Link to Goodreads Profile / Shelf / List"
-#~ msgstr "Link para Perfil / Estante / Lista do Goodreads"
-
-#~ msgid "Shelf will be imported as a new collection."
-#~ msgstr "A estante será importada como uma nova coleção."
-
-#~ msgid "List will be imported as a new collection."
-#~ msgstr "A lista será importada como uma nova coleção."
-
-#~ msgid "Turn on crosspost to timeline by default"
-#~ msgstr "Ativar publicação cruzada na linha do tempo por padrão"
-
-#~ msgid "Username in use"
-#~ msgstr "Nome de usuário em uso"
-
-#~ msgid "Invalid URL."
-#~ msgstr "URL inválida."

--- a/neodb/locale/ru/LC_MESSAGES/django.po
+++ b/neodb/locale/ru/LC_MESSAGES/django.po
@@ -7,172 +7,170 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-23 15:40-0400\n"
+"POT-Creation-Date: 2026-09-06 20:04-0400\n"
 "PO-Revision-Date: 2026-08-09 06:32+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Russian <https://hosted.weblate.org/projects/neodb/neodb/ru/"
-">\n"
+"Language-Team: Russian <https://hosted.weblate.org/projects/neodb/neodb/ru/>\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: boofilsic/settings.py:472 common/models/lang.py:230
+#: boofilsic/settings.py:501 common/models/lang.py:232
 msgid "English"
 msgstr "Английский"
 
-#: boofilsic/settings.py:473 common/models/lang.py:77
+#: boofilsic/settings.py:502 common/models/lang.py:79
 msgid "Danish"
 msgstr "Датский"
 
-#: boofilsic/settings.py:474 common/models/lang.py:78
+#: boofilsic/settings.py:503 common/models/lang.py:80
 msgid "German"
 msgstr "Немецкий"
 
-#: boofilsic/settings.py:475 common/models/lang.py:183
+#: boofilsic/settings.py:504 common/models/lang.py:185
 msgid "Spanish"
 msgstr ""
 
-#: boofilsic/settings.py:476 common/models/lang.py:87
+#: boofilsic/settings.py:505 common/models/lang.py:89
 msgid "French"
 msgstr "Французский"
 
-#: boofilsic/settings.py:477 common/models/lang.py:112
+#: boofilsic/settings.py:506 common/models/lang.py:114
 msgid "Italian"
 msgstr "Итальянский"
 
-#: boofilsic/settings.py:478 common/models/lang.py:166
-#: common/models/lang.py:305
+#: boofilsic/settings.py:507 common/models/lang.py:168
+#: common/models/lang.py:307
 msgid "Portuguese"
 msgstr "Португальский"
 
-#: boofilsic/settings.py:479
+#: boofilsic/settings.py:508
 msgid "Brazilian Portuguese"
 msgstr "Бразильский португальский"
 
-#: boofilsic/settings.py:480 common/models/lang.py:316
+#: boofilsic/settings.py:509 common/models/lang.py:318
 msgid "Simplified Chinese"
 msgstr "Упрощенный китайский"
 
-#: boofilsic/settings.py:481 common/models/lang.py:317
+#: boofilsic/settings.py:510 common/models/lang.py:319
 msgid "Traditional Chinese"
 msgstr "Традиционный китайский"
 
-#: catalog/forms.py:35 catalog/models/item.py:291
+#: catalog/forms.py:35 catalog/models/item.py:307
 msgid "Primary ID Type"
 msgstr ""
 
-#: catalog/forms.py:40 catalog/models/item.py:294
+#: catalog/forms.py:40 catalog/models/item.py:310
 msgid "Primary ID Value"
 msgstr ""
 
-#: catalog/forms.py:181
+#: catalog/forms.py:176
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
-#: catalog/models/book.py:139 catalog/models/book.py:158
-#: catalog/models/common.py:280 catalog/models/common.py:298
+#: catalog/models/book.py:141 catalog/models/book.py:160
+#: catalog/models/common.py:279 catalog/models/common.py:297
 msgid "locale"
 msgstr ""
 
-#: catalog/models/book.py:142 catalog/models/book.py:161
-#: catalog/models/common.py:283 catalog/models/common.py:303
+#: catalog/models/book.py:144 catalog/models/book.py:163
+#: catalog/models/common.py:282 catalog/models/common.py:302
 msgid "text content"
 msgstr ""
 
-#: catalog/models/book.py:177
+#: catalog/models/book.py:179
 msgid "Paperback"
 msgstr ""
 
-#: catalog/models/book.py:178
+#: catalog/models/book.py:180
 msgid "Hardcover"
 msgstr ""
 
-#: catalog/models/book.py:179
+#: catalog/models/book.py:181
 msgid "eBook"
 msgstr ""
 
-#: catalog/models/book.py:180
+#: catalog/models/book.py:182
 msgid "Audiobook"
 msgstr ""
 
-#: catalog/models/book.py:182
+#: catalog/models/book.py:184
 msgid "Web Fiction"
 msgstr ""
 
-#: catalog/models/book.py:183 catalog/models/game.py:38
+#: catalog/models/book.py:185 catalog/models/game.py:38
 msgid "Other"
 msgstr ""
 
-#: catalog/models/book.py:260
+#: catalog/models/book.py:262
 msgid "subtitle"
 msgstr ""
 
-#: catalog/models/book.py:270 catalog/models/movie.py:120
-#: catalog/models/performance.py:385 catalog/models/tv.py:211
-#: catalog/models/tv.py:437
+#: catalog/models/book.py:272 catalog/models/movie.py:120
+#: catalog/models/performance.py:385 catalog/models/tv.py:213
+#: catalog/models/tv.py:439
 msgid "original title"
 msgstr ""
 
-#: catalog/models/book.py:274
+#: catalog/models/book.py:276
 msgid "other title"
 msgstr ""
 
-#: catalog/models/book.py:280 catalog/models/book.py:564
-#: catalog/models/item.py:123
+#: catalog/models/book.py:282 catalog/models/book.py:566
+#: catalog/models/item.py:119
 msgid "author"
 msgstr ""
 
-#: catalog/models/book.py:287 catalog/models/item.py:124
+#: catalog/models/book.py:289 catalog/models/item.py:120
 msgid "translator"
 msgstr ""
 
-#: catalog/models/book.py:294 catalog/templates/edition.html:26
+#: catalog/models/book.py:296 catalog/templates/edition.html:26
 msgid "book format"
 msgstr ""
 
-#: catalog/models/book.py:301 catalog/models/game.py:135
-#: catalog/models/item.py:138 catalog/models/music.py:142
+#: catalog/models/book.py:303 catalog/models/game.py:135
+#: catalog/models/item.py:134 catalog/models/music.py:142
 msgid "publisher"
 msgstr ""
 
-#: catalog/models/book.py:308
+#: catalog/models/book.py:310
 msgid "publication year"
 msgstr ""
 
-#: catalog/models/book.py:314
+#: catalog/models/book.py:316
 msgid "publication month"
 msgstr ""
 
-#: catalog/models/book.py:319
+#: catalog/models/book.py:321
 msgid "binding"
 msgstr ""
 
-#: catalog/models/book.py:320
+#: catalog/models/book.py:322
 msgid "pages"
 msgstr ""
 
-#: catalog/models/book.py:321 catalog/templates/edition.html:45
+#: catalog/models/book.py:323 catalog/templates/edition.html:45
 msgid "series"
 msgstr ""
 
-#: catalog/models/book.py:322 catalog/templates/edition.html:65
+#: catalog/models/book.py:324 catalog/templates/edition.html:65
 msgid "contents"
 msgstr ""
 
-#: catalog/models/book.py:323 catalog/templates/edition.html:51
+#: catalog/models/book.py:325 catalog/templates/edition.html:51
 msgid "price"
 msgstr "цена"
 
-#: catalog/models/book.py:324 catalog/models/item.py:149
+#: catalog/models/book.py:326 catalog/models/item.py:145
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr ""
 
-#: catalog/models/common.py:26 common/models/lang.py:256
+#: catalog/models/common.py:26 common/models/lang.py:258
 msgid "Unknown"
 msgstr ""
 
@@ -180,11 +178,11 @@ msgstr ""
 msgid "Douban"
 msgstr ""
 
-#: catalog/models/common.py:28 catalog/models/common.py:79
+#: catalog/models/common.py:28 catalog/models/common.py:81
 msgid "Goodreads"
 msgstr ""
 
-#: catalog/models/common.py:29 catalog/models/common.py:81
+#: catalog/models/common.py:29 catalog/models/common.py:83
 msgid "Google Books"
 msgstr ""
 
@@ -192,16 +190,16 @@ msgstr ""
 msgid "BooksTW"
 msgstr ""
 
-#: catalog/models/common.py:31 catalog/models/common.py:91
-#: catalog/models/common.py:93
+#: catalog/models/common.py:31 catalog/models/common.py:93
+#: catalog/models/common.py:95
 msgid "Bibliotek.dk"
 msgstr ""
 
-#: catalog/models/common.py:32 catalog/models/common.py:92
+#: catalog/models/common.py:32 catalog/models/common.py:94
 msgid "eReolen.dk"
 msgstr ""
 
-#: catalog/models/common.py:33 catalog/models/common.py:74
+#: catalog/models/common.py:33 catalog/models/common.py:76
 #: catalog/templates/movie.html:41 catalog/templates/people.html:37
 #: catalog/templates/tvseason.html:58 catalog/templates/tvshow.html:53
 msgid "IMDb"
@@ -211,7 +209,7 @@ msgstr ""
 msgid "TMDB"
 msgstr ""
 
-#: catalog/models/common.py:35 catalog/models/common.py:94
+#: catalog/models/common.py:35 catalog/models/common.py:96
 msgid "Bandcamp"
 msgstr ""
 
@@ -227,11 +225,11 @@ msgstr ""
 msgid "Steam"
 msgstr ""
 
-#: catalog/models/common.py:39 catalog/models/common.py:114
+#: catalog/models/common.py:39 catalog/models/common.py:116
 msgid "itch.io"
 msgstr ""
 
-#: catalog/models/common.py:40 catalog/models/common.py:115
+#: catalog/models/common.py:40 catalog/models/common.py:117
 msgid "Bangumi"
 msgstr ""
 
@@ -239,7 +237,7 @@ msgstr ""
 msgid "BGG"
 msgstr ""
 
-#: catalog/models/common.py:42 catalog/models/common.py:116
+#: catalog/models/common.py:42 catalog/models/common.py:118
 msgid "Apple Podcast"
 msgstr "Apple Podcast"
 
@@ -252,37 +250,37 @@ msgstr "RSS"
 msgid "Discogs"
 msgstr "Discogs"
 
-#: catalog/models/common.py:45 catalog/models/common.py:117
+#: catalog/models/common.py:45 catalog/models/common.py:119
 #, fuzzy
 msgid "Apple Music"
 msgstr "Apple Music"
 
-#: catalog/models/common.py:46 catalog/models/common.py:119
+#: catalog/models/common.py:46 catalog/models/common.py:121
 #, fuzzy
 msgid "Fediverse"
 msgstr "Fediverse"
 
-#: catalog/models/common.py:47 catalog/models/common.py:120
+#: catalog/models/common.py:47 catalog/models/common.py:122
 msgid "Qidian"
 msgstr "Qidian"
 
-#: catalog/models/common.py:48 catalog/models/common.py:121
+#: catalog/models/common.py:48 catalog/models/common.py:123
 msgid "Ypshuo"
 msgstr "Ypshuo"
 
-#: catalog/models/common.py:49 catalog/models/common.py:122
+#: catalog/models/common.py:49 catalog/models/common.py:124
 msgid "Archive of Our Own"
 msgstr "Archive of Our Own"
 
-#: catalog/models/common.py:50 catalog/models/common.py:123
+#: catalog/models/common.py:50 catalog/models/common.py:125
 msgid "JinJiang"
 msgstr "JinJiang"
 
-#: catalog/models/common.py:51 catalog/models/common.py:64
+#: catalog/models/common.py:51 catalog/models/common.py:66
 msgid "WikiData"
 msgstr "WikiData"
 
-#: catalog/models/common.py:52 catalog/models/common.py:124
+#: catalog/models/common.py:52 catalog/models/common.py:126
 msgid "Open Library"
 msgstr "Open Library"
 
@@ -294,15 +292,15 @@ msgstr "MusicBrainz"
 msgid "WorldCat"
 msgstr "WorldCat"
 
-#: catalog/models/common.py:55 catalog/models/common.py:126
+#: catalog/models/common.py:55 catalog/models/common.py:128
 msgid "MobyGames"
 msgstr ""
 
-#: catalog/models/common.py:56 catalog/models/common.py:127
+#: catalog/models/common.py:56 catalog/models/common.py:129
 msgid "StoryGraph"
 msgstr ""
 
-#: catalog/models/common.py:57 catalog/models/common.py:118
+#: catalog/models/common.py:57 catalog/models/common.py:120
 msgid "YouTube Music"
 msgstr ""
 
@@ -318,339 +316,348 @@ msgstr ""
 msgid "Readmoo"
 msgstr ""
 
-#: catalog/models/common.py:65
+#: catalog/models/common.py:61
+msgid "MyAnimeList"
+msgstr ""
+
+#: catalog/models/common.py:62 catalog/models/common.py:140
+msgid "MangaUpdates"
+msgstr ""
+
+#: catalog/models/common.py:67
 msgid "ISBN10"
 msgstr "ISBN10"
 
-#: catalog/models/common.py:66 catalog/templates/edition.html:19
+#: catalog/models/common.py:68 catalog/templates/edition.html:19
 msgid "ISBN"
 msgstr "ISBN"
 
-#: catalog/models/common.py:67
+#: catalog/models/common.py:69
 msgid "ASIN"
 msgstr "ASIN"
 
-#: catalog/models/common.py:68
+#: catalog/models/common.py:70
 msgid "ISSN"
 msgstr "ISSN"
 
-#: catalog/models/common.py:69
+#: catalog/models/common.py:71
 msgid "CUBN"
 msgstr "CUBN"
 
-#: catalog/models/common.py:70
+#: catalog/models/common.py:72
 msgid "ISRC"
 msgstr "ISRC"
 
-#: catalog/models/common.py:71
+#: catalog/models/common.py:73
 msgid "GTIN UPC EAN"
 msgstr "GTIN UPC EAN"
 
-#: catalog/models/common.py:72
+#: catalog/models/common.py:74
 msgid "OCLC Number"
 msgstr "OCLC-код"
 
-#: catalog/models/common.py:73
+#: catalog/models/common.py:75
 msgid "RSS Feed URL"
 msgstr ""
 
-#: catalog/models/common.py:75
+#: catalog/models/common.py:77
 msgid "TMDB TV Series"
 msgstr ""
 
-#: catalog/models/common.py:76
+#: catalog/models/common.py:78
 msgid "TMDB TV Season"
 msgstr ""
 
-#: catalog/models/common.py:77
+#: catalog/models/common.py:79
 msgid "TMDB TV Episode"
 msgstr ""
 
-#: catalog/models/common.py:78
+#: catalog/models/common.py:80
 msgid "TMDB Movie"
 msgstr ""
 
-#: catalog/models/common.py:80
+#: catalog/models/common.py:82
 msgid "Goodreads Work"
 msgstr ""
 
-#: catalog/models/common.py:82
+#: catalog/models/common.py:84
 msgid "Douban Book"
 msgstr ""
 
-#: catalog/models/common.py:83
+#: catalog/models/common.py:85
 msgid "Douban Book Work"
 msgstr ""
 
-#: catalog/models/common.py:84
+#: catalog/models/common.py:86
 msgid "Douban Movie"
 msgstr ""
 
-#: catalog/models/common.py:85
+#: catalog/models/common.py:87
 msgid "Douban Music"
 msgstr ""
 
-#: catalog/models/common.py:86
+#: catalog/models/common.py:88
 msgid "Douban Game"
 msgstr ""
 
-#: catalog/models/common.py:87
+#: catalog/models/common.py:89
 msgid "Douban Drama"
 msgstr ""
 
-#: catalog/models/common.py:88
+#: catalog/models/common.py:90
 msgid "Douban Drama Version"
 msgstr ""
 
-#: catalog/models/common.py:89
+#: catalog/models/common.py:91
 msgid "BooksTW Book"
 msgstr ""
 
-#: catalog/models/common.py:90
+#: catalog/models/common.py:92
 msgid "Readmoo Book"
 msgstr ""
 
-#: catalog/models/common.py:95
+#: catalog/models/common.py:97
 msgid "Spotify Album"
 msgstr ""
 
-#: catalog/models/common.py:96
+#: catalog/models/common.py:98
 msgid "Spotify Podcast"
 msgstr ""
 
-#: catalog/models/common.py:97
+#: catalog/models/common.py:99
 msgid "Discogs Release"
 msgstr ""
 
-#: catalog/models/common.py:98
+#: catalog/models/common.py:100
 msgid "Discogs Master"
 msgstr ""
 
-#: catalog/models/common.py:101
+#: catalog/models/common.py:103
 msgid "MusicBrainz Release Group"
 msgstr ""
 
-#: catalog/models/common.py:103
+#: catalog/models/common.py:105
 msgid "MusicBrainz Release"
 msgstr ""
 
-#: catalog/models/common.py:104
+#: catalog/models/common.py:106
 #, fuzzy
 #| msgid "MusicBrainz"
 msgid "MusicBrainz Artist"
 msgstr "MusicBrainz"
 
-#: catalog/models/common.py:105
+#: catalog/models/common.py:107
 msgid "Douban Personage"
 msgstr ""
 
-#: catalog/models/common.py:106
+#: catalog/models/common.py:108
 msgid "Goodreads Author"
 msgstr ""
 
-#: catalog/models/common.py:107
+#: catalog/models/common.py:109
 msgid "Spotify Artist"
 msgstr ""
 
-#: catalog/models/common.py:108
+#: catalog/models/common.py:110
 msgid "TMDB Person"
 msgstr ""
 
-#: catalog/models/common.py:109
+#: catalog/models/common.py:111
 #, fuzzy
 #| msgid "Open Library"
 msgid "Open Library Author"
 msgstr "Open Library"
 
-#: catalog/models/common.py:110
+#: catalog/models/common.py:112
 msgid "IGDB Company"
 msgstr ""
 
-#: catalog/models/common.py:111
+#: catalog/models/common.py:113
 msgid "IGDB Game"
 msgstr ""
 
-#: catalog/models/common.py:112
+#: catalog/models/common.py:114
 msgid "BGG Boardgame"
 msgstr ""
 
-#: catalog/models/common.py:113
+#: catalog/models/common.py:115
 msgid "Steam Game"
 msgstr ""
 
-#: catalog/models/common.py:125
+#: catalog/models/common.py:127
 msgid "Open Library Work"
 msgstr ""
 
-#: catalog/models/common.py:128
+#: catalog/models/common.py:130
 msgid "RateYourMusic Release"
 msgstr ""
 
-#: catalog/models/common.py:132
+#: catalog/models/common.py:134
 msgid "AniList Anime"
 msgstr ""
 
-#: catalog/models/common.py:133
+#: catalog/models/common.py:135
 msgid "AniList Manga"
 msgstr ""
 
-#: catalog/models/common.py:134
+#: catalog/models/common.py:136
 msgid "MyAnimeList Anime"
 msgstr ""
 
-#: catalog/models/common.py:135
+#: catalog/models/common.py:137
 msgid "MyAnimeList Manga"
 msgstr ""
 
-#: catalog/models/common.py:156
+#: catalog/models/common.py:161
 msgid "Edition"
 msgstr ""
 
-#: catalog/models/common.py:157 catalog/templates/_sidebar_edit.html:286
+#: catalog/models/common.py:162 catalog/templates/_sidebar_edit.html:289
 msgid "Work"
 msgstr ""
 
-#: catalog/models/common.py:158
+#: catalog/models/common.py:163
 msgid "TV Series"
 msgstr ""
 
-#: catalog/models/common.py:159 catalog/templates/_sidebar_edit.html:207
+#: catalog/models/common.py:164 catalog/templates/_sidebar_edit.html:202
+#: catalog/views/edit.py:385
 msgid "TV Season"
 msgstr ""
 
-#: catalog/models/common.py:160
+#: catalog/models/common.py:165
 msgid "TV Episode"
 msgstr ""
 
-#: catalog/models/common.py:161 catalog/models/common.py:177
-#: catalog/models/common.py:191 catalog/templates/_sidebar_edit.html:200
-#: journal/templates/_sidebar_user_mark_list.html:35
+#: catalog/models/common.py:166 catalog/models/common.py:182
+#: catalog/models/common.py:196 catalog/templates/_sidebar_edit.html:196
+#: catalog/views/edit.py:384 journal/templates/_sidebar_user_mark_list.html:35
 #: journal/templates/_sidebar_user_tag_filter.html:27
 msgid "Movie"
 msgstr ""
 
-#: catalog/models/common.py:162
+#: catalog/models/common.py:167
 msgid "Album"
 msgstr ""
 
-#: catalog/models/common.py:163 catalog/models/common.py:180
-#: catalog/models/common.py:194 common/templates/_header.html:43
+#: catalog/models/common.py:168 catalog/models/common.py:185
+#: catalog/models/common.py:199 common/templates/_header.html:53
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
 msgstr ""
 
-#: catalog/models/common.py:164
+#: catalog/models/common.py:169
 msgid "Podcast Program"
 msgstr ""
 
-#: catalog/models/common.py:165
+#: catalog/models/common.py:170
 msgid "Podcast Episode"
 msgstr ""
 
-#: catalog/models/common.py:166 catalog/models/common.py:182
-#: catalog/models/common.py:196 common/templates/_header.html:47
+#: catalog/models/common.py:171 catalog/models/common.py:187
+#: catalog/models/common.py:201 common/templates/_header.html:57
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
 msgstr ""
 
-#: catalog/models/common.py:167
+#: catalog/models/common.py:172
 msgid "Production"
 msgstr ""
 
-#: catalog/models/common.py:168
+#: catalog/models/common.py:173
 msgid "Exhibition"
 msgstr ""
 
-#: catalog/models/common.py:169 catalog/models/common.py:186
+#: catalog/models/common.py:174 catalog/models/common.py:191
 #: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr ""
 
-#: catalog/models/common.py:172 catalog/models/common.py:185
+#: catalog/models/common.py:177 catalog/models/common.py:190
 msgid "Person / Organization"
 msgstr ""
 
-#: catalog/models/common.py:176 catalog/models/common.py:190
-#: common/templates/_header.html:27
+#: catalog/models/common.py:181 catalog/models/common.py:195
+#: common/templates/_header.html:37
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
 msgstr "Книга"
 
-#: catalog/models/common.py:178 catalog/models/common.py:192
+#: catalog/models/common.py:183 catalog/models/common.py:197
 #: journal/templates/_sidebar_user_mark_list.html:38
 #: journal/templates/_sidebar_user_tag_filter.html:30
 msgid "TV"
 msgstr ""
 
-#: catalog/models/common.py:179 catalog/models/common.py:193
-#: common/templates/_header.html:39
+#: catalog/models/common.py:184 catalog/models/common.py:198
+#: common/templates/_header.html:49
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr ""
 
-#: catalog/models/common.py:181 catalog/models/common.py:195
-#: catalog/templates/_sidebar_edit.html:219 common/templates/_header.html:35
+#: catalog/models/common.py:186 catalog/models/common.py:200
+#: catalog/templates/_sidebar_edit.html:213 common/templates/_header.html:45
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
 msgstr ""
 
-#: catalog/models/common.py:346 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:345 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr "жанр"
 
-#: catalog/models/common.py:384
+#: catalog/models/common.py:383
 msgid "origin country"
 msgstr ""
 
-#: catalog/models/common.py:413 catalog/templates/album.html:33
+#: catalog/models/common.py:412 catalog/templates/album.html:33
 msgid "album type"
 msgstr "тип альбома"
 
-#: catalog/models/common.py:417 catalog/templates/_platform_list.html:5
+#: catalog/models/common.py:416 catalog/templates/_platform_list.html:5
 msgid "platform"
 msgstr "платформа"
 
-#: catalog/models/common.py:421
+#: catalog/models/common.py:420
 msgid "media format"
 msgstr ""
 
-#: catalog/models/common.py:426 catalog/templates/_language_list.html:5
-#: users/models/user.py:142
+#: catalog/models/common.py:425 catalog/templates/_language_list.html:5
+#: users/models/user.py:144
 msgid "language"
 msgstr "язык"
 
-#: catalog/models/creator.py:24
+#: catalog/models/creator.py:26
 msgid "pending"
 msgstr ""
 
-#: catalog/models/creator.py:25
+#: catalog/models/creator.py:27
 msgid "verified"
 msgstr ""
 
-#: catalog/models/creator.py:26
+#: catalog/models/creator.py:28
 msgid "failed"
 msgstr ""
 
-#: catalog/models/creator.py:29
+#: catalog/models/creator.py:31
 msgid "no feed url available for this item"
 msgstr ""
 
-#: catalog/models/creator.py:30
+#: catalog/models/creator.py:32
 msgid "unable to fetch or parse the feed"
 msgstr ""
 
-#: catalog/models/creator.py:31
+#: catalog/models/creator.py:33
 msgid "no audio episode found in the feed"
 msgstr ""
 
-#: catalog/models/creator.py:34
+#: catalog/models/creator.py:36
 msgid "no matching identity found in the feed or its linked website"
 msgstr ""
 
@@ -686,16 +693,16 @@ msgstr ""
 msgid "Special Edition"
 msgstr ""
 
-#: catalog/models/game.py:111 catalog/models/item.py:130
+#: catalog/models/game.py:111 catalog/models/item.py:126
 msgid "designer"
 msgstr ""
 
-#: catalog/models/game.py:119 catalog/models/item.py:129
+#: catalog/models/game.py:119 catalog/models/item.py:125
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr ""
 
-#: catalog/models/game.py:127 catalog/models/item.py:139
+#: catalog/models/game.py:127 catalog/models/item.py:135
 msgid "developer"
 msgstr ""
 
@@ -704,8 +711,8 @@ msgid "date of publication"
 msgstr ""
 
 #: catalog/models/game.py:147 catalog/models/movie.py:156
-#: catalog/models/music.py:128 catalog/models/tv.py:247
-#: catalog/models/tv.py:473
+#: catalog/models/music.py:128 catalog/models/tv.py:249
+#: catalog/models/tv.py:475
 msgid "YYYY, YYYY-MM or YYYY-MM-DD"
 msgstr ""
 
@@ -716,7 +723,7 @@ msgstr ""
 #: catalog/models/game.py:180 catalog/models/movie.py:158
 #: catalog/models/people.py:178 catalog/models/performance.py:258
 #: catalog/models/performance.py:465 catalog/models/podcast.py:89
-#: catalog/models/tv.py:249 catalog/models/tv.py:476
+#: catalog/models/tv.py:251 catalog/models/tv.py:478
 #: catalog/templates/game.html:33 catalog/templates/movie.html:48
 #: catalog/templates/people.html:44 catalog/templates/performance.html:35
 #: catalog/templates/performanceproduction.html:35
@@ -725,146 +732,146 @@ msgstr ""
 msgid "website"
 msgstr "вебсайт"
 
-#: catalog/models/item.py:125 catalog/models/movie.py:123
+#: catalog/models/item.py:121 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
-#: catalog/models/tv.py:214 catalog/models/tv.py:440
+#: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr ""
 
-#: catalog/models/item.py:126 catalog/models/movie.py:130
+#: catalog/models/item.py:122 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
-#: catalog/models/tv.py:221 catalog/models/tv.py:447
+#: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr ""
 
-#: catalog/models/item.py:127 catalog/models/movie.py:137
+#: catalog/models/item.py:123 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
-#: catalog/models/tv.py:228 catalog/models/tv.py:454
+#: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr ""
 
-#: catalog/models/item.py:128 catalog/models/movie.py:144
-#: catalog/models/tv.py:235 catalog/models/tv.py:461
+#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/tv.py:237 catalog/models/tv.py:463
 msgid "producer"
 msgstr ""
 
-#: catalog/models/item.py:131 catalog/models/performance.py:203
+#: catalog/models/item.py:127 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr "композитор"
 
-#: catalog/models/item.py:132 catalog/models/performance.py:210
+#: catalog/models/item.py:128 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr "хореограф"
 
-#: catalog/models/item.py:133 catalog/models/performance.py:224
+#: catalog/models/item.py:129 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr "исполнитель"
 
-#: catalog/models/item.py:134 catalog/models/podcast.py:80
+#: catalog/models/item.py:130 catalog/models/podcast.py:80
 msgid "host"
 msgstr ""
 
-#: catalog/models/item.py:135 catalog/models/performance.py:196
+#: catalog/models/item.py:131 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr ""
 
-#: catalog/models/item.py:136 catalog/models/performance.py:238
+#: catalog/models/item.py:132 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr ""
 
-#: catalog/models/item.py:140
+#: catalog/models/item.py:136
 msgid "production company"
 msgstr ""
 
-#: catalog/models/item.py:141
+#: catalog/models/item.py:137
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:142
+#: catalog/models/item.py:138
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:139
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:144 catalog/models/performance.py:231
+#: catalog/models/item.py:140 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr ""
 
-#: catalog/models/item.py:147
+#: catalog/models/item.py:143
 msgid "voice actor"
 msgstr ""
 
-#: catalog/models/item.py:148 catalog/templates/edition.html:30
+#: catalog/models/item.py:144 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr ""
 
-#: catalog/models/item.py:173 catalog/models/people.py:476
+#: catalog/models/item.py:169 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr "роль"
 
-#: catalog/models/item.py:174 catalog/models/people.py:155
+#: catalog/models/item.py:170 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr ""
 
-#: catalog/models/item.py:176 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:288 catalog/models/item.py:320
-#: journal/models/collection.py:96
+#: catalog/models/item.py:304 catalog/models/item.py:336
+#: journal/models/collection.py:100
 msgid "title"
 msgstr ""
 
-#: catalog/models/item.py:289 catalog/models/item.py:328
-#: journal/models/collection.py:97
+#: catalog/models/item.py:305 catalog/models/item.py:344
+#: journal/models/collection.py:101
 msgid "description"
 msgstr ""
 
-#: catalog/models/item.py:300 catalog/models/people.py:484
+#: catalog/models/item.py:316 catalog/models/people.py:484
 msgid "metadata"
 msgstr "метаданные"
 
-#: catalog/models/item.py:302 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
 msgid "cover"
 msgstr "обложка"
 
-#: catalog/models/item.py:1485
+#: catalog/models/item.py:1526
 msgid "source site"
 msgstr ""
 
-#: catalog/models/item.py:1487
+#: catalog/models/item.py:1528
 msgid "ID on source site"
 msgstr ""
 
-#: catalog/models/item.py:1489
+#: catalog/models/item.py:1530
 msgid "source url"
 msgstr ""
 
-#: catalog/models/item.py:1505
+#: catalog/models/item.py:1546
 msgid "IdType of the source site"
 msgstr ""
 
-#: catalog/models/item.py:1511
+#: catalog/models/item.py:1552
 msgid "Primary Id on the source site"
 msgstr ""
 
-#: catalog/models/item.py:1514
+#: catalog/models/item.py:1555
 msgid "url to the resource"
 msgstr ""
 
 #: catalog/models/movie.py:152 catalog/models/music.py:124
-#: catalog/models/tv.py:243 catalog/models/tv.py:469
+#: catalog/models/tv.py:245 catalog/models/tv.py:471
 #: catalog/templates/_item_card_metadata_album.html:16
 #: catalog/templates/album.html:17 catalog/templates/game.html:22
 #: catalog/templates/movie.html:36 catalog/templates/tvseason.html:53
@@ -879,7 +886,7 @@ msgid "length"
 msgstr ""
 
 #: catalog/models/movie.py:162 catalog/models/music.py:131
-#: catalog/models/tv.py:259 catalog/models/tv.py:486
+#: catalog/models/tv.py:261 catalog/models/tv.py:488
 msgid "seconds"
 msgstr ""
 
@@ -1049,42 +1056,91 @@ msgstr "дата открытия"
 msgid "closing date"
 msgstr "дата закрытия"
 
-#: catalog/models/tv.py:186 catalog/templates/tvseason.html:38
+#: catalog/models/tv.py:188 catalog/templates/tvseason.html:38
 #: catalog/templates/tvshow.html:33
 msgid "number of seasons"
 msgstr "количество сезонов"
 
-#: catalog/models/tv.py:189 catalog/models/tv.py:415
+#: catalog/models/tv.py:191 catalog/models/tv.py:417
 #: catalog/templates/tvseason.html:43 catalog/templates/tvshow.html:38
 msgid "number of episodes"
 msgstr "количество эпизодов"
 
-#: catalog/models/tv.py:256 catalog/models/tv.py:483
+#: catalog/models/tv.py:258 catalog/models/tv.py:485
 msgid "episode length"
 msgstr "длительность эпизода"
 
-#: catalog/models/tv.py:412 catalog/templates/tvseason.html:33
+#: catalog/models/tv.py:414 catalog/templates/tvseason.html:33
 msgid "season number"
 msgstr "номер сезон"
 
-#: catalog/models/tv.py:530
+#: catalog/models/tv.py:532
 #, python-brace-format
 msgid "{show_title} Season {season_number}"
 msgstr "{show_title}, {season_number}-й сезон"
 
-#: catalog/models/tv.py:684
+#: catalog/models/tv.py:686
 #, python-brace-format
 msgid "{season_title} E{episode_number}"
 msgstr "{season_title}, Э-{episode_number}"
+
+#: catalog/templates/_catalog_confirm_item.html:7
+#: catalog/templates/catalog_edit.html:62
+msgid "Item has been deleted."
+msgstr ""
+
+#: catalog/templates/_catalog_confirm_item.html:12
+#: catalog/templates/catalog_edit.html:65
+msgid "Item contains sub-items."
+msgstr ""
+
+#: catalog/templates/_catalog_confirm_item.html:17
+msgid "Item has been merged to another item."
+msgstr ""
+
+#: catalog/templates/_catalog_confirm_item.html:22
+msgid "Item has been marked by users."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:11
+msgid "Confirm changes"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:16
+msgid "Please correct the errors below."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:24
+msgid "Field"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:25
+msgid "From"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:26
+msgid "To"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:45
+msgid "No changes detected."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:54
+#: users/templates/users/register.html:104
+msgid "Confirm and save"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:57
+msgid "Back to editing"
+msgstr ""
 
 #: catalog/templates/_country_list.html:5
 msgid "region"
 msgstr "регион"
 
 #: catalog/templates/_fetch_failed.html:4
-msgid ""
-"Unable to fetch from the link, please check again. Some sites may require "
-"login for certain links, please manually create them here."
+msgid "Unable to fetch from the link, please check again. Some sites may require login for certain links, please manually create them here."
 msgstr ""
 
 #: catalog/templates/_item_card_metadata_album.html:7
@@ -1140,7 +1196,7 @@ msgstr ""
 #: journal/templates/profile_posts.html:21
 #: journal/templates/user_follow_list_items.html:63
 #: journal/templates/user_post_list_items.html:24
-#: social/templates/events.html:43 social/templates/feed_events.html:28
+#: social/templates/events.html:43 social/templates/feed_events.html:27
 msgid "nothing more."
 msgstr ""
 
@@ -1231,7 +1287,7 @@ msgid "Add note"
 msgstr "мои заметки"
 
 #: catalog/templates/_item_user_pieces.html:83
-#: common/templates/_sidebar.html:196 journal/templates/profile_items.html:46
+#: common/templates/_sidebar.html:195 journal/templates/profile_items.html:46
 #, fuzzy
 #| msgid "Sync in progress."
 msgid "Set progress"
@@ -1261,6 +1317,10 @@ msgstr "моя коллекция"
 msgid "mark history"
 msgstr "история отметок"
 
+#: catalog/templates/_search_suggest.html:2
+msgid "Suggestions"
+msgstr ""
+
 #: catalog/templates/_sidebar_edit.html:8
 msgid "edit"
 msgstr "редактировать"
@@ -1288,15 +1348,15 @@ msgid "Edit Options"
 msgstr "Изменить параметры"
 
 #: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
-#: catalog/views/edit.py:82 catalog/views/edit.py:143 catalog/views/edit.py:197
-#: catalog/views/edit.py:218 catalog/views/edit.py:259
-#: catalog/views/edit.py:328 catalog/views/edit.py:332
-#: catalog/views/edit.py:351 catalog/views/edit.py:400
-#: catalog/views/edit.py:425 catalog/views/edit.py:440
-#: catalog/views/edit.py:480 catalog/views/edit.py:490
-#: catalog/views/edit.py:517 catalog/views/edit.py:582
-#: catalog/views/edit.py:637 catalog/views/edit.py:659
-#: catalog/views/search.py:367
+#: catalog/views/edit.py:160 catalog/views/edit.py:221
+#: catalog/views/edit.py:288 catalog/views/edit.py:309
+#: catalog/views/edit.py:364 catalog/views/edit.py:471
+#: catalog/views/edit.py:475 catalog/views/edit.py:509
+#: catalog/views/edit.py:576 catalog/views/edit.py:601
+#: catalog/views/edit.py:624 catalog/views/edit.py:664
+#: catalog/views/edit.py:674 catalog/views/edit.py:703
+#: catalog/views/edit.py:782 catalog/views/edit.py:837
+#: catalog/views/edit.py:859 catalog/views/search.py:418
 msgid "Editing this item is restricted."
 msgstr "Редактирование этого элемента ограничено."
 
@@ -1324,7 +1384,7 @@ msgstr "Этот элемент был отмечен пользователям
 msgid "The following items are merged into this item"
 msgstr "Следующие элементы включены в этот элемент"
 
-#: catalog/templates/_sidebar_edit.html:70
+#: catalog/templates/_sidebar_edit.html:70 catalog/views/edit.py:456
 msgid "External website"
 msgstr "Внешний вебсайт"
 
@@ -1338,45 +1398,37 @@ msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:88
 msgid "Existing metadata might get overwritten, sure to proceed?"
-msgstr ""
-"Существующие метаданные могут быть перезаписаны, уверены, что хотите "
-"продолжить?"
+msgstr "Существующие метаданные могут быть перезаписаны, уверены, что хотите продолжить?"
 
 #: catalog/templates/_sidebar_edit.html:92
 msgid "Fetch again"
 msgstr "Скачать ещё раз"
 
-#: catalog/templates/_sidebar_edit.html:97
-msgid "You may not be able to undo this operation, sure to remove?"
-msgstr ""
-"Возможно, вы не сможете отменить эту операцию, уверены, что хотите "
-"продолжить?"
-
-#: catalog/templates/_sidebar_edit.html:102
+#: catalog/templates/_sidebar_edit.html:100
 msgid "Remove link to site"
 msgstr "Удалить ссылку на сайт"
 
-#: catalog/templates/_sidebar_edit.html:110
+#: catalog/templates/_sidebar_edit.html:108
 msgid "Choose cover"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:119
+#: catalog/templates/_sidebar_edit.html:117
+#: catalog/templates/_sidebar_edit.html:118
 #: catalog/templates/_sidebar_edit.html:120
-#: catalog/templates/_sidebar_edit.html:122
 msgid "Current cover"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:139
+#: catalog/templates/_sidebar_edit.html:137
 msgid "Select an image to use as the cover of this item."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:140
-#: catalog/templates/catalog_edit.html:65
-#: common/templates/manage/settings.html:136
+#: catalog/templates/_sidebar_edit.html:138
+#: catalog/templates/catalog_edit.html:78
+#: common/templates/manage/settings.html:19
 #: journal/templates/add_to_collection.html:43
 #: journal/templates/article_edit.html:60
 #: journal/templates/collection_edit.html:39 journal/templates/comment.html:41
-#: journal/templates/mark.html:134 journal/templates/note.html:65
+#: journal/templates/mark.html:138 journal/templates/note.html:65
 #: journal/templates/post_compose.html:103
 #: journal/templates/review_edit.html:46 journal/templates/tag_edit.html:51
 #: users/templates/users/_pref_device.html:37
@@ -1385,181 +1437,157 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:147
+#: catalog/templates/_sidebar_edit.html:145
 msgid "Edit sub-items"
 msgstr "Изменить под-элементы"
 
-#: catalog/templates/_sidebar_edit.html:160
+#: catalog/templates/_sidebar_edit.html:158
 msgid "create"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:166
+#: catalog/templates/_sidebar_edit.html:164
 msgid "Fetch all episodes"
 msgstr "Скачать все эпизоды"
 
-#: catalog/templates/_sidebar_edit.html:171
+#: catalog/templates/_sidebar_edit.html:169
 msgid "Fetch all"
 msgstr "Скачать всё"
 
-#: catalog/templates/_sidebar_edit.html:172
-msgid ""
-"Due to differences in how Douban, IMDB, and TMDB handle season data, a small "
-"number of TV shows and animations may not return correct results. Please "
-"manually verify and clean up after updating."
+#: catalog/templates/_sidebar_edit.html:170
+msgid "Due to differences in how Douban, IMDB, and TMDB handle season data, a small number of TV shows and animations may not return correct results. Please manually verify and clean up after updating."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:173
+#: catalog/templates/_sidebar_edit.html:171
 msgid "Up to 250 episodes will be fetched for a season."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:176
-msgid ""
-"To fetch all episodes, season numbers and IMDB information are required. If "
-"filling this out is inconvenient, you can also manually create sub-entries."
+#: catalog/templates/_sidebar_edit.html:174
+msgid "To fetch all episodes, season numbers and IMDB information are required. If filling this out is inconvenient, you can also manually create sub-entries."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:182
-#: catalog/templates/_sidebar_edit.html:194
-#: catalog/templates/_sidebar_edit.html:213
+#: catalog/templates/_sidebar_edit.html:180
+#: catalog/templates/_sidebar_edit.html:191
+#: catalog/templates/_sidebar_edit.html:208
 msgid "switch category"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:185
-msgid "Switching may remove some metadata. Sure to proceed?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:188
+#: catalog/templates/_sidebar_edit.html:185 catalog/views/edit.py:383
 msgid "TV Show"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:227
+#: catalog/templates/_sidebar_edit.html:221
 msgid "Link to parent item"
 msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:230
-msgid "Sure to link?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:237
 msgid "Update link"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:243
+#: catalog/templates/_sidebar_edit.html:236
 msgid "Cleanup seasons"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:246
-#: catalog/templates/catalog_delete.html:45
-msgid "This operation cannot be undone. Sure to delete?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:250
+#: catalog/templates/_sidebar_edit.html:242
 msgid "remove seasons not marked"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:256
-#: catalog/templates/catalog_merge.html:12
+#: catalog/templates/_sidebar_edit.html:248
 msgid "Merge"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:262
+#: catalog/templates/_sidebar_edit.html:254
 msgid "URL of target item, or empty if undo merge"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:268
-#: catalog/templates/_sidebar_edit.html:348
+#: catalog/templates/_sidebar_edit.html:260
+#: catalog/templates/_sidebar_edit.html:350
 msgid "merge to another item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:273
-#: catalog/templates/_sidebar_edit.html:277
-#: catalog/templates/catalog_delete.html:12
+#: catalog/templates/_sidebar_edit.html:265
+#: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
 #: journal/templates/article.html:199 journal/templates/collection.html:188
-#: journal/templates/mark.html:149 journal/templates/note.html:82
+#: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
 #: users/templates/users/account.html:254
 msgid "Delete"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:287
+#: catalog/templates/_sidebar_edit.html:275
+#: catalog/templates/_sidebar_edit.html:279
+msgid "Undo delete"
+msgstr ""
+
+#: catalog/templates/_sidebar_edit.html:280
+msgid "Links to external sites and parent item were removed on delete and will not be restored."
+msgstr ""
+
+#: catalog/templates/_sidebar_edit.html:290
 msgid "This edition belongs to the following work"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:292
-msgid "Sure to unlink?"
-msgstr ""
-
-#: catalog/templates/_sidebar_edit.html:298
+#: catalog/templates/_sidebar_edit.html:300
 msgid "Unlink from work"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:304
+#: catalog/templates/_sidebar_edit.html:306
 msgid "Link"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:315
+#: catalog/templates/_sidebar_edit.html:317
 msgid "Link to another edition from same work"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:324
+#: catalog/templates/_sidebar_edit.html:326
 msgid "Restriction"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:337
+#: catalog/templates/_sidebar_edit.html:339
 #: journal/templates/collection_update_item_note.html:4
 msgid "Update"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:342
+#: catalog/templates/_sidebar_edit.html:344
 msgid "Suggest Edits"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:347
+#: catalog/templates/_sidebar_edit.html:349
 msgid "proposed action"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:349
+#: catalog/templates/_sidebar_edit.html:351
 msgid "link to another item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:350
+#: catalog/templates/_sidebar_edit.html:352
 msgid "change item category"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:351
+#: catalog/templates/_sidebar_edit.html:353
 msgid "change item metadata"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:352
+#: catalog/templates/_sidebar_edit.html:354
 msgid "remove item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:353
+#: catalog/templates/_sidebar_edit.html:355
 msgid "other"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:357
-msgid ""
-"To suggest merging or association, please include the URL of the target item"
+#: catalog/templates/_sidebar_edit.html:359
+msgid "To suggest merging or association, please include the URL of the target item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:358
+#: catalog/templates/_sidebar_edit.html:360
 #: catalog/templates/catalog_verify.html:116
 msgid "submit"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:359
-msgid ""
-"As a user of this community, you may edit some metadata of items on this "
-"site. If you are unsure whether your edits are appropriate or are unable to "
-"make a certain change, you can make suggestions here. Moderators will "
-"consider each suggestion, although there is no guarantee that they will "
-"always be fully adopted; suggestions may also be viewed or discussed by "
-"other community users. If you have suggestions that are not related to a "
-"specific item, please contact us. Thank you for your support and "
-"contribution."
+#: catalog/templates/_sidebar_edit.html:361
+msgid "As a user of this community, you may edit some metadata of items on this site. If you are unsure whether your edits are appropriate or are unable to make a certain change, you can make suggestions here. Moderators will consider each suggestion, although there is no guarantee that they will always be fully adopted; suggestions may also be viewed or discussed by other community users. If you have suggestions that are not related to a specific item, please contact us. Thank you for your support and contribution."
 msgstr ""
 
 #: catalog/templates/_sidebar_search.html:5
@@ -1657,16 +1685,14 @@ msgid "matched"
 msgstr ""
 
 #: catalog/templates/_verify_status.html:21
-msgid ""
-"Sure to remove your creator verification? Anyone will be able to edit this "
-"item again."
+msgid "Sure to remove your creator verification? Anyone will be able to edit this item again."
 msgstr ""
 
 #: catalog/templates/_verify_status.html:26
 msgid "Remove my verification"
 msgstr ""
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:309
+#: catalog/templates/_verify_status.html:31 users/views/account.py:311
 msgid "Verification failed"
 msgstr ""
 
@@ -1705,43 +1731,11 @@ msgstr ""
 msgid "album media"
 msgstr ""
 
-#: catalog/templates/catalog_delete.html:19
-msgid "Are you sure to delete?"
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:24
-#: catalog/templates/catalog_edit.html:52
-#: catalog/templates/catalog_merge.html:36
-#: catalog/templates/catalog_merge.html:64
-msgid "Item has been deleted."
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:29
-#: catalog/templates/catalog_edit.html:55
-#: catalog/templates/catalog_merge.html:41
-#: catalog/templates/catalog_merge.html:69
-msgid "Item contains sub-items."
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:34
-#: catalog/templates/catalog_merge.html:46
-#: catalog/templates/catalog_merge.html:74
-msgid "Item has been merged to another item."
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:39
-#: catalog/templates/catalog_merge.html:51
-#: catalog/templates/catalog_merge.html:79
-msgid "Item has been marked by users."
-msgstr ""
-
-#: catalog/templates/catalog_delete.html:48
-#: catalog/templates/catalog_merge.html:92 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:55 common/views_manage.py:139
 msgid "Yes"
 msgstr ""
 
-#: catalog/templates/catalog_delete.html:49
-#: catalog/templates/catalog_merge.html:93 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:56 common/views_manage.py:139
 msgid "No"
 msgstr ""
 
@@ -1750,36 +1744,18 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: catalog/templates/catalog_edit.html:68
+#: catalog/templates/catalog_edit.html:81
 #: journal/templates/collection_update_item_note.html:8
 #: journal/templates/piece_delete.html:38
 msgid "Cancel"
 msgstr ""
 
-#: catalog/templates/catalog_edit.html:104
+#: catalog/templates/catalog_edit.html:118
 msgid "open linked people page"
 msgstr ""
 
-#: catalog/templates/catalog_merge.html:22
-msgid "Are you sure to merge?"
-msgstr ""
-
-#: catalog/templates/catalog_merge.html:24
-msgid "Are you sure to cancel merge?"
-msgstr ""
-
-#: catalog/templates/catalog_merge.html:27
-msgid "Are you sure to link?"
-msgstr ""
-
-#: catalog/templates/catalog_merge.html:86
-msgid "This operation cannot be undone. Sure to merge?"
-msgstr ""
-
 #: catalog/templates/catalog_verify.html:21
-msgid ""
-"If you are a creator of this podcast, you may verify the ownership, so that "
-"only you (and other verified creators) can edit its metadata on this site."
+msgid "If you are a creator of this podcast, you may verify the ownership, so that only you (and other verified creators) can edit its metadata on this site."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:22
@@ -1787,9 +1763,7 @@ msgid "Your recent episodes may also occasionally be featured in discovery."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:24
-msgid ""
-"To verify, prove you control one of the following identifiers of your "
-"account (click to copy):"
+msgid "To verify, prove you control one of the following identifiers of your account (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:30
@@ -1800,18 +1774,11 @@ msgid "copied"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:35
-msgid ""
-"You can prove this in a few ways, then start verification: add one of the "
-"identifiers above to the podcast feed's description; add a <code>rel=\"me\"</"
-"code> link back to one of them on the web page your feed links to (the link "
-"verification Mastodon uses); or point your feed's website at your Bluesky "
-"handle's own domain."
+msgid "You can prove this in a few ways, then start verification: add one of the identifiers above to the podcast feed's description; add a <code>rel=\"me\"</code> link back to one of them on the web page your feed links to (the link verification Mastodon uses); or point your feed's website at your Bluesky handle's own domain."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:44
-msgid ""
-"For example, add this rel=me link to the web page your feed links to (click "
-"to copy):"
+msgid "For example, add this rel=me link to the web page your feed links to (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:50
@@ -1819,9 +1786,7 @@ msgid "or, in the page's head:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:57
-msgid ""
-"Can't edit the website? Just add a line like this to your feed's description "
-"instead (click to copy):"
+msgid "Can't edit the website? Just add a line like this to your feed's description instead (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:62
@@ -1829,10 +1794,7 @@ msgid "Welcome to follow me on the Fediverse:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:66
-msgid ""
-"NeoDB does not re-check this periodically at the moment, but we recommend "
-"you keep it so that your audience can discover and connect with you in "
-"distributed social media."
+msgid "NeoDB does not re-check this periodically at the moment, but we recommend you keep it so that your audience can discover and connect with you in distributed social media."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:72
@@ -1862,12 +1824,11 @@ msgid "Send feedback"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:115
-msgid ""
-"Questions or issues with creator verification? Let the site moderators know."
+msgid "Questions or issues with creator verification? Let the site moderators know."
 msgstr ""
 
-#: catalog/templates/discover.html:28 common/views_manage.py:145
-#: common/views_manage.py:353 users/templates/users/preferences.html:34
+#: catalog/templates/discover.html:28 common/views_manage.py:35
+#: common/views_manage.py:431 users/templates/users/preferences.html:34
 msgid "Discover"
 msgstr ""
 
@@ -1905,17 +1866,17 @@ msgstr ""
 msgid "hide"
 msgstr ""
 
-#: catalog/templates/discover.html:206 common/templates/_sidebar.html:14
+#: catalog/templates/discover.html:206 common/templates/_sidebar.html:13
 msgid "Unread Announcements"
 msgstr ""
 
-#: catalog/templates/discover.html:212 common/templates/_sidebar.html:20
+#: catalog/templates/discover.html:212 common/templates/_sidebar.html:19
 #: social/templates/notification.html:67
 msgid "mark all as read"
 msgstr ""
 
 #: catalog/templates/discover.html:222
-#: common/templates/_sidebar_anonymous.html:55
+#: common/templates/_sidebar_anonymous.html:54
 msgid "Popular Tags"
 msgstr ""
 
@@ -1926,9 +1887,9 @@ msgstr ""
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
 #: catalog/templates/user_verified_works.html:23
-#: common/templates/_sidebar.html:127
-#: common/templates/_sidebar_anonymous.html:46
-#: common/templates/_sidebar_anonymous.html:62 journal/templates/posts.html:8
+#: common/templates/_sidebar.html:126
+#: common/templates/_sidebar_anonymous.html:45
+#: common/templates/_sidebar_anonymous.html:61 journal/templates/posts.html:7
 #: journal/templates/profile_articles.html:24
 #: journal/templates/profile_articles.html:26
 #: journal/templates/profile_items.html:65
@@ -1944,7 +1905,7 @@ msgstr ""
 msgid "nothing so far."
 msgstr ""
 
-#: catalog/templates/discover.html:239 common/templates/_sidebar.html:269
+#: catalog/templates/discover.html:239 common/templates/_sidebar.html:268
 msgid "Recent Posts"
 msgstr ""
 
@@ -1972,9 +1933,7 @@ msgid "Borrow or Buy"
 msgstr ""
 
 #: catalog/templates/external_search_results.html:10
-msgid ""
-"Some items were found from other websites and instances, click their title "
-"to save them locally."
+msgid "Some items were found from other websites and instances, click their title to save them locally."
 msgstr ""
 
 #: catalog/templates/fetch_pending.html:13
@@ -2074,12 +2033,12 @@ msgstr ""
 msgid "number of Episodes"
 msgstr ""
 
-#: catalog/templates/people.html:13 common/templates/_sidebar.html:77
-#: common/templates/_sidebar.html:84 journal/models/shelf.py:326
+#: catalog/templates/people.html:13 common/templates/_sidebar.html:76
+#: common/templates/_sidebar.html:83 journal/models/shelf.py:328
 msgid "following"
 msgstr ""
 
-#: catalog/templates/people.html:15 journal/models/shelf.py:324
+#: catalog/templates/people.html:15 journal/models/shelf.py:326
 #: social/templates/notification.html:60
 msgid "follow"
 msgstr ""
@@ -2098,7 +2057,6 @@ msgstr ""
 #: journal/templates/_sidebar_collection_filter.html:14
 #: journal/templates/_sidebar_collection_filter.html:28
 #: journal/templates/_sidebar_user_mark_list.html:56
-#: social/templates/feed.html:42 social/templates/feed.html:44
 #: social/templates/notification.html:56
 msgid "all"
 msgstr ""
@@ -2126,7 +2084,7 @@ msgstr "композитор"
 msgid "production"
 msgstr ""
 
-#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:54
+#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:53
 msgid "verified creator"
 msgstr ""
 
@@ -2207,10 +2165,7 @@ msgid "No items matching your search query."
 msgstr ""
 
 #: catalog/templates/search_results.html:34
-msgid ""
-"If you have URL from one of these sites, please put the full URL (e.g. "
-"<code>https://www.imdb.com/title/tt2513074/</code>) to the search box and "
-"press Enter."
+msgid "If you have URL from one of these sites, please put the full URL (e.g. <code>https://www.imdb.com/title/tt2513074/</code>) to the search box and press Enter."
 msgstr ""
 
 #: catalog/templates/search_results.html:48
@@ -2247,97 +2202,176 @@ msgstr ""
 msgid "Editions"
 msgstr ""
 
-#: catalog/views/edit.py:202 catalog/views/edit.py:205
-#: catalog/views/edit.py:306 catalog/views/edit.py:309
-#: catalog/views/verify.py:197 journal/views/collection.py:77
-#: journal/views/collection.py:102 journal/views/collection.py:556
-#: journal/views/collection.py:651 journal/views/common.py:221
-#: journal/views/mark.py:196 journal/views/post.py:117
-#: journal/views/post.py:119 journal/views/post.py:166
-#: journal/views/post.py:185 journal/views/post.py:187
-#: journal/views/post.py:228 journal/views/post.py:241
+#: catalog/views/edit.py:293 catalog/views/edit.py:296
+#: catalog/views/edit.py:440 catalog/views/edit.py:443
+#: catalog/views/verify.py:197 journal/views/collection.py:75
+#: journal/views/collection.py:100 journal/views/collection.py:538
+#: journal/views/collection.py:634 journal/views/common.py:231
+#: journal/views/mark.py:244 journal/views/post.py:119
+#: journal/views/post.py:121 journal/views/post.py:168
+#: journal/views/post.py:187 journal/views/post.py:189
+#: journal/views/post.py:230 journal/views/post.py:243
 #: journal/views/review.py:154 journal/views/review.py:158
-#: users/views/actions.py:179
+#: users/views/actions.py:178
 msgid "Invalid parameter"
 msgstr ""
 
-#: catalog/views/edit.py:220
+#: catalog/views/edit.py:313
 msgid "Item in use."
 msgstr ""
 
-#: catalog/views/edit.py:222
+#: catalog/views/edit.py:315
 msgid "Item cannot be deleted."
 msgstr ""
 
-#: catalog/views/edit.py:247 catalog/views/edit.py:303
-#: catalog/views/edit.py:427 catalog/views/edit.py:519
-#: catalog/views/edit.py:552 catalog/views/verify.py:158
+#: catalog/views/edit.py:319 catalog/views/edit.py:515
+msgid "Are you sure to delete?"
+msgstr ""
+
+#: catalog/views/edit.py:323 catalog/views/edit.py:518
+#: catalog/views/edit.py:617
+msgid "This operation cannot be undone."
+msgstr ""
+
+#: catalog/views/edit.py:344 catalog/views/edit.py:437
+#: catalog/views/edit.py:603 catalog/views/edit.py:705
+#: catalog/views/edit.py:752 catalog/views/verify.py:158
 #: catalog/views/verify.py:206 journal/views/article.py:44
 #: journal/views/article.py:133 journal/views/article.py:153
 #: journal/views/collection.py:248 journal/views/collection.py:341
-#: journal/views/collection.py:360 journal/views/collection.py:384
-#: journal/views/collection.py:457 journal/views/collection.py:500
-#: journal/views/collection.py:539 journal/views/collection.py:551
-#: journal/views/collection.py:576 journal/views/collection.py:613
-#: journal/views/common.py:300 journal/views/mark.py:281
-#: journal/views/post.py:58 journal/views/post.py:78 journal/views/post.py:100
-#: journal/views/post.py:170 journal/views/post.py:199
-#: journal/views/post.py:272 journal/views/post.py:287
-#: journal/views/post.py:394 journal/views/post.py:549
+#: journal/views/collection.py:354 journal/views/collection.py:372
+#: journal/views/collection.py:439 journal/views/collection.py:482
+#: journal/views/collection.py:521 journal/views/collection.py:533
+#: journal/views/collection.py:558 journal/views/collection.py:595
+#: journal/views/common.py:304 journal/views/mark.py:317
+#: journal/views/post.py:60 journal/views/post.py:80 journal/views/post.py:102
+#: journal/views/post.py:172 journal/views/post.py:201
+#: journal/views/post.py:274 journal/views/post.py:289
+#: journal/views/post.py:390 journal/views/post.py:539
 #: journal/views/review.py:64 journal/views/review.py:81
 #: journal/views/review.py:106
 msgid "Insufficient permission"
 msgstr ""
 
-#: catalog/views/edit.py:374
+#: catalog/views/edit.py:346
+#, fuzzy
+#| msgid "This item has been deleted."
+msgid "Item is not deleted"
+msgstr "Этот элемент был удален."
+
+#: catalog/views/edit.py:389
+msgid "Switching may remove some metadata."
+msgstr ""
+
+#: catalog/views/edit.py:395
+#, fuzzy
+#| msgid "The following items are merged into this item"
+msgid "The following seasons will be detached from this show"
+msgstr "Следующие элементы включены в этот элемент"
+
+#: catalog/views/edit.py:400
+msgid "Links to IMDB and TMDB will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:403
+msgid "Are you sure to switch category?"
+msgstr ""
+
+#: catalog/views/edit.py:451
+msgid "Are you sure to remove the link to this site?"
+msgstr ""
+
+#: catalog/views/edit.py:457
+#, fuzzy
+#| msgid "You may not be able to undo this operation, sure to remove?"
+msgid "You may not be able to undo this operation."
+msgstr "Возможно, вы не сможете отменить эту операцию, уверены, что хотите продолжить?"
+
+#: catalog/views/edit.py:483
+msgid "Current parent item"
+msgstr ""
+
+#: catalog/views/edit.py:487
+msgid "The link to the parent item will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:490 catalog/views/edit.py:680
+msgid "Are you sure to link?"
+msgstr ""
+
+#: catalog/views/edit.py:521
+msgid "The following seasons will be deleted"
+msgstr ""
+
+#: catalog/views/edit.py:525
+msgid "The following seasons will be kept"
+msgstr ""
+
+#: catalog/views/edit.py:550
 msgid "TV Season with IMDB id and season number required."
 msgstr ""
 
-#: catalog/views/edit.py:380
+#: catalog/views/edit.py:556
 msgid "Updating episodes"
 msgstr ""
 
-#: catalog/views/edit.py:405
+#: catalog/views/edit.py:581
 msgid "This person has no supported source to fetch works from."
 msgstr ""
 
-#: catalog/views/edit.py:412
+#: catalog/views/edit.py:588
 msgid "Already pulling works for this person, try again later."
 msgstr ""
 
-#: catalog/views/edit.py:416
+#: catalog/views/edit.py:592
 msgid "Pulling works in background."
 msgstr ""
 
-#: catalog/views/edit.py:438
+#: catalog/views/edit.py:609
+msgid "Are you sure to merge?"
+msgstr ""
+
+#: catalog/views/edit.py:611
+msgid "Are you sure to cancel merge?"
+msgstr ""
+
+#: catalog/views/edit.py:622
 msgid "Cannot be merged to an item already deleted or merged"
 msgstr ""
 
-#: catalog/views/edit.py:443
+#: catalog/views/edit.py:627
 msgid "Cannot merge items in different categories"
 msgstr ""
 
-#: catalog/views/edit.py:447
+#: catalog/views/edit.py:631
 msgid "Cannot merge an item to itself"
 msgstr ""
 
-#: catalog/views/edit.py:488
+#: catalog/views/edit.py:672
 msgid "Cannot be linked to an item already deleted or merged"
 msgstr ""
 
-#: catalog/views/edit.py:492
+#: catalog/views/edit.py:676
 msgid "Cannot link items other than editions"
 msgstr ""
 
-#: catalog/views/search.py:96
+#: catalog/views/edit.py:710
+msgid "Are you sure to unlink?"
+msgstr ""
+
+#: catalog/views/edit.py:715
+msgid "This edition will be unlinked from the following work"
+msgstr ""
+
+#: catalog/views/search.py:113
 msgid "the internet"
 msgstr ""
 
-#: catalog/views/search.py:359
+#: catalog/views/search.py:410
 msgid "Invalid URL"
 msgstr ""
 
-#: catalog/views/search.py:362
+#: catalog/views/search.py:413
 msgid "Unsupported URL"
 msgstr ""
 
@@ -2361,9 +2395,9 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:122 common/utils.py:163
+#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
 #: journal/views/article.py:186 journal/views/review.py:182
-#: users/views/actions.py:45 users/views/actions.py:131
+#: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
 msgstr ""
 
@@ -2377,15 +2411,15 @@ msgstr ""
 msgid "Creator verification removed."
 msgstr "Пожалуйста, введите полученный проверочный код."
 
-#: catalog/views/view.py:74 catalog/views/view.py:99
+#: catalog/views/view.py:77 catalog/views/view.py:102
 msgid "Item not found"
 msgstr ""
 
-#: catalog/views/view.py:78 catalog/views/view.py:107 catalog/views/view.py:190
+#: catalog/views/view.py:81 catalog/views/view.py:110 catalog/views/view.py:193
 msgid "Item no longer exists"
 msgstr ""
 
-#: catalog/views/view.py:187
+#: catalog/views/view.py:190
 #, fuzzy
 #| msgid "Invalid file."
 msgid "Invalid role"
@@ -2884,759 +2918,759 @@ msgctxt "genre"
 msgid "Health"
 msgstr ""
 
-#: common/models/lang.py:54
+#: common/models/lang.py:56
 msgid "Afar"
 msgstr ""
 
-#: common/models/lang.py:55
+#: common/models/lang.py:57
 msgid "Afrikaans"
 msgstr ""
 
-#: common/models/lang.py:56
+#: common/models/lang.py:58
 msgid "Akan"
 msgstr ""
 
-#: common/models/lang.py:57
+#: common/models/lang.py:59
 msgid "Aragonese"
 msgstr ""
 
-#: common/models/lang.py:58
+#: common/models/lang.py:60
 msgid "Assamese"
 msgstr ""
 
-#: common/models/lang.py:59
+#: common/models/lang.py:61
 msgid "Avaric"
 msgstr ""
 
-#: common/models/lang.py:60
+#: common/models/lang.py:62
 msgid "Avestan"
 msgstr ""
 
-#: common/models/lang.py:61
+#: common/models/lang.py:63
 msgid "Aymara"
 msgstr ""
 
-#: common/models/lang.py:62
+#: common/models/lang.py:64
 msgid "Azerbaijani"
 msgstr ""
 
-#: common/models/lang.py:63
+#: common/models/lang.py:65
 msgid "Bashkir"
 msgstr ""
 
-#: common/models/lang.py:64
+#: common/models/lang.py:66
 msgid "Bambara"
 msgstr ""
 
-#: common/models/lang.py:65
+#: common/models/lang.py:67
 msgid "Bislama"
 msgstr ""
 
-#: common/models/lang.py:66
+#: common/models/lang.py:68
 msgid "Tibetan"
 msgstr ""
 
-#: common/models/lang.py:67
+#: common/models/lang.py:69
 msgid "Breton"
 msgstr ""
 
-#: common/models/lang.py:68
+#: common/models/lang.py:70
 msgid "Catalan"
 msgstr ""
 
-#: common/models/lang.py:69
+#: common/models/lang.py:71
 msgid "Czech"
 msgstr ""
 
-#: common/models/lang.py:70
+#: common/models/lang.py:72
 msgid "Chechen"
 msgstr ""
 
-#: common/models/lang.py:71
+#: common/models/lang.py:73
 msgid "Slavic"
 msgstr ""
 
-#: common/models/lang.py:72
+#: common/models/lang.py:74
 msgid "Chuvash"
 msgstr ""
 
-#: common/models/lang.py:73
+#: common/models/lang.py:75
 msgid "Cornish"
 msgstr ""
 
-#: common/models/lang.py:74
+#: common/models/lang.py:76
 msgid "Corsican"
 msgstr ""
 
-#: common/models/lang.py:75
+#: common/models/lang.py:77
 msgid "Cree"
 msgstr ""
 
-#: common/models/lang.py:76
+#: common/models/lang.py:78
 msgid "Welsh"
 msgstr ""
 
-#: common/models/lang.py:79
+#: common/models/lang.py:81
 msgid "Divehi"
 msgstr ""
 
-#: common/models/lang.py:80
+#: common/models/lang.py:82
 msgid "Dzongkha"
 msgstr ""
 
-#: common/models/lang.py:81
+#: common/models/lang.py:83
 msgid "Esperanto"
 msgstr ""
 
-#: common/models/lang.py:82
+#: common/models/lang.py:84
 msgid "Estonian"
 msgstr ""
 
-#: common/models/lang.py:83
+#: common/models/lang.py:85
 msgid "Basque"
 msgstr ""
 
-#: common/models/lang.py:84
+#: common/models/lang.py:86
 msgid "Faroese"
 msgstr ""
 
-#: common/models/lang.py:85
+#: common/models/lang.py:87
 msgid "Fijian"
 msgstr ""
 
-#: common/models/lang.py:86
+#: common/models/lang.py:88
 msgid "Finnish"
 msgstr ""
 
-#: common/models/lang.py:88
+#: common/models/lang.py:90
 msgid "Frisian"
 msgstr ""
 
-#: common/models/lang.py:89
+#: common/models/lang.py:91
 msgid "Fulah"
 msgstr ""
 
-#: common/models/lang.py:90
+#: common/models/lang.py:92
 msgid "Gaelic"
 msgstr ""
 
-#: common/models/lang.py:91
+#: common/models/lang.py:93
 msgid "Irish"
 msgstr ""
 
-#: common/models/lang.py:92
+#: common/models/lang.py:94
 msgid "Galician"
 msgstr ""
 
-#: common/models/lang.py:93
+#: common/models/lang.py:95
 msgid "Manx"
 msgstr ""
 
-#: common/models/lang.py:94
+#: common/models/lang.py:96
 msgid "Guarani"
 msgstr ""
 
-#: common/models/lang.py:95
+#: common/models/lang.py:97
 msgid "Gujarati"
 msgstr ""
 
-#: common/models/lang.py:96
+#: common/models/lang.py:98
 msgid "Haitian; Haitian Creole"
 msgstr ""
 
-#: common/models/lang.py:97
+#: common/models/lang.py:99
 msgid "Hausa"
 msgstr ""
 
-#: common/models/lang.py:98
+#: common/models/lang.py:100
 msgid "Serbo-Croatian"
 msgstr ""
 
-#: common/models/lang.py:99
+#: common/models/lang.py:101
 msgid "Herero"
 msgstr ""
 
-#: common/models/lang.py:100
+#: common/models/lang.py:102
 msgid "Hiri Motu"
 msgstr ""
 
-#: common/models/lang.py:101
+#: common/models/lang.py:103
 msgid "Croatian"
 msgstr ""
 
-#: common/models/lang.py:102
+#: common/models/lang.py:104
 msgid "Hungarian"
 msgstr ""
 
-#: common/models/lang.py:103
+#: common/models/lang.py:105
 msgid "Igbo"
 msgstr ""
 
-#: common/models/lang.py:104
+#: common/models/lang.py:106
 msgid "Ido"
 msgstr ""
 
-#: common/models/lang.py:105
+#: common/models/lang.py:107
 msgid "Yi"
 msgstr ""
 
-#: common/models/lang.py:106
+#: common/models/lang.py:108
 msgid "Inuktitut"
 msgstr ""
 
-#: common/models/lang.py:107
+#: common/models/lang.py:109
 msgid "Interlingue"
 msgstr ""
 
-#: common/models/lang.py:108
+#: common/models/lang.py:110
 msgid "Interlingua"
 msgstr ""
 
-#: common/models/lang.py:109
+#: common/models/lang.py:111
 msgid "Indonesian"
 msgstr ""
 
-#: common/models/lang.py:110
+#: common/models/lang.py:112
 msgid "Inupiaq"
 msgstr ""
 
-#: common/models/lang.py:111
+#: common/models/lang.py:113
 msgid "Icelandic"
 msgstr ""
 
-#: common/models/lang.py:113
+#: common/models/lang.py:115
 msgid "Javanese"
 msgstr ""
 
-#: common/models/lang.py:114
+#: common/models/lang.py:116
 msgid "Japanese"
 msgstr ""
 
-#: common/models/lang.py:115
+#: common/models/lang.py:117
 msgid "Kalaallisut"
 msgstr ""
 
-#: common/models/lang.py:116
+#: common/models/lang.py:118
 msgid "Kannada"
 msgstr ""
 
-#: common/models/lang.py:117
+#: common/models/lang.py:119
 msgid "Kashmiri"
 msgstr ""
 
-#: common/models/lang.py:118
+#: common/models/lang.py:120
 msgid "Kanuri"
 msgstr ""
 
-#: common/models/lang.py:119
+#: common/models/lang.py:121
 msgid "Kazakh"
 msgstr ""
 
-#: common/models/lang.py:120
+#: common/models/lang.py:122
 msgid "Khmer"
 msgstr ""
 
-#: common/models/lang.py:121
+#: common/models/lang.py:123
 msgid "Kikuyu"
 msgstr ""
 
-#: common/models/lang.py:122
+#: common/models/lang.py:124
 msgid "Kinyarwanda"
 msgstr ""
 
-#: common/models/lang.py:123
+#: common/models/lang.py:125
 msgid "Kirghiz"
 msgstr ""
 
-#: common/models/lang.py:124
+#: common/models/lang.py:126
 msgid "Komi"
 msgstr ""
 
-#: common/models/lang.py:125
+#: common/models/lang.py:127
 msgid "Kongo"
 msgstr ""
 
-#: common/models/lang.py:126
+#: common/models/lang.py:128
 msgid "Korean"
 msgstr ""
 
-#: common/models/lang.py:127
+#: common/models/lang.py:129
 msgid "Kuanyama"
 msgstr ""
 
-#: common/models/lang.py:128
+#: common/models/lang.py:130
 msgid "Kurdish"
 msgstr ""
 
-#: common/models/lang.py:129
+#: common/models/lang.py:131
 msgid "Lao"
 msgstr ""
 
-#: common/models/lang.py:130
+#: common/models/lang.py:132
 msgid "Latin"
 msgstr ""
 
-#: common/models/lang.py:131
+#: common/models/lang.py:133
 msgid "Latvian"
 msgstr ""
 
-#: common/models/lang.py:132
+#: common/models/lang.py:134
 msgid "Limburgish"
 msgstr ""
 
-#: common/models/lang.py:133
+#: common/models/lang.py:135
 msgid "Lingala"
 msgstr ""
 
-#: common/models/lang.py:134
+#: common/models/lang.py:136
 msgid "Lithuanian"
 msgstr ""
 
-#: common/models/lang.py:135
+#: common/models/lang.py:137
 msgid "Letzeburgesch"
 msgstr ""
 
-#: common/models/lang.py:136
+#: common/models/lang.py:138
 msgid "Luba-Katanga"
 msgstr ""
 
-#: common/models/lang.py:137
+#: common/models/lang.py:139
 msgid "Ganda"
 msgstr ""
 
-#: common/models/lang.py:138
+#: common/models/lang.py:140
 msgid "Marshall"
 msgstr ""
 
-#: common/models/lang.py:139
+#: common/models/lang.py:141
 msgid "Malayalam"
 msgstr ""
 
-#: common/models/lang.py:140
+#: common/models/lang.py:142
 msgid "Marathi"
 msgstr ""
 
-#: common/models/lang.py:141
+#: common/models/lang.py:143
 msgid "Malagasy"
 msgstr ""
 
-#: common/models/lang.py:142
+#: common/models/lang.py:144
 msgid "Maltese"
 msgstr ""
 
-#: common/models/lang.py:143
+#: common/models/lang.py:145
 msgid "Moldavian"
 msgstr ""
 
-#: common/models/lang.py:144
+#: common/models/lang.py:146
 msgid "Mongolian"
 msgstr ""
 
-#: common/models/lang.py:145
+#: common/models/lang.py:147
 msgid "Maori"
 msgstr ""
 
-#: common/models/lang.py:146
+#: common/models/lang.py:148
 msgid "Malay"
 msgstr ""
 
-#: common/models/lang.py:147
+#: common/models/lang.py:149
 msgid "Burmese"
 msgstr ""
 
-#: common/models/lang.py:148
+#: common/models/lang.py:150
 msgid "Nauru"
 msgstr ""
 
-#: common/models/lang.py:149
+#: common/models/lang.py:151
 msgid "Navajo"
 msgstr ""
 
-#: common/models/lang.py:150 common/models/lang.py:151
+#: common/models/lang.py:152 common/models/lang.py:153
 msgid "Ndebele"
 msgstr ""
 
-#: common/models/lang.py:152
+#: common/models/lang.py:154
 msgid "Ndonga"
 msgstr ""
 
-#: common/models/lang.py:153
+#: common/models/lang.py:155
 msgid "Nepali"
 msgstr ""
 
-#: common/models/lang.py:154
+#: common/models/lang.py:156
 msgid "Dutch"
 msgstr ""
 
-#: common/models/lang.py:155
+#: common/models/lang.py:157
 msgid "Norwegian Nynorsk"
 msgstr ""
 
-#: common/models/lang.py:156
+#: common/models/lang.py:158
 msgid "Norwegian Bokmål"
 msgstr ""
 
-#: common/models/lang.py:157
+#: common/models/lang.py:159
 msgid "Norwegian"
 msgstr ""
 
-#: common/models/lang.py:158
+#: common/models/lang.py:160
 msgid "Chichewa; Nyanja"
 msgstr ""
 
-#: common/models/lang.py:159
+#: common/models/lang.py:161
 msgid "Occitan"
 msgstr ""
 
-#: common/models/lang.py:160
+#: common/models/lang.py:162
 msgid "Ojibwa"
 msgstr ""
 
-#: common/models/lang.py:161
+#: common/models/lang.py:163
 msgid "Oriya"
 msgstr ""
 
-#: common/models/lang.py:162
+#: common/models/lang.py:164
 msgid "Oromo"
 msgstr ""
 
-#: common/models/lang.py:163
+#: common/models/lang.py:165
 msgid "Ossetian; Ossetic"
 msgstr ""
 
-#: common/models/lang.py:164
+#: common/models/lang.py:166
 msgid "Pali"
 msgstr ""
 
-#: common/models/lang.py:165
+#: common/models/lang.py:167
 msgid "Polish"
 msgstr ""
 
-#: common/models/lang.py:167
+#: common/models/lang.py:169
 msgid "Quechua"
 msgstr ""
 
-#: common/models/lang.py:168
+#: common/models/lang.py:170
 msgid "Raeto-Romance"
 msgstr ""
 
-#: common/models/lang.py:169
+#: common/models/lang.py:171
 msgid "Romanian"
 msgstr ""
 
-#: common/models/lang.py:170
+#: common/models/lang.py:172
 msgid "Rundi"
 msgstr ""
 
-#: common/models/lang.py:171
+#: common/models/lang.py:173
 msgid "Russian"
 msgstr ""
 
-#: common/models/lang.py:172
+#: common/models/lang.py:174
 msgid "Sango"
 msgstr ""
 
-#: common/models/lang.py:173
+#: common/models/lang.py:175
 msgid "Sanskrit"
 msgstr ""
 
-#: common/models/lang.py:174
+#: common/models/lang.py:176
 msgid "Sinhalese"
 msgstr ""
 
-#: common/models/lang.py:175
+#: common/models/lang.py:177
 msgid "Slovak"
 msgstr ""
 
-#: common/models/lang.py:176
+#: common/models/lang.py:178
 msgid "Slovenian"
 msgstr ""
 
-#: common/models/lang.py:177
+#: common/models/lang.py:179
 msgid "Northern Sami"
 msgstr ""
 
-#: common/models/lang.py:178
+#: common/models/lang.py:180
 msgid "Samoan"
 msgstr ""
 
-#: common/models/lang.py:179
+#: common/models/lang.py:181
 msgid "Shona"
 msgstr ""
 
-#: common/models/lang.py:180
+#: common/models/lang.py:182
 msgid "Sindhi"
 msgstr ""
 
-#: common/models/lang.py:181
+#: common/models/lang.py:183
 msgid "Somali"
 msgstr ""
 
-#: common/models/lang.py:182
+#: common/models/lang.py:184
 msgid "Sotho"
 msgstr ""
 
-#: common/models/lang.py:184
+#: common/models/lang.py:186
 msgid "Albanian"
 msgstr ""
 
-#: common/models/lang.py:185
+#: common/models/lang.py:187
 msgid "Sardinian"
 msgstr ""
 
-#: common/models/lang.py:186
+#: common/models/lang.py:188
 msgid "Serbian"
 msgstr ""
 
-#: common/models/lang.py:187
+#: common/models/lang.py:189
 msgid "Swati"
 msgstr ""
 
-#: common/models/lang.py:188
+#: common/models/lang.py:190
 msgid "Sundanese"
 msgstr ""
 
-#: common/models/lang.py:189
+#: common/models/lang.py:191
 msgid "Swahili"
 msgstr ""
 
-#: common/models/lang.py:190
+#: common/models/lang.py:192
 msgid "Swedish"
 msgstr ""
 
-#: common/models/lang.py:191
+#: common/models/lang.py:193
 msgid "Tahitian"
 msgstr ""
 
-#: common/models/lang.py:192
+#: common/models/lang.py:194
 msgid "Tamil"
 msgstr ""
 
-#: common/models/lang.py:193
+#: common/models/lang.py:195
 msgid "Tatar"
 msgstr ""
 
-#: common/models/lang.py:194
+#: common/models/lang.py:196
 msgid "Telugu"
 msgstr ""
 
-#: common/models/lang.py:195
+#: common/models/lang.py:197
 msgid "Tajik"
 msgstr ""
 
-#: common/models/lang.py:196
+#: common/models/lang.py:198
 msgid "Tagalog"
 msgstr ""
 
-#: common/models/lang.py:197
+#: common/models/lang.py:199
 msgid "Thai"
 msgstr ""
 
-#: common/models/lang.py:198
+#: common/models/lang.py:200
 msgid "Tigrinya"
 msgstr ""
 
-#: common/models/lang.py:199
+#: common/models/lang.py:201
 msgid "Tonga"
 msgstr ""
 
-#: common/models/lang.py:200
+#: common/models/lang.py:202
 msgid "Tswana"
 msgstr ""
 
-#: common/models/lang.py:201
+#: common/models/lang.py:203
 msgid "Tsonga"
 msgstr ""
 
-#: common/models/lang.py:202
+#: common/models/lang.py:204
 msgid "Turkmen"
 msgstr ""
 
-#: common/models/lang.py:203
+#: common/models/lang.py:205
 msgid "Turkish"
 msgstr ""
 
-#: common/models/lang.py:204
+#: common/models/lang.py:206
 msgid "Twi"
 msgstr ""
 
-#: common/models/lang.py:205
+#: common/models/lang.py:207
 msgid "Uighur"
 msgstr ""
 
-#: common/models/lang.py:206
+#: common/models/lang.py:208
 msgid "Ukrainian"
 msgstr ""
 
-#: common/models/lang.py:207
+#: common/models/lang.py:209
 msgid "Urdu"
 msgstr ""
 
-#: common/models/lang.py:208
+#: common/models/lang.py:210
 msgid "Uzbek"
 msgstr ""
 
-#: common/models/lang.py:209
+#: common/models/lang.py:211
 msgid "Venda"
 msgstr ""
 
-#: common/models/lang.py:210
+#: common/models/lang.py:212
 msgid "Vietnamese"
 msgstr ""
 
-#: common/models/lang.py:211
+#: common/models/lang.py:213
 msgid "Volapük"
 msgstr ""
 
-#: common/models/lang.py:212
+#: common/models/lang.py:214
 msgid "Walloon"
 msgstr ""
 
-#: common/models/lang.py:213
+#: common/models/lang.py:215
 msgid "Wolof"
 msgstr ""
 
-#: common/models/lang.py:214
+#: common/models/lang.py:216
 msgid "Xhosa"
 msgstr ""
 
-#: common/models/lang.py:215
+#: common/models/lang.py:217
 msgid "Yiddish"
 msgstr ""
 
-#: common/models/lang.py:216
+#: common/models/lang.py:218
 msgid "Zhuang"
 msgstr ""
 
-#: common/models/lang.py:217
+#: common/models/lang.py:219
 msgid "Zulu"
 msgstr ""
 
-#: common/models/lang.py:218
+#: common/models/lang.py:220
 msgid "Abkhazian"
 msgstr ""
 
-#: common/models/lang.py:219
+#: common/models/lang.py:221
 msgid "Chinese"
 msgstr ""
 
-#: common/models/lang.py:220
+#: common/models/lang.py:222
 msgid "Pushto"
 msgstr ""
 
-#: common/models/lang.py:221
+#: common/models/lang.py:223
 msgid "Amharic"
 msgstr ""
 
-#: common/models/lang.py:222
+#: common/models/lang.py:224
 msgid "Arabic"
 msgstr ""
 
-#: common/models/lang.py:223
+#: common/models/lang.py:225
 msgid "Bulgarian"
 msgstr ""
 
-#: common/models/lang.py:224
+#: common/models/lang.py:226
 msgid "Macedonian"
 msgstr ""
 
-#: common/models/lang.py:225
+#: common/models/lang.py:227
 msgid "Greek"
 msgstr ""
 
-#: common/models/lang.py:226
+#: common/models/lang.py:228
 msgid "Persian"
 msgstr ""
 
-#: common/models/lang.py:227
+#: common/models/lang.py:229
 msgid "Hebrew"
 msgstr ""
 
-#: common/models/lang.py:228
+#: common/models/lang.py:230
 msgid "Hindi"
 msgstr ""
 
-#: common/models/lang.py:229
+#: common/models/lang.py:231
 msgid "Armenian"
 msgstr ""
 
-#: common/models/lang.py:231
+#: common/models/lang.py:233
 msgid "Ewe"
 msgstr ""
 
-#: common/models/lang.py:232
+#: common/models/lang.py:234
 msgid "Georgian"
 msgstr ""
 
-#: common/models/lang.py:233
+#: common/models/lang.py:235
 msgid "Punjabi"
 msgstr ""
 
-#: common/models/lang.py:234
+#: common/models/lang.py:236
 msgid "Bengali"
 msgstr ""
 
-#: common/models/lang.py:235
+#: common/models/lang.py:237
 msgid "Bosnian"
 msgstr ""
 
-#: common/models/lang.py:236
+#: common/models/lang.py:238
 msgid "Chamorro"
 msgstr ""
 
-#: common/models/lang.py:237
+#: common/models/lang.py:239
 msgid "Belarusian"
 msgstr ""
 
-#: common/models/lang.py:238
+#: common/models/lang.py:240
 msgid "Yoruba"
 msgstr ""
 
-#: common/models/lang.py:300
+#: common/models/lang.py:302
 msgid "Simplified Chinese (Mainland)"
 msgstr ""
 
-#: common/models/lang.py:301
+#: common/models/lang.py:303
 msgid "Traditional Chinese (Taiwan)"
 msgstr ""
 
-#: common/models/lang.py:302
+#: common/models/lang.py:304
 msgid "Traditional Chinese (Hongkong)"
 msgstr ""
 
-#: common/models/lang.py:310
+#: common/models/lang.py:312
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: common/models/lang.py:313
+#: common/models/lang.py:315
 msgid "Simplified Chinese (Singapore)"
 msgstr ""
 
-#: common/models/lang.py:314
+#: common/models/lang.py:316
 msgid "Simplified Chinese (Malaysia)"
 msgstr ""
 
-#: common/models/lang.py:315
+#: common/models/lang.py:317
 msgid "Traditional Chinese (Macau)"
 msgstr ""
 
-#: common/models/lang.py:323
+#: common/models/lang.py:325
 msgid "Mandarin Chinese"
 msgstr ""
 
-#: common/models/lang.py:324
+#: common/models/lang.py:326
 msgid "Yue Chinese"
 msgstr ""
 
-#: common/models/lang.py:328
+#: common/models/lang.py:330
 msgid "Min Nan Chinese"
 msgstr ""
 
-#: common/models/lang.py:329
+#: common/models/lang.py:331
 msgid "Wu Chinese"
 msgstr ""
 
-#: common/models/lang.py:330
+#: common/models/lang.py:332
 msgid "Hakka Chinese"
 msgstr ""
 
@@ -3772,22 +3806,16 @@ msgid "VCD"
 msgstr ""
 
 #: common/templates/400.html:23
-msgid ""
-"You may have submitted invalid data, or the content may have been deleted by "
-"the author."
+msgid "You may have submitted invalid data, or the content may have been deleted by the author."
 msgstr ""
 
 #: common/templates/400.html:25 common/templates/403.html:24
 #: common/templates/404.html:24
-msgid ""
-"If you believe this is our mistake, please contact us through the link at "
-"the bottom of the page."
+msgid "If you believe this is our mistake, please contact us through the link at the bottom of the page."
 msgstr ""
 
 #: common/templates/403.html:22
-msgid ""
-"Author may require you to log in before accessing this content, or you do "
-"not have permission to view it."
+msgid "Author may require you to log in before accessing this content, or you do not have permission to view it."
 msgstr ""
 
 #: common/templates/404.html:20
@@ -3795,9 +3823,7 @@ msgid "Something is missing"
 msgstr ""
 
 #: common/templates/404.html:22
-msgid ""
-"You may have visited an incorrect URL, or the content you are looking for "
-"has been deleted by the author."
+msgid "You may have visited an incorrect URL, or the content you are looking for has been deleted by the author."
 msgstr ""
 
 #: common/templates/404.html:26
@@ -3805,15 +3831,11 @@ msgid "Go to Home"
 msgstr ""
 
 #: common/templates/500.html:22
-msgid ""
-"An internal error occurred. If this error occurs repeatedly, it will be "
-"recorded and handled by a human."
+msgid "An internal error occurred. If this error occurs repeatedly, it will be recorded and handled by a human."
 msgstr ""
 
 #: common/templates/500.html:24
-msgid ""
-"If you have an urgent situation or any questions, please contact us through "
-"the link at the bottom of the page."
+msgid "If you have an urgent situation or any questions, please contact us through the link at the bottom of the page."
 msgstr ""
 
 #: common/templates/_footer.html:6
@@ -3828,207 +3850,184 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: common/templates/_footer.html:12 users/templates/users/login.html:265
+#: common/templates/_footer.html:12 users/templates/users/login.html:259
 #, python-format
-msgid ""
-"You are visiting an alternative domain for %(site_name)s, please always use "
-"<a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if "
-"possible."
+msgid "You are visiting an alternative domain for %(site_name)s, please always use <a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if possible."
 msgstr ""
 
-#: common/templates/_header.html:19 common/templates/_header.html:164
+#: common/templates/_header.html:19 common/templates/_header.html:177
 msgid "title, creator, ISBN, item url, @user, @user@instance"
 msgstr ""
 
-#: common/templates/_header.html:24
+#: common/templates/_header.html:34
 msgid "All Items"
 msgstr ""
 
-#: common/templates/_header.html:31
+#: common/templates/_header.html:41
 msgid "Movie & TV"
 msgstr ""
 
-#: common/templates/_header.html:50
+#: common/templates/_header.html:60
 msgid "People & Organizations"
 msgstr ""
 
-#: common/templates/_header.html:52
+#: common/templates/_header.html:62
 msgid "Journal"
 msgstr ""
 
-#: common/templates/_header.html:54 journal/templates/user_post_list.html:10
+#: common/templates/_header.html:64 journal/templates/user_post_list.html:10
 #: journal/templates/user_post_list.html:23
 msgid "Posts"
 msgstr ""
 
-#: common/templates/_header.html:89
+#: common/templates/_header.html:102
 msgid "Explore"
 msgstr ""
 
-#: common/templates/_header.html:93
+#: common/templates/_header.html:106 common/views_manage.py:36
 msgid "Feed"
 msgstr ""
 
-#: common/templates/_header.html:98 journal/templates/profile.html:13
+#: common/templates/_header.html:111 journal/templates/profile.html:13
 #: users/templates/users/preferences.html:46
 msgid "Home"
 msgstr ""
 
-#: common/templates/_header.html:114 common/templates/common/scan.html:9
+#: common/templates/_header.html:127 common/templates/common/scan.html:9
 #: common/templates/common/scan.html:42
 msgid "Scan Barcode"
 msgstr ""
 
-#: common/templates/_header.html:118 social/templates/notification.html:12
+#: common/templates/_header.html:131 social/templates/notification.html:12
 #: social/templates/notification.html:53
 msgid "Notification"
 msgstr ""
 
-#: common/templates/_header.html:122 users/models/task.py:21
+#: common/templates/_header.html:135 users/models/task.py:23
 #: users/templates/users/account.html:219
 #: users/templates/users/crossposts.html:9
 msgid "Pending"
 msgstr ""
 
-#: common/templates/_header.html:125
+#: common/templates/_header.html:138
 msgid "Data"
 msgstr ""
 
-#: common/templates/_header.html:128 common/templates/_header.html:146
+#: common/templates/_header.html:141 common/templates/_header.html:159
 #: users/templates/users/preferences.html:12
 #: users/templates/users/preferences.html:23
 #: users/templates/users/preferences_anonymous.html:13
 msgid "Preferences"
 msgstr ""
 
-#: common/templates/_header.html:131
+#: common/templates/_header.html:144
 msgid "Account"
 msgstr ""
 
-#: common/templates/_header.html:135
+#: common/templates/_header.html:148
 msgid "Manage"
 msgstr ""
 
-#: common/templates/_header.html:139
+#: common/templates/_header.html:152
 msgid "Logout"
 msgstr ""
 
-#: common/templates/_header.html:143
+#: common/templates/_header.html:156
 msgid "Sign up or Login"
 msgstr ""
 
-#: common/templates/_header.html:160
-msgid ""
-"title or content  category:tv  status:complete  rating:8..10  "
-"date:2021-09-11..2022-02"
+#: common/templates/_header.html:173
+msgid "title or content  category:tv  status:complete  rating:8..10  date:2021-09-11..2022-02"
 msgstr ""
 
-#: common/templates/_header.html:162
+#: common/templates/_header.html:175
 msgid "name of a person or company"
 msgstr ""
 
-#: common/templates/_header.html:179
+#: common/templates/_header.html:192
 msgid "Open"
 msgstr ""
 
-#: common/templates/_sidebar.html:62
+#: common/templates/_sidebar.html:61
 #: users/templates/users/profile_actions.html:36
 msgid "approving followers manually"
 msgstr ""
 
-#: common/templates/_sidebar.html:81 common/templates/_sidebar.html:86
+#: common/templates/_sidebar.html:80 common/templates/_sidebar.html:85
 msgid "followers"
 msgstr ""
 
-#: common/templates/_sidebar.html:112
+#: common/templates/_sidebar.html:111
 msgid "Current Targets"
 msgstr ""
 
-#: common/templates/_sidebar.html:125
+#: common/templates/_sidebar.html:124
 msgid "Set a collection as target, its progress will show up here."
 msgstr ""
 
-#: common/templates/_sidebar.html:138
+#: common/templates/_sidebar.html:137
 msgid "Recent podcast episodes"
 msgstr ""
 
-#: common/templates/_sidebar.html:173
+#: common/templates/_sidebar.html:172
 msgid "Currently reading"
 msgstr ""
 
-#: common/templates/_sidebar.html:215
+#: common/templates/_sidebar.html:214
 msgid "Currently watching"
 msgstr ""
 
-#: common/templates/_sidebar.html:238 journal/forms.py:217
+#: common/templates/_sidebar.html:237 journal/forms.py:217
 #: journal/templates/user_tag_list.html:13
 #: journal/templates/user_tagmember_list.html:4
 msgid "Tags"
 msgstr ""
 
-#: common/templates/_sidebar.html:244 journal/templates/user_tag_list.html:28
+#: common/templates/_sidebar.html:243 journal/templates/user_tag_list.html:28
 #: journal/templates/user_tagmember_list.html:10
 msgid "featured tag"
 msgstr ""
 
-#: common/templates/_sidebar.html:247 journal/templates/user_tag_list.html:31
+#: common/templates/_sidebar.html:246 journal/templates/user_tag_list.html:31
 #: journal/templates/user_tagmember_list.html:15
 msgid "personal tag"
 msgstr ""
 
-#: common/templates/_sidebar.html:254 journal/templates/user_tag_list.html:39
+#: common/templates/_sidebar.html:253 journal/templates/user_tag_list.html:39
 msgid "no tags so far."
 msgstr ""
 
-#: common/templates/_sidebar.html:258 common/templates/_sidebar.html:271
+#: common/templates/_sidebar.html:257 common/templates/_sidebar.html:270
 msgid "show all"
 msgstr ""
 
-#: common/templates/_sidebar_anonymous.html:16
+#: common/templates/_sidebar_anonymous.html:15
 #, python-format
 msgid ""
 "\n"
 "        <h3>Welcome 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is "
-"committed to creating a free, open, and interconnected space for collecting "
-"and reviewing books, movies, music, games, and podcasts. Here, you can "
-"manage your collections, share your thoughts, discover new content, and "
-"connect with others.\n"
+"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is committed to creating a free, open, and interconnected space for collecting and reviewing books, movies, music, games, and podcasts. Here, you can manage your collections, share your thoughts, discover new content, and connect with others.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in "
-"to %(site_name)s is through a Fediverse (a distributed social network, "
-"including Mastodon/Pleroma/etc) instance account. If you haven’t registered "
-"yet, you can <a href=\"https://joinmastodon.org/en/servers\" "
-"target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
+"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in to %(site_name)s is through a Fediverse (a distributed social network, including Mastodon/Pleroma/etc) instance account. If you haven’t registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log "
-"in is through a Bluesky (another distributed social network, also called "
-"ATProto) account. If you haven’t registered yet, you may <a href=\"https://"
-"bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
+"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log in is through a Bluesky (another distributed social network, also called ATProto) account. If you haven’t registered yet, you may <a href=\"https://bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready "
-"to join either Fediverse or Bluesky, that’s perfectly fine. You can create "
-"an account here using your email address, and link it to the Fediverse and "
-"Bluesky in settings whenever you’re ready.\n"
+"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready to join either Fediverse or Bluesky, that’s perfectly fine. You can create an account here using your email address, and link it to the Fediverse and Bluesky in settings whenever you’re ready.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have "
-"any questions or suggestions, please feel free to contact us via <a "
-"href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://"
-"discord.gg/uprvcH8gqD\">Discord</a>.\n"
+"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have any questions or suggestions, please feel free to contact us via <a href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-"href=\"%(login_url)s\">Click here</a> to register or log in.\n"
+"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Click here</a> to register or log in.\n"
 "        </p>\n"
 "        "
 msgstr ""
 
-#: common/templates/_sidebar_anonymous.html:43
+#: common/templates/_sidebar_anonymous.html:42
 #: users/templates/users/announcements.html:12
 #: users/templates/users/announcements.html:39
 msgid "Announcements"
@@ -4050,7 +4049,7 @@ msgstr ""
 msgid "Registration"
 msgstr ""
 
-#: common/templates/common/about.html:35 common/views_manage.py:493
+#: common/templates/common/about.html:35 common/views_manage.py:594
 msgid "Invite Only"
 msgstr ""
 
@@ -4058,7 +4057,7 @@ msgstr ""
 msgid "Open Registration"
 msgstr ""
 
-#: common/templates/common/about.html:40 common/views_manage.py:556
+#: common/templates/common/about.html:40 common/views_manage.py:657
 msgid "Preferred Languages"
 msgstr ""
 
@@ -4103,9 +4102,7 @@ msgid "Error"
 msgstr ""
 
 #: common/templates/common/scan.html:45
-msgid ""
-"Point the camera at a book ISBN or product barcode (EAN / UPC). You will be "
-"redirected to the search once a code is detected."
+msgid "Point the camera at a book ISBN or product barcode (EAN / UPC). You will be redirected to the search once a code is detected."
 msgstr ""
 
 #: common/templates/common/scan.html:50
@@ -4116,7 +4113,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:628
+#: common/templates/common/scan.html:60 common/views_manage.py:738
 msgid "Search"
 msgstr ""
 
@@ -4148,16 +4145,28 @@ msgstr ""
 msgid "Camera unavailable. Use manual entry below."
 msgstr ""
 
-#: common/templates/manage/settings.html:9
+#: common/templates/manage/base.html:9
 msgid "Site Settings"
 msgstr ""
 
-#: common/templates/manage/settings.html:109
+#: common/templates/manage/base.html:127
 msgid "Takahe Admin"
 msgstr ""
 
-#: common/templates/manage/settings.html:112
+#: common/templates/manage/base.html:130
 msgid "Database Admin"
+msgstr ""
+
+#: common/templates/manage/environment.html:6
+msgid "These settings come from environment variables and cannot be changed here. Edit .env and restart the server to change them. Passwords and keys are hidden."
+msgstr ""
+
+#: common/templates/manage/environment.html:23
+msgid "(empty)"
+msgstr ""
+
+#: common/templates/manage/environment.html:26
+msgid "default"
 msgstr ""
 
 #: common/templatetags/duration.py:59
@@ -4176,7 +4185,7 @@ msgstr ""
 msgid "following you"
 msgstr ""
 
-#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:95
+#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:90
 msgid "you"
 msgstr ""
 
@@ -4184,811 +4193,818 @@ msgstr ""
 msgid "unavailable"
 msgstr ""
 
-#: common/utils.py:126 common/utils.py:167 users/views/actions.py:134
+#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr ""
 
-#: common/utils.py:133 common/utils.py:135 common/utils.py:138
-#: common/utils.py:174 common/utils.py:178 journal/views/profile.py:499
+#: common/utils.py:135 common/utils.py:137 common/utils.py:140
+#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
 msgid "Access denied"
 msgstr ""
 
-#: common/utils.py:141 common/utils.py:143 journal/views/article.py:204
+#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr ""
 
-#: common/views_manage.py:144 common/views_manage.py:295
+#: common/views_manage.py:34 common/views_manage.py:373
 msgid "Branding"
 msgstr ""
 
-#: common/views_manage.py:146
+#: common/views_manage.py:37
 msgid "Recommendations"
 msgstr ""
 
-#: common/views_manage.py:147
+#: common/views_manage.py:38
 #, fuzzy
 #| msgid "Accept"
 msgid "Access"
 msgstr "Принять"
 
-#: common/views_manage.py:148 common/views_manage.py:623
+#: common/views_manage.py:39 common/views_manage.py:733
 msgid "Federation"
 msgstr ""
 
-#: common/views_manage.py:149
+#: common/views_manage.py:40
 msgid "Catalog"
 msgstr ""
 
-#: common/views_manage.py:150
+#: common/views_manage.py:41
 msgid "API Keys"
 msgstr ""
 
-#: common/views_manage.py:151
+#: common/views_manage.py:42
 msgid "Downloader"
 msgstr ""
 
-#: common/views_manage.py:152 common/views_manage.py:303
+#: common/views_manage.py:43 common/views_manage.py:381
 #: users/templates/users/steam_import.html:113
 msgid "Advanced"
 msgstr ""
 
-#: common/views_manage.py:202
+#: common/views_manage.py:44
+msgid "Environment"
+msgstr ""
+
+#: common/views_manage.py:280
 #, fuzzy
 #| msgid "Invalid file."
 msgid "Invalid value."
 msgstr "Некорректный файл."
 
-#: common/views_manage.py:206
+#: common/views_manage.py:284
 msgid "Invalid configuration. Please check your input."
 msgstr ""
 
-#: common/views_manage.py:211
+#: common/views_manage.py:289
 #, fuzzy
 #| msgid "Settings saved."
 msgid "Settings have been saved."
 msgstr "Настройки сохранены."
 
-#: common/views_manage.py:231
+#: common/views_manage.py:309
 msgid "Site Name"
 msgstr ""
 
-#: common/views_manage.py:234
+#: common/views_manage.py:312
 msgid "Site Description"
 msgstr ""
 
-#: common/views_manage.py:235
+#: common/views_manage.py:313
 msgid "Short description shown in metadata and about page."
 msgstr ""
 
-#: common/views_manage.py:238
+#: common/views_manage.py:316
 msgid "Site Logo URL"
 msgstr ""
 
-#: common/views_manage.py:239
+#: common/views_manage.py:317
 msgid "URL path to the site logo image."
 msgstr ""
 
-#: common/views_manage.py:242
+#: common/views_manage.py:320
 msgid "Site Icon URL"
 msgstr ""
 
-#: common/views_manage.py:243
+#: common/views_manage.py:321
 msgid "URL path to the site icon/favicon."
 msgstr ""
 
-#: common/views_manage.py:246
+#: common/views_manage.py:324
 msgid "Default User Avatar URL"
 msgstr ""
 
-#: common/views_manage.py:247
+#: common/views_manage.py:325
 msgid "URL path to the default user avatar."
 msgstr ""
 
-#: common/views_manage.py:250
+#: common/views_manage.py:328
 msgid "Site Color Theme"
 msgstr ""
 
-#: common/views_manage.py:251
+#: common/views_manage.py:329
 msgid "PicoCSS color theme."
 msgstr ""
 
-#: common/views_manage.py:276
+#: common/views_manage.py:354
 msgid "Site Introduction"
 msgstr ""
 
-#: common/views_manage.py:277
+#: common/views_manage.py:355
 msgid "URL path for the intro/welcome sidebar page."
 msgstr ""
 
-#: common/views_manage.py:280
+#: common/views_manage.py:358
 msgid "Custom HTML Head"
 msgstr ""
 
-#: common/views_manage.py:281
+#: common/views_manage.py:359
 msgid "Extra HTML injected into the <head> of all pages."
 msgstr ""
 
-#: common/views_manage.py:285
+#: common/views_manage.py:363
 msgid "Footer Links"
 msgstr ""
 
-#: common/views_manage.py:286
+#: common/views_manage.py:364
 msgid "Link title mapped to URL."
 msgstr ""
 
-#: common/views_manage.py:315
+#: common/views_manage.py:393
 msgid "Minimum Marks for Discover"
 msgstr ""
 
-#: common/views_manage.py:317
+#: common/views_manage.py:395
 msgid "Number of marks required for an item to appear in discover."
 msgstr ""
 
-#: common/views_manage.py:322
+#: common/views_manage.py:400
 msgid "Update Interval (minutes)"
 msgstr ""
 
-#: common/views_manage.py:323
+#: common/views_manage.py:401
 msgid "How often to refresh the popular items list."
 msgstr ""
 
-#: common/views_manage.py:327
+#: common/views_manage.py:405
 msgid "Filter by Preferred Languages"
 msgstr ""
 
-#: common/views_manage.py:328
+#: common/views_manage.py:406
 msgid "Only show items with titles in the preferred languages."
 msgstr ""
 
-#: common/views_manage.py:331
+#: common/views_manage.py:409
 msgid "Show Local Only"
 msgstr ""
 
-#: common/views_manage.py:333
+#: common/views_manage.py:411
 msgid "Only show items marked by local users, not the entire network."
 msgstr ""
 
-#: common/views_manage.py:337
+#: common/views_manage.py:415
 msgid "Show Popular Posts"
 msgstr ""
 
-#: common/views_manage.py:338
+#: common/views_manage.py:416
 msgid "Show popular public posts instead of recent ones."
 msgstr ""
 
-#: common/views_manage.py:341
+#: common/views_manage.py:419
 msgid "Show Popular Tags"
 msgstr ""
 
-#: common/views_manage.py:342
+#: common/views_manage.py:420
 msgid "Show popular public tags on the discover page."
 msgstr ""
 
-#: common/views_manage.py:345
+#: common/views_manage.py:423
 msgid "Show Verified Podcasts"
 msgstr ""
 
-#: common/views_manage.py:347
-msgid ""
-"Show a shelf of recent episodes from podcasts with a verified creator on the "
-"discover page."
+#: common/views_manage.py:425
+msgid "Show a shelf of recent episodes from podcasts with a verified creator on the discover page."
 msgstr ""
 
-#: common/views_manage.py:386
+#: common/views_manage.py:447
+msgid "Show World Timeline"
+msgstr ""
+
+#: common/views_manage.py:449
+msgid "Offer a tab with public posts from this site and every server it federates with."
+msgstr ""
+
+#: common/views_manage.py:454
+msgid "Show Local Timeline"
+msgstr ""
+
+#: common/views_manage.py:455
+msgid "Offer a tab with public posts from this site only."
+msgstr ""
+
+#: common/views_manage.py:459
+msgid "Timelines"
+msgstr ""
+
+#: common/views_manage.py:487
 msgid "Enable Recommendations"
 msgstr ""
 
-#: common/views_manage.py:388
-msgid ""
-"Master switch. When off, all recommendation surfaces are hidden and the cron "
-"jobs are not scheduled."
+#: common/views_manage.py:489
+msgid "Master switch. When off, all recommendation surfaces are hidden and the cron jobs are not scheduled."
 msgstr ""
 
-#: common/views_manage.py:393
+#: common/views_manage.py:494
 msgid "Source Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:395
-msgid ""
-"Minimum public marks an item needs before similarity rows are built for it."
+#: common/views_manage.py:496
+msgid "Minimum public marks an item needs before similarity rows are built for it."
 msgstr ""
 
-#: common/views_manage.py:401
+#: common/views_manage.py:502
 msgid "Target Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:403
-msgid ""
-"Minimum public marks an item needs to be eligible as a recommendation target."
+#: common/views_manage.py:504
+msgid "Minimum public marks an item needs to be eligible as a recommendation target."
 msgstr ""
 
-#: common/views_manage.py:409
+#: common/views_manage.py:510
 msgid "Top-K Similar Items per Source"
 msgstr ""
 
-#: common/views_manage.py:410
+#: common/views_manage.py:511
 msgid "Number of similar items stored per source item."
 msgstr ""
 
-#: common/views_manage.py:414
+#: common/views_manage.py:515
 msgid "Top-N Recommendations per User"
 msgstr ""
 
-#: common/views_manage.py:415
+#: common/views_manage.py:516
 msgid "Number of personalised rows stored per user."
 msgstr ""
 
-#: common/views_manage.py:419
+#: common/views_manage.py:520
 msgid "Dampen Heavy Shelvers"
 msgstr ""
 
-#: common/views_manage.py:421
-msgid ""
-"Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-"
-"shelvers in similarity scoring."
+#: common/views_manage.py:522
+msgid "Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-shelvers in similarity scoring."
 msgstr ""
 
-#: common/views_manage.py:426
+#: common/views_manage.py:527
 msgid "Per-User Mark Cap (training)"
 msgstr ""
 
-#: common/views_manage.py:428
-msgid ""
-"Truncate each user's contribution to their N most recent marks when building "
-"the similarity matrix."
-msgstr ""
-
-#: common/views_manage.py:434
-msgid "Active-User Window (days)"
-msgstr ""
-
-#: common/views_manage.py:436
-msgid ""
-"Refresh personalised recommendations for users with at least one public mark "
-"in the last N days."
-msgstr ""
-
-#: common/views_manage.py:442
-msgid "Per-User Seed Cap (serving)"
-msgstr ""
-
-#: common/views_manage.py:444
-msgid ""
-"Number of recent marks used as seeds when scoring personalised "
-"recommendations for one user."
-msgstr ""
-
-#: common/views_manage.py:450
-msgid "Lazy Refresh TTL (days)"
-msgstr ""
-
-#: common/views_manage.py:452
-msgid ""
-"How long cached on-demand recommendations are valid before the next request "
-"triggers a refresh."
-msgstr ""
-
-#: common/views_manage.py:458
-msgid "Circles Window (days)"
-msgstr ""
-
-#: common/views_manage.py:460
-msgid ""
-"Look back N days when finding items recently marked by people the viewer "
-"follows."
-msgstr ""
-
-#: common/views_manage.py:467
-msgid "Master Switch"
-msgstr ""
-
-#: common/views_manage.py:470
-msgid "Similarity Builder"
-msgstr ""
-
-#: common/views_manage.py:477
-msgid "Personalisation"
-msgstr ""
-
-#: common/views_manage.py:495
-msgid ""
-"Require an invite token to register. Invite tokens can be generated with "
-"neodb-manage invite --create."
-msgstr ""
-
-#: common/views_manage.py:500
-msgid "Enable Local-Only Posting"
-msgstr ""
-
-#: common/views_manage.py:501
-msgid "Allow users to create posts visible only to local users."
-msgstr ""
-
-#: common/views_manage.py:504
-msgid "Mastodon Login Whitelist"
-msgstr ""
-
-#: common/views_manage.py:505
-msgid "One domain per line. Leave empty to allow any instance."
-msgstr ""
-
-#: common/views_manage.py:508
-msgid "Registration Captcha Items"
-msgstr ""
-
-#: common/views_manage.py:512
-msgid ""
-"Number of item covers a new user must sort into two category rows before "
-"choosing a username. 0 disables the captcha; 5-6 is recommended. The covers "
-"carry no title text, so this cannot be solved with a screen reader: if you "
-"enable it, keep another way in, such as an invite link."
-msgstr ""
-
-#: common/views_manage.py:520
-msgid "Registration Captcha Minimum Marks"
-msgstr ""
-
-#: common/views_manage.py:523
-msgid ""
-"Marks an item needs before the captcha treats it as well known enough to be "
-"recognizable. Categories with too few such items fall back to any item."
-msgstr ""
-
 #: common/views_manage.py:529
-msgid "Enable Mastodon Login"
-msgstr ""
-
-#: common/views_manage.py:532
-msgid "Enable Bluesky Login"
+msgid "Truncate each user's contribution to their N most recent marks when building the similarity matrix."
 msgstr ""
 
 #: common/views_manage.py:535
-msgid "Enable Threads Login"
+msgid "Active-User Window (days)"
 msgstr ""
 
-#: common/views_manage.py:538
-msgid "Email URL"
+#: common/views_manage.py:537
+msgid "Refresh personalised recommendations for users with at least one public mark in the last N days."
 msgstr ""
 
-#: common/views_manage.py:540
-msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
-msgstr ""
-
-#: common/views_manage.py:544
-msgid "Email From"
+#: common/views_manage.py:543
+msgid "Per-User Seed Cap (serving)"
 msgstr ""
 
 #: common/views_manage.py:545
+msgid "Number of recent marks used as seeds when scoring personalised recommendations for one user."
+msgstr ""
+
+#: common/views_manage.py:551
+msgid "Lazy Refresh TTL (days)"
+msgstr ""
+
+#: common/views_manage.py:553
+msgid "How long cached on-demand recommendations are valid before the next request triggers a refresh."
+msgstr ""
+
+#: common/views_manage.py:559
+msgid "Circles Window (days)"
+msgstr ""
+
+#: common/views_manage.py:561
+msgid "Look back N days when finding items recently marked by people the viewer follows."
+msgstr ""
+
+#: common/views_manage.py:568
+msgid "Master Switch"
+msgstr ""
+
+#: common/views_manage.py:571
+msgid "Similarity Builder"
+msgstr ""
+
+#: common/views_manage.py:578
+msgid "Personalisation"
+msgstr ""
+
+#: common/views_manage.py:596
+msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
+msgstr ""
+
+#: common/views_manage.py:601
+msgid "Enable Local-Only Posting"
+msgstr ""
+
+#: common/views_manage.py:602
+msgid "Allow users to create posts visible only to local users."
+msgstr ""
+
+#: common/views_manage.py:605
+msgid "Mastodon Login Whitelist"
+msgstr ""
+
+#: common/views_manage.py:606
+msgid "One domain per line. Leave empty to allow any instance."
+msgstr ""
+
+#: common/views_manage.py:609
+msgid "Registration Captcha Items"
+msgstr ""
+
+#: common/views_manage.py:613
+msgid "Number of item covers a new user must sort into two category rows before choosing a username. 0 disables the captcha; 5-6 is recommended. The covers carry no title text, so this cannot be solved with a screen reader: if you enable it, keep another way in, such as an invite link."
+msgstr ""
+
+#: common/views_manage.py:621
+msgid "Registration Captcha Minimum Marks"
+msgstr ""
+
+#: common/views_manage.py:624
+msgid "Marks an item needs before the captcha treats it as well known enough to be recognizable. Categories with too few such items fall back to any item."
+msgstr ""
+
+#: common/views_manage.py:630
+msgid "Enable Mastodon Login"
+msgstr ""
+
+#: common/views_manage.py:633
+msgid "Enable Bluesky Login"
+msgstr ""
+
+#: common/views_manage.py:636
+msgid "Enable Threads Login"
+msgstr ""
+
+#: common/views_manage.py:639
+msgid "Email URL"
+msgstr ""
+
+#: common/views_manage.py:641
+msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
+msgstr ""
+
+#: common/views_manage.py:645
+msgid "Email From"
+msgstr ""
+
+#: common/views_manage.py:646
 msgid "Sender name and address for outgoing email."
 msgstr ""
 
-#: common/views_manage.py:548
+#: common/views_manage.py:649
 #, fuzzy
 #| msgid "language"
 msgid "Default Language"
 msgstr "язык"
 
-#: common/views_manage.py:551
-msgid ""
-"Interface language for visitors and for users who have not chosen one "
-"themselves."
+#: common/views_manage.py:652
+msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:558
-msgid ""
-"Language codes, one per line (e.g. en, zh, ja). First language is the "
-"default."
+#: common/views_manage.py:659
+msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:564
+#: common/views_manage.py:665
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:571
+#: common/views_manage.py:672
 msgid "Login Methods"
 msgstr ""
 
-#: common/views_manage.py:576 mastodon/models/common.py:28
+#: common/views_manage.py:677 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr ""
 
-#: common/views_manage.py:580
+#: common/views_manage.py:681
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:591
+#: common/views_manage.py:692
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:593
-msgid ""
-"Disable relay.neodb.net federation for sharing public ratings across "
-"instances."
+#: common/views_manage.py:694
+msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:598
+#: common/views_manage.py:699
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:599
+#: common/views_manage.py:700
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:603
+#: common/views_manage.py:704
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:605
+#: common/views_manage.py:706
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:610
+#: common/views_manage.py:711
 msgid "Search Sites"
 msgstr ""
 
-#: common/views_manage.py:611
+#: common/views_manage.py:712
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:614
+#: common/views_manage.py:715
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:615
+#: common/views_manage.py:716
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:618
+#: common/views_manage.py:719
 msgid "Hidden Categories"
 msgstr ""
 
-#: common/views_manage.py:619
+#: common/views_manage.py:720
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:640
+#: common/views_manage.py:723
+msgid "Guest Search Page Limit"
+msgstr ""
+
+#: common/views_manage.py:725
+msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
+msgstr ""
+
+#: common/views_manage.py:751
 msgid "Spotify API Key"
 msgstr ""
 
-#: common/views_manage.py:641
+#: common/views_manage.py:752
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:644
+#: common/views_manage.py:755
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:645
+#: common/views_manage.py:756
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:648
+#: common/views_manage.py:759
 msgid "Google Books API Key"
 msgstr ""
 
-#: common/views_manage.py:649
+#: common/views_manage.py:760
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:652
+#: common/views_manage.py:763
 #, fuzzy
 #| msgid "Discogs"
 msgid "Discogs API Key"
 msgstr "Discogs"
 
-#: common/views_manage.py:654
+#: common/views_manage.py:765
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:658
+#: common/views_manage.py:769
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:770
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:662
+#: common/views_manage.py:773
 msgid "IGDB Client Secret"
 msgstr ""
 
-#: common/views_manage.py:665
+#: common/views_manage.py:776
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:667
-msgid ""
-"Bearer token from https://boardgamegeek.com/applications (see https://"
-"boardgamegeek.com/using_the_xml_api#toc9)."
+#: common/views_manage.py:778
+msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:672 users/templates/users/steam_import.html:26
+#: common/views_manage.py:783
+msgid "MyAnimeList Client ID"
+msgstr ""
+
+#: common/views_manage.py:785
+msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
+msgstr ""
+
+#: common/views_manage.py:790 users/templates/users/steam_import.html:26
 msgid "Steam API Key"
 msgstr ""
 
-#: common/views_manage.py:674
-msgid ""
-"https://steamcommunity.com/dev - fallback key for Steam importer. Users can "
-"provide their own key when importing."
+#: common/views_manage.py:792
+msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:679
+#: common/views_manage.py:797
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:680
+#: common/views_manage.py:798
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:683
+#: common/views_manage.py:801
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:686
+#: common/views_manage.py:804
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:689
+#: common/views_manage.py:807
 msgid "Threads App ID"
 msgstr ""
 
-#: common/views_manage.py:690
+#: common/views_manage.py:808
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:693
+#: common/views_manage.py:811
 msgid "Threads App Secret"
 msgstr ""
 
-#: common/views_manage.py:696
+#: common/views_manage.py:814
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:698
-msgid ""
-"Webhook URLs keyed by channel (default, report, audit, suggest, system). All "
-"channels must be Discord forum or media channels (thread mode) because "
-"notifications are posted as threads."
+#: common/views_manage.py:816
+msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:715
+#: common/views_manage.py:833
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:844
 msgid "Translation"
 msgstr ""
 
-#: common/views_manage.py:730
+#: common/views_manage.py:849
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:734 social/templates/feed.html:27
+#: common/views_manage.py:853 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr ""
 
-#: common/views_manage.py:744
+#: common/views_manage.py:863
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:745
+#: common/views_manage.py:864
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:748
+#: common/views_manage.py:867
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:749
+#: common/views_manage.py:868
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:752
+#: common/views_manage.py:871
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:874
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:758
+#: common/views_manage.py:877
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:761
+#: common/views_manage.py:880
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:764
+#: common/views_manage.py:883
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:767
+#: common/views_manage.py:886
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:768
+#: common/views_manage.py:887
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:771
+#: common/views_manage.py:890
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:775
+#: common/views_manage.py:894
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:779
+#: common/views_manage.py:898
 msgid "Retries"
 msgstr ""
 
-#: common/views_manage.py:784
+#: common/views_manage.py:903
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:789
+#: common/views_manage.py:908
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:796
+#: common/views_manage.py:915
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:808
+#: common/views_manage.py:927
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:809
+#: common/views_manage.py:928
 msgid "One domain per line."
 msgstr ""
 
-#: common/views_manage.py:812
+#: common/views_manage.py:931
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:813
+#: common/views_manage.py:932
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:935
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:818
-msgid ""
-"Timeout for requests to Mastodon instances and remote fediverse servers."
+#: common/views_manage.py:937
+msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:824
+#: common/views_manage.py:943
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:825
+#: common/views_manage.py:944
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:828
+#: common/views_manage.py:947
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:829
+#: common/views_manage.py:948
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:839
+#: common/views_manage.py:958
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:841
-msgid ""
-"Delete import/export tasks and their files after this many days. Set to 0 to "
-"disable cleanup."
+#: common/views_manage.py:960
+msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:847
+#: common/views_manage.py:966
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:849
-msgid ""
-"Post-migration job keys to skip, one per line (e.g. normalize_genre). "
-"Checked by the worker at dequeue time; skipped jobs log a warning and notify "
-"the Discord system channel."
+#: common/views_manage.py:968
+msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:855
+#: common/views_manage.py:974
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:857
-msgid ""
-"Private key (JWK) identifying this site to ATProto authorization servers. "
-"Auto-generated on first Bluesky login; clear to regenerate."
+#: common/views_manage.py:976
+msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:983
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:986
 #, fuzzy
 #| msgid "optional"
 msgid "Operational"
 msgstr "опционально"
 
-#: common/views_manage.py:883
+#: common/views_manage.py:1002
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:885
-msgid ""
-"Genre codes offered in the Movie edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1004
+msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:1009
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:892
-msgid ""
-"Genre codes offered in the TV edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1011
+msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:897
+#: common/views_manage.py:1016
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:899
-msgid ""
-"Genre codes offered in the Music edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1018
+msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:904
+#: common/views_manage.py:1023
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:906
-msgid ""
-"Genre codes offered in the Game edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1025
+msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:911
+#: common/views_manage.py:1030
 msgid "Podcast Genres"
 msgstr ""
 
-#: common/views_manage.py:913
-msgid ""
-"Genre codes offered in the Podcast edit dropdown, one per line. Leave empty "
-"to use the built-in default."
+#: common/views_manage.py:1032
+msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:918
+#: common/views_manage.py:1037
 msgid "Performance Genres"
 msgstr ""
 
-#: common/views_manage.py:920
-msgid ""
-"Genre codes offered in the Performance edit dropdown, one per line. Leave "
-"empty to use the built-in default."
+#: common/views_manage.py:1039
+msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:926
+#: common/views_manage.py:1045
 msgid "Genres by Category"
 msgstr ""
 
+#: common/views_manage.py:1069
+msgid "Site"
+msgstr ""
+
+#: common/views_manage.py:1079
+msgid "Database and Services"
+msgstr ""
+
+#: common/views_manage.py:1089
+msgid "Media and Files"
+msgstr ""
+
+#: common/views_manage.py:1098
+msgid "Monitoring"
+msgstr ""
+
+#: common/views_manage.py:1102
+msgid "Security"
+msgstr ""
+
+#: common/views_manage.py:1111
+msgid "Other Environment Variables"
+msgstr ""
+
+#: common/views_manage.py:1113
+msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
+msgstr ""
+
 #: journal/forms.py:12
-msgid ""
-"Tips: use >!text!< for spoilers; some instances may not be able to show "
-"posts longer than 360 charactors."
+msgid "Tips: use >!text!< for spoilers; some instances may not be able to show posts longer than 360 charactors."
 msgstr ""
 
 #: journal/forms.py:29 journal/forms.py:31 journal/forms.py:80
@@ -5003,12 +5019,12 @@ msgid "Content (Markdown)"
 msgstr ""
 
 #: journal/forms.py:46 journal/forms.py:124 journal/forms.py:226
-#: journal/forms.py:288 journal/views/note.py:38
+#: journal/forms.py:288 journal/views/note.py:37
 msgid "Crosspost"
 msgstr ""
 
 #: journal/forms.py:47 journal/forms.py:125 journal/forms.py:227
-#: journal/forms.py:289 journal/views/note.py:39
+#: journal/forms.py:289 journal/views/note.py:38
 msgid "Crosspost to your connected social networks"
 msgstr ""
 
@@ -5023,10 +5039,10 @@ msgstr ""
 #: journal/forms.py:59 journal/forms.py:137 journal/forms.py:162
 #: journal/forms.py:219 journal/forms.py:281
 #: journal/templates/collection_share.html:24
-#: journal/templates/wrapped_share.html:36 journal/views/note.py:31
-#: users/templates/users/data.html:45 users/templates/users/data.html:98
-#: users/templates/users/data.html:155 users/templates/users/data.html:206
-#: users/templates/users/data.html:269 users/templates/users/data.html:328
+#: journal/templates/wrapped_share.html:36 journal/views/note.py:30
+#: users/templates/users/data.html:60 users/templates/users/data.html:113
+#: users/templates/users/data.html:170 users/templates/users/data.html:221
+#: users/templates/users/data.html:284 users/templates/users/data.html:346
 #: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
@@ -5065,7 +5081,6 @@ msgid "Collaborative editing"
 msgstr ""
 
 #: journal/forms.py:204 users/templates/users/crossposts.html:51
-#: users/templates/users/data.html:483
 msgid "Status"
 msgstr ""
 
@@ -5077,48 +5092,46 @@ msgstr ""
 msgid "Rating"
 msgstr ""
 
-#: journal/importers/goodreads.py:196 journal/importers/letterboxd.py:144
-#: journal/importers/rym.py:442 journal/importers/storygraph.py:500
+#: journal/importers/goodreads.py:198 journal/importers/letterboxd.py:147
+#: journal/importers/rym.py:444 journal/importers/storygraph.py:504
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr ""
 
-#: journal/importers/opml.py:45
+#: journal/importers/opml.py:49
 #, python-brace-format
 msgid "{username}'s podcast subscriptions"
 msgstr ""
 
-#: journal/importers/rym.py:168 journal/importers/storygraph.py:128
+#: journal/importers/rym.py:170 journal/importers/storygraph.py:132
 #, python-brace-format
-msgid ""
-"Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
+msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:178 journal/importers/storygraph.py:138
+#: journal/importers/rym.py:180 journal/importers/storygraph.py:142
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/importers/rym.py:233 journal/importers/storygraph.py:184
+#: journal/importers/rym.py:235 journal/importers/storygraph.py:188
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:348 journal/importers/storygraph.py:389
+#: journal/importers/rym.py:350 journal/importers/storygraph.py:393
 msgid "Matched file missing; cannot import."
 msgstr ""
 
-#: journal/importers/rym.py:376 journal/importers/storygraph.py:412
+#: journal/importers/rym.py:378 journal/importers/storygraph.py:416
 #, python-brace-format
-msgid ""
-"Import complete: {imported} imported, {skipped} skipped, {failed} failed"
+msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:212 journal/views/article.py:218
+#: journal/models/article.py:215 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
-#: journal/models/collection.py:44 journal/templates/add_to_collection.html:39
+#: journal/models/collection.py:48 journal/templates/add_to_collection.html:39
 #: journal/templates/collection_edit.html:64
 #: journal/templates/collection_share.html:63
 #: journal/templates/collection_update_item_note.html:3
@@ -5126,11 +5139,11 @@ msgstr ""
 msgid "note"
 msgstr ""
 
-#: journal/models/collection.py:111
+#: journal/models/collection.py:115
 msgid "search query for dynamic collection"
 msgstr ""
 
-#: journal/models/collection.py:524 journal/templatetags/collection.py:35
+#: journal/models/collection.py:566 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
@@ -5138,7 +5151,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: journal/models/collection.py:529 journal/templatetags/collection.py:43
+#: journal/models/collection.py:571 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
@@ -5146,7 +5159,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: journal/models/collection.py:534 journal/templatetags/collection.py:51
+#: journal/models/collection.py:576 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
@@ -5154,7 +5167,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: journal/models/collection.py:539 journal/templatetags/collection.py:59
+#: journal/models/collection.py:581 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
@@ -5162,7 +5175,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: journal/models/collection.py:544 journal/templatetags/collection.py:67
+#: journal/models/collection.py:586 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
@@ -5170,7 +5183,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: journal/models/collection.py:549 journal/templatetags/collection.py:75
+#: journal/models/collection.py:591 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
@@ -5178,7 +5191,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: journal/models/collection.py:555 journal/templatetags/collection.py:83
+#: journal/models/collection.py:597 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
@@ -5186,7 +5199,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: journal/models/collection.py:563 journal/templatetags/collection.py:91
+#: journal/models/collection.py:605 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
@@ -5194,13 +5207,13 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: journal/models/common.py:50 journal/templates/action_open_post.html:15
-#: journal/templates/collection_share.html:35 journal/templates/mark.html:84
+#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
-#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:54
-#: users/templates/users/data.html:107 users/templates/users/data.html:164
-#: users/templates/users/data.html:215 users/templates/users/data.html:277
-#: users/templates/users/data.html:337 users/templates/users/data.html:534
+#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
+#: users/templates/users/data.html:122 users/templates/users/data.html:179
+#: users/templates/users/data.html:230 users/templates/users/data.html:292
+#: users/templates/users/data.html:355 users/templates/users/data.html:534
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5208,13 +5221,13 @@ msgstr[2] ""
 msgid "Public"
 msgstr ""
 
-#: journal/models/common.py:51 journal/templates/action_open_post.html:9
-#: journal/templates/collection_share.html:46 journal/templates/mark.html:91
+#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
-#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
-#: users/templates/users/data.html:115 users/templates/users/data.html:172
-#: users/templates/users/data.html:223 users/templates/users/data.html:285
-#: users/templates/users/data.html:345 users/templates/users/data.html:542
+#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
+#: users/templates/users/data.html:130 users/templates/users/data.html:187
+#: users/templates/users/data.html:238 users/templates/users/data.html:300
+#: users/templates/users/data.html:363 users/templates/users/data.html:542
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5222,12 +5235,12 @@ msgstr ""
 msgid "Followers Only"
 msgstr ""
 
-#: journal/models/common.py:52 journal/templates/collection_share.html:57
-#: journal/templates/mark.html:98 journal/templates/post_compose.html:72
-#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
-#: users/templates/users/data.html:123 users/templates/users/data.html:180
-#: users/templates/users/data.html:231 users/templates/users/data.html:293
-#: users/templates/users/data.html:353 users/templates/users/data.html:550
+#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/templates/mark.html:102 journal/templates/post_compose.html:72
+#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
+#: users/templates/users/data.html:138 users/templates/users/data.html:195
+#: users/templates/users/data.html:246 users/templates/users/data.html:308
+#: users/templates/users/data.html:371 users/templates/users/data.html:550
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5235,29 +5248,27 @@ msgstr ""
 msgid "Mentioned Only"
 msgstr ""
 
-#: journal/models/common.py:790
-msgid ""
-"A recent post was not posted to Bluesky, please login NeoDB using ATProto "
-"again to re-authorize."
+#: journal/models/common.py:806
+msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr ""
 
-#: journal/models/common.py:987
+#: journal/models/common.py:1003
 msgid "A recent post was not posted to Threads."
 msgstr ""
 
-#: journal/models/common.py:1020
+#: journal/models/common.py:1036
 msgid "A recent post was not boosted on Mastodon."
 msgstr ""
 
-#: journal/models/common.py:1030
+#: journal/models/common.py:1046
 msgid "Original post no longer exists."
 msgstr ""
 
-#: journal/models/common.py:1044
+#: journal/models/common.py:1060
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr ""
 
-#: journal/models/common.py:1053
+#: journal/models/common.py:1069
 msgid "A recent post was not posted to Mastodon."
 msgstr ""
 
@@ -5265,7 +5276,7 @@ msgstr ""
 msgid "Authorization expired"
 msgstr ""
 
-#: journal/models/crosspost.py:17 users/models/task.py:24
+#: journal/models/crosspost.py:17 users/models/task.py:26
 msgid "Failed"
 msgstr ""
 
@@ -5273,83 +5284,83 @@ msgstr ""
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:469
+#: journal/models/mark.py:475
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:473
+#: journal/models/mark.py:479
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:480
+#: journal/models/mark.py:486
 #, fuzzy
 #| msgid "Sync in progress."
 msgid "Invalid progress type."
 msgstr "Синхронизация в процессе."
 
-#: journal/models/mark.py:482
+#: journal/models/mark.py:488
 msgid "Invalid progress type for this item."
 msgstr ""
 
-#: journal/models/note.py:34 users/templates/users/rym_import.html:73
+#: journal/models/note.py:47 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr ""
 
-#: journal/models/note.py:35
+#: journal/models/note.py:48
 msgid "Chapter"
 msgstr ""
 
-#: journal/models/note.py:38
+#: journal/models/note.py:51
 msgid "Part"
 msgstr ""
 
-#: journal/models/note.py:39
+#: journal/models/note.py:52
 msgid "Episode"
 msgstr ""
 
-#: journal/models/note.py:40
+#: journal/models/note.py:53
 msgid "Track"
 msgstr ""
 
-#: journal/models/note.py:41
+#: journal/models/note.py:54
 msgid "Cycle"
 msgstr ""
 
-#: journal/models/note.py:42
+#: journal/models/note.py:55
 msgid "Timestamp"
 msgstr ""
 
-#: journal/models/note.py:43
+#: journal/models/note.py:56
 msgid "Percentage"
 msgstr ""
 
-#: journal/models/note.py:60
+#: journal/models/note.py:77
 #, python-brace-format
 msgid "Page {value}"
 msgstr ""
 
-#: journal/models/note.py:61
+#: journal/models/note.py:78
 #, python-brace-format
 msgid "Chapter {value}"
 msgstr ""
 
-#: journal/models/note.py:64
+#: journal/models/note.py:81
 #, python-brace-format
 msgid "Part {value}"
 msgstr ""
 
-#: journal/models/note.py:65
+#: journal/models/note.py:82
 #, python-brace-format
 msgid "Episode {value}"
 msgstr ""
 
-#: journal/models/note.py:66
+#: journal/models/note.py:83
 #, python-brace-format
 msgid "Track {value}"
 msgstr ""
 
-#: journal/models/note.py:67
+#: journal/models/note.py:84
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr ""
@@ -5359,439 +5370,439 @@ msgstr ""
 msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr ""
 
-#: journal/models/review.py:78
+#: journal/models/review.py:79
 #, python-brace-format
 msgid "a review of {title}"
 msgstr ""
 
-#: journal/models/review.py:80
+#: journal/models/review.py:81
 msgid "(may contain spoilers)"
 msgstr ""
 
-#: journal/models/shelf.py:37
+#: journal/models/shelf.py:39
 msgid "WISHLIST"
 msgstr ""
 
-#: journal/models/shelf.py:38
+#: journal/models/shelf.py:40
 msgid "PROGRESS"
 msgstr ""
 
-#: journal/models/shelf.py:39
+#: journal/models/shelf.py:41
 msgid "COMPLETE"
 msgstr ""
 
-#: journal/models/shelf.py:40
+#: journal/models/shelf.py:42
 msgid "DROPPED"
 msgstr ""
 
-#: journal/models/shelf.py:49
+#: journal/models/shelf.py:51
 msgid "books to read"
 msgstr ""
 
-#: journal/models/shelf.py:50
+#: journal/models/shelf.py:52
 msgid "want to read"
 msgstr ""
 
-#: journal/models/shelf.py:51
+#: journal/models/shelf.py:53
 #, python-brace-format
 msgid "wants to read {item}"
 msgstr ""
 
-#: journal/models/shelf.py:52
+#: journal/models/shelf.py:54
 msgid "to read"
 msgstr ""
 
-#: journal/models/shelf.py:57
+#: journal/models/shelf.py:59
 msgid "books reading"
 msgstr ""
 
-#: journal/models/shelf.py:58
+#: journal/models/shelf.py:60
 msgid "start reading"
 msgstr ""
 
-#: journal/models/shelf.py:59
+#: journal/models/shelf.py:61
 #, python-brace-format
 msgid "started reading {item}"
 msgstr ""
 
-#: journal/models/shelf.py:60
+#: journal/models/shelf.py:62
 msgid "reading"
 msgstr ""
 
-#: journal/models/shelf.py:65
+#: journal/models/shelf.py:67
 msgid "books completed"
 msgstr ""
 
-#: journal/models/shelf.py:66
+#: journal/models/shelf.py:68
 msgid "finish reading"
 msgstr ""
 
-#: journal/models/shelf.py:67
+#: journal/models/shelf.py:69
 #, python-brace-format
 msgid "finished reading {item}"
 msgstr ""
 
-#: journal/models/shelf.py:68
+#: journal/models/shelf.py:70
 msgid "read"
 msgstr ""
 
-#: journal/models/shelf.py:73
+#: journal/models/shelf.py:75
 msgid "books dropped"
 msgstr ""
 
-#: journal/models/shelf.py:74
+#: journal/models/shelf.py:76
 msgid "stop reading"
 msgstr ""
 
-#: journal/models/shelf.py:75
+#: journal/models/shelf.py:77
 #, python-brace-format
 msgid "stopped reading {item}"
 msgstr ""
 
-#: journal/models/shelf.py:76
+#: journal/models/shelf.py:78
 msgid "stopped reading"
 msgstr ""
 
-#: journal/models/shelf.py:81
+#: journal/models/shelf.py:83
 msgid "books reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:82 journal/models/shelf.py:122
-#: journal/models/shelf.py:162 journal/models/shelf.py:202
-#: journal/models/shelf.py:242 journal/models/shelf.py:282
-#: journal/models/shelf.py:316
+#: journal/models/shelf.py:84 journal/models/shelf.py:124
+#: journal/models/shelf.py:164 journal/models/shelf.py:204
+#: journal/models/shelf.py:244 journal/models/shelf.py:284
+#: journal/models/shelf.py:318
 msgid "review"
 msgstr ""
 
-#: journal/models/shelf.py:83 journal/models/shelf.py:123
-#: journal/models/shelf.py:163 journal/models/shelf.py:203
-#: journal/models/shelf.py:243 journal/models/shelf.py:283
-#: journal/models/shelf.py:317
+#: journal/models/shelf.py:85 journal/models/shelf.py:125
+#: journal/models/shelf.py:165 journal/models/shelf.py:205
+#: journal/models/shelf.py:245 journal/models/shelf.py:285
+#: journal/models/shelf.py:319
 #, python-brace-format
 msgid "wrote a review of {item}"
 msgstr ""
 
-#: journal/models/shelf.py:89
+#: journal/models/shelf.py:91
 msgid "movies to watch"
 msgstr ""
 
-#: journal/models/shelf.py:90 journal/models/shelf.py:130
+#: journal/models/shelf.py:92 journal/models/shelf.py:132
 msgid "want to watch"
 msgstr ""
 
-#: journal/models/shelf.py:91 journal/models/shelf.py:131
+#: journal/models/shelf.py:93 journal/models/shelf.py:133
 #, python-brace-format
 msgid "wants to watch {item}"
 msgstr ""
 
-#: journal/models/shelf.py:92 journal/models/shelf.py:132
+#: journal/models/shelf.py:94 journal/models/shelf.py:134
 msgid "to watch"
 msgstr ""
 
-#: journal/models/shelf.py:97
+#: journal/models/shelf.py:99
 msgid "movies watching"
 msgstr ""
 
-#: journal/models/shelf.py:98 journal/models/shelf.py:138
+#: journal/models/shelf.py:100 journal/models/shelf.py:140
 msgid "start watching"
 msgstr ""
 
-#: journal/models/shelf.py:99 journal/models/shelf.py:139
+#: journal/models/shelf.py:101 journal/models/shelf.py:141
 #, python-brace-format
 msgid "started watching {item}"
 msgstr ""
 
-#: journal/models/shelf.py:100 journal/models/shelf.py:140
+#: journal/models/shelf.py:102 journal/models/shelf.py:142
 msgid "watching"
 msgstr ""
 
-#: journal/models/shelf.py:105
+#: journal/models/shelf.py:107
 msgid "movies watched"
 msgstr ""
 
-#: journal/models/shelf.py:106 journal/models/shelf.py:146
+#: journal/models/shelf.py:108 journal/models/shelf.py:148
 msgid "finish watching"
 msgstr ""
 
-#: journal/models/shelf.py:107 journal/models/shelf.py:147
+#: journal/models/shelf.py:109 journal/models/shelf.py:149
 #, python-brace-format
 msgid "finished watching {item}"
 msgstr ""
 
-#: journal/models/shelf.py:108 journal/models/shelf.py:148
+#: journal/models/shelf.py:110 journal/models/shelf.py:150
 msgid "watched"
 msgstr ""
 
-#: journal/models/shelf.py:113
+#: journal/models/shelf.py:115
 msgid "movies dropped"
 msgstr ""
 
-#: journal/models/shelf.py:114 journal/models/shelf.py:154
+#: journal/models/shelf.py:116 journal/models/shelf.py:156
 msgid "stop watching"
 msgstr ""
 
-#: journal/models/shelf.py:115 journal/models/shelf.py:155
+#: journal/models/shelf.py:117 journal/models/shelf.py:157
 #, python-brace-format
 msgid "stopped watching {item}"
 msgstr ""
 
-#: journal/models/shelf.py:116 journal/models/shelf.py:156
+#: journal/models/shelf.py:118 journal/models/shelf.py:158
 msgid "stopped watching"
 msgstr ""
 
-#: journal/models/shelf.py:121
+#: journal/models/shelf.py:123
 msgid "movies reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:129
+#: journal/models/shelf.py:131
 msgid "TV shows to watch"
 msgstr ""
 
-#: journal/models/shelf.py:137
+#: journal/models/shelf.py:139
 msgid "TV shows watching"
 msgstr ""
 
-#: journal/models/shelf.py:145
+#: journal/models/shelf.py:147
 msgid "TV shows watched"
 msgstr ""
 
-#: journal/models/shelf.py:153
+#: journal/models/shelf.py:155
 msgid "TV shows dropped"
 msgstr ""
 
-#: journal/models/shelf.py:161
+#: journal/models/shelf.py:163
 msgid "TV shows reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:169
+#: journal/models/shelf.py:171
 msgid "albums to listen"
 msgstr ""
 
-#: journal/models/shelf.py:170 journal/models/shelf.py:250
+#: journal/models/shelf.py:172 journal/models/shelf.py:252
 msgid "want to listen"
 msgstr ""
 
-#: journal/models/shelf.py:171 journal/models/shelf.py:251
+#: journal/models/shelf.py:173 journal/models/shelf.py:253
 #, python-brace-format
 msgid "wants to listen {item}"
 msgstr ""
 
-#: journal/models/shelf.py:172 journal/models/shelf.py:252
+#: journal/models/shelf.py:174 journal/models/shelf.py:254
 msgid "to listen"
 msgstr ""
 
-#: journal/models/shelf.py:177
+#: journal/models/shelf.py:179
 msgid "albums listening"
 msgstr ""
 
-#: journal/models/shelf.py:178 journal/models/shelf.py:258
+#: journal/models/shelf.py:180 journal/models/shelf.py:260
 msgid "start listening"
 msgstr ""
 
-#: journal/models/shelf.py:179 journal/models/shelf.py:259
+#: journal/models/shelf.py:181 journal/models/shelf.py:261
 #, python-brace-format
 msgid "started listening {item}"
 msgstr ""
 
-#: journal/models/shelf.py:180 journal/models/shelf.py:260
+#: journal/models/shelf.py:182 journal/models/shelf.py:262
 msgid "listening"
 msgstr ""
 
-#: journal/models/shelf.py:185
+#: journal/models/shelf.py:187
 msgid "albums listened"
 msgstr ""
 
-#: journal/models/shelf.py:186 journal/models/shelf.py:266
+#: journal/models/shelf.py:188 journal/models/shelf.py:268
 msgid "finish listening"
 msgstr ""
 
-#: journal/models/shelf.py:187 journal/models/shelf.py:267
+#: journal/models/shelf.py:189 journal/models/shelf.py:269
 #, python-brace-format
 msgid "finished listening {item}"
 msgstr ""
 
-#: journal/models/shelf.py:188 journal/models/shelf.py:268
+#: journal/models/shelf.py:190 journal/models/shelf.py:270
 msgid "listened"
 msgstr ""
 
-#: journal/models/shelf.py:193
+#: journal/models/shelf.py:195
 msgid "albums dropped"
 msgstr ""
 
-#: journal/models/shelf.py:194 journal/models/shelf.py:274
+#: journal/models/shelf.py:196 journal/models/shelf.py:276
 msgid "stop listening"
 msgstr ""
 
-#: journal/models/shelf.py:195 journal/models/shelf.py:275
+#: journal/models/shelf.py:197 journal/models/shelf.py:277
 #, python-brace-format
 msgid "stopped listening {item}"
 msgstr ""
 
-#: journal/models/shelf.py:196 journal/models/shelf.py:276
+#: journal/models/shelf.py:198 journal/models/shelf.py:278
 msgid "stopped listening"
 msgstr ""
 
-#: journal/models/shelf.py:201
+#: journal/models/shelf.py:203
 msgid "albums reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:209
+#: journal/models/shelf.py:211
 msgid "games to play"
 msgstr ""
 
-#: journal/models/shelf.py:210
+#: journal/models/shelf.py:212
 msgid "want to play"
 msgstr ""
 
-#: journal/models/shelf.py:211
+#: journal/models/shelf.py:213
 #, python-brace-format
 msgid "wants to play {item}"
 msgstr ""
 
-#: journal/models/shelf.py:212
+#: journal/models/shelf.py:214
 msgid "to play"
 msgstr ""
 
-#: journal/models/shelf.py:217
+#: journal/models/shelf.py:219
 msgid "games playing"
 msgstr ""
 
-#: journal/models/shelf.py:218
+#: journal/models/shelf.py:220
 msgid "start playing"
 msgstr ""
 
-#: journal/models/shelf.py:219
+#: journal/models/shelf.py:221
 #, python-brace-format
 msgid "started playing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:220
+#: journal/models/shelf.py:222
 msgid "playing"
 msgstr ""
 
-#: journal/models/shelf.py:225
+#: journal/models/shelf.py:227
 msgid "games played"
 msgstr ""
 
-#: journal/models/shelf.py:226
+#: journal/models/shelf.py:228
 msgid "finish playing"
 msgstr ""
 
-#: journal/models/shelf.py:227
+#: journal/models/shelf.py:229
 #, python-brace-format
 msgid "finished playing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:228
+#: journal/models/shelf.py:230
 msgid "played"
 msgstr ""
 
-#: journal/models/shelf.py:233
+#: journal/models/shelf.py:235
 msgid "games dropped"
 msgstr ""
 
-#: journal/models/shelf.py:234
+#: journal/models/shelf.py:236
 msgid "stop playing"
 msgstr ""
 
-#: journal/models/shelf.py:235
+#: journal/models/shelf.py:237
 #, python-brace-format
 msgid "stopped playing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:236
+#: journal/models/shelf.py:238
 msgid "stopped playing"
 msgstr ""
 
-#: journal/models/shelf.py:241
+#: journal/models/shelf.py:243
 msgid "games reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:249
+#: journal/models/shelf.py:251
 msgid "podcasts to listen"
 msgstr ""
 
-#: journal/models/shelf.py:257
+#: journal/models/shelf.py:259
 msgid "podcasts listening"
 msgstr ""
 
-#: journal/models/shelf.py:265
+#: journal/models/shelf.py:267
 msgid "podcasts listened"
 msgstr ""
 
-#: journal/models/shelf.py:273
+#: journal/models/shelf.py:275
 msgid "podcasts dropped"
 msgstr ""
 
-#: journal/models/shelf.py:281
+#: journal/models/shelf.py:283
 msgid "podcasts reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:289
+#: journal/models/shelf.py:291
 msgid "performances to see"
 msgstr ""
 
-#: journal/models/shelf.py:290
+#: journal/models/shelf.py:292
 msgid "want to see"
 msgstr ""
 
-#: journal/models/shelf.py:291
+#: journal/models/shelf.py:293
 #, python-brace-format
 msgid "wants to see {item}"
 msgstr ""
 
-#: journal/models/shelf.py:292
+#: journal/models/shelf.py:294
 msgid "to see"
 msgstr ""
 
-#: journal/models/shelf.py:299
+#: journal/models/shelf.py:301
 msgid "performances saw"
 msgstr ""
 
-#: journal/models/shelf.py:300
+#: journal/models/shelf.py:302
 msgid "finish seeing"
 msgstr ""
 
-#: journal/models/shelf.py:301
+#: journal/models/shelf.py:303
 #, python-brace-format
 msgid "finished seeing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:302
+#: journal/models/shelf.py:304
 msgid "seen"
 msgstr ""
 
-#: journal/models/shelf.py:307
+#: journal/models/shelf.py:309
 msgid "performances dropped"
 msgstr ""
 
-#: journal/models/shelf.py:308
+#: journal/models/shelf.py:310
 msgid "stop seeing"
 msgstr ""
 
-#: journal/models/shelf.py:309
+#: journal/models/shelf.py:311
 #, python-brace-format
 msgid "stopped seeing {item}"
 msgstr ""
 
-#: journal/models/shelf.py:310
+#: journal/models/shelf.py:312
 msgid "stopped seeing"
 msgstr ""
 
-#: journal/models/shelf.py:315
+#: journal/models/shelf.py:317
 msgid "performances reviewed"
 msgstr ""
 
-#: journal/models/shelf.py:323
+#: journal/models/shelf.py:325
 msgid "people following"
 msgstr ""
 
-#: journal/models/shelf.py:325
+#: journal/models/shelf.py:327
 #, python-brace-format
 msgid "started following {item}"
 msgstr ""
 
-#: journal/models/shelf.py:921
+#: journal/models/shelf.py:923
 msgid "removed mark"
 msgstr ""
 
@@ -5819,30 +5830,20 @@ msgstr ""
 msgid "Remove from collection"
 msgstr ""
 
-#: journal/templates/_list_item.html:34
-msgid "add mark"
-msgstr ""
-
-#: journal/templates/_list_item.html:42
-msgid "update mark"
-msgstr ""
-
-#: journal/templates/_list_item.html:60
+#: journal/templates/_list_item.html:43
 #: journal/templates/collection_update_item_note_ok.html:3
 msgid "Update note"
 msgstr ""
 
-#: journal/templates/_list_item.html:100 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:123
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
 msgstr ""
 
-#: journal/templates/_list_item.html:133
+#: journal/templates/_list_item.html:91
 #, python-format
-msgid ""
-"%(dups)s item(s) are from the same work or have the same identifier, click "
-"here to display:"
+msgid "%(dups)s item(s) are from the same work or have the same identifier, click here to display:"
 msgstr ""
 
 #: journal/templates/_sidebar_collection_filter.html:32
@@ -5950,6 +5951,14 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
+#: journal/templates/action_mark_item.html:10
+msgid "add mark"
+msgstr ""
+
+#: journal/templates/action_mark_item.html:18
+msgid "update mark"
+msgstr ""
+
 #: journal/templates/action_open_post.html:7
 msgid "Quiet Public"
 msgstr ""
@@ -6002,13 +6011,13 @@ msgstr ""
 msgid "Create a new collection"
 msgstr ""
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:81
+#: journal/templates/article.html:104 social/templates/_event_post.html:76
 #, fuzzy
 #| msgid "write a review"
 msgid "wrote a review"
 msgstr "написать обзор"
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:83
+#: journal/templates/article.html:106 social/templates/_event_post.html:78
 #, fuzzy
 #| msgid "write a review"
 msgid "wrote an article"
@@ -6126,19 +6135,19 @@ msgstr ""
 msgid "Mark"
 msgstr ""
 
-#: journal/templates/mark.html:50
+#: journal/templates/mark.html:54
 msgid "not rated"
 msgstr ""
 
-#: journal/templates/mark.html:70
+#: journal/templates/mark.html:74
 msgid "add a tag and press Enter"
 msgstr ""
 
-#: journal/templates/mark.html:122
+#: journal/templates/mark.html:126
 msgid "change mark date"
 msgstr ""
 
-#: journal/templates/mark.html:148
+#: journal/templates/mark.html:156
 msgid "Sure to delete mark, comment and tags for this item?"
 msgstr ""
 
@@ -6181,12 +6190,11 @@ msgid ""
 "Content Cell  | Content Cell\n"
 "Content Cell  | Content Cell\n"
 "\n"
-"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/"
-"Wikipedia-logo-v2.svg)\n"
+"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 "\n"
 msgstr ""
 
-#: journal/templates/note.html:19 journal/views/note.py:23
+#: journal/templates/note.html:19 journal/views/note.py:22
 msgid "Note"
 msgstr ""
 
@@ -6213,9 +6221,7 @@ msgid "Are you sure to delete this entire content?"
 msgstr ""
 
 #: journal/templates/piece_delete.html:24
-msgid ""
-"By deleting it, you will also lose track of others' comments and feedbacks "
-"to your content."
+msgid "By deleting it, you will also lose track of others' comments and feedbacks to your content."
 msgstr ""
 
 #: journal/templates/piece_delete.html:25
@@ -6295,7 +6301,7 @@ msgstr ""
 msgid "Articles"
 msgstr ""
 
-#: journal/templates/profile.html:166 journal/views/collection.py:427
+#: journal/templates/profile.html:166 journal/views/collection.py:409
 #: journal/views/profile.py:401
 msgid "collection"
 msgstr ""
@@ -6329,9 +6335,7 @@ msgid "Personal"
 msgstr ""
 
 #: journal/templates/tag_edit.html:52
-msgid ""
-"Personal tags are not included in public index. However, if you use this tag "
-"when marking an item publicly, it might still be visible to others."
+msgid "Personal tags are not included in public index. However, if you use this tag when marking an item publicly, it might still be visible to others."
 msgstr ""
 
 #: journal/templates/tag_edit.html:55
@@ -6400,115 +6404,116 @@ msgstr ""
 msgid "Link invalid"
 msgstr ""
 
-#: journal/views/collection.py:58 journal/views/collection.py:96
+#: journal/views/collection.py:62 journal/views/collection.py:94
 #, python-brace-format
 msgid "Collection by {0}"
 msgstr ""
 
-#: journal/views/collection.py:432
+#: journal/views/collection.py:414
 msgid "shared my collection"
 msgstr ""
 
-#: journal/views/collection.py:435
+#: journal/views/collection.py:417
 #, python-brace-format
 msgid "shared {username}'s collection"
 msgstr ""
 
-#: journal/views/collection.py:502 journal/views/collection.py:541
-#: journal/views/collection.py:553 journal/views/collection.py:579
+#: journal/views/collection.py:484 journal/views/collection.py:523
+#: journal/views/collection.py:535 journal/views/collection.py:561
 msgid "Dynamic collection is not editable"
 msgstr ""
 
-#: journal/views/collection.py:518
+#: journal/views/collection.py:500
 msgid "The item is already in the collection."
 msgstr ""
 
-#: journal/views/collection.py:520
+#: journal/views/collection.py:502
 msgid "Unable to find the item, please use item url from this site."
 msgstr ""
 
-#: journal/views/collection.py:566
+#: journal/views/collection.py:548
 msgid "Saved."
 msgstr ""
 
-#: journal/views/common.py:119 journal/views/mark.py:225
-#: journal/views/mark.py:279 journal/views/note.py:175
+#: journal/views/common.py:126 journal/views/mark.py:273
+#: journal/views/mark.py:315 journal/views/note.py:167
 #: journal/views/profile.py:42 journal/views/review.py:59
 #: journal/views/review.py:79
 msgid "Content not found"
 msgstr ""
 
-#: journal/views/common.py:174 journal/views/mark.py:159
+#: journal/views/common.py:184 journal/views/mark.py:210
 msgid "Data saved but unable to crosspost to Fediverse instance."
 msgstr ""
 
-#: journal/views/common.py:176
+#: journal/views/common.py:186
 msgid "Redirecting to your Fediverse instance now to re-authenticate."
 msgstr ""
 
-#: journal/views/common.py:183
+#: journal/views/common.py:193
 msgid "List not found."
 msgstr ""
 
-#: journal/views/mark.py:150
+#: journal/views/mark.py:206
 msgid "Content too long for your Fediverse instance."
 msgstr ""
 
-#: journal/views/mark.py:178 journal/views/mark.py:238
+#: journal/views/mark.py:224 journal/views/mark.py:226
+#: journal/views/mark.py:280
 #, fuzzy
 #| msgid "Invalid file."
 msgid "Invalid input"
 msgstr "Некорректный файл."
 
-#: journal/views/note.py:23
+#: journal/views/note.py:22
 msgid "Progress"
 msgstr ""
 
-#: journal/views/note.py:28
+#: journal/views/note.py:27
 msgid "Update progress"
 msgstr ""
 
-#: journal/views/note.py:59
+#: journal/views/note.py:58
 msgid "Progress (optional)"
 msgstr ""
 
-#: journal/views/note.py:61
+#: journal/views/note.py:60
 msgid "Note Content"
 msgstr ""
 
-#: journal/views/note.py:63
+#: journal/views/note.py:62
 msgid "Content Warning (optional)"
 msgstr ""
 
-#: journal/views/note.py:85
+#: journal/views/note.py:84
 msgid "Progress Type (optional)"
 msgstr ""
 
-#: journal/views/note.py:123 journal/views/note.py:183
+#: journal/views/note.py:115 journal/views/note.py:175
 msgid "Only in-progress items can have progress."
 msgstr ""
 
-#: journal/views/post.py:98 journal/views/post.py:392
+#: journal/views/post.py:100 journal/views/post.py:388
 msgid "Post not found"
 msgstr ""
 
-#: journal/views/post.py:189
+#: journal/views/post.py:191
 msgid "Visibility too high for quoting this post"
 msgstr ""
 
-#: journal/views/post.py:337 journal/views/post.py:418
+#: journal/views/post.py:339 journal/views/post.py:414
 msgid "Content cannot be empty."
 msgstr ""
 
-#: journal/views/post.py:396
+#: journal/views/post.py:392
 msgid "This post cannot be edited here"
 msgstr ""
 
-#: journal/views/post.py:541
+#: journal/views/post.py:531
 msgid "Invalid choices"
 msgstr ""
 
-#: journal/views/post.py:544
+#: journal/views/post.py:534
 msgid "Invalid post"
 msgstr ""
 
@@ -6526,56 +6531,54 @@ msgstr ""
 msgid "may contain spoiler or triggering content"
 msgstr ""
 
-#: journal/views/tag.py:47 journal/views/tag.py:61
+#: journal/views/tag.py:46 journal/views/tag.py:60
 msgid "Invalid tag"
 msgstr ""
 
-#: journal/views/tag.py:50
+#: journal/views/tag.py:49
 msgid "Tag not found"
 msgstr ""
 
-#: journal/views/tag.py:72
+#: journal/views/tag.py:65
 msgid "Tag deleted."
 msgstr ""
 
-#: journal/views/tag.py:82
+#: journal/views/tag.py:75
 msgid "Duplicated tag."
 msgstr ""
 
-#: journal/views/tag.py:96
+#: journal/views/tag.py:83
 msgid "Tag updated."
 msgstr ""
 
-#: journal/views/wrapped.py:160
+#: journal/views/wrapped.py:161
 msgid "Summary posted to timeline."
 msgstr ""
 
-#: mastodon/models/common.py:29
+#: mastodon/models/common.py:31
 msgid "Mastodon"
 msgstr ""
 
-#: mastodon/models/common.py:30 users/templates/users/login.html:120
+#: mastodon/models/common.py:32 users/templates/users/login.html:114
 msgid "Threads"
 msgstr ""
 
-#: mastodon/models/common.py:31
+#: mastodon/models/common.py:33
 msgid "Bluesky"
 msgstr ""
 
-#: mastodon/models/email.py:59
+#: mastodon/models/email.py:63
 msgid ""
 "\n"
 "\n"
-"If you did not mean to register or login, please ignore this email. If you "
-"are concerned with your account security, please change the email linked "
-"with your account, or contact us."
+"If you did not mean to register or login, please ignore this email. If you are concerned with your account security, please change the email linked with your account, or contact us."
 msgstr ""
 
-#: mastodon/models/email.py:64 mastodon/models/email.py:69
+#: mastodon/models/email.py:68 mastodon/models/email.py:73
 msgid "Verification Code"
 msgstr ""
 
-#: mastodon/models/email.py:66
+#: mastodon/models/email.py:70
 #, python-brace-format
 msgid ""
 "Use this code to verify your email address {email}\n"
@@ -6583,7 +6586,7 @@ msgid ""
 "{code}"
 msgstr ""
 
-#: mastodon/models/email.py:70
+#: mastodon/models/email.py:74
 #, python-brace-format
 msgid ""
 "Use this code to login as {email}\n"
@@ -6591,23 +6594,21 @@ msgid ""
 "{code}"
 msgstr ""
 
-#: mastodon/models/email.py:74 users/templates/users/captcha.html:13
+#: mastodon/models/email.py:78 users/templates/users/captcha.html:13
 #: users/templates/users/captcha_solved.html:9
 #: users/templates/users/login.html:20 users/templates/users/register.html:9
 #: users/templates/users/welcome.html:10
 msgid "Register"
 msgstr ""
 
-#: mastodon/models/email.py:76
+#: mastodon/models/email.py:80
 #, python-brace-format
 msgid ""
 "There is no account registered with this email address yet: {email}\n"
 "\n"
-"If you already have an account with us, just login and add this email to you "
-"account.\n"
+"If you already have an account with us, just login and add this email to you account.\n"
 "\n"
-"If you prefer to register a new account with this email, please use this "
-"verification code: {code}"
+"If you prefer to register a new account with this email, please use this verification code: {code}"
 msgstr ""
 
 #: mastodon/models/mastodon.py:570
@@ -6650,46 +6651,51 @@ msgstr ""
 msgid "New Post"
 msgstr ""
 
-#: mastodon/views/bluesky.py:26 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:32 mastodon/views/bluesky.py:93
 msgid "Bluesky login is disabled."
 msgstr ""
 
-#: mastodon/views/bluesky.py:28 mastodon/views/email.py:35
-#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:29
-#: users/templates/users/login.html:6 users/views/webauthn.py:133
+#: mastodon/views/bluesky.py:47 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:65 mastodon/views/bluesky.py:98
+#: mastodon/views/bluesky.py:106 mastodon/views/bluesky.py:112
+#: mastodon/views/common.py:36 mastodon/views/mastodon.py:62
+#: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
+#: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
+#: mastodon/views/threads.py:57 mastodon/views/threads.py:65
+#: mastodon/views/threads.py:71 users/views/account.py:256
+#: users/views/account.py:375
+msgid "Authentication failed"
+msgstr ""
+
+#: mastodon/views/bluesky.py:47 mastodon/views/common.py:103
+msgid "Identity not found."
+msgstr ""
+
+#: mastodon/views/bluesky.py:53 mastodon/views/email.py:35
+#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:31
+#: users/templates/users/login.html:6 users/views/webauthn.py:136
 #, fuzzy
 #| msgid "Export file expired. Please export again."
 msgid "Security check failed. Please try again."
 msgstr "Экспорт файла истёк. Пожалуйста, экспортируйте снова."
 
-#: mastodon/views/bluesky.py:34 mastodon/views/bluesky.py:40
-#: mastodon/views/bluesky.py:64 mastodon/views/bluesky.py:72
-#: mastodon/views/bluesky.py:78 mastodon/views/common.py:36
-#: mastodon/views/mastodon.py:62 mastodon/views/mastodon.py:70
-#: mastodon/views/mastodon.py:77 mastodon/views/mastodon.py:87
-#: mastodon/views/mastodon.py:94 mastodon/views/threads.py:55
-#: mastodon/views/threads.py:63 mastodon/views/threads.py:69
-#: users/views/account.py:254 users/views/account.py:373
-msgid "Authentication failed"
-msgstr ""
-
-#: mastodon/views/bluesky.py:35 mastodon/views/email.py:66
+#: mastodon/views/bluesky.py:60 mastodon/views/email.py:66
 msgid "Too many attempts, please try again later."
 msgstr ""
 
-#: mastodon/views/bluesky.py:40
+#: mastodon/views/bluesky.py:65
 msgid "ATProto handle is required."
 msgstr ""
 
-#: mastodon/views/bluesky.py:50
+#: mastodon/views/bluesky.py:84
 msgid "Error connecting to your ATProto server"
 msgstr ""
 
-#: mastodon/views/bluesky.py:73
+#: mastodon/views/bluesky.py:107
 msgid "Invalid response from ATProto authorization server."
 msgstr ""
 
-#: mastodon/views/bluesky.py:78
+#: mastodon/views/bluesky.py:112
 msgid "Invalid account data from Bluesky."
 msgstr ""
 
@@ -6697,7 +6703,7 @@ msgstr ""
 msgid "Invalid user."
 msgstr ""
 
-#: mastodon/views/common.py:52 users/views/account.py:414
+#: mastodon/views/common.py:52 users/views/account.py:416
 msgid "Registration failed"
 msgstr ""
 
@@ -6727,10 +6733,6 @@ msgstr ""
 #: mastodon/views/common.py:103 mastodon/views/common.py:107
 #: mastodon/views/common.py:116
 msgid "Disconnect identity failed"
-msgstr ""
-
-#: mastodon/views/common.py:103
-msgid "Identity not found."
 msgstr ""
 
 #: mastodon/views/common.py:117
@@ -6774,7 +6776,7 @@ msgstr ""
 msgid "Invalid response from Fediverse instance."
 msgstr ""
 
-#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:64
+#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:66
 msgid "Invalid OAuth state. Please try again."
 msgstr ""
 
@@ -6794,19 +6796,17 @@ msgstr ""
 msgid "Invalid account data from Fediverse instance."
 msgstr ""
 
-#: mastodon/views/threads.py:69
+#: mastodon/views/threads.py:71
 msgid "Invalid account data from Threads."
 msgstr ""
 
-#: mastodon/views/threads.py:147
+#: mastodon/views/threads.py:149
 msgid "Data deletion completed"
 msgstr ""
 
-#: mastodon/views/threads.py:149
+#: mastodon/views/threads.py:151
 #, python-brace-format
-msgid ""
-"Data linked to your Threads account has been deleted. Confirmation code: "
-"{code}"
+msgid "Data linked to your Threads account has been deleted. Confirmation code: {code}"
 msgstr ""
 
 #: social/templates/_article_teaser.html:10
@@ -6841,15 +6841,11 @@ msgstr ""
 msgid "play"
 msgstr ""
 
-#: social/templates/_event_post.html:50
-msgid "mark"
-msgstr ""
-
-#: social/templates/_event_post.html:79
+#: social/templates/_event_post.html:74
 msgid "wrote a note"
 msgstr ""
 
-#: social/templates/_event_post.html:88
+#: social/templates/_event_post.html:83
 msgid "replying to"
 msgstr ""
 
@@ -6862,7 +6858,7 @@ msgstr ""
 msgid "Untitled article"
 msgstr ""
 
-#: social/templates/event/boosted.html:3
+#: social/templates/event/boosted.html:2
 msgid "boosted your post"
 msgstr ""
 
@@ -6905,8 +6901,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
 #: social/templates/event/boosted_shelfmember.html:3
@@ -6924,7 +6919,7 @@ msgstr ""
 msgid "followed you"
 msgstr ""
 
-#: social/templates/event/liked.html:3
+#: social/templates/event/liked.html:2
 msgid "liked your post"
 msgstr ""
 
@@ -6967,8 +6962,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
 #: social/templates/event/liked_shelfmember.html:3
@@ -6978,7 +6972,7 @@ msgid ""
 "liked your mark on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
-#: social/templates/event/mentioned.html:3
+#: social/templates/event/mentioned.html:2
 msgid "mentioned you"
 msgstr ""
 
@@ -7021,8 +7015,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
 #: social/templates/event/mentioned_shelfmember.html:3
@@ -7032,26 +7025,39 @@ msgid ""
 "replied to your mark on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 
-#: social/templates/feed.html:12 social/templates/feed.html:39
-#: social/templates/search_feed.html:12
-msgid "Activities from those you follow"
+#: social/templates/feed.html:39 users/templates/users/preferences.html:40
+msgid "Activities"
 msgstr ""
 
-#: social/templates/feed.html:42 social/templates/feed.html:44
+#: social/templates/feed.html:43 social/templates/feed.html:45
+#, fuzzy
+#| msgid "WorldCat"
+msgid "world"
+msgstr "WorldCat"
+
+#: social/templates/feed.html:51 social/templates/feed.html:53
+msgid "local"
+msgstr ""
+
+#: social/templates/feed.html:58 social/templates/feed.html:60
+msgid "those you follow"
+msgstr ""
+
+#: social/templates/feed.html:64 social/templates/feed.html:66
 msgid "what they read/watch/..."
 msgstr ""
 
-#: social/templates/feed_events.html:30
+#: social/templates/feed_events.html:29
 msgid "no matching activities."
 msgstr ""
 
-#: social/templates/feed_events.html:33
+#: social/templates/feed_events.html:31
+msgid "no public activities yet."
+msgstr ""
+
+#: social/templates/feed_events.html:34
 #, python-format
-msgid ""
-"Find and mark some books/movies/podcasts/games, <a "
-"href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/"
-"Douban, follow some fellow %(site_name)s users on the fediverse, so their "
-"recent activities and yours will show up here."
+msgid "Find and mark some books/movies/podcasts/games, <a href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/Douban, follow some fellow %(site_name)s users on the fediverse, so their recent activities and yours will show up here."
 msgstr ""
 
 #: social/templates/notification.html:58
@@ -7086,6 +7092,10 @@ msgstr ""
 msgid "Poll ending at %(end_time)s"
 msgstr ""
 
+#: social/templates/search_feed.html:12 social/views.py:57 social/views.py:58
+msgid "Activities from those you follow"
+msgstr ""
+
 #: social/templates/single_post.html:13 social/templates/single_post.html:32
 msgid "Post"
 msgstr ""
@@ -7098,57 +7108,63 @@ msgstr ""
 msgid "Poll"
 msgstr ""
 
-#: takahe/models.py:453
+#: social/views.py:59
+msgid "Activities on this site"
+msgstr ""
+
+#: social/views.py:60
+msgid "Activities from the fediverse"
+msgstr ""
+
+#: takahe/models.py:445
 msgid "Display Name"
 msgstr ""
 
-#: takahe/models.py:455
+#: takahe/models.py:447
 msgid "Bio"
 msgstr ""
 
-#: takahe/models.py:457
+#: takahe/models.py:449
 msgid "Manually approve new followers"
 msgstr ""
 
-#: takahe/models.py:461
+#: takahe/models.py:453
 msgid "Include profile, marks and posts in discovery"
 msgstr ""
 
-#: takahe/models.py:464
+#: takahe/models.py:456
 msgid "Include posts in search results"
 msgstr ""
 
-#: takahe/models.py:482
+#: takahe/models.py:474
 msgid "Profile picture"
 msgstr ""
 
-#: takahe/models.py:489
+#: takahe/models.py:481
 msgid "Header picture"
 msgstr ""
 
-#: users/models/task.py:22
+#: users/models/task.py:24
 msgid "Started"
 msgstr ""
 
-#: users/models/task.py:23
+#: users/models/task.py:25
 msgid "Complete"
 msgstr ""
 
-#: users/models/user.py:69
-msgid ""
-"Enter a valid username. This value may contain only unaccented lowercase a-z "
-"and uppercase A-Z letters, numbers, and _ characters."
+#: users/models/user.py:71
+msgid "Enter a valid username. This value may contain only unaccented lowercase a-z and uppercase A-Z letters, numbers, and _ characters."
 msgstr ""
 
-#: users/models/user.py:130
+#: users/models/user.py:132
 msgid "username"
 msgstr ""
 
-#: users/models/user.py:135
+#: users/models/user.py:137
 msgid "Required. 50 characters or fewer. Letters, digits and _ only."
 msgstr ""
 
-#: users/models/user.py:138
+#: users/models/user.py:140
 msgid "A user with that username already exists."
 msgstr ""
 
@@ -7283,9 +7299,7 @@ msgid "Cancel import"
 msgstr ""
 
 #: users/templates/users/_rym_section.html:29
-msgid ""
-"On RateYourMusic, go to your profile and use the <b>Export your music "
-"catalog</b> option to download your library as a CSV file."
+msgid "On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:31
@@ -7294,18 +7308,12 @@ msgid "Upload the downloaded CSV file below."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:33
-msgid ""
-"Albums are matched by title + artist (and year if present) — first against "
-"the local catalog, then MusicBrainz, then Spotify. After auto-matching, "
-"you'll preview the matches in a table, edit any link or shelf status, and "
-"confirm the import."
+msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:36
 #: users/templates/users/_storygraph_section.html:38
-msgid ""
-"You can also re-upload a previously-downloaded matched CSV — the existing "
-"<code>link</code> column will be honoured as the default match."
+msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:40
@@ -7332,18 +7340,11 @@ msgid "Cancel the StoryGraph import? Progress will be discarded."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:31
-msgid ""
-"On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to "
-"download your library as a CSV file."
+msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:35
-msgid ""
-"Books are matched by ISBN — first against the local catalog, then Google "
-"Books and OpenLibrary — with a title + author search as fallback. After auto-"
-"matching, you'll preview the matches in a table, edit any link or shelf "
-"status, and confirm the import."
+msgid "Books are matched by ISBN — first against the local catalog, then Google Books and OpenLibrary — with a title + author search as fallback. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/account.html:11
@@ -7355,9 +7356,7 @@ msgid "Display name, avatar and other information"
 msgstr ""
 
 #: users/templates/users/account.html:23
-msgid ""
-"Updating profile information here will turn off automatic sync of display "
-"name, bio and avatar from your Mastodon instance. Sure to continue?"
+msgid "Updating profile information here will turn off automatic sync of display name, bio and avatar from your Mastodon instance. Sure to continue?"
 msgstr ""
 
 #: users/templates/users/account.html:26
@@ -7370,16 +7369,11 @@ msgstr ""
 
 #: users/templates/users/account.html:59 users/templates/users/register.html:47
 #, python-format
-msgid ""
-"Please click the confirmation link in the email sent to %(pending_email)s; "
-"if you haven't received it for more than a few minutes, please input and "
-"save again."
+msgid "Please click the confirmation link in the email sent to %(pending_email)s; if you haven't received it for more than a few minutes, please input and save again."
 msgstr ""
 
 #: users/templates/users/account.html:61 users/templates/users/register.html:50
-msgid ""
-"Email is recommended as a backup login method, if you log in via a Fediverse "
-"instance"
+msgid "Email is recommended as a backup login method, if you log in via a Fediverse instance"
 msgstr ""
 
 #: users/templates/users/account.html:73 users/templates/users/login.html:84
@@ -7397,22 +7391,15 @@ msgid "Last updated"
 msgstr ""
 
 #: users/templates/users/account.html:92
-msgid ""
-"If you have not yet registered with any Federated instance, you may <a "
-"href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an "
-"instance</a> and register."
+msgid "If you have not yet registered with any Federated instance, you may <a href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an instance</a> and register."
 msgstr ""
 
 #: users/templates/users/account.html:97
-msgid ""
-"To associate with another federated identity, please enter the domain name "
-"of the instance where the new identity is located."
+msgid "To associate with another federated identity, please enter the domain name of the instance where the new identity is located."
 msgstr ""
 
 #: users/templates/users/account.html:99
-msgid ""
-"If you have registered with a Federated instance, please enter the instance "
-"domain name."
+msgid "If you have registered with a Federated instance, please enter the instance domain name."
 msgstr ""
 
 #: users/templates/users/account.html:104
@@ -7424,24 +7411,17 @@ msgid "Go to target instance and authorize with the identity"
 msgstr ""
 
 #: users/templates/users/account.html:113
-msgid ""
-"After replacing the association, you may use the new Fediverse identity to "
-"log in and control data visibility. Existing data such as tags, comments, "
-"and collections will not be affected."
+msgid "After replacing the association, you may use the new Fediverse identity to log in and control data visibility. Existing data such as tags, comments, and collections will not be affected."
 msgstr ""
 
 #: users/templates/users/account.html:115
-msgid ""
-"Once associated with Fediverse identity, you can discover more users and use "
-"the full features of this site."
+msgid "Once associated with Fediverse identity, you can discover more users and use the full features of this site."
 msgstr ""
 
 #: users/templates/users/account.html:123
 #: users/templates/users/account.html:160
 #: users/templates/users/account.html:206
-msgid ""
-"Once disconnected, you will no longer be able login with this identity. Are "
-"you sure to continue?"
+msgid "Once disconnected, you will no longer be able login with this identity. Are you sure to continue?"
 msgstr ""
 
 #: users/templates/users/account.html:126
@@ -7468,7 +7448,7 @@ msgstr ""
 msgid "Disconnect with Threads"
 msgstr ""
 
-#: users/templates/users/account.html:173 users/templates/users/login.html:112
+#: users/templates/users/account.html:173 users/templates/users/login.html:106
 msgid "Bluesky (ATProto)"
 msgstr ""
 
@@ -7476,7 +7456,7 @@ msgstr ""
 msgid "Verified ATProto identity"
 msgstr ""
 
-#: users/templates/users/account.html:194 users/templates/users/login.html:216
+#: users/templates/users/account.html:194 users/templates/users/login.html:210
 msgid "ATProto handle"
 msgstr ""
 
@@ -7501,7 +7481,7 @@ msgid "Name this passkey:"
 msgstr ""
 
 #: users/templates/users/account.html:227 users/templates/users/login.html:69
-#: users/templates/users/welcome.html:33 users/views/webauthn.py:106
+#: users/templates/users/welcome.html:33 users/views/webauthn.py:109
 msgid "Passkey"
 msgstr ""
 
@@ -7544,9 +7524,7 @@ msgid "Save sync settings"
 msgstr ""
 
 #: users/templates/users/account.html:297
-msgid ""
-"New follow, mute and blocks in the associated identity may be automatically "
-"imported; removal has to be done manually."
+msgid "New follow, mute and blocks in the associated identity may be automatically imported; removal has to be done manually."
 msgstr ""
 
 #: users/templates/users/account.html:304
@@ -7583,15 +7561,11 @@ msgid "Log out everywhere"
 msgstr ""
 
 #: users/templates/users/account.html:365
-msgid ""
-"This will log you out of all browsers and devices (including the current "
-"one), and revoke all API tokens. Continue?"
+msgid "This will log you out of all browsers and devices (including the current one), and revoke all API tokens. Continue?"
 msgstr ""
 
 #: users/templates/users/account.html:368
-msgid ""
-"If you notice any suspicious activity or have logged in on a shared "
-"computer, you can log out of all sessions and revoke all API tokens."
+msgid "If you notice any suspicious activity or have logged in on a shared computer, you can log out of all sessions and revoke all API tokens."
 msgstr ""
 
 #: users/templates/users/account.html:378
@@ -7652,10 +7626,10 @@ msgstr ""
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:74
-#: users/templates/users/data.html:126 users/templates/users/data.html:183
-#: users/templates/users/data.html:234 users/templates/users/data.html:298
-#: users/templates/users/data.html:358 users/templates/users/data.html:553
+#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/data.html:141 users/templates/users/data.html:198
+#: users/templates/users/data.html:249 users/templates/users/data.html:313
+#: users/templates/users/data.html:376 users/templates/users/data.html:553
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr ""
@@ -7680,9 +7654,7 @@ msgid "Migrate Account"
 msgstr ""
 
 #: users/templates/users/account.html:488
-msgid ""
-"Linking an email to your account is highly recommended before migrating from "
-"another Fediverse instance."
+msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
 msgstr ""
 
 #: users/templates/users/account.html:491
@@ -7702,9 +7674,7 @@ msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
 msgstr ""
 
 #: users/templates/users/account.html:507
-msgid ""
-"Enter full <code>username@instance.social</code> or <code>email@domain.com</"
-"code> to confirm deletion."
+msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
 msgstr ""
 
 #: users/templates/users/account.html:517
@@ -7756,9 +7726,7 @@ msgid "Token Created"
 msgstr ""
 
 #: users/templates/users/authorized_app_created.html:22
-msgid ""
-"Your new personal access token has been created. Copy it now -- you will not "
-"be able to see it again."
+msgid "Your new personal access token has been created. Copy it now -- you will not be able to see it again."
 msgstr ""
 
 #: users/templates/users/authorized_app_created.html:25
@@ -7786,9 +7754,7 @@ msgid "One quick check"
 msgstr ""
 
 #: users/templates/users/captcha.html:28
-msgid ""
-"Put every cover into the row it belongs to. Drag it, or select a cover and "
-"then select a row."
+msgid "Put every cover into the row it belongs to. Drag it, or select a cover and then select a row."
 msgstr ""
 
 #: users/templates/users/captcha.html:41 users/templates/users/captcha.html:43
@@ -7822,7 +7788,7 @@ msgstr ""
 msgid "That is all we needed. Let's get you a username."
 msgstr ""
 
-#: users/templates/users/captcha_solved.html:34
+#: users/templates/users/captcha_solved.html:32
 #: users/templates/users/login.html:63
 #: users/templates/users/verify_email.html:25
 #: users/templates/users/welcome.html:51
@@ -7842,10 +7808,7 @@ msgid "Failed Crossposts"
 msgstr ""
 
 #: users/templates/users/crossposts.html:42
-msgid ""
-"These posts could not be crossposted to your linked social accounts. Re-"
-"authorize the account if needed, then retry. In rare cases retrying may "
-"create a duplicate post."
+msgid "These posts could not be crossposted to your linked social accounts. Re-authorize the account if needed, then retry. In rare cases retrying may create a duplicate post."
 msgstr ""
 
 #: users/templates/users/crossposts.html:48
@@ -7866,208 +7829,161 @@ msgstr ""
 msgid "Data Management"
 msgstr ""
 
-#: users/templates/users/data.html:27
+#: users/templates/users/data.html:39
 msgid "Import Marks and Reviews from Douban"
 msgstr ""
 
-#: users/templates/users/data.html:31
-msgid ""
-"Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
-"target=\"_blank\" rel=\"noopener\">Doufen</a>"
+#: users/templates/users/data.html:43
+msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr ""
 
 #: users/templates/users/data.html:45
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
-"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
-"NeoDB Archive</a> below."
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON format instead; upload it under <a href=\"#import-neodb-archive\">Import NeoDB Archive</a> below."
 msgstr ""
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:256
+#: users/templates/users/data.html:49 users/templates/users/data.html:271
 msgid "Import Method"
 msgstr ""
 
-#: users/templates/users/data.html:37
-msgid ""
-"Merge: only update when status changes from wishlist to in-progress, or from "
-"in-progress to complete."
+#: users/templates/users/data.html:52
+msgid "Merge: only update when status changes from wishlist to in-progress, or from in-progress to complete."
 msgstr ""
 
-#: users/templates/users/data.html:41
+#: users/templates/users/data.html:56
 msgid "Overwrite: update all imported status."
 msgstr ""
 
-#: users/templates/users/data.html:74
-msgid ""
-"Another import is in progress, starting a new import may cause issues, sure "
-"to import?"
+#: users/templates/users/data.html:89
+msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
 msgstr ""
 
-#: users/templates/users/data.html:74
+#: users/templates/users/data.html:89 users/views/data.py:1130
 msgid "Import in progress, please wait"
 msgstr ""
 
-#: users/templates/users/data.html:81
+#: users/templates/users/data.html:96
 msgid "Import from Goodreads"
 msgstr ""
 
-#: users/templates/users/data.html:87
-msgid ""
-"On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download "
-"your library as a CSV file."
+#: users/templates/users/data.html:102
+msgid "On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download your library as a CSV file."
 msgstr ""
 
-#: users/templates/users/data.html:90
-msgid ""
-"Upload the downloaded <code>goodreads_library_export.csv</code> file below."
+#: users/templates/users/data.html:105
+msgid "Upload the downloaded <code>goodreads_library_export.csv</code> file below."
 msgstr ""
 
-#: users/templates/users/data.html:93
-msgid ""
-"want-to-read / currently-reading / read / did-not-finish books and their "
-"reviews will be imported."
-msgstr ""
-
-#: users/templates/users/data.html:134
-msgid "Import from Letterboxd"
-msgstr ""
-
-#: users/templates/users/data.html:140
-msgid ""
-"on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" "
-"target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap "
-"Advanced Settings in Settings, tap EXPORT YOUR DATA"
-msgstr ""
-
-#: users/templates/users/data.html:143
-msgid ""
-"download file with name like <code>letterboxd-username-2018-03-11-07-52-"
-"utc.zip</code>, do not unzip"
-msgstr ""
-
-#: users/templates/users/data.html:146
-msgid ""
-"the following files in the zip file will be processed: <code>reviews.csv</"
-"code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</"
-"code> <code>lists/*.csv</code>"
+#: users/templates/users/data.html:108
+msgid "want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported."
 msgstr ""
 
 #: users/templates/users/data.html:149
-msgid ""
-"exported file does not indicate whether a list is private, unlisted or "
-"public, so all imported marks, reviews and collections will be created with "
-"the visibility selected below"
+msgid "Import from Letterboxd"
 msgstr ""
 
-#: users/templates/users/data.html:184 users/templates/users/data.html:235
+#: users/templates/users/data.html:155
+msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
+msgstr ""
+
+#: users/templates/users/data.html:158
+msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
+msgstr ""
+
+#: users/templates/users/data.html:161
+msgid "the following files in the zip file will be processed: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
+msgstr ""
+
+#: users/templates/users/data.html:164
+msgid "exported file does not indicate whether a list is private, unlisted or public, so all imported marks, reviews and collections will be created with the visibility selected below"
+msgstr ""
+
+#: users/templates/users/data.html:199 users/templates/users/data.html:250
 msgid "Only forward changes(none->to-watch->watched) will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:191
+#: users/templates/users/data.html:206
 msgid "Import from Trakt"
 msgstr ""
 
-#: users/templates/users/data.html:197
-msgid ""
-"On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" "
-"rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait "
-"for the download link to appear."
+#: users/templates/users/data.html:212
+msgid "On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait for the download link to appear."
 msgstr ""
 
-#: users/templates/users/data.html:200
+#: users/templates/users/data.html:215
 msgid "Upload the downloaded <code>.zip</code> file below, do not unzip."
 msgstr ""
 
-#: users/templates/users/data.html:202
+#: users/templates/users/data.html:217
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:243
+#: users/templates/users/data.html:258
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr ""
 
-#: users/templates/users/data.html:246
+#: users/templates/users/data.html:261
 msgid "Login with Steam"
 msgstr ""
 
-#: users/templates/users/data.html:252
+#: users/templates/users/data.html:267
 msgid "Import Podcast Subscriptions"
 msgstr ""
 
-#: users/templates/users/data.html:263
+#: users/templates/users/data.html:278
 msgid "Mark as listening"
 msgstr ""
 
-#: users/templates/users/data.html:267
+#: users/templates/users/data.html:282
 msgid "Import as a new collection"
 msgstr ""
 
-#: users/templates/users/data.html:296
+#: users/templates/users/data.html:311
 msgid "Select OPML file"
 msgstr ""
 
-#: users/templates/users/data.html:306
+#: users/templates/users/data.html:321
 msgid "Import NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:312
-msgid ""
-"Upload a <code>.zip</code> file containing <code>.csv</code> or "
-"<code>.ndjson</code> files exported from NeoDB."
+#: users/templates/users/data.html:327
+msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr ""
 
 #: users/templates/users/data.html:330
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
-"imported here."
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is imported here."
 msgstr ""
 
-#: users/templates/users/data.html:314
+#: users/templates/users/data.html:332
 msgid "Existing data may be overwritten."
 msgstr ""
 
-#: users/templates/users/data.html:324
+#: users/templates/users/data.html:342
 msgid "Detected format"
 msgstr ""
 
-#: users/templates/users/data.html:385
+#: users/templates/users/data.html:403
 msgid "Detecting format..."
 msgstr ""
 
-#: users/templates/users/data.html:411
+#: users/templates/users/data.html:429
 msgid "Unknown format"
 msgstr ""
 
-#: users/templates/users/data.html:436
+#: users/templates/users/data.html:454
 msgid "Error detecting format"
 msgstr ""
 
-#: users/templates/users/data.html:460
+#: users/templates/users/data.html:478
 msgid "Export NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:464
+#: users/templates/users/data.html:482
 msgid "Export marks, reviews and notes in CSV"
 msgstr ""
 
-#: users/templates/users/data.html:471
+#: users/templates/users/data.html:489
 msgid "Export everything in NDJSON"
-msgstr ""
-
-#: users/templates/users/data.html:479
-msgid "Export marks and reviews in XLSX (Doufen format)"
-msgstr ""
-
-#: users/templates/users/data.html:482
-msgid "Last export"
-msgstr ""
-
-#: users/templates/users/data.html:487
-msgid "Download"
 msgstr ""
 
 #: users/templates/users/data.html:496
@@ -8075,22 +7991,15 @@ msgid "Import and Export Articles (WordPress)"
 msgstr ""
 
 #: users/templates/users/data.html:499
-msgid ""
-"Your articles are exchanged as WordPress posts in the WXR format, which "
-"WordPress and most blogging tools can read and write. Marks, reviews and "
-"notes are not included: use the NeoDB archive above for those."
+msgid "Your articles are exchanged as WordPress posts in the WXR format, which WordPress and most blogging tools can read and write. Marks, reviews and notes are not included: use the NeoDB archive above for those."
 msgstr ""
 
 #: users/templates/users/data.html:502
-msgid ""
-"Article title, body, excerpt, tags, dates and featured image are exchanged. "
-"Comments and custom fields are ignored."
+msgid "Article title, body, excerpt, tags, dates and featured image are exchanged. Comments and custom fields are ignored."
 msgstr ""
 
 #: users/templates/users/data.html:505
-msgid ""
-"The body is converted between Markdown and HTML, so formatting is kept but "
-"the text is not character-for-character identical."
+msgid "The body is converted between Markdown and HTML, so formatting is kept but the text is not character-for-character identical."
 msgstr ""
 
 #: users/templates/users/data.html:512
@@ -8098,16 +8007,11 @@ msgid "Export articles in WordPress format"
 msgstr ""
 
 #: users/templates/users/data.html:519
-msgid ""
-"In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download "
-"an <code>.xml</code> file, then upload it below."
+msgid "In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download an <code>.xml</code> file, then upload it below."
 msgstr ""
 
 #: users/templates/users/data.html:522
-msgid ""
-"Only published posts use the visibility below. Drafts, pending, private and "
-"password-protected posts are always imported as mentioned-only, so nothing "
-"unpublished becomes public."
+msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
 #: users/templates/users/data.html:560
@@ -8115,9 +8019,7 @@ msgid "View Annual Summary"
 msgstr ""
 
 #: users/templates/users/fetch_identity_failed.html:4
-msgid ""
-"Unable to find the user, please check your spelling; or the server may be "
-"busy, please try again later."
+msgid "Unable to find the user, please check your spelling; or the server may be busy, please try again later."
 msgstr ""
 
 #: users/templates/users/fetch_identity_pending.html:13
@@ -8137,94 +8039,76 @@ msgstr ""
 msgid "logo"
 msgstr ""
 
-#: users/templates/users/login.html:127
-msgid ""
-"Sign in with a passkey saved on this device or in your password manager."
+#: users/templates/users/login.html:121
+msgid "Sign in with a passkey saved on this device or in your password manager."
 msgstr ""
 
-#: users/templates/users/login.html:132
+#: users/templates/users/login.html:126
 msgid "Sign in with Passkey"
 msgstr ""
 
-#: users/templates/users/login.html:148
+#: users/templates/users/login.html:142
 msgid "Enter your email address"
 msgstr ""
 
-#: users/templates/users/login.html:152
+#: users/templates/users/login.html:146
 msgid "Send verification code"
 msgstr ""
 
-#: users/templates/users/login.html:171
+#: users/templates/users/login.html:165
 msgid "Domain of your instance, e.g. mastodon.social"
 msgstr ""
 
-#: users/templates/users/login.html:177
-msgid ""
-"Please enter domain of your instance; e.g. if your id is "
-"<i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
+#: users/templates/users/login.html:171
+msgid "Please enter domain of your instance; e.g. if your id is <i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
 msgstr ""
 
-#: users/templates/users/login.html:182 users/templates/users/login.html:246
+#: users/templates/users/login.html:176 users/templates/users/login.html:240
 msgid "Authorize via Fediverse instance"
 msgstr ""
 
-#: users/templates/users/login.html:187
-msgid ""
-"If you don't have a <a href=\"https://joinmastodon.org/servers\" "
-"target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or "
-"login with Email first, and link it with Fediverse (Mastodon) later in "
-"account settings."
+#: users/templates/users/login.html:181
+msgid "If you don't have a <a href=\"https://joinmastodon.org/servers\" target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or login with Email first, and link it with Fediverse (Mastodon) later in account settings."
 msgstr ""
 
-#: users/templates/users/login.html:200
+#: users/templates/users/login.html:194
 msgid "Authorize via Threads"
 msgstr ""
 
-#: users/templates/users/login.html:221
-msgid ""
-"Please input your ATProto handle (e.g. neodb.bsky.social, without the "
-"leading @), do not use email. If you changed handle recently, just use the "
-"latest one."
+#: users/templates/users/login.html:215
+msgid "Please input your ATProto handle (e.g. neodb.bsky.social, without the leading @), do not use email. If you changed handle recently, just use the latest one."
 msgstr ""
 
-#: users/templates/users/login.html:224
+#: users/templates/users/login.html:218
 msgid "Authorize via ATProto server"
 msgstr ""
 
-#: users/templates/users/login.html:231
+#: users/templates/users/login.html:225
 #, python-format
-msgid ""
-"Please choose one to register or login %(site_name)s. Have more than one of "
-"these identities? Don't worry, you may link them in account settings once "
-"logged in."
+msgid "Please choose one to register or login %(site_name)s. Have more than one of these identities? Don't worry, you may link them in account settings once logged in."
 msgstr ""
 
-#: users/templates/users/login.html:255
+#: users/templates/users/login.html:249
 msgid "Valid invitation code, please login or register."
 msgstr ""
 
-#: users/templates/users/login.html:257
-msgid ""
-"Please use invitation link to register a new account; existing user may "
-"login."
+#: users/templates/users/login.html:251
+msgid "Please use invitation link to register a new account; existing user may login."
 msgstr ""
 
-#: users/templates/users/login.html:259
+#: users/templates/users/login.html:253
 msgid "Invitation code invalid or expired."
 msgstr ""
 
-#: users/templates/users/login.html:267
+#: users/templates/users/login.html:261
 msgid "Loading timed out, please check your network (VPN) settings."
 msgstr ""
 
-#: users/templates/users/login.html:273
-msgid ""
-"Continue using this site implies consent to our <a href=\"/pages/rules/"
-"\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using "
-"cookies to provide necessary functionality."
+#: users/templates/users/login.html:267
+msgid "Continue using this site implies consent to our <a href=\"/pages/rules/\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using cookies to provide necessary functionality."
 msgstr ""
 
-#: users/templates/users/login.html:287
+#: users/templates/users/login.html:281
 msgid "Domain of your instance (excl. @)"
 msgstr ""
 
@@ -8234,9 +8118,7 @@ msgid "Migrate Here"
 msgstr ""
 
 #: users/templates/users/migrate_in.html:22
-msgid ""
-"To move another account to this one, first add it as an alias here, and then "
-"go to the server where it is hosted and initiate the move."
+msgid "To move another account to this one, first add it as an alias here, and then go to the server where it is hosted and initiate the move."
 msgstr ""
 
 #: users/templates/users/migrate_in.html:27
@@ -8282,16 +8164,11 @@ msgstr ""
 
 #: users/templates/users/migrate_out.html:46
 #, python-format
-msgid ""
-"To migrate to another account, first add <code>@%(handle)s</code> as an "
-"alias on the target server, and then type the target account below to start "
-"the migration."
+msgid "To migrate to another account, first add <code>@%(handle)s</code> as an alias on the target server, and then type the target account below to start the migration."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:50
-msgid ""
-"Are you sure you want to migrate your account? Your followers will be moved "
-"to the target account."
+msgid "Are you sure you want to migrate your account? Your followers will be moved to the target account."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:53
@@ -8304,10 +8181,6 @@ msgstr ""
 
 #: users/templates/users/preferences.html:28
 msgid "Default view once logged in"
-msgstr ""
-
-#: users/templates/users/preferences.html:40
-msgid "Activities"
 msgstr ""
 
 #: users/templates/users/preferences.html:49
@@ -8337,9 +8210,7 @@ msgstr ""
 
 #: users/templates/users/preferences.html:111
 #: users/templates/users/register.html:88
-msgid ""
-"If a Mastodon account is linked with this identity, boosting a post will "
-"also make the same post boosted with that Mastodon account."
+msgid "If a Mastodon account is linked with this identity, boosting a post will also make the same post boosted with that Mastodon account."
 msgstr ""
 
 #: users/templates/users/preferences.html:115
@@ -8355,16 +8226,12 @@ msgid "Create a new post"
 msgstr ""
 
 #: users/templates/users/preferences.html:130
-msgid ""
-"this method is less optimal, may generate duplicated posts and miss "
-"reactions."
+msgid "this method is less optimal, may generate duplicated posts and miss reactions."
 msgstr ""
 
 #: users/templates/users/preferences.html:140
 #: users/templates/users/register.html:97
-msgid ""
-"Always publish my public marks, reviews and articles as data records to my "
-"PDS."
+msgid "Always publish my public marks, reviews and articles as data records to my PDS."
 msgstr ""
 
 #: users/templates/users/preferences.html:145
@@ -8384,12 +8251,7 @@ msgid "Automatic bookmark for these categories"
 msgstr ""
 
 #: users/templates/users/preferences.html:175
-msgid ""
-"When start to read/watch/play/... an item in these categories, a bookmark "
-"will be created automatically. Bookmarks can be viewed and managed in most "
-"<a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon "
-"compatible apps</a>; your replies to these posts will automatically become "
-"notes for the item."
+msgid "When start to read/watch/play/... an item in these categories, a bookmark will be created automatically. Bookmarks can be viewed and managed in most <a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon compatible apps</a>; your replies to these posts will automatically become notes for the item."
 msgstr ""
 
 #: users/templates/users/preferences.html:183
@@ -8409,9 +8271,7 @@ msgid "Profile visible to anonymous web visitors and search engines"
 msgstr ""
 
 #: users/templates/users/preferences.html:217
-msgid ""
-"this option limits web visits only; to limit fediverse visibility, choose "
-"followers only or mentioned only when posting"
+msgid "this option limits web visits only; to limit fediverse visibility, choose followers only or mentioned only when posting"
 msgstr ""
 
 #: users/templates/users/preferences.html:225
@@ -8423,17 +8283,7 @@ msgid "Do not show me item recommendations"
 msgstr ""
 
 #: users/templates/users/preferences.html:237
-msgid ""
-"Recommendations are generated only from public marks, processed in batch on "
-"this server. Your private and follower-only marks are never used as a signal "
-"for anyone, and we never share your data with third parties for this "
-"feature. When you share marks publicly and keep your profile discoverable, "
-"your marks help others here and across the Fediverse find things they might "
-"enjoy -- that voluntary contribution is what makes the feature work for "
-"everyone. If you'd rather not contribute, uncheck \"Include profile, marks "
-"and posts in discovery\" on your account page; this setting is published "
-"over ActivityPub, so other servers will also stop including you in their "
-"discovery features."
+msgid "Recommendations are generated only from public marks, processed in batch on this server. Your private and follower-only marks are never used as a signal for anyone, and we never share your data with third parties for this feature. When you share marks publicly and keep your profile discoverable, your marks help others here and across the Fediverse find things they might enjoy -- that voluntary contribution is what makes the feature work for everyone. If you'd rather not contribute, uncheck \"Include profile, marks and posts in discovery\" on your account page; this setting is published over ActivityPub, so other servers will also stop including you in their discovery features."
 msgstr ""
 
 #: users/templates/users/profile_actions.html:12
@@ -8534,21 +8384,11 @@ msgid "2-30 alphabets, numbers or underscore, can't be changed once saved"
 msgstr ""
 
 #: users/templates/users/register.html:72
-msgid ""
-"Use display name, bio and avatar from the social network you authenticated "
-"with"
-msgstr ""
-"Использовать отображаемое имя, биографию и аватар из социальной сети, с "
-"которой вы аутентифицировались"
+msgid "Use display name, bio and avatar from the social network you authenticated with"
+msgstr "Использовать отображаемое имя, биографию и аватар из социальной сети, с которой вы аутентифицировались"
 
 #: users/templates/users/register.html:80
-msgid ""
-"Add follow, mute and block list from the social network you authenticated "
-"with"
-msgstr ""
-
-#: users/templates/users/register.html:104
-msgid "Confirm and save"
+msgid "Add follow, mute and block list from the social network you authenticated with"
 msgstr ""
 
 #: users/templates/users/register.html:106
@@ -8579,8 +8419,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"              Matched %(local)s locally, %(external)s externally, "
-"%(unmatched)s unmatched out of %(total)s rows.\n"
+"              Matched %(local)s locally, %(external)s externally, %(unmatched)s unmatched out of %(total)s rows.\n"
 "            "
 msgstr ""
 
@@ -8697,9 +8536,7 @@ msgid "Played"
 msgstr ""
 
 #: users/templates/users/steam_import.html:90
-msgid ""
-"Games in wishlist; or purchased in library but never played, mark date will "
-"be set as today"
+msgid "Games in wishlist; or purchased in library but never played, mark date will be set as today"
 msgstr ""
 
 #: users/templates/users/steam_import.html:91
@@ -8739,15 +8576,11 @@ msgid "Comma-separated Steam AppIDs"
 msgstr ""
 
 #: users/templates/users/steam_import.html:121
-msgid ""
-"Allow reverse override of status (e.g. playing -> want to, or played -> "
-"playing)"
+msgid "Allow reverse override of status (e.g. playing -> want to, or played -> playing)"
 msgstr ""
 
 #: users/templates/users/steam_import.html:139
-msgid ""
-"To import from Steam, your game details must be visible to public in Steam "
-"privacy settings."
+msgid "To import from Steam, your game details must be visible to public in Steam privacy settings."
 msgstr ""
 
 #: users/templates/users/storygraph_import.html:9
@@ -8792,23 +8625,16 @@ msgstr "Добро пожаловать"
 #, python-format
 msgid ""
 "\n"
-"              %(site_name)s is flourishing because of collaborations and "
-"contributions from users like you. Please read our <a href=\"/pages/"
-"rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</"
-"a> if you have any question or feedback.\n"
+"              %(site_name)s is flourishing because of collaborations and contributions from users like you. Please read our <a href=\"/pages/rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</a> if you have any question or feedback.\n"
 "        "
 msgstr ""
 
 #: users/templates/users/welcome.html:37
-msgid ""
-"Set up a passkey to sign in quickly next time using your fingerprint, face, "
-"or screen lock."
+msgid "Set up a passkey to sign in quickly next time using your fingerprint, face, or screen lock."
 msgstr ""
 
 #: users/templates/users/welcome.html:39
-msgid ""
-"Creating a passkey is highly recommended, as the website or email you use to "
-"create this account may not be always available."
+msgid "Creating a passkey is highly recommended, as the website or email you use to create this account may not be always available."
 msgstr ""
 
 #: users/templates/users/welcome.html:43
@@ -8823,246 +8649,229 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:124
+#: users/views/account.py:126
 msgid "This username is already in use."
 msgstr "Это имя пользователя уже используется."
 
-#: users/views/account.py:135
+#: users/views/account.py:137
 msgid "This email address is already in use."
 msgstr "Этот email-адрес уже используется."
 
-#: users/views/account.py:255 users/views/account.py:374
+#: users/views/account.py:257 users/views/account.py:376
 msgid "Registration is for invitation only"
 msgstr "Регистрация только по приглашению"
 
-#: users/views/account.py:266 users/views/account.py:338
+#: users/views/account.py:268 users/views/account.py:340
 msgid "Time is up"
 msgstr ""
 
-#: users/views/account.py:267 users/views/account.py:310
-#: users/views/account.py:339
+#: users/views/account.py:269 users/views/account.py:312
+#: users/views/account.py:341
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:313
+#: users/views/account.py:315
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:325
+#: users/views/account.py:327
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:326
+#: users/views/account.py:328
 msgid "Please try again later."
 msgstr ""
 
-#: users/views/account.py:415
+#: users/views/account.py:417
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:445
+#: users/views/account.py:447
 msgid "Valid username required"
 msgstr "Требуется корректное имя пользователя"
 
-#: users/views/account.py:526
+#: users/views/account.py:518
 msgid "Account is being deleted."
 msgstr "Аккаунт удаляется."
 
-#: users/views/account.py:529
+#: users/views/account.py:521
 msgid "Account mismatch."
 msgstr "Несоответствие аккаунта."
 
-#: users/views/data.py:262 users/views/data.py:294
+#: users/views/data.py:264 users/views/data.py:296
 msgid "Export file not available."
 msgstr "Экспортируемый файл недоступен."
 
-#: users/views/data.py:288
+#: users/views/data.py:290
 msgid "Generating exports."
 msgstr "Формирование экспорта."
 
-#: users/views/data.py:306
+#: users/views/data.py:308
 msgid "Export file expired. Please export again."
 msgstr "Экспорт файла истёк. Пожалуйста, экспортируйте снова."
 
-#: users/views/data.py:321 users/views/data.py:342 users/views/data.py:363
+#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
 msgid "Recent export still in progress."
 msgstr "Последний экспорт всё ещё в процессе."
 
-#: users/views/data.py:379 users/views/data.py:513 users/views/data.py:547
-#: users/views/data.py:772 users/views/data.py:989 users/views/data.py:1015
-#: users/views/data.py:1040 users/views/data.py:1065
+#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
+#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
+#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
 msgid "Invalid file."
 msgstr "Некорректный файл."
 
-#: users/views/data.py:403
+#: users/views/data.py:405
 msgid "Sync in progress."
 msgstr "Синхронизация в процессе."
 
-#: users/views/data.py:417
+#: users/views/data.py:419
 msgid "Settings saved."
 msgstr "Настройки сохранены."
 
-#: users/views/data.py:472
+#: users/views/data.py:474
 #, fuzzy
 #| msgid "Account is being deleted."
 msgid "Account no longer linked."
 msgstr "Аккаунт удаляется."
 
-#: users/views/data.py:475
+#: users/views/data.py:477
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:503
+#: users/views/data.py:505
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:583 users/views/data.py:808
+#: users/views/data.py:585 users/views/data.py:810
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:608 users/views/data.py:837
+#: users/views/data.py:610 users/views/data.py:839
 msgid "Cancelled."
 msgstr ""
 
-#: users/views/data.py:628
+#: users/views/data.py:630
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:636 users/views/data.py:746 users/views/data.py:867
-#: users/views/data.py:972
+#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
+#: users/views/data.py:974
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:732 users/views/data.py:958
+#: users/views/data.py:734 users/views/data.py:960
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:742 users/views/data.py:968
+#: users/views/data.py:744 users/views/data.py:970
 #, fuzzy
 #| msgid "Export file not available."
 msgid "No matched file available."
 msgstr "Экспортируемый файл недоступен."
 
-#: users/views/data.py:859
+#: users/views/data.py:861
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1188
+#: users/views/data.py:1226
 #, fuzzy
 #| msgid "Valid username required"
 msgid "Name is required."
 msgstr "Требуется корректное имя пользователя"
 
-#: users/views/data.py:1210
+#: users/views/data.py:1248
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1264
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1231
+#: users/views/data.py:1269
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1241 users/views/data.py:1292
+#: users/views/data.py:1279 users/views/data.py:1330
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:1248
+#: users/views/data.py:1286
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:1253
+#: users/views/data.py:1291
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:1279
+#: users/views/data.py:1317
 msgid "Migration cancelled."
 msgstr ""
 
-#: users/views/data.py:1284
+#: users/views/data.py:1322
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:1297
+#: users/views/data.py:1335
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:1308
+#: users/views/data.py:1346
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:1314
+#: users/views/data.py:1352
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr ""
 
-#: users/views/data.py:1372
+#: users/views/data.py:1410
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1388
+#: users/views/data.py:1426
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1392
+#: users/views/data.py:1430
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1402
+#: users/views/data.py:1440
 #, python-brace-format
-msgid ""
-"Import of {count} entries received. They will be processed in the background."
+msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""
 
-#: users/views/webauthn.py:103
+#: users/views/webauthn.py:106
 msgid "Passkey registration failed"
 msgstr ""
 
-#: users/views/webauthn.py:123
+#: users/views/webauthn.py:126
 msgid "Credential already registered"
 msgstr ""
 
-#: users/views/webauthn.py:165 users/views/webauthn.py:172
-#: users/views/webauthn.py:181
+#: users/views/webauthn.py:168 users/views/webauthn.py:175
+#: users/views/webauthn.py:184
 msgid "Passkey not recognized"
 msgstr ""
 
-#: users/views/webauthn.py:186
+#: users/views/webauthn.py:189
 #, fuzzy
 #| msgid "Account is being deleted."
 msgid "Account is inactive"
 msgstr "Аккаунт удаляется."
 
-#: users/views/webauthn.py:202
+#: users/views/webauthn.py:205
 msgid "Passkey verification failed"
 msgstr ""
 
-#: users/views/webauthn.py:228 users/views/webauthn.py:250
+#: users/views/webauthn.py:231 users/views/webauthn.py:253
 msgid "Passkey not found"
 msgstr ""
 
-#: users/views/webauthn.py:244
+#: users/views/webauthn.py:247
 #, fuzzy
 #| msgid "Valid username required"
 msgid "Name is required"
 msgstr "Требуется корректное имя пользователя"
-
-#~ msgid "year"
-#~ msgstr "год"
-
-#~ msgctxt "music"
-#~ msgid "genre"
-#~ msgstr "жанр"
-
-#~ msgid "Region or Event"
-#~ msgstr "Регион или событие"
-
-#~ msgid "Username in use"
-#~ msgstr "Имя пользователя занято"
-
-#~ msgid "Invalid URL."
-#~ msgstr "Некорректный URL."

--- a/neodb/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hant/LC_MESSAGES/django.po
@@ -6,11 +6,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-23 15:40-0400\n"
+"POT-Creation-Date: 2026-09-06 20:04-0400\n"
 "PO-Revision-Date: 2026-08-09 06:32+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/"
-"projects/neodb/neodb/zh_Hant/>\n"
+"Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hant/>\n"
 "Language: zh_Hant\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -18,161 +17,161 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: boofilsic/settings.py:472 common/models/lang.py:230
+#: boofilsic/settings.py:501 common/models/lang.py:232
 msgid "English"
 msgstr "英語"
 
-#: boofilsic/settings.py:473 common/models/lang.py:77
+#: boofilsic/settings.py:502 common/models/lang.py:79
 msgid "Danish"
 msgstr "丹麥語"
 
-#: boofilsic/settings.py:474 common/models/lang.py:78
+#: boofilsic/settings.py:503 common/models/lang.py:80
 msgid "German"
 msgstr "德語"
 
-#: boofilsic/settings.py:475 common/models/lang.py:183
+#: boofilsic/settings.py:504 common/models/lang.py:185
 msgid "Spanish"
 msgstr "西班牙語"
 
-#: boofilsic/settings.py:476 common/models/lang.py:87
+#: boofilsic/settings.py:505 common/models/lang.py:89
 msgid "French"
 msgstr "法語"
 
-#: boofilsic/settings.py:477 common/models/lang.py:112
+#: boofilsic/settings.py:506 common/models/lang.py:114
 msgid "Italian"
 msgstr "意大利語"
 
-#: boofilsic/settings.py:478 common/models/lang.py:166
-#: common/models/lang.py:305
+#: boofilsic/settings.py:507 common/models/lang.py:168
+#: common/models/lang.py:307
 msgid "Portuguese"
 msgstr "葡萄牙語"
 
-#: boofilsic/settings.py:479
+#: boofilsic/settings.py:508
 #, fuzzy
 #| msgid "Portuguese"
 msgid "Brazilian Portuguese"
 msgstr "葡萄牙語"
 
-#: boofilsic/settings.py:480 common/models/lang.py:316
+#: boofilsic/settings.py:509 common/models/lang.py:318
 msgid "Simplified Chinese"
 msgstr "簡體中文"
 
-#: boofilsic/settings.py:481 common/models/lang.py:317
+#: boofilsic/settings.py:510 common/models/lang.py:319
 msgid "Traditional Chinese"
 msgstr "繁體中文"
 
-#: catalog/forms.py:35 catalog/models/item.py:291
+#: catalog/forms.py:35 catalog/models/item.py:307
 msgid "Primary ID Type"
 msgstr "主要標識類型"
 
-#: catalog/forms.py:40 catalog/models/item.py:294
+#: catalog/forms.py:40 catalog/models/item.py:310
 msgid "Primary ID Value"
 msgstr "主要標識數據"
 
-#: catalog/forms.py:181
+#: catalog/forms.py:176
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
-#: catalog/models/book.py:139 catalog/models/book.py:158
-#: catalog/models/common.py:280 catalog/models/common.py:298
+#: catalog/models/book.py:141 catalog/models/book.py:160
+#: catalog/models/common.py:279 catalog/models/common.py:297
 msgid "locale"
 msgstr "區域語言"
 
-#: catalog/models/book.py:142 catalog/models/book.py:161
-#: catalog/models/common.py:283 catalog/models/common.py:303
+#: catalog/models/book.py:144 catalog/models/book.py:163
+#: catalog/models/common.py:282 catalog/models/common.py:302
 msgid "text content"
 msgstr "文本內容"
 
-#: catalog/models/book.py:177
+#: catalog/models/book.py:179
 msgid "Paperback"
 msgstr "平裝"
 
-#: catalog/models/book.py:178
+#: catalog/models/book.py:180
 msgid "Hardcover"
 msgstr "精裝"
 
-#: catalog/models/book.py:179
+#: catalog/models/book.py:181
 msgid "eBook"
 msgstr "電子書"
 
-#: catalog/models/book.py:180
+#: catalog/models/book.py:182
 msgid "Audiobook"
 msgstr "有聲書"
 
-#: catalog/models/book.py:182
+#: catalog/models/book.py:184
 msgid "Web Fiction"
 msgstr "網絡作品"
 
-#: catalog/models/book.py:183 catalog/models/game.py:38
+#: catalog/models/book.py:185 catalog/models/game.py:38
 msgid "Other"
 msgstr "其它"
 
-#: catalog/models/book.py:260
+#: catalog/models/book.py:262
 msgid "subtitle"
 msgstr "副標題"
 
-#: catalog/models/book.py:270 catalog/models/movie.py:120
-#: catalog/models/performance.py:385 catalog/models/tv.py:211
-#: catalog/models/tv.py:437
+#: catalog/models/book.py:272 catalog/models/movie.py:120
+#: catalog/models/performance.py:385 catalog/models/tv.py:213
+#: catalog/models/tv.py:439
 msgid "original title"
 msgstr "原名"
 
-#: catalog/models/book.py:274
+#: catalog/models/book.py:276
 msgid "other title"
 msgstr "其它標題"
 
-#: catalog/models/book.py:280 catalog/models/book.py:564
-#: catalog/models/item.py:123
+#: catalog/models/book.py:282 catalog/models/book.py:566
+#: catalog/models/item.py:119
 msgid "author"
 msgstr "作者"
 
-#: catalog/models/book.py:287 catalog/models/item.py:124
+#: catalog/models/book.py:289 catalog/models/item.py:120
 msgid "translator"
 msgstr "譯者"
 
-#: catalog/models/book.py:294 catalog/templates/edition.html:26
+#: catalog/models/book.py:296 catalog/templates/edition.html:26
 msgid "book format"
 msgstr "格式"
 
-#: catalog/models/book.py:301 catalog/models/game.py:135
-#: catalog/models/item.py:138 catalog/models/music.py:142
+#: catalog/models/book.py:303 catalog/models/game.py:135
+#: catalog/models/item.py:134 catalog/models/music.py:142
 msgid "publisher"
 msgstr "出版發行"
 
-#: catalog/models/book.py:308
+#: catalog/models/book.py:310
 msgid "publication year"
 msgstr "發行年份"
 
-#: catalog/models/book.py:314
+#: catalog/models/book.py:316
 msgid "publication month"
 msgstr "發行月份"
 
-#: catalog/models/book.py:319
+#: catalog/models/book.py:321
 msgid "binding"
 msgstr "裝訂"
 
-#: catalog/models/book.py:320
+#: catalog/models/book.py:322
 msgid "pages"
 msgstr "頁數"
 
-#: catalog/models/book.py:321 catalog/templates/edition.html:45
+#: catalog/models/book.py:323 catalog/templates/edition.html:45
 msgid "series"
 msgstr "叢書"
 
-#: catalog/models/book.py:322 catalog/templates/edition.html:65
+#: catalog/models/book.py:324 catalog/templates/edition.html:65
 msgid "contents"
 msgstr "目錄"
 
-#: catalog/models/book.py:323 catalog/templates/edition.html:51
+#: catalog/models/book.py:325 catalog/templates/edition.html:51
 msgid "price"
 msgstr "價格"
 
-#: catalog/models/book.py:324 catalog/models/item.py:149
+#: catalog/models/book.py:326 catalog/models/item.py:145
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr "出品方"
 
-#: catalog/models/common.py:26 common/models/lang.py:256
+#: catalog/models/common.py:26 common/models/lang.py:258
 msgid "Unknown"
 msgstr "未知"
 
@@ -180,11 +179,11 @@ msgstr "未知"
 msgid "Douban"
 msgstr "豆瓣"
 
-#: catalog/models/common.py:28 catalog/models/common.py:79
+#: catalog/models/common.py:28 catalog/models/common.py:81
 msgid "Goodreads"
 msgstr "Goodreads"
 
-#: catalog/models/common.py:29 catalog/models/common.py:81
+#: catalog/models/common.py:29 catalog/models/common.py:83
 msgid "Google Books"
 msgstr "谷歌圖書"
 
@@ -192,16 +191,16 @@ msgstr "谷歌圖書"
 msgid "BooksTW"
 msgstr "博客來"
 
-#: catalog/models/common.py:31 catalog/models/common.py:91
-#: catalog/models/common.py:93
+#: catalog/models/common.py:31 catalog/models/common.py:93
+#: catalog/models/common.py:95
 msgid "Bibliotek.dk"
 msgstr ""
 
-#: catalog/models/common.py:32 catalog/models/common.py:92
+#: catalog/models/common.py:32 catalog/models/common.py:94
 msgid "eReolen.dk"
 msgstr ""
 
-#: catalog/models/common.py:33 catalog/models/common.py:74
+#: catalog/models/common.py:33 catalog/models/common.py:76
 #: catalog/templates/movie.html:41 catalog/templates/people.html:37
 #: catalog/templates/tvseason.html:58 catalog/templates/tvshow.html:53
 msgid "IMDb"
@@ -211,7 +210,7 @@ msgstr "IMDb"
 msgid "TMDB"
 msgstr "TMDB"
 
-#: catalog/models/common.py:35 catalog/models/common.py:94
+#: catalog/models/common.py:35 catalog/models/common.py:96
 msgid "Bandcamp"
 msgstr "Bandcamp"
 
@@ -227,11 +226,11 @@ msgstr "IGDB"
 msgid "Steam"
 msgstr "Steam"
 
-#: catalog/models/common.py:39 catalog/models/common.py:114
+#: catalog/models/common.py:39 catalog/models/common.py:116
 msgid "itch.io"
 msgstr ""
 
-#: catalog/models/common.py:40 catalog/models/common.py:115
+#: catalog/models/common.py:40 catalog/models/common.py:117
 msgid "Bangumi"
 msgstr "Bangumi"
 
@@ -239,7 +238,7 @@ msgstr "Bangumi"
 msgid "BGG"
 msgstr "BGG"
 
-#: catalog/models/common.py:42 catalog/models/common.py:116
+#: catalog/models/common.py:42 catalog/models/common.py:118
 msgid "Apple Podcast"
 msgstr "蘋果播客"
 
@@ -251,35 +250,35 @@ msgstr "RSS"
 msgid "Discogs"
 msgstr "Discogs"
 
-#: catalog/models/common.py:45 catalog/models/common.py:117
+#: catalog/models/common.py:45 catalog/models/common.py:119
 msgid "Apple Music"
 msgstr "蘋果音樂"
 
-#: catalog/models/common.py:46 catalog/models/common.py:119
+#: catalog/models/common.py:46 catalog/models/common.py:121
 msgid "Fediverse"
 msgstr "聯邦宇宙"
 
-#: catalog/models/common.py:47 catalog/models/common.py:120
+#: catalog/models/common.py:47 catalog/models/common.py:122
 msgid "Qidian"
 msgstr "起點"
 
-#: catalog/models/common.py:48 catalog/models/common.py:121
+#: catalog/models/common.py:48 catalog/models/common.py:123
 msgid "Ypshuo"
 msgstr "閱評說"
 
-#: catalog/models/common.py:49 catalog/models/common.py:122
+#: catalog/models/common.py:49 catalog/models/common.py:124
 msgid "Archive of Our Own"
 msgstr "AO3"
 
-#: catalog/models/common.py:50 catalog/models/common.py:123
+#: catalog/models/common.py:50 catalog/models/common.py:125
 msgid "JinJiang"
 msgstr "晉江文學"
 
-#: catalog/models/common.py:51 catalog/models/common.py:64
+#: catalog/models/common.py:51 catalog/models/common.py:66
 msgid "WikiData"
 msgstr "維基數據"
 
-#: catalog/models/common.py:52 catalog/models/common.py:124
+#: catalog/models/common.py:52 catalog/models/common.py:126
 msgid "Open Library"
 msgstr ""
 
@@ -293,17 +292,17 @@ msgstr "MusicBrainz ID"
 msgid "WorldCat"
 msgstr ""
 
-#: catalog/models/common.py:55 catalog/models/common.py:126
+#: catalog/models/common.py:55 catalog/models/common.py:128
 #, fuzzy
 #| msgid "Game"
 msgid "MobyGames"
 msgstr "遊戲"
 
-#: catalog/models/common.py:56 catalog/models/common.py:127
+#: catalog/models/common.py:56 catalog/models/common.py:129
 msgid "StoryGraph"
 msgstr ""
 
-#: catalog/models/common.py:57 catalog/models/common.py:118
+#: catalog/models/common.py:57 catalog/models/common.py:120
 #, fuzzy
 #| msgid "Douban Music"
 msgid "YouTube Music"
@@ -321,361 +320,372 @@ msgstr ""
 msgid "Readmoo"
 msgstr ""
 
-#: catalog/models/common.py:65
+#: catalog/models/common.py:61
+msgid "MyAnimeList"
+msgstr ""
+
+#: catalog/models/common.py:62 catalog/models/common.py:140
+#, fuzzy
+#| msgid "Update"
+msgid "MangaUpdates"
+msgstr "更新"
+
+#: catalog/models/common.py:67
 msgid "ISBN10"
 msgstr "ISBN10"
 
-#: catalog/models/common.py:66 catalog/templates/edition.html:19
+#: catalog/models/common.py:68 catalog/templates/edition.html:19
 msgid "ISBN"
 msgstr "ISBN"
 
-#: catalog/models/common.py:67
+#: catalog/models/common.py:69
 msgid "ASIN"
 msgstr "ASIN"
 
-#: catalog/models/common.py:68
+#: catalog/models/common.py:70
 msgid "ISSN"
 msgstr "ISSN"
 
-#: catalog/models/common.py:69
+#: catalog/models/common.py:71
 msgid "CUBN"
 msgstr "統一書號"
 
-#: catalog/models/common.py:70
+#: catalog/models/common.py:72
 msgid "ISRC"
 msgstr "ISRC"
 
-#: catalog/models/common.py:71
+#: catalog/models/common.py:73
 msgid "GTIN UPC EAN"
 msgstr "條形碼"
 
-#: catalog/models/common.py:72
+#: catalog/models/common.py:74
 msgid "OCLC Number"
 msgstr ""
 
-#: catalog/models/common.py:73
+#: catalog/models/common.py:75
 msgid "RSS Feed URL"
 msgstr "RSS網址"
 
-#: catalog/models/common.py:75
+#: catalog/models/common.py:77
 #, fuzzy
 #| msgid "TMDB TV Serie"
 msgid "TMDB TV Series"
 msgstr "TMDB電視劇集"
 
-#: catalog/models/common.py:76
+#: catalog/models/common.py:78
 msgid "TMDB TV Season"
 msgstr "TMDB電視分季"
 
-#: catalog/models/common.py:77
+#: catalog/models/common.py:79
 msgid "TMDB TV Episode"
 msgstr "TMDB電視單集"
 
-#: catalog/models/common.py:78
+#: catalog/models/common.py:80
 msgid "TMDB Movie"
 msgstr "TMDB電影"
 
-#: catalog/models/common.py:80
+#: catalog/models/common.py:82
 msgid "Goodreads Work"
 msgstr "Goodreads著作"
 
-#: catalog/models/common.py:82
+#: catalog/models/common.py:84
 msgid "Douban Book"
 msgstr "豆瓣圖書"
 
-#: catalog/models/common.py:83
+#: catalog/models/common.py:85
 msgid "Douban Book Work"
 msgstr "豆瓣圖書著作"
 
-#: catalog/models/common.py:84
+#: catalog/models/common.py:86
 msgid "Douban Movie"
 msgstr "豆瓣電影"
 
-#: catalog/models/common.py:85
+#: catalog/models/common.py:87
 msgid "Douban Music"
 msgstr "豆瓣音樂"
 
-#: catalog/models/common.py:86
+#: catalog/models/common.py:88
 msgid "Douban Game"
 msgstr "豆瓣遊戲"
 
-#: catalog/models/common.py:87
+#: catalog/models/common.py:89
 msgid "Douban Drama"
 msgstr "豆瓣舞臺劇"
 
-#: catalog/models/common.py:88
+#: catalog/models/common.py:90
 msgid "Douban Drama Version"
 msgstr "豆瓣舞臺劇版本"
 
-#: catalog/models/common.py:89
+#: catalog/models/common.py:91
 msgid "BooksTW Book"
 msgstr "博客來圖書"
 
-#: catalog/models/common.py:90
+#: catalog/models/common.py:92
 msgid "Readmoo Book"
 msgstr ""
 
-#: catalog/models/common.py:95
+#: catalog/models/common.py:97
 msgid "Spotify Album"
 msgstr "Spotify專輯"
 
-#: catalog/models/common.py:96
+#: catalog/models/common.py:98
 msgid "Spotify Podcast"
 msgstr "Spotify播客"
 
-#: catalog/models/common.py:97
+#: catalog/models/common.py:99
 msgid "Discogs Release"
 msgstr "Discogs發行"
 
-#: catalog/models/common.py:98
+#: catalog/models/common.py:100
 msgid "Discogs Master"
 msgstr "Discogs作品"
 
-#: catalog/models/common.py:101
+#: catalog/models/common.py:103
 #, fuzzy
 #| msgid "MusicBrainz ID"
 msgid "MusicBrainz Release Group"
 msgstr "MusicBrainz ID"
 
-#: catalog/models/common.py:103
+#: catalog/models/common.py:105
 #, fuzzy
 #| msgid "MusicBrainz ID"
 msgid "MusicBrainz Release"
 msgstr "MusicBrainz ID"
 
-#: catalog/models/common.py:104
+#: catalog/models/common.py:106
 #, fuzzy
 #| msgid "MusicBrainz ID"
 msgid "MusicBrainz Artist"
 msgstr "MusicBrainz ID"
 
-#: catalog/models/common.py:105
+#: catalog/models/common.py:107
 #, fuzzy
 #| msgid "Douban Game"
 msgid "Douban Personage"
 msgstr "豆瓣遊戲"
 
-#: catalog/models/common.py:106
+#: catalog/models/common.py:108
 #, fuzzy
 #| msgid "Goodreads Work"
 msgid "Goodreads Author"
 msgstr "Goodreads著作"
 
-#: catalog/models/common.py:107
+#: catalog/models/common.py:109
 #, fuzzy
 #| msgid "Spotify Podcast"
 msgid "Spotify Artist"
 msgstr "Spotify播客"
 
-#: catalog/models/common.py:108
+#: catalog/models/common.py:110
 #, fuzzy
 #| msgid "TMDB TV Season"
 msgid "TMDB Person"
 msgstr "TMDB電視分季"
 
-#: catalog/models/common.py:109
+#: catalog/models/common.py:111
 msgid "Open Library Author"
 msgstr ""
 
-#: catalog/models/common.py:110
+#: catalog/models/common.py:112
 msgid "IGDB Company"
 msgstr ""
 
-#: catalog/models/common.py:111
+#: catalog/models/common.py:113
 msgid "IGDB Game"
 msgstr "IGDB遊戲"
 
-#: catalog/models/common.py:112
+#: catalog/models/common.py:114
 msgid "BGG Boardgame"
 msgstr "BGG桌遊"
 
-#: catalog/models/common.py:113
+#: catalog/models/common.py:115
 msgid "Steam Game"
 msgstr "Steam遊戲"
 
-#: catalog/models/common.py:125
+#: catalog/models/common.py:127
 msgid "Open Library Work"
 msgstr ""
 
-#: catalog/models/common.py:128
+#: catalog/models/common.py:130
 msgid "RateYourMusic Release"
 msgstr ""
 
-#: catalog/models/common.py:132
+#: catalog/models/common.py:134
 msgid "AniList Anime"
 msgstr ""
 
-#: catalog/models/common.py:133
+#: catalog/models/common.py:135
 msgid "AniList Manga"
 msgstr ""
 
-#: catalog/models/common.py:134
+#: catalog/models/common.py:136
 msgid "MyAnimeList Anime"
 msgstr ""
 
-#: catalog/models/common.py:135
+#: catalog/models/common.py:137
 msgid "MyAnimeList Manga"
 msgstr ""
 
-#: catalog/models/common.py:156
+#: catalog/models/common.py:161
 msgid "Edition"
 msgstr "版本"
 
-#: catalog/models/common.py:157 catalog/templates/_sidebar_edit.html:286
+#: catalog/models/common.py:162 catalog/templates/_sidebar_edit.html:289
 msgid "Work"
 msgstr "作品"
 
-#: catalog/models/common.py:158
+#: catalog/models/common.py:163
 #, fuzzy
 #| msgid "TV Serie"
 msgid "TV Series"
 msgstr "電視劇集"
 
-#: catalog/models/common.py:159 catalog/templates/_sidebar_edit.html:207
+#: catalog/models/common.py:164 catalog/templates/_sidebar_edit.html:202
+#: catalog/views/edit.py:385
 msgid "TV Season"
 msgstr "電視分季"
 
-#: catalog/models/common.py:160
+#: catalog/models/common.py:165
 msgid "TV Episode"
 msgstr "電視單集"
 
-#: catalog/models/common.py:161 catalog/models/common.py:177
-#: catalog/models/common.py:191 catalog/templates/_sidebar_edit.html:200
-#: journal/templates/_sidebar_user_mark_list.html:35
+#: catalog/models/common.py:166 catalog/models/common.py:182
+#: catalog/models/common.py:196 catalog/templates/_sidebar_edit.html:196
+#: catalog/views/edit.py:384 journal/templates/_sidebar_user_mark_list.html:35
 #: journal/templates/_sidebar_user_tag_filter.html:27
 msgid "Movie"
 msgstr "電影"
 
-#: catalog/models/common.py:162
+#: catalog/models/common.py:167
 msgid "Album"
 msgstr "專輯"
 
-#: catalog/models/common.py:163 catalog/models/common.py:180
-#: catalog/models/common.py:194 common/templates/_header.html:43
+#: catalog/models/common.py:168 catalog/models/common.py:185
+#: catalog/models/common.py:199 common/templates/_header.html:53
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
 msgstr "遊戲"
 
-#: catalog/models/common.py:164
+#: catalog/models/common.py:169
 msgid "Podcast Program"
 msgstr "播客節目"
 
-#: catalog/models/common.py:165
+#: catalog/models/common.py:170
 msgid "Podcast Episode"
 msgstr "播客單集"
 
-#: catalog/models/common.py:166 catalog/models/common.py:182
-#: catalog/models/common.py:196 common/templates/_header.html:47
+#: catalog/models/common.py:171 catalog/models/common.py:187
+#: catalog/models/common.py:201 common/templates/_header.html:57
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
 msgstr "演出"
 
-#: catalog/models/common.py:167
+#: catalog/models/common.py:172
 msgid "Production"
 msgstr "上演"
 
-#: catalog/models/common.py:168
+#: catalog/models/common.py:173
 msgid "Exhibition"
 msgstr "展覽"
 
-#: catalog/models/common.py:169 catalog/models/common.py:186
+#: catalog/models/common.py:174 catalog/models/common.py:191
 #: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr "收藏單"
 
-#: catalog/models/common.py:172 catalog/models/common.py:185
+#: catalog/models/common.py:177 catalog/models/common.py:190
 msgid "Person / Organization"
 msgstr ""
 
-#: catalog/models/common.py:176 catalog/models/common.py:190
-#: common/templates/_header.html:27
+#: catalog/models/common.py:181 catalog/models/common.py:195
+#: common/templates/_header.html:37
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
 msgstr "圖書"
 
-#: catalog/models/common.py:178 catalog/models/common.py:192
+#: catalog/models/common.py:183 catalog/models/common.py:197
 #: journal/templates/_sidebar_user_mark_list.html:38
 #: journal/templates/_sidebar_user_tag_filter.html:30
 msgid "TV"
 msgstr "劇集"
 
-#: catalog/models/common.py:179 catalog/models/common.py:193
-#: common/templates/_header.html:39
+#: catalog/models/common.py:184 catalog/models/common.py:198
+#: common/templates/_header.html:49
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr "音樂"
 
-#: catalog/models/common.py:181 catalog/models/common.py:195
-#: catalog/templates/_sidebar_edit.html:219 common/templates/_header.html:35
+#: catalog/models/common.py:186 catalog/models/common.py:200
+#: catalog/templates/_sidebar_edit.html:213 common/templates/_header.html:45
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
 msgstr "播客"
 
-#: catalog/models/common.py:346 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:345 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr "類型"
 
-#: catalog/models/common.py:384
+#: catalog/models/common.py:383
 #, fuzzy
 #| msgid "original creator"
 msgid "origin country"
 msgstr "原始創作者"
 
-#: catalog/models/common.py:413 catalog/templates/album.html:33
+#: catalog/models/common.py:412 catalog/templates/album.html:33
 msgid "album type"
 msgstr "專輯類型"
 
-#: catalog/models/common.py:417 catalog/templates/_platform_list.html:5
+#: catalog/models/common.py:416 catalog/templates/_platform_list.html:5
 msgid "platform"
 msgstr "平臺"
 
-#: catalog/models/common.py:421
+#: catalog/models/common.py:420
 #, fuzzy
 #| msgid "media type"
 msgid "media format"
 msgstr "介質類型"
 
-#: catalog/models/common.py:426 catalog/templates/_language_list.html:5
-#: users/models/user.py:142
+#: catalog/models/common.py:425 catalog/templates/_language_list.html:5
+#: users/models/user.py:144
 msgid "language"
 msgstr "語言"
 
-#: catalog/models/creator.py:24
+#: catalog/models/creator.py:26
 #, fuzzy
 #| msgid "Pending"
 msgid "pending"
 msgstr "等待"
 
-#: catalog/models/creator.py:25
+#: catalog/models/creator.py:27
 msgid "verified"
 msgstr ""
 
-#: catalog/models/creator.py:26
+#: catalog/models/creator.py:28
 #, fuzzy
 #| msgid "Failed"
 msgid "failed"
 msgstr "失敗"
 
-#: catalog/models/creator.py:29
+#: catalog/models/creator.py:31
 msgid "no feed url available for this item"
 msgstr ""
 
-#: catalog/models/creator.py:30
+#: catalog/models/creator.py:32
 msgid "unable to fetch or parse the feed"
 msgstr ""
 
-#: catalog/models/creator.py:31
+#: catalog/models/creator.py:33
 msgid "no audio episode found in the feed"
 msgstr ""
 
-#: catalog/models/creator.py:34
+#: catalog/models/creator.py:36
 msgid "no matching identity found in the feed or its linked website"
 msgstr ""
 
@@ -711,16 +721,16 @@ msgstr "重製"
 msgid "Special Edition"
 msgstr "特別版"
 
-#: catalog/models/game.py:111 catalog/models/item.py:130
+#: catalog/models/game.py:111 catalog/models/item.py:126
 msgid "designer"
 msgstr "設計者"
 
-#: catalog/models/game.py:119 catalog/models/item.py:129
+#: catalog/models/game.py:119 catalog/models/item.py:125
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr "藝術家"
 
-#: catalog/models/game.py:127 catalog/models/item.py:139
+#: catalog/models/game.py:127 catalog/models/item.py:135
 msgid "developer"
 msgstr "開發者"
 
@@ -729,8 +739,8 @@ msgid "date of publication"
 msgstr "發行日期"
 
 #: catalog/models/game.py:147 catalog/models/movie.py:156
-#: catalog/models/music.py:128 catalog/models/tv.py:247
-#: catalog/models/tv.py:473
+#: catalog/models/music.py:128 catalog/models/tv.py:249
+#: catalog/models/tv.py:475
 msgid "YYYY, YYYY-MM or YYYY-MM-DD"
 msgstr ""
 
@@ -741,7 +751,7 @@ msgstr "發佈類型"
 #: catalog/models/game.py:180 catalog/models/movie.py:158
 #: catalog/models/people.py:178 catalog/models/performance.py:258
 #: catalog/models/performance.py:465 catalog/models/podcast.py:89
-#: catalog/models/tv.py:249 catalog/models/tv.py:476
+#: catalog/models/tv.py:251 catalog/models/tv.py:478
 #: catalog/templates/game.html:33 catalog/templates/movie.html:48
 #: catalog/templates/people.html:44 catalog/templates/performance.html:35
 #: catalog/templates/performanceproduction.html:35
@@ -750,152 +760,152 @@ msgstr "發佈類型"
 msgid "website"
 msgstr "網站"
 
-#: catalog/models/item.py:125 catalog/models/movie.py:123
+#: catalog/models/item.py:121 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
-#: catalog/models/tv.py:214 catalog/models/tv.py:440
+#: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr "導演"
 
-#: catalog/models/item.py:126 catalog/models/movie.py:130
+#: catalog/models/item.py:122 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
-#: catalog/models/tv.py:221 catalog/models/tv.py:447
+#: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr "編劇"
 
-#: catalog/models/item.py:127 catalog/models/movie.py:137
+#: catalog/models/item.py:123 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
-#: catalog/models/tv.py:228 catalog/models/tv.py:454
+#: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr "演員"
 
-#: catalog/models/item.py:128 catalog/models/movie.py:144
-#: catalog/models/tv.py:235 catalog/models/tv.py:461
+#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/tv.py:237 catalog/models/tv.py:463
 #, fuzzy
 #| msgid "production"
 msgid "producer"
 msgstr "上演"
 
-#: catalog/models/item.py:131 catalog/models/performance.py:203
+#: catalog/models/item.py:127 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr "作曲"
 
-#: catalog/models/item.py:132 catalog/models/performance.py:210
+#: catalog/models/item.py:128 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr "編舞"
 
-#: catalog/models/item.py:133 catalog/models/performance.py:224
+#: catalog/models/item.py:129 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr "表演者"
 
-#: catalog/models/item.py:134 catalog/models/podcast.py:80
+#: catalog/models/item.py:130 catalog/models/podcast.py:80
 msgid "host"
 msgstr "主播"
 
-#: catalog/models/item.py:135 catalog/models/performance.py:196
+#: catalog/models/item.py:131 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr "原始創作者"
 
-#: catalog/models/item.py:136 catalog/models/performance.py:238
+#: catalog/models/item.py:132 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr "工作人員"
 
-#: catalog/models/item.py:140
+#: catalog/models/item.py:136
 #, fuzzy
 #| msgid "production"
 msgid "production company"
 msgstr "上演"
 
-#: catalog/models/item.py:141
+#: catalog/models/item.py:137
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:142
+#: catalog/models/item.py:138
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:139
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:144 catalog/models/performance.py:231
+#: catalog/models/item.py:140 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr "劇團"
 
-#: catalog/models/item.py:147
+#: catalog/models/item.py:143
 #, fuzzy
 #| msgid "director"
 msgid "voice actor"
 msgstr "導演"
 
-#: catalog/models/item.py:148 catalog/templates/edition.html:30
+#: catalog/models/item.py:144 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr "出版社"
 
-#: catalog/models/item.py:173 catalog/models/people.py:476
+#: catalog/models/item.py:169 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr "角色"
 
-#: catalog/models/item.py:174 catalog/models/people.py:155
+#: catalog/models/item.py:170 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr "名字"
 
-#: catalog/models/item.py:176 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:288 catalog/models/item.py:320
-#: journal/models/collection.py:96
+#: catalog/models/item.py:304 catalog/models/item.py:336
+#: journal/models/collection.py:100
 msgid "title"
 msgstr "標題"
 
-#: catalog/models/item.py:289 catalog/models/item.py:328
-#: journal/models/collection.py:97
+#: catalog/models/item.py:305 catalog/models/item.py:344
+#: journal/models/collection.py:101
 msgid "description"
 msgstr "描述"
 
-#: catalog/models/item.py:300 catalog/models/people.py:484
+#: catalog/models/item.py:316 catalog/models/people.py:484
 msgid "metadata"
 msgstr "元數據"
 
-#: catalog/models/item.py:302 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
 msgid "cover"
 msgstr "封面"
 
-#: catalog/models/item.py:1485
+#: catalog/models/item.py:1526
 msgid "source site"
 msgstr "來源站點"
 
-#: catalog/models/item.py:1487
+#: catalog/models/item.py:1528
 msgid "ID on source site"
 msgstr "來源站點標識"
 
-#: catalog/models/item.py:1489
+#: catalog/models/item.py:1530
 msgid "source url"
 msgstr "來源站點網址"
 
-#: catalog/models/item.py:1505
+#: catalog/models/item.py:1546
 msgid "IdType of the source site"
 msgstr "來源站點的主要標識類型"
 
-#: catalog/models/item.py:1511
+#: catalog/models/item.py:1552
 msgid "Primary Id on the source site"
 msgstr "來源站點的主要標識數據"
 
-#: catalog/models/item.py:1514
+#: catalog/models/item.py:1555
 msgid "url to the resource"
 msgstr "指向外部資源的網址"
 
 #: catalog/models/movie.py:152 catalog/models/music.py:124
-#: catalog/models/tv.py:243 catalog/models/tv.py:469
+#: catalog/models/tv.py:245 catalog/models/tv.py:471
 #: catalog/templates/_item_card_metadata_album.html:16
 #: catalog/templates/album.html:17 catalog/templates/game.html:22
 #: catalog/templates/movie.html:36 catalog/templates/tvseason.html:53
@@ -910,7 +920,7 @@ msgid "length"
 msgstr "長度"
 
 #: catalog/models/movie.py:162 catalog/models/music.py:131
-#: catalog/models/tv.py:259 catalog/models/tv.py:486
+#: catalog/models/tv.py:261 catalog/models/tv.py:488
 #, fuzzy
 #| msgid "milliseconds"
 msgid "seconds"
@@ -1118,45 +1128,98 @@ msgstr "上演日期"
 msgid "closing date"
 msgstr "結束日期"
 
-#: catalog/models/tv.py:186 catalog/templates/tvseason.html:38
+#: catalog/models/tv.py:188 catalog/templates/tvseason.html:38
 #: catalog/templates/tvshow.html:33
 msgid "number of seasons"
 msgstr "季數"
 
-#: catalog/models/tv.py:189 catalog/models/tv.py:415
+#: catalog/models/tv.py:191 catalog/models/tv.py:417
 #: catalog/templates/tvseason.html:43 catalog/templates/tvshow.html:38
 msgid "number of episodes"
 msgstr "集數"
 
-#: catalog/models/tv.py:256 catalog/models/tv.py:483
+#: catalog/models/tv.py:258 catalog/models/tv.py:485
 msgid "episode length"
 msgstr "單集長度"
 
-#: catalog/models/tv.py:412 catalog/templates/tvseason.html:33
+#: catalog/models/tv.py:414 catalog/templates/tvseason.html:33
 msgid "season number"
 msgstr "本季序號"
 
-#: catalog/models/tv.py:530
+#: catalog/models/tv.py:532
 #, python-brace-format
 msgid "{show_title} Season {season_number}"
 msgstr "{show_title} 第{season_number}季"
 
-#: catalog/models/tv.py:684
+#: catalog/models/tv.py:686
 #, python-brace-format
 msgid "{season_title} E{episode_number}"
 msgstr "{season_title} 第{episode_number}集"
+
+#: catalog/templates/_catalog_confirm_item.html:7
+#: catalog/templates/catalog_edit.html:62
+msgid "Item has been deleted."
+msgstr "條目已被刪除"
+
+#: catalog/templates/_catalog_confirm_item.html:12
+#: catalog/templates/catalog_edit.html:65
+msgid "Item contains sub-items."
+msgstr "條目下已有子項"
+
+#: catalog/templates/_catalog_confirm_item.html:17
+msgid "Item has been merged to another item."
+msgstr "條目已被合併到其他條目"
+
+#: catalog/templates/_catalog_confirm_item.html:22
+msgid "Item has been marked by users."
+msgstr "條目已被用戶標記過"
+
+#: catalog/templates/_catalog_edit_preview.html:11
+#, fuzzy
+#| msgid "Confirm and save"
+msgid "Confirm changes"
+msgstr "確認並儲存"
+
+#: catalog/templates/_catalog_edit_preview.html:16
+msgid "Please correct the errors below."
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:24
+msgid "Field"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:25
+msgid "From"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:26
+msgid "To"
+msgstr ""
+
+#: catalog/templates/_catalog_edit_preview.html:45
+#, fuzzy
+#| msgid "Tag deleted."
+msgid "No changes detected."
+msgstr "標籤已刪除"
+
+#: catalog/templates/_catalog_edit_preview.html:54
+#: users/templates/users/register.html:104
+msgid "Confirm and save"
+msgstr "確認並儲存"
+
+#: catalog/templates/_catalog_edit_preview.html:57
+#, fuzzy
+#| msgid "back to item"
+msgid "Back to editing"
+msgstr "回到條目"
 
 #: catalog/templates/_country_list.html:5
 msgid "region"
 msgstr "地區"
 
 #: catalog/templates/_fetch_failed.html:4
-msgid ""
-"Unable to fetch from the link, please check again. Some sites may require "
-"login for certain links, please manually create them here."
-msgstr ""
-"無法加載條目，請確認連結正確。部分網站可能刪除條目或隱藏條目爲僅登入可見，歡"
-"迎在本站手工添加這些條目。"
+msgid "Unable to fetch from the link, please check again. Some sites may require login for certain links, please manually create them here."
+msgstr "無法加載條目，請確認連結正確。部分網站可能刪除條目或隱藏條目爲僅登入可見，歡迎在本站手工添加這些條目。"
 
 #: catalog/templates/_item_card_metadata_album.html:7
 #: catalog/templates/_item_card_metadata_edition.html:7
@@ -1213,7 +1276,7 @@ msgstr "顯示更多"
 #: journal/templates/profile_posts.html:21
 #: journal/templates/user_follow_list_items.html:63
 #: journal/templates/user_post_list_items.html:24
-#: social/templates/events.html:43 social/templates/feed_events.html:28
+#: social/templates/events.html:43 social/templates/feed_events.html:27
 msgid "nothing more."
 msgstr "沒有更多內容了。"
 
@@ -1312,7 +1375,7 @@ msgid "Add note"
 msgstr "添加電影"
 
 #: catalog/templates/_item_user_pieces.html:83
-#: common/templates/_sidebar.html:196 journal/templates/profile_items.html:46
+#: common/templates/_sidebar.html:195 journal/templates/profile_items.html:46
 #, fuzzy
 #| msgid "Sync in progress."
 msgid "Set progress"
@@ -1341,6 +1404,12 @@ msgstr "我的收藏單"
 #: catalog/templates/_item_user_pieces.html:214
 msgid "mark history"
 msgstr "標記歷史"
+
+#: catalog/templates/_search_suggest.html:2
+#, fuzzy
+#| msgid "Suggest Edits"
+msgid "Suggestions"
+msgstr "修改建議"
 
 #: catalog/templates/_sidebar_edit.html:8
 msgid "edit"
@@ -1371,15 +1440,15 @@ msgid "Edit Options"
 msgstr "編輯選項"
 
 #: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
-#: catalog/views/edit.py:82 catalog/views/edit.py:143 catalog/views/edit.py:197
-#: catalog/views/edit.py:218 catalog/views/edit.py:259
-#: catalog/views/edit.py:328 catalog/views/edit.py:332
-#: catalog/views/edit.py:351 catalog/views/edit.py:400
-#: catalog/views/edit.py:425 catalog/views/edit.py:440
-#: catalog/views/edit.py:480 catalog/views/edit.py:490
-#: catalog/views/edit.py:517 catalog/views/edit.py:582
-#: catalog/views/edit.py:637 catalog/views/edit.py:659
-#: catalog/views/search.py:367
+#: catalog/views/edit.py:160 catalog/views/edit.py:221
+#: catalog/views/edit.py:288 catalog/views/edit.py:309
+#: catalog/views/edit.py:364 catalog/views/edit.py:471
+#: catalog/views/edit.py:475 catalog/views/edit.py:509
+#: catalog/views/edit.py:576 catalog/views/edit.py:601
+#: catalog/views/edit.py:624 catalog/views/edit.py:664
+#: catalog/views/edit.py:674 catalog/views/edit.py:703
+#: catalog/views/edit.py:782 catalog/views/edit.py:837
+#: catalog/views/edit.py:859 catalog/views/search.py:418
 #, fuzzy
 #| msgid "Edit this item"
 msgid "Editing this item is restricted."
@@ -1417,7 +1486,7 @@ msgstr "條目已被用戶標記過"
 msgid "The following items are merged into this item"
 msgstr "以下條目被併入本條目"
 
-#: catalog/templates/_sidebar_edit.html:70
+#: catalog/templates/_sidebar_edit.html:70 catalog/views/edit.py:456
 msgid "External website"
 msgstr "外部網站"
 
@@ -1437,39 +1506,35 @@ msgstr "現有信息可能會被覆蓋。確認重新獲取嗎？"
 msgid "Fetch again"
 msgstr "重新獲取"
 
-#: catalog/templates/_sidebar_edit.html:97
-msgid "You may not be able to undo this operation, sure to remove?"
-msgstr "本操作不可撤銷。確認取消關聯嗎？"
-
-#: catalog/templates/_sidebar_edit.html:102
+#: catalog/templates/_sidebar_edit.html:100
 msgid "Remove link to site"
 msgstr "取消關聯"
 
-#: catalog/templates/_sidebar_edit.html:110
+#: catalog/templates/_sidebar_edit.html:108
 #, fuzzy
 #| msgid "Discover"
 msgid "Choose cover"
 msgstr "發現"
 
-#: catalog/templates/_sidebar_edit.html:119
+#: catalog/templates/_sidebar_edit.html:117
+#: catalog/templates/_sidebar_edit.html:118
 #: catalog/templates/_sidebar_edit.html:120
-#: catalog/templates/_sidebar_edit.html:122
 #, fuzzy
 #| msgid "Current Targets"
 msgid "Current cover"
 msgstr "當前目標"
 
-#: catalog/templates/_sidebar_edit.html:139
+#: catalog/templates/_sidebar_edit.html:137
 msgid "Select an image to use as the cover of this item."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:140
-#: catalog/templates/catalog_edit.html:65
-#: common/templates/manage/settings.html:136
+#: catalog/templates/_sidebar_edit.html:138
+#: catalog/templates/catalog_edit.html:78
+#: common/templates/manage/settings.html:19
 #: journal/templates/add_to_collection.html:43
 #: journal/templates/article_edit.html:60
 #: journal/templates/collection_edit.html:39 journal/templates/comment.html:41
-#: journal/templates/mark.html:134 journal/templates/note.html:65
+#: journal/templates/mark.html:138 journal/templates/note.html:65
 #: journal/templates/post_compose.html:103
 #: journal/templates/review_edit.html:46 journal/templates/tag_edit.html:51
 #: users/templates/users/_pref_device.html:37
@@ -1478,191 +1543,162 @@ msgstr ""
 msgid "Save"
 msgstr "保存"
 
-#: catalog/templates/_sidebar_edit.html:147
+#: catalog/templates/_sidebar_edit.html:145
 msgid "Edit sub-items"
 msgstr "編輯下級條目"
 
-#: catalog/templates/_sidebar_edit.html:160
+#: catalog/templates/_sidebar_edit.html:158
 msgid "create"
 msgstr "創建"
 
-#: catalog/templates/_sidebar_edit.html:166
+#: catalog/templates/_sidebar_edit.html:164
 msgid "Fetch all episodes"
 msgstr "批量獲取單集條目"
 
-#: catalog/templates/_sidebar_edit.html:171
+#: catalog/templates/_sidebar_edit.html:169
 msgid "Fetch all"
 msgstr "批量獲取"
 
-#: catalog/templates/_sidebar_edit.html:172
-msgid ""
-"Due to differences in how Douban, IMDB, and TMDB handle season data, a small "
-"number of TV shows and animations may not return correct results. Please "
-"manually verify and clean up after updating."
-msgstr ""
-"因豆瓣/IMDB/TMDB之間對分季處理的差異，少量劇集和動畫可能無法返回正確結果，更"
-"新後請手工確認和清理。"
+#: catalog/templates/_sidebar_edit.html:170
+msgid "Due to differences in how Douban, IMDB, and TMDB handle season data, a small number of TV shows and animations may not return correct results. Please manually verify and clean up after updating."
+msgstr "因豆瓣/IMDB/TMDB之間對分季處理的差異，少量劇集和動畫可能無法返回正確結果，更新後請手工確認和清理。"
 
-#: catalog/templates/_sidebar_edit.html:173
+#: catalog/templates/_sidebar_edit.html:171
 msgid "Up to 250 episodes will be fetched for a season."
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:176
-msgid ""
-"To fetch all episodes, season numbers and IMDB information are required. If "
-"filling this out is inconvenient, you can also manually create sub-entries."
-msgstr ""
-"批量獲取單集子條目需要本季序號和IMDB信息，不便填寫也可以手工創建子條目。"
+#: catalog/templates/_sidebar_edit.html:174
+msgid "To fetch all episodes, season numbers and IMDB information are required. If filling this out is inconvenient, you can also manually create sub-entries."
+msgstr "批量獲取單集子條目需要本季序號和IMDB信息，不便填寫也可以手工創建子條目。"
 
-#: catalog/templates/_sidebar_edit.html:182
-#: catalog/templates/_sidebar_edit.html:194
-#: catalog/templates/_sidebar_edit.html:213
+#: catalog/templates/_sidebar_edit.html:180
+#: catalog/templates/_sidebar_edit.html:191
+#: catalog/templates/_sidebar_edit.html:208
 msgid "switch category"
 msgstr "切換分類"
 
-#: catalog/templates/_sidebar_edit.html:185
-msgid "Switching may remove some metadata. Sure to proceed?"
-msgstr "切換分類可能移除部分數據字段，確認切換嗎？"
-
-#: catalog/templates/_sidebar_edit.html:188
+#: catalog/templates/_sidebar_edit.html:185 catalog/views/edit.py:383
 msgid "TV Show"
 msgstr "電視劇集"
 
-#: catalog/templates/_sidebar_edit.html:227
+#: catalog/templates/_sidebar_edit.html:221
 msgid "Link to parent item"
 msgstr "關聯到上一級條目"
 
 #: catalog/templates/_sidebar_edit.html:230
-msgid "Sure to link?"
-msgstr "確認關聯嗎？"
-
-#: catalog/templates/_sidebar_edit.html:237
 msgid "Update link"
 msgstr "更新關聯"
 
-#: catalog/templates/_sidebar_edit.html:243
+#: catalog/templates/_sidebar_edit.html:236
 msgid "Cleanup seasons"
 msgstr "本劇所有季"
 
-#: catalog/templates/_sidebar_edit.html:246
-#: catalog/templates/catalog_delete.html:45
-msgid "This operation cannot be undone. Sure to delete?"
-msgstr "本操作不可撤銷。確認刪除嗎？"
-
-#: catalog/templates/_sidebar_edit.html:250
+#: catalog/templates/_sidebar_edit.html:242
 msgid "remove seasons not marked"
 msgstr "清理單季"
 
-#: catalog/templates/_sidebar_edit.html:256
-#: catalog/templates/catalog_merge.html:12
+#: catalog/templates/_sidebar_edit.html:248
 msgid "Merge"
 msgstr "合併"
 
-#: catalog/templates/_sidebar_edit.html:262
+#: catalog/templates/_sidebar_edit.html:254
 msgid "URL of target item, or empty if undo merge"
 msgstr "目標條目URL，留空則取消現有合併"
 
-#: catalog/templates/_sidebar_edit.html:268
-#: catalog/templates/_sidebar_edit.html:348
+#: catalog/templates/_sidebar_edit.html:260
+#: catalog/templates/_sidebar_edit.html:350
 msgid "merge to another item"
 msgstr "合併到另一條目"
 
-#: catalog/templates/_sidebar_edit.html:273
-#: catalog/templates/_sidebar_edit.html:277
-#: catalog/templates/catalog_delete.html:12
+#: catalog/templates/_sidebar_edit.html:265
+#: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
 #: journal/templates/article.html:199 journal/templates/collection.html:188
-#: journal/templates/mark.html:149 journal/templates/note.html:82
+#: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
 #: users/templates/users/account.html:254
 msgid "Delete"
 msgstr "刪除"
 
-#: catalog/templates/_sidebar_edit.html:287
+#: catalog/templates/_sidebar_edit.html:275
+#: catalog/templates/_sidebar_edit.html:279
+#, fuzzy
+#| msgid "Tag deleted."
+msgid "Undo delete"
+msgstr "標籤已刪除"
+
+#: catalog/templates/_sidebar_edit.html:280
+msgid "Links to external sites and parent item were removed on delete and will not be restored."
+msgstr ""
+
+#: catalog/templates/_sidebar_edit.html:290
 msgid "This edition belongs to the following work"
 msgstr "這個圖書版本屬於以下作品"
 
-#: catalog/templates/_sidebar_edit.html:292
-msgid "Sure to unlink?"
-msgstr "確認取消關聯嗎？"
-
-#: catalog/templates/_sidebar_edit.html:298
+#: catalog/templates/_sidebar_edit.html:300
 msgid "Unlink from work"
 msgstr "取消關聯到上述著作"
 
-#: catalog/templates/_sidebar_edit.html:304
+#: catalog/templates/_sidebar_edit.html:306
 msgid "Link"
 msgstr "關聯"
 
-#: catalog/templates/_sidebar_edit.html:315
+#: catalog/templates/_sidebar_edit.html:317
 msgid "Link to another edition from same work"
 msgstr "關聯到同一著作的另一本書"
 
-#: catalog/templates/_sidebar_edit.html:324
+#: catalog/templates/_sidebar_edit.html:326
 #, fuzzy
 #| msgid "description"
 msgid "Restriction"
 msgstr "描述"
 
-#: catalog/templates/_sidebar_edit.html:337
+#: catalog/templates/_sidebar_edit.html:339
 #: journal/templates/collection_update_item_note.html:4
 msgid "Update"
 msgstr "更新"
 
-#: catalog/templates/_sidebar_edit.html:342
+#: catalog/templates/_sidebar_edit.html:344
 msgid "Suggest Edits"
 msgstr "修改建議"
 
-#: catalog/templates/_sidebar_edit.html:347
+#: catalog/templates/_sidebar_edit.html:349
 msgid "proposed action"
 msgstr "請選擇建議類型..."
 
-#: catalog/templates/_sidebar_edit.html:349
+#: catalog/templates/_sidebar_edit.html:351
 msgid "link to another item"
 msgstr "關聯到另一條目"
 
-#: catalog/templates/_sidebar_edit.html:350
+#: catalog/templates/_sidebar_edit.html:352
 msgid "change item category"
 msgstr "更改條目類型"
 
-#: catalog/templates/_sidebar_edit.html:351
+#: catalog/templates/_sidebar_edit.html:353
 msgid "change item metadata"
 msgstr "更正條目信息"
 
-#: catalog/templates/_sidebar_edit.html:352
+#: catalog/templates/_sidebar_edit.html:354
 msgid "remove item"
 msgstr "刪除條目"
 
-#: catalog/templates/_sidebar_edit.html:353
+#: catalog/templates/_sidebar_edit.html:355
 msgid "other"
 msgstr "其它"
 
-#: catalog/templates/_sidebar_edit.html:357
-msgid ""
-"To suggest merging or association, please include the URL of the target item"
+#: catalog/templates/_sidebar_edit.html:359
+msgid "To suggest merging or association, please include the URL of the target item"
 msgstr "建議詳情。如提議合併或關聯，請包含目標條目網址。"
 
-#: catalog/templates/_sidebar_edit.html:358
+#: catalog/templates/_sidebar_edit.html:360
 #: catalog/templates/catalog_verify.html:116
 msgid "submit"
 msgstr "提交"
 
-#: catalog/templates/_sidebar_edit.html:359
-msgid ""
-"As a user of this community, you may edit some metadata of items on this "
-"site. If you are unsure whether your edits are appropriate or are unable to "
-"make a certain change, you can make suggestions here. Moderators will "
-"consider each suggestion, although there is no guarantee that they will "
-"always be fully adopted; suggestions may also be viewed or discussed by "
-"other community users. If you have suggestions that are not related to a "
-"specific item, please contact us. Thank you for your support and "
-"contribution."
-msgstr ""
-"本站由用戶共同維護，用戶可自主修改部分條目信息。當你不確定自己的修改是否得當"
-"或不能做出某種修改時，可在此處向管理員提出建議。管理員會認真考慮處理每一條建"
-"議，雖然不保證總是完全採納；建議也可能被社區其他用戶查看或討論。如果有與具體"
-"條目不相關的建議，請訪問討論區或聯繫我們的社交帳號。感謝你的支持和貢獻。"
+#: catalog/templates/_sidebar_edit.html:361
+msgid "As a user of this community, you may edit some metadata of items on this site. If you are unsure whether your edits are appropriate or are unable to make a certain change, you can make suggestions here. Moderators will consider each suggestion, although there is no guarantee that they will always be fully adopted; suggestions may also be viewed or discussed by other community users. If you have suggestions that are not related to a specific item, please contact us. Thank you for your support and contribution."
+msgstr "本站由用戶共同維護，用戶可自主修改部分條目信息。當你不確定自己的修改是否得當或不能做出某種修改時，可在此處向管理員提出建議。管理員會認真考慮處理每一條建議，雖然不保證總是完全採納；建議也可能被社區其他用戶查看或討論。如果有與具體條目不相關的建議，請訪問討論區或聯繫我們的社交帳號。感謝你的支持和貢獻。"
 
 #: catalog/templates/_sidebar_search.html:5
 #: journal/templates/_sidebar_search_journal.html:4
@@ -1775,9 +1811,7 @@ msgid "matched"
 msgstr "看過"
 
 #: catalog/templates/_verify_status.html:21
-msgid ""
-"Sure to remove your creator verification? Anyone will be able to edit this "
-"item again."
+msgid "Sure to remove your creator verification? Anyone will be able to edit this item again."
 msgstr ""
 
 #: catalog/templates/_verify_status.html:26
@@ -1786,7 +1820,7 @@ msgstr ""
 msgid "Remove my verification"
 msgstr "從收藏單中移除"
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:309
+#: catalog/templates/_verify_status.html:31 users/views/account.py:311
 #, fuzzy
 #| msgid "Verification Code"
 msgid "Verification failed"
@@ -1829,43 +1863,11 @@ msgstr "條形碼"
 msgid "album media"
 msgstr "專輯介質"
 
-#: catalog/templates/catalog_delete.html:19
-msgid "Are you sure to delete?"
-msgstr "確認刪除嗎？"
-
-#: catalog/templates/catalog_delete.html:24
-#: catalog/templates/catalog_edit.html:52
-#: catalog/templates/catalog_merge.html:36
-#: catalog/templates/catalog_merge.html:64
-msgid "Item has been deleted."
-msgstr "條目已被刪除"
-
-#: catalog/templates/catalog_delete.html:29
-#: catalog/templates/catalog_edit.html:55
-#: catalog/templates/catalog_merge.html:41
-#: catalog/templates/catalog_merge.html:69
-msgid "Item contains sub-items."
-msgstr "條目下已有子項"
-
-#: catalog/templates/catalog_delete.html:34
-#: catalog/templates/catalog_merge.html:46
-#: catalog/templates/catalog_merge.html:74
-msgid "Item has been merged to another item."
-msgstr "條目已被合併到其他條目"
-
-#: catalog/templates/catalog_delete.html:39
-#: catalog/templates/catalog_merge.html:51
-#: catalog/templates/catalog_merge.html:79
-msgid "Item has been marked by users."
-msgstr "條目已被用戶標記過"
-
-#: catalog/templates/catalog_delete.html:48
-#: catalog/templates/catalog_merge.html:92 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:55 common/views_manage.py:139
 msgid "Yes"
 msgstr "是"
 
-#: catalog/templates/catalog_delete.html:49
-#: catalog/templates/catalog_merge.html:93 common/views_manage.py:51
+#: catalog/templates/catalog_confirm.html:56 common/views_manage.py:139
 msgid "No"
 msgstr "否"
 
@@ -1874,36 +1876,18 @@ msgstr "否"
 msgid "Create"
 msgstr "創建"
 
-#: catalog/templates/catalog_edit.html:68
+#: catalog/templates/catalog_edit.html:81
 #: journal/templates/collection_update_item_note.html:8
 #: journal/templates/piece_delete.html:38
 msgid "Cancel"
 msgstr "取消"
 
-#: catalog/templates/catalog_edit.html:104
+#: catalog/templates/catalog_edit.html:118
 msgid "open linked people page"
 msgstr ""
 
-#: catalog/templates/catalog_merge.html:22
-msgid "Are you sure to merge?"
-msgstr "確定合併嗎？"
-
-#: catalog/templates/catalog_merge.html:24
-msgid "Are you sure to cancel merge?"
-msgstr "確定取消合併嗎？"
-
-#: catalog/templates/catalog_merge.html:27
-msgid "Are you sure to link?"
-msgstr "確定關聯嗎？"
-
-#: catalog/templates/catalog_merge.html:86
-msgid "This operation cannot be undone. Sure to merge?"
-msgstr "本操作不可撤銷。確認合併嗎？"
-
 #: catalog/templates/catalog_verify.html:21
-msgid ""
-"If you are a creator of this podcast, you may verify the ownership, so that "
-"only you (and other verified creators) can edit its metadata on this site."
+msgid "If you are a creator of this podcast, you may verify the ownership, so that only you (and other verified creators) can edit its metadata on this site."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:22
@@ -1911,9 +1895,7 @@ msgid "Your recent episodes may also occasionally be featured in discovery."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:24
-msgid ""
-"To verify, prove you control one of the following identifiers of your "
-"account (click to copy):"
+msgid "To verify, prove you control one of the following identifiers of your account (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:30
@@ -1924,18 +1906,11 @@ msgid "copied"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:35
-msgid ""
-"You can prove this in a few ways, then start verification: add one of the "
-"identifiers above to the podcast feed's description; add a <code>rel=\"me\"</"
-"code> link back to one of them on the web page your feed links to (the link "
-"verification Mastodon uses); or point your feed's website at your Bluesky "
-"handle's own domain."
+msgid "You can prove this in a few ways, then start verification: add one of the identifiers above to the podcast feed's description; add a <code>rel=\"me\"</code> link back to one of them on the web page your feed links to (the link verification Mastodon uses); or point your feed's website at your Bluesky handle's own domain."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:44
-msgid ""
-"For example, add this rel=me link to the web page your feed links to (click "
-"to copy):"
+msgid "For example, add this rel=me link to the web page your feed links to (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:50
@@ -1943,9 +1918,7 @@ msgid "or, in the page's head:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:57
-msgid ""
-"Can't edit the website? Just add a line like this to your feed's description "
-"instead (click to copy):"
+msgid "Can't edit the website? Just add a line like this to your feed's description instead (click to copy):"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:62
@@ -1953,10 +1926,7 @@ msgid "Welcome to follow me on the Fediverse:"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:66
-msgid ""
-"NeoDB does not re-check this periodically at the moment, but we recommend "
-"you keep it so that your audience can discover and connect with you in "
-"distributed social media."
+msgid "NeoDB does not re-check this periodically at the moment, but we recommend you keep it so that your audience can discover and connect with you in distributed social media."
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:72
@@ -1986,12 +1956,11 @@ msgid "Send feedback"
 msgstr ""
 
 #: catalog/templates/catalog_verify.html:115
-msgid ""
-"Questions or issues with creator verification? Let the site moderators know."
+msgid "Questions or issues with creator verification? Let the site moderators know."
 msgstr ""
 
-#: catalog/templates/discover.html:28 common/views_manage.py:145
-#: common/views_manage.py:353 users/templates/users/preferences.html:34
+#: catalog/templates/discover.html:28 common/views_manage.py:35
+#: common/views_manage.py:431 users/templates/users/preferences.html:34
 msgid "Discover"
 msgstr "發現"
 
@@ -2029,17 +1998,17 @@ msgstr "顯示"
 msgid "hide"
 msgstr "隱藏"
 
-#: catalog/templates/discover.html:206 common/templates/_sidebar.html:14
+#: catalog/templates/discover.html:206 common/templates/_sidebar.html:13
 msgid "Unread Announcements"
 msgstr "未讀公告"
 
-#: catalog/templates/discover.html:212 common/templates/_sidebar.html:20
+#: catalog/templates/discover.html:212 common/templates/_sidebar.html:19
 #: social/templates/notification.html:67
 msgid "mark all as read"
 msgstr "全部標爲已讀"
 
 #: catalog/templates/discover.html:222
-#: common/templates/_sidebar_anonymous.html:55
+#: common/templates/_sidebar_anonymous.html:54
 msgid "Popular Tags"
 msgstr "熱門標籤"
 
@@ -2050,9 +2019,9 @@ msgstr "熱門標籤"
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
 #: catalog/templates/user_verified_works.html:23
-#: common/templates/_sidebar.html:127
-#: common/templates/_sidebar_anonymous.html:46
-#: common/templates/_sidebar_anonymous.html:62 journal/templates/posts.html:8
+#: common/templates/_sidebar.html:126
+#: common/templates/_sidebar_anonymous.html:45
+#: common/templates/_sidebar_anonymous.html:61 journal/templates/posts.html:7
 #: journal/templates/profile_articles.html:24
 #: journal/templates/profile_articles.html:26
 #: journal/templates/profile_items.html:65
@@ -2068,7 +2037,7 @@ msgstr "熱門標籤"
 msgid "nothing so far."
 msgstr "暫無內容。"
 
-#: catalog/templates/discover.html:239 common/templates/_sidebar.html:269
+#: catalog/templates/discover.html:239 common/templates/_sidebar.html:268
 msgid "Recent Posts"
 msgstr "近期帖文"
 
@@ -2097,12 +2066,8 @@ msgstr "借閱或購買"
 
 #: catalog/templates/external_search_results.html:10
 #, fuzzy
-#| msgid ""
-#| "System will search other websites and instances, click title of the item "
-#| "to save them locally. "
-msgid ""
-"Some items were found from other websites and instances, click their title "
-"to save them locally."
+#| msgid "System will search other websites and instances, click title of the item to save them locally. "
+msgid "Some items were found from other websites and instances, click their title to save them locally."
 msgstr "系統會嘗試搜索其它網站的條目，點擊標題可添加到本站。 "
 
 #: catalog/templates/fetch_pending.html:13
@@ -2204,14 +2169,14 @@ msgstr "季數"
 msgid "number of Episodes"
 msgstr "集數"
 
-#: catalog/templates/people.html:13 common/templates/_sidebar.html:77
-#: common/templates/_sidebar.html:84 journal/models/shelf.py:326
+#: catalog/templates/people.html:13 common/templates/_sidebar.html:76
+#: common/templates/_sidebar.html:83 journal/models/shelf.py:328
 #, fuzzy
 #| msgid "following you"
 msgid "following"
 msgstr "關注了你"
 
-#: catalog/templates/people.html:15 journal/models/shelf.py:324
+#: catalog/templates/people.html:15 journal/models/shelf.py:326
 #: social/templates/notification.html:60
 msgid "follow"
 msgstr "關注"
@@ -2230,7 +2195,6 @@ msgstr ""
 #: journal/templates/_sidebar_collection_filter.html:14
 #: journal/templates/_sidebar_collection_filter.html:28
 #: journal/templates/_sidebar_user_mark_list.html:56
-#: social/templates/feed.html:42 social/templates/feed.html:44
 #: social/templates/notification.html:56
 msgid "all"
 msgstr "全部"
@@ -2258,7 +2222,7 @@ msgstr "完成"
 msgid "production"
 msgstr "上演"
 
-#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:54
+#: catalog/templates/podcast.html:20 common/templates/_sidebar.html:53
 #, fuzzy
 #| msgid "original creator"
 msgid "verified creator"
@@ -2343,13 +2307,8 @@ msgid "No items matching your search query."
 msgstr "無站內條目匹配。"
 
 #: catalog/templates/search_results.html:34
-msgid ""
-"If you have URL from one of these sites, please put the full URL (e.g. "
-"<code>https://www.imdb.com/title/tt2513074/</code>) to the search box and "
-"press Enter."
-msgstr ""
-"如果你在以下網站找到了相關條目，也可以把連結(如 <code>https://"
-"movie.douban.com/subject/1309046/</code> )輸入到搜索欄中提交保存到本站。"
+msgid "If you have URL from one of these sites, please put the full URL (e.g. <code>https://www.imdb.com/title/tt2513074/</code>) to the search box and press Enter."
+msgstr "如果你在以下網站找到了相關條目，也可以把連結(如 <code>https://movie.douban.com/subject/1309046/</code> )輸入到搜索欄中提交保存到本站。"
 
 #: catalog/templates/search_results.html:48
 msgid "Searching from other sites"
@@ -2387,97 +2346,190 @@ msgstr ""
 msgid "Editions"
 msgstr "版本"
 
-#: catalog/views/edit.py:202 catalog/views/edit.py:205
-#: catalog/views/edit.py:306 catalog/views/edit.py:309
-#: catalog/views/verify.py:197 journal/views/collection.py:77
-#: journal/views/collection.py:102 journal/views/collection.py:556
-#: journal/views/collection.py:651 journal/views/common.py:221
-#: journal/views/mark.py:196 journal/views/post.py:117
-#: journal/views/post.py:119 journal/views/post.py:166
-#: journal/views/post.py:185 journal/views/post.py:187
-#: journal/views/post.py:228 journal/views/post.py:241
+#: catalog/views/edit.py:293 catalog/views/edit.py:296
+#: catalog/views/edit.py:440 catalog/views/edit.py:443
+#: catalog/views/verify.py:197 journal/views/collection.py:75
+#: journal/views/collection.py:100 journal/views/collection.py:538
+#: journal/views/collection.py:634 journal/views/common.py:231
+#: journal/views/mark.py:244 journal/views/post.py:119
+#: journal/views/post.py:121 journal/views/post.py:168
+#: journal/views/post.py:187 journal/views/post.py:189
+#: journal/views/post.py:230 journal/views/post.py:243
 #: journal/views/review.py:154 journal/views/review.py:158
-#: users/views/actions.py:179
+#: users/views/actions.py:178
 msgid "Invalid parameter"
 msgstr "無效參數"
 
-#: catalog/views/edit.py:220
+#: catalog/views/edit.py:313
 msgid "Item in use."
 msgstr "條目已被引用或標記。"
 
-#: catalog/views/edit.py:222
+#: catalog/views/edit.py:315
 msgid "Item cannot be deleted."
 msgstr "條目不可被刪除。"
 
-#: catalog/views/edit.py:247 catalog/views/edit.py:303
-#: catalog/views/edit.py:427 catalog/views/edit.py:519
-#: catalog/views/edit.py:552 catalog/views/verify.py:158
+#: catalog/views/edit.py:319 catalog/views/edit.py:515
+msgid "Are you sure to delete?"
+msgstr "確認刪除嗎？"
+
+#: catalog/views/edit.py:323 catalog/views/edit.py:518
+#: catalog/views/edit.py:617
+#, fuzzy
+#| msgid "This operation cannot be undone. Sure to merge?"
+msgid "This operation cannot be undone."
+msgstr "本操作不可撤銷。確認合併嗎？"
+
+#: catalog/views/edit.py:344 catalog/views/edit.py:437
+#: catalog/views/edit.py:603 catalog/views/edit.py:705
+#: catalog/views/edit.py:752 catalog/views/verify.py:158
 #: catalog/views/verify.py:206 journal/views/article.py:44
 #: journal/views/article.py:133 journal/views/article.py:153
 #: journal/views/collection.py:248 journal/views/collection.py:341
-#: journal/views/collection.py:360 journal/views/collection.py:384
-#: journal/views/collection.py:457 journal/views/collection.py:500
-#: journal/views/collection.py:539 journal/views/collection.py:551
-#: journal/views/collection.py:576 journal/views/collection.py:613
-#: journal/views/common.py:300 journal/views/mark.py:281
-#: journal/views/post.py:58 journal/views/post.py:78 journal/views/post.py:100
-#: journal/views/post.py:170 journal/views/post.py:199
-#: journal/views/post.py:272 journal/views/post.py:287
-#: journal/views/post.py:394 journal/views/post.py:549
+#: journal/views/collection.py:354 journal/views/collection.py:372
+#: journal/views/collection.py:439 journal/views/collection.py:482
+#: journal/views/collection.py:521 journal/views/collection.py:533
+#: journal/views/collection.py:558 journal/views/collection.py:595
+#: journal/views/common.py:304 journal/views/mark.py:317
+#: journal/views/post.py:60 journal/views/post.py:80 journal/views/post.py:102
+#: journal/views/post.py:172 journal/views/post.py:201
+#: journal/views/post.py:274 journal/views/post.py:289
+#: journal/views/post.py:390 journal/views/post.py:539
 #: journal/views/review.py:64 journal/views/review.py:81
 #: journal/views/review.py:106
 msgid "Insufficient permission"
 msgstr "權限不足"
 
-#: catalog/views/edit.py:374
+#: catalog/views/edit.py:346
+#, fuzzy
+#| msgid "Item has been deleted."
+msgid "Item is not deleted"
+msgstr "條目已被刪除"
+
+#: catalog/views/edit.py:389
+#, fuzzy
+#| msgid "Switching may remove some metadata. Sure to proceed?"
+msgid "Switching may remove some metadata."
+msgstr "切換分類可能移除部分數據字段，確認切換嗎？"
+
+#: catalog/views/edit.py:395
+#, fuzzy
+#| msgid "The following items are merged into this item"
+msgid "The following seasons will be detached from this show"
+msgstr "以下條目被併入本條目"
+
+#: catalog/views/edit.py:400
+msgid "Links to IMDB and TMDB will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:403
+#, fuzzy
+#| msgid "Are you sure to merge?"
+msgid "Are you sure to switch category?"
+msgstr "確定合併嗎？"
+
+#: catalog/views/edit.py:451
+#, fuzzy
+#| msgid "Are you sure to delete this post?"
+msgid "Are you sure to remove the link to this site?"
+msgstr "確認刪除這則帖文嗎？"
+
+#: catalog/views/edit.py:457
+#, fuzzy
+#| msgid "You may not be able to undo this operation, sure to remove?"
+msgid "You may not be able to undo this operation."
+msgstr "本操作不可撤銷。確認取消關聯嗎？"
+
+#: catalog/views/edit.py:483
+#, fuzzy
+#| msgid "Link to parent item"
+msgid "Current parent item"
+msgstr "關聯到上一級條目"
+
+#: catalog/views/edit.py:487
+msgid "The link to the parent item will be removed."
+msgstr ""
+
+#: catalog/views/edit.py:490 catalog/views/edit.py:680
+msgid "Are you sure to link?"
+msgstr "確定關聯嗎？"
+
+#: catalog/views/edit.py:521
+msgid "The following seasons will be deleted"
+msgstr ""
+
+#: catalog/views/edit.py:525
+msgid "The following seasons will be kept"
+msgstr ""
+
+#: catalog/views/edit.py:550
 msgid "TV Season with IMDB id and season number required."
 msgstr "必須是電視劇分季，且包含IMDB id和分季序號。"
 
-#: catalog/views/edit.py:380
+#: catalog/views/edit.py:556
 msgid "Updating episodes"
 msgstr "正在更新單集列表"
 
-#: catalog/views/edit.py:405
+#: catalog/views/edit.py:581
 msgid "This person has no supported source to fetch works from."
 msgstr ""
 
-#: catalog/views/edit.py:412
+#: catalog/views/edit.py:588
 msgid "Already pulling works for this person, try again later."
 msgstr ""
 
-#: catalog/views/edit.py:416
+#: catalog/views/edit.py:592
 msgid "Pulling works in background."
 msgstr ""
 
-#: catalog/views/edit.py:438
+#: catalog/views/edit.py:609
+msgid "Are you sure to merge?"
+msgstr "確定合併嗎？"
+
+#: catalog/views/edit.py:611
+msgid "Are you sure to cancel merge?"
+msgstr "確定取消合併嗎？"
+
+#: catalog/views/edit.py:622
 msgid "Cannot be merged to an item already deleted or merged"
 msgstr "無法合併到一個已經被合併或刪除的條目"
 
-#: catalog/views/edit.py:443
+#: catalog/views/edit.py:627
 msgid "Cannot merge items in different categories"
 msgstr "無法合併不同類型的條目"
 
-#: catalog/views/edit.py:447
+#: catalog/views/edit.py:631
 msgid "Cannot merge an item to itself"
 msgstr "無法合併條目和牠自身"
 
-#: catalog/views/edit.py:488
+#: catalog/views/edit.py:672
 msgid "Cannot be linked to an item already deleted or merged"
 msgstr "無法關聯到一個已經被合併或刪除的條目"
 
-#: catalog/views/edit.py:492
+#: catalog/views/edit.py:676
 msgid "Cannot link items other than editions"
 msgstr "無法關聯到非圖書類的條目"
 
-#: catalog/views/search.py:96
+#: catalog/views/edit.py:710
+#, fuzzy
+#| msgid "Are you sure to link?"
+msgid "Are you sure to unlink?"
+msgstr "確定關聯嗎？"
+
+#: catalog/views/edit.py:715
+#, fuzzy
+#| msgid "This edition belongs to the following work"
+msgid "This edition will be unlinked from the following work"
+msgstr "這個圖書版本屬於以下作品"
+
+#: catalog/views/search.py:113
 msgid "the internet"
 msgstr ""
 
-#: catalog/views/search.py:359
+#: catalog/views/search.py:410
 msgid "Invalid URL"
 msgstr "無效網址"
 
-#: catalog/views/search.py:362
+#: catalog/views/search.py:413
 msgid "Unsupported URL"
 msgstr "此類網址尚未支持"
 
@@ -2501,9 +2553,9 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:122 common/utils.py:163
+#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
 #: journal/views/article.py:186 journal/views/review.py:182
-#: users/views/actions.py:45 users/views/actions.py:131
+#: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
 msgstr "用戶不存在"
 
@@ -2517,15 +2569,15 @@ msgstr ""
 msgid "Creator verification removed."
 msgstr "發送驗證碼"
 
-#: catalog/views/view.py:74 catalog/views/view.py:99
+#: catalog/views/view.py:77 catalog/views/view.py:102
 msgid "Item not found"
 msgstr "條目不存在"
 
-#: catalog/views/view.py:78 catalog/views/view.py:107 catalog/views/view.py:190
+#: catalog/views/view.py:81 catalog/views/view.py:110 catalog/views/view.py:193
 msgid "Item no longer exists"
 msgstr "條目已不存在"
 
-#: catalog/views/view.py:187
+#: catalog/views/view.py:190
 #, fuzzy
 #| msgid "Invalid file."
 msgid "Invalid role"
@@ -3073,759 +3125,759 @@ msgctxt "genre"
 msgid "Health"
 msgstr ""
 
-#: common/models/lang.py:54
+#: common/models/lang.py:56
 msgid "Afar"
 msgstr ""
 
-#: common/models/lang.py:55
+#: common/models/lang.py:57
 msgid "Afrikaans"
 msgstr ""
 
-#: common/models/lang.py:56
+#: common/models/lang.py:58
 msgid "Akan"
 msgstr ""
 
-#: common/models/lang.py:57
+#: common/models/lang.py:59
 msgid "Aragonese"
 msgstr ""
 
-#: common/models/lang.py:58
+#: common/models/lang.py:60
 msgid "Assamese"
 msgstr ""
 
-#: common/models/lang.py:59
+#: common/models/lang.py:61
 msgid "Avaric"
 msgstr ""
 
-#: common/models/lang.py:60
+#: common/models/lang.py:62
 msgid "Avestan"
 msgstr ""
 
-#: common/models/lang.py:61
+#: common/models/lang.py:63
 msgid "Aymara"
 msgstr ""
 
-#: common/models/lang.py:62
+#: common/models/lang.py:64
 msgid "Azerbaijani"
 msgstr ""
 
-#: common/models/lang.py:63
+#: common/models/lang.py:65
 msgid "Bashkir"
 msgstr ""
 
-#: common/models/lang.py:64
+#: common/models/lang.py:66
 msgid "Bambara"
 msgstr ""
 
-#: common/models/lang.py:65
+#: common/models/lang.py:67
 msgid "Bislama"
 msgstr ""
 
-#: common/models/lang.py:66
+#: common/models/lang.py:68
 msgid "Tibetan"
 msgstr "藏語"
 
-#: common/models/lang.py:67
+#: common/models/lang.py:69
 msgid "Breton"
 msgstr ""
 
-#: common/models/lang.py:68
+#: common/models/lang.py:70
 msgid "Catalan"
 msgstr ""
 
-#: common/models/lang.py:69
+#: common/models/lang.py:71
 msgid "Czech"
 msgstr ""
 
-#: common/models/lang.py:70
+#: common/models/lang.py:72
 msgid "Chechen"
 msgstr ""
 
-#: common/models/lang.py:71
+#: common/models/lang.py:73
 msgid "Slavic"
 msgstr ""
 
-#: common/models/lang.py:72
+#: common/models/lang.py:74
 msgid "Chuvash"
 msgstr ""
 
-#: common/models/lang.py:73
+#: common/models/lang.py:75
 msgid "Cornish"
 msgstr ""
 
-#: common/models/lang.py:74
+#: common/models/lang.py:76
 msgid "Corsican"
 msgstr ""
 
-#: common/models/lang.py:75
+#: common/models/lang.py:77
 msgid "Cree"
 msgstr ""
 
-#: common/models/lang.py:76
+#: common/models/lang.py:78
 msgid "Welsh"
 msgstr ""
 
-#: common/models/lang.py:79
+#: common/models/lang.py:81
 msgid "Divehi"
 msgstr ""
 
-#: common/models/lang.py:80
+#: common/models/lang.py:82
 msgid "Dzongkha"
 msgstr ""
 
-#: common/models/lang.py:81
+#: common/models/lang.py:83
 msgid "Esperanto"
 msgstr ""
 
-#: common/models/lang.py:82
+#: common/models/lang.py:84
 msgid "Estonian"
 msgstr ""
 
-#: common/models/lang.py:83
+#: common/models/lang.py:85
 msgid "Basque"
 msgstr ""
 
-#: common/models/lang.py:84
+#: common/models/lang.py:86
 msgid "Faroese"
 msgstr ""
 
-#: common/models/lang.py:85
+#: common/models/lang.py:87
 msgid "Fijian"
 msgstr ""
 
-#: common/models/lang.py:86
+#: common/models/lang.py:88
 msgid "Finnish"
 msgstr ""
 
-#: common/models/lang.py:88
+#: common/models/lang.py:90
 msgid "Frisian"
 msgstr ""
 
-#: common/models/lang.py:89
+#: common/models/lang.py:91
 msgid "Fulah"
 msgstr ""
 
-#: common/models/lang.py:90
+#: common/models/lang.py:92
 msgid "Gaelic"
 msgstr ""
 
-#: common/models/lang.py:91
+#: common/models/lang.py:93
 msgid "Irish"
 msgstr ""
 
-#: common/models/lang.py:92
+#: common/models/lang.py:94
 msgid "Galician"
 msgstr ""
 
-#: common/models/lang.py:93
+#: common/models/lang.py:95
 msgid "Manx"
 msgstr ""
 
-#: common/models/lang.py:94
+#: common/models/lang.py:96
 msgid "Guarani"
 msgstr ""
 
-#: common/models/lang.py:95
+#: common/models/lang.py:97
 msgid "Gujarati"
 msgstr ""
 
-#: common/models/lang.py:96
+#: common/models/lang.py:98
 msgid "Haitian; Haitian Creole"
 msgstr ""
 
-#: common/models/lang.py:97
+#: common/models/lang.py:99
 msgid "Hausa"
 msgstr ""
 
-#: common/models/lang.py:98
+#: common/models/lang.py:100
 msgid "Serbo-Croatian"
 msgstr ""
 
-#: common/models/lang.py:99
+#: common/models/lang.py:101
 msgid "Herero"
 msgstr ""
 
-#: common/models/lang.py:100
+#: common/models/lang.py:102
 msgid "Hiri Motu"
 msgstr ""
 
-#: common/models/lang.py:101
+#: common/models/lang.py:103
 msgid "Croatian"
 msgstr ""
 
-#: common/models/lang.py:102
+#: common/models/lang.py:104
 msgid "Hungarian"
 msgstr ""
 
-#: common/models/lang.py:103
+#: common/models/lang.py:105
 msgid "Igbo"
 msgstr ""
 
-#: common/models/lang.py:104
+#: common/models/lang.py:106
 msgid "Ido"
 msgstr ""
 
-#: common/models/lang.py:105
+#: common/models/lang.py:107
 msgid "Yi"
 msgstr ""
 
-#: common/models/lang.py:106
+#: common/models/lang.py:108
 msgid "Inuktitut"
 msgstr ""
 
-#: common/models/lang.py:107
+#: common/models/lang.py:109
 msgid "Interlingue"
 msgstr ""
 
-#: common/models/lang.py:108
+#: common/models/lang.py:110
 msgid "Interlingua"
 msgstr ""
 
-#: common/models/lang.py:109
+#: common/models/lang.py:111
 msgid "Indonesian"
 msgstr ""
 
-#: common/models/lang.py:110
+#: common/models/lang.py:112
 msgid "Inupiaq"
 msgstr ""
 
-#: common/models/lang.py:111
+#: common/models/lang.py:113
 msgid "Icelandic"
 msgstr ""
 
-#: common/models/lang.py:113
+#: common/models/lang.py:115
 msgid "Javanese"
 msgstr ""
 
-#: common/models/lang.py:114
+#: common/models/lang.py:116
 msgid "Japanese"
 msgstr "日語"
 
-#: common/models/lang.py:115
+#: common/models/lang.py:117
 msgid "Kalaallisut"
 msgstr ""
 
-#: common/models/lang.py:116
+#: common/models/lang.py:118
 msgid "Kannada"
 msgstr ""
 
-#: common/models/lang.py:117
+#: common/models/lang.py:119
 msgid "Kashmiri"
 msgstr ""
 
-#: common/models/lang.py:118
+#: common/models/lang.py:120
 msgid "Kanuri"
 msgstr ""
 
-#: common/models/lang.py:119
+#: common/models/lang.py:121
 msgid "Kazakh"
 msgstr ""
 
-#: common/models/lang.py:120
+#: common/models/lang.py:122
 msgid "Khmer"
 msgstr ""
 
-#: common/models/lang.py:121
+#: common/models/lang.py:123
 msgid "Kikuyu"
 msgstr ""
 
-#: common/models/lang.py:122
+#: common/models/lang.py:124
 msgid "Kinyarwanda"
 msgstr ""
 
-#: common/models/lang.py:123
+#: common/models/lang.py:125
 msgid "Kirghiz"
 msgstr ""
 
-#: common/models/lang.py:124
+#: common/models/lang.py:126
 msgid "Komi"
 msgstr ""
 
-#: common/models/lang.py:125
+#: common/models/lang.py:127
 msgid "Kongo"
 msgstr ""
 
-#: common/models/lang.py:126
+#: common/models/lang.py:128
 msgid "Korean"
 msgstr "韓語"
 
-#: common/models/lang.py:127
+#: common/models/lang.py:129
 msgid "Kuanyama"
 msgstr ""
 
-#: common/models/lang.py:128
+#: common/models/lang.py:130
 msgid "Kurdish"
 msgstr ""
 
-#: common/models/lang.py:129
+#: common/models/lang.py:131
 msgid "Lao"
 msgstr ""
 
-#: common/models/lang.py:130
+#: common/models/lang.py:132
 msgid "Latin"
 msgstr ""
 
-#: common/models/lang.py:131
+#: common/models/lang.py:133
 msgid "Latvian"
 msgstr ""
 
-#: common/models/lang.py:132
+#: common/models/lang.py:134
 msgid "Limburgish"
 msgstr ""
 
-#: common/models/lang.py:133
+#: common/models/lang.py:135
 msgid "Lingala"
 msgstr ""
 
-#: common/models/lang.py:134
+#: common/models/lang.py:136
 msgid "Lithuanian"
 msgstr ""
 
-#: common/models/lang.py:135
+#: common/models/lang.py:137
 msgid "Letzeburgesch"
 msgstr ""
 
-#: common/models/lang.py:136
+#: common/models/lang.py:138
 msgid "Luba-Katanga"
 msgstr ""
 
-#: common/models/lang.py:137
+#: common/models/lang.py:139
 msgid "Ganda"
 msgstr ""
 
-#: common/models/lang.py:138
+#: common/models/lang.py:140
 msgid "Marshall"
 msgstr ""
 
-#: common/models/lang.py:139
+#: common/models/lang.py:141
 msgid "Malayalam"
 msgstr ""
 
-#: common/models/lang.py:140
+#: common/models/lang.py:142
 msgid "Marathi"
 msgstr ""
 
-#: common/models/lang.py:141
+#: common/models/lang.py:143
 msgid "Malagasy"
 msgstr ""
 
-#: common/models/lang.py:142
+#: common/models/lang.py:144
 msgid "Maltese"
 msgstr ""
 
-#: common/models/lang.py:143
+#: common/models/lang.py:145
 msgid "Moldavian"
 msgstr ""
 
-#: common/models/lang.py:144
+#: common/models/lang.py:146
 msgid "Mongolian"
 msgstr ""
 
-#: common/models/lang.py:145
+#: common/models/lang.py:147
 msgid "Maori"
 msgstr ""
 
-#: common/models/lang.py:146
+#: common/models/lang.py:148
 msgid "Malay"
 msgstr ""
 
-#: common/models/lang.py:147
+#: common/models/lang.py:149
 msgid "Burmese"
 msgstr ""
 
-#: common/models/lang.py:148
+#: common/models/lang.py:150
 msgid "Nauru"
 msgstr ""
 
-#: common/models/lang.py:149
+#: common/models/lang.py:151
 msgid "Navajo"
 msgstr ""
 
-#: common/models/lang.py:150 common/models/lang.py:151
+#: common/models/lang.py:152 common/models/lang.py:153
 msgid "Ndebele"
 msgstr ""
 
-#: common/models/lang.py:152
+#: common/models/lang.py:154
 msgid "Ndonga"
 msgstr ""
 
-#: common/models/lang.py:153
+#: common/models/lang.py:155
 msgid "Nepali"
 msgstr ""
 
-#: common/models/lang.py:154
+#: common/models/lang.py:156
 msgid "Dutch"
 msgstr ""
 
-#: common/models/lang.py:155
+#: common/models/lang.py:157
 msgid "Norwegian Nynorsk"
 msgstr ""
 
-#: common/models/lang.py:156
+#: common/models/lang.py:158
 msgid "Norwegian Bokmål"
 msgstr ""
 
-#: common/models/lang.py:157
+#: common/models/lang.py:159
 msgid "Norwegian"
 msgstr ""
 
-#: common/models/lang.py:158
+#: common/models/lang.py:160
 msgid "Chichewa; Nyanja"
 msgstr ""
 
-#: common/models/lang.py:159
+#: common/models/lang.py:161
 msgid "Occitan"
 msgstr ""
 
-#: common/models/lang.py:160
+#: common/models/lang.py:162
 msgid "Ojibwa"
 msgstr ""
 
-#: common/models/lang.py:161
+#: common/models/lang.py:163
 msgid "Oriya"
 msgstr ""
 
-#: common/models/lang.py:162
+#: common/models/lang.py:164
 msgid "Oromo"
 msgstr ""
 
-#: common/models/lang.py:163
+#: common/models/lang.py:165
 msgid "Ossetian; Ossetic"
 msgstr ""
 
-#: common/models/lang.py:164
+#: common/models/lang.py:166
 msgid "Pali"
 msgstr ""
 
-#: common/models/lang.py:165
+#: common/models/lang.py:167
 msgid "Polish"
 msgstr "波蘭語"
 
-#: common/models/lang.py:167
+#: common/models/lang.py:169
 msgid "Quechua"
 msgstr ""
 
-#: common/models/lang.py:168
+#: common/models/lang.py:170
 msgid "Raeto-Romance"
 msgstr ""
 
-#: common/models/lang.py:169
+#: common/models/lang.py:171
 msgid "Romanian"
 msgstr ""
 
-#: common/models/lang.py:170
+#: common/models/lang.py:172
 msgid "Rundi"
 msgstr ""
 
-#: common/models/lang.py:171
+#: common/models/lang.py:173
 msgid "Russian"
 msgstr "俄語"
 
-#: common/models/lang.py:172
+#: common/models/lang.py:174
 msgid "Sango"
 msgstr ""
 
-#: common/models/lang.py:173
+#: common/models/lang.py:175
 msgid "Sanskrit"
 msgstr ""
 
-#: common/models/lang.py:174
+#: common/models/lang.py:176
 msgid "Sinhalese"
 msgstr ""
 
-#: common/models/lang.py:175
+#: common/models/lang.py:177
 msgid "Slovak"
 msgstr ""
 
-#: common/models/lang.py:176
+#: common/models/lang.py:178
 msgid "Slovenian"
 msgstr ""
 
-#: common/models/lang.py:177
+#: common/models/lang.py:179
 msgid "Northern Sami"
 msgstr ""
 
-#: common/models/lang.py:178
+#: common/models/lang.py:180
 msgid "Samoan"
 msgstr ""
 
-#: common/models/lang.py:179
+#: common/models/lang.py:181
 msgid "Shona"
 msgstr ""
 
-#: common/models/lang.py:180
+#: common/models/lang.py:182
 msgid "Sindhi"
 msgstr ""
 
-#: common/models/lang.py:181
+#: common/models/lang.py:183
 msgid "Somali"
 msgstr ""
 
-#: common/models/lang.py:182
+#: common/models/lang.py:184
 msgid "Sotho"
 msgstr ""
 
-#: common/models/lang.py:184
+#: common/models/lang.py:186
 msgid "Albanian"
 msgstr ""
 
-#: common/models/lang.py:185
+#: common/models/lang.py:187
 msgid "Sardinian"
 msgstr ""
 
-#: common/models/lang.py:186
+#: common/models/lang.py:188
 msgid "Serbian"
 msgstr ""
 
-#: common/models/lang.py:187
+#: common/models/lang.py:189
 msgid "Swati"
 msgstr ""
 
-#: common/models/lang.py:188
+#: common/models/lang.py:190
 msgid "Sundanese"
 msgstr ""
 
-#: common/models/lang.py:189
+#: common/models/lang.py:191
 msgid "Swahili"
 msgstr ""
 
-#: common/models/lang.py:190
+#: common/models/lang.py:192
 msgid "Swedish"
 msgstr ""
 
-#: common/models/lang.py:191
+#: common/models/lang.py:193
 msgid "Tahitian"
 msgstr ""
 
-#: common/models/lang.py:192
+#: common/models/lang.py:194
 msgid "Tamil"
 msgstr ""
 
-#: common/models/lang.py:193
+#: common/models/lang.py:195
 msgid "Tatar"
 msgstr ""
 
-#: common/models/lang.py:194
+#: common/models/lang.py:196
 msgid "Telugu"
 msgstr ""
 
-#: common/models/lang.py:195
+#: common/models/lang.py:197
 msgid "Tajik"
 msgstr ""
 
-#: common/models/lang.py:196
+#: common/models/lang.py:198
 msgid "Tagalog"
 msgstr ""
 
-#: common/models/lang.py:197
+#: common/models/lang.py:199
 msgid "Thai"
 msgstr ""
 
-#: common/models/lang.py:198
+#: common/models/lang.py:200
 msgid "Tigrinya"
 msgstr ""
 
-#: common/models/lang.py:199
+#: common/models/lang.py:201
 msgid "Tonga"
 msgstr ""
 
-#: common/models/lang.py:200
+#: common/models/lang.py:202
 msgid "Tswana"
 msgstr ""
 
-#: common/models/lang.py:201
+#: common/models/lang.py:203
 msgid "Tsonga"
 msgstr ""
 
-#: common/models/lang.py:202
+#: common/models/lang.py:204
 msgid "Turkmen"
 msgstr ""
 
-#: common/models/lang.py:203
+#: common/models/lang.py:205
 msgid "Turkish"
 msgstr ""
 
-#: common/models/lang.py:204
+#: common/models/lang.py:206
 msgid "Twi"
 msgstr ""
 
-#: common/models/lang.py:205
+#: common/models/lang.py:207
 msgid "Uighur"
 msgstr ""
 
-#: common/models/lang.py:206
+#: common/models/lang.py:208
 msgid "Ukrainian"
 msgstr "烏克蘭語"
 
-#: common/models/lang.py:207
+#: common/models/lang.py:209
 msgid "Urdu"
 msgstr "烏爾都語"
 
-#: common/models/lang.py:208
+#: common/models/lang.py:210
 msgid "Uzbek"
 msgstr ""
 
-#: common/models/lang.py:209
+#: common/models/lang.py:211
 msgid "Venda"
 msgstr ""
 
-#: common/models/lang.py:210
+#: common/models/lang.py:212
 msgid "Vietnamese"
 msgstr "越南語"
 
-#: common/models/lang.py:211
+#: common/models/lang.py:213
 msgid "Volapük"
 msgstr ""
 
-#: common/models/lang.py:212
+#: common/models/lang.py:214
 msgid "Walloon"
 msgstr ""
 
-#: common/models/lang.py:213
+#: common/models/lang.py:215
 msgid "Wolof"
 msgstr ""
 
-#: common/models/lang.py:214
+#: common/models/lang.py:216
 msgid "Xhosa"
 msgstr ""
 
-#: common/models/lang.py:215
+#: common/models/lang.py:217
 msgid "Yiddish"
 msgstr ""
 
-#: common/models/lang.py:216
+#: common/models/lang.py:218
 msgid "Zhuang"
 msgstr ""
 
-#: common/models/lang.py:217
+#: common/models/lang.py:219
 msgid "Zulu"
 msgstr ""
 
-#: common/models/lang.py:218
+#: common/models/lang.py:220
 msgid "Abkhazian"
 msgstr ""
 
-#: common/models/lang.py:219
+#: common/models/lang.py:221
 msgid "Chinese"
 msgstr "中文"
 
-#: common/models/lang.py:220
+#: common/models/lang.py:222
 msgid "Pushto"
 msgstr ""
 
-#: common/models/lang.py:221
+#: common/models/lang.py:223
 msgid "Amharic"
 msgstr ""
 
-#: common/models/lang.py:222
+#: common/models/lang.py:224
 msgid "Arabic"
 msgstr "阿拉伯語"
 
-#: common/models/lang.py:223
+#: common/models/lang.py:225
 msgid "Bulgarian"
 msgstr ""
 
-#: common/models/lang.py:224
+#: common/models/lang.py:226
 msgid "Macedonian"
 msgstr ""
 
-#: common/models/lang.py:225
+#: common/models/lang.py:227
 msgid "Greek"
 msgstr ""
 
-#: common/models/lang.py:226
+#: common/models/lang.py:228
 msgid "Persian"
 msgstr "波斯語"
 
-#: common/models/lang.py:227
+#: common/models/lang.py:229
 msgid "Hebrew"
 msgstr ""
 
-#: common/models/lang.py:228
+#: common/models/lang.py:230
 msgid "Hindi"
 msgstr "印度語"
 
-#: common/models/lang.py:229
+#: common/models/lang.py:231
 msgid "Armenian"
 msgstr ""
 
-#: common/models/lang.py:231
+#: common/models/lang.py:233
 msgid "Ewe"
 msgstr ""
 
-#: common/models/lang.py:232
+#: common/models/lang.py:234
 msgid "Georgian"
 msgstr ""
 
-#: common/models/lang.py:233
+#: common/models/lang.py:235
 msgid "Punjabi"
 msgstr ""
 
-#: common/models/lang.py:234
+#: common/models/lang.py:236
 msgid "Bengali"
 msgstr ""
 
-#: common/models/lang.py:235
+#: common/models/lang.py:237
 msgid "Bosnian"
 msgstr ""
 
-#: common/models/lang.py:236
+#: common/models/lang.py:238
 msgid "Chamorro"
 msgstr ""
 
-#: common/models/lang.py:237
+#: common/models/lang.py:239
 msgid "Belarusian"
 msgstr ""
 
-#: common/models/lang.py:238
+#: common/models/lang.py:240
 msgid "Yoruba"
 msgstr ""
 
-#: common/models/lang.py:300
+#: common/models/lang.py:302
 msgid "Simplified Chinese (Mainland)"
 msgstr "簡體中文(大陸)"
 
-#: common/models/lang.py:301
+#: common/models/lang.py:303
 msgid "Traditional Chinese (Taiwan)"
 msgstr "正體中文(臺灣)"
 
-#: common/models/lang.py:302
+#: common/models/lang.py:304
 msgid "Traditional Chinese (Hongkong)"
 msgstr "繁體中文(香港)"
 
-#: common/models/lang.py:310
+#: common/models/lang.py:312
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: common/models/lang.py:313
+#: common/models/lang.py:315
 msgid "Simplified Chinese (Singapore)"
 msgstr "簡體中文(新加坡)"
 
-#: common/models/lang.py:314
+#: common/models/lang.py:316
 msgid "Simplified Chinese (Malaysia)"
 msgstr "簡體中文(馬來西亞)"
 
-#: common/models/lang.py:315
+#: common/models/lang.py:317
 msgid "Traditional Chinese (Macau)"
 msgstr "繁體中文(澳門)"
 
-#: common/models/lang.py:323
+#: common/models/lang.py:325
 msgid "Mandarin Chinese"
 msgstr "普通話"
 
-#: common/models/lang.py:324
+#: common/models/lang.py:326
 msgid "Yue Chinese"
 msgstr "粵語"
 
-#: common/models/lang.py:328
+#: common/models/lang.py:330
 msgid "Min Nan Chinese"
 msgstr "閩南語"
 
-#: common/models/lang.py:329
+#: common/models/lang.py:331
 msgid "Wu Chinese"
 msgstr "吳語"
 
-#: common/models/lang.py:330
+#: common/models/lang.py:332
 msgid "Hakka Chinese"
 msgstr "客家話"
 
@@ -3971,22 +4023,16 @@ msgid "VCD"
 msgstr ""
 
 #: common/templates/400.html:23
-msgid ""
-"You may have submitted invalid data, or the content may have been deleted by "
-"the author."
+msgid "You may have submitted invalid data, or the content may have been deleted by the author."
 msgstr "您可能提交了無效的數據，或者相關內容已被作者刪除。"
 
 #: common/templates/400.html:25 common/templates/403.html:24
 #: common/templates/404.html:24
-msgid ""
-"If you believe this is our mistake, please contact us through the link at "
-"the bottom of the page."
+msgid "If you believe this is our mistake, please contact us through the link at the bottom of the page."
 msgstr "如果您確信這是我們的錯誤，請通過頁面底部的連結聯繫我們。"
 
 #: common/templates/403.html:22
-msgid ""
-"Author may require you to log in before accessing this content, or you do "
-"not have permission to view it."
+msgid "Author may require you to log in before accessing this content, or you do not have permission to view it."
 msgstr "作者可能希望您登入後訪問，或者您沒有權限查看此內容。"
 
 #: common/templates/404.html:20
@@ -3994,9 +4040,7 @@ msgid "Something is missing"
 msgstr "未找到所需內容"
 
 #: common/templates/404.html:22
-msgid ""
-"You may have visited an incorrect URL, or the content you are looking for "
-"has been deleted by the author."
+msgid "You may have visited an incorrect URL, or the content you are looking for has been deleted by the author."
 msgstr "您可能訪問了錯誤的網址，或者相關內容已被作者刪除。"
 
 #: common/templates/404.html:26
@@ -4004,15 +4048,11 @@ msgid "Go to Home"
 msgstr ""
 
 #: common/templates/500.html:22
-msgid ""
-"An internal error occurred. If this error occurs repeatedly, it will be "
-"recorded and handled by a human."
+msgid "An internal error occurred. If this error occurs repeatedly, it will be recorded and handled by a human."
 msgstr "發生了一個內部錯誤，如果這個錯誤多次出現，後臺會記錄並會由人工處理。"
 
 #: common/templates/500.html:24
-msgid ""
-"If you have an urgent situation or any questions, please contact us through "
-"the link at the bottom of the page."
+msgid "If you have an urgent situation or any questions, please contact us through the link at the bottom of the page."
 msgstr "如果您有緊急情況或任何疑問，請通過頁面底部的連結聯繫我們。"
 
 #: common/templates/_footer.html:6
@@ -4027,277 +4067,225 @@ msgstr "服務協議"
 msgid "About"
 msgstr ""
 
-#: common/templates/_footer.html:12 users/templates/users/login.html:265
+#: common/templates/_footer.html:12 users/templates/users/login.html:259
 #, python-format
-msgid ""
-"You are visiting an alternative domain for %(site_name)s, please always use "
-"<a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if "
-"possible."
-msgstr ""
-"這是%(site_name)s的臨時鏡像，請儘可能使用<a "
-"href=\"%(site_url)s%(request.get_full_path)s\">原始站點</a>。"
+msgid "You are visiting an alternative domain for %(site_name)s, please always use <a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if possible."
+msgstr "這是%(site_name)s的臨時鏡像，請儘可能使用<a href=\"%(site_url)s%(request.get_full_path)s\">原始站點</a>。"
 
-#: common/templates/_header.html:19 common/templates/_header.html:164
+#: common/templates/_header.html:19 common/templates/_header.html:177
 msgid "title, creator, ISBN, item url, @user, @user@instance"
 msgstr "標題、創作者、ISBN、站外條目連結、@用戶名、@用戶名@實例"
 
-#: common/templates/_header.html:24
+#: common/templates/_header.html:34
 msgid "All Items"
 msgstr "所有條目"
 
-#: common/templates/_header.html:31
+#: common/templates/_header.html:41
 msgid "Movie & TV"
 msgstr "影視"
 
-#: common/templates/_header.html:50
+#: common/templates/_header.html:60
 msgid "People & Organizations"
 msgstr ""
 
-#: common/templates/_header.html:52
+#: common/templates/_header.html:62
 msgid "Journal"
 msgstr "記錄"
 
-#: common/templates/_header.html:54 journal/templates/user_post_list.html:10
+#: common/templates/_header.html:64 journal/templates/user_post_list.html:10
 #: journal/templates/user_post_list.html:23
 msgid "Posts"
 msgstr "帖文"
 
-#: common/templates/_header.html:89
+#: common/templates/_header.html:102
 msgid "Explore"
 msgstr "發現"
 
-#: common/templates/_header.html:93
+#: common/templates/_header.html:106 common/views_manage.py:36
 msgid "Feed"
 msgstr "動態"
 
-#: common/templates/_header.html:98 journal/templates/profile.html:13
+#: common/templates/_header.html:111 journal/templates/profile.html:13
 #: users/templates/users/preferences.html:46
 msgid "Home"
 msgstr "主頁"
 
-#: common/templates/_header.html:114 common/templates/common/scan.html:9
+#: common/templates/_header.html:127 common/templates/common/scan.html:9
 #: common/templates/common/scan.html:42
 #, fuzzy
 #| msgid "barcode"
 msgid "Scan Barcode"
 msgstr "條形碼"
 
-#: common/templates/_header.html:118 social/templates/notification.html:12
+#: common/templates/_header.html:131 social/templates/notification.html:12
 #: social/templates/notification.html:53
 msgid "Notification"
 msgstr "通知"
 
-#: common/templates/_header.html:122 users/models/task.py:21
+#: common/templates/_header.html:135 users/models/task.py:23
 #: users/templates/users/account.html:219
 #: users/templates/users/crossposts.html:9
 msgid "Pending"
 msgstr "等待"
 
-#: common/templates/_header.html:125
+#: common/templates/_header.html:138
 msgid "Data"
 msgstr "數據"
 
-#: common/templates/_header.html:128 common/templates/_header.html:146
+#: common/templates/_header.html:141 common/templates/_header.html:159
 #: users/templates/users/preferences.html:12
 #: users/templates/users/preferences.html:23
 #: users/templates/users/preferences_anonymous.html:13
 msgid "Preferences"
 msgstr "設定"
 
-#: common/templates/_header.html:131
+#: common/templates/_header.html:144
 msgid "Account"
 msgstr "帳號"
 
-#: common/templates/_header.html:135
+#: common/templates/_header.html:148
 msgid "Manage"
 msgstr "管理"
 
-#: common/templates/_header.html:139
+#: common/templates/_header.html:152
 msgid "Logout"
 msgstr "登出"
 
-#: common/templates/_header.html:143
+#: common/templates/_header.html:156
 msgid "Sign up or Login"
 msgstr "註冊或登入"
 
-#: common/templates/_header.html:160
-msgid ""
-"title or content  category:tv  status:complete  rating:8..10  "
-"date:2021-09-11..2022-02"
-msgstr ""
-"搜索你的評論或條目，可加過濾條件如 category:tv status:complete rating:8..10 "
-"date:2021-09-11..2022-02"
+#: common/templates/_header.html:173
+msgid "title or content  category:tv  status:complete  rating:8..10  date:2021-09-11..2022-02"
+msgstr "搜索你的評論或條目，可加過濾條件如 category:tv status:complete rating:8..10 date:2021-09-11..2022-02"
 
-#: common/templates/_header.html:162
+#: common/templates/_header.html:175
 msgid "name of a person or company"
 msgstr ""
 
-#: common/templates/_header.html:179
+#: common/templates/_header.html:192
 msgid "Open"
 msgstr "打開"
 
-#: common/templates/_sidebar.html:62
+#: common/templates/_sidebar.html:61
 #: users/templates/users/profile_actions.html:36
 msgid "approving followers manually"
 msgstr "已開啓關注審覈"
 
-#: common/templates/_sidebar.html:81 common/templates/_sidebar.html:86
+#: common/templates/_sidebar.html:80 common/templates/_sidebar.html:85
 #, fuzzy
 #| msgid "followed"
 msgid "followers"
 msgstr "已關注"
 
-#: common/templates/_sidebar.html:112
+#: common/templates/_sidebar.html:111
 msgid "Current Targets"
 msgstr "當前目標"
 
-#: common/templates/_sidebar.html:125
+#: common/templates/_sidebar.html:124
 msgid "Set a collection as target, its progress will show up here."
 msgstr "將自己或他人的收藏單設爲目標，這裏就會顯示進度"
 
-#: common/templates/_sidebar.html:138
+#: common/templates/_sidebar.html:137
 msgid "Recent podcast episodes"
 msgstr "近期播客節目"
 
-#: common/templates/_sidebar.html:173
+#: common/templates/_sidebar.html:172
 msgid "Currently reading"
 msgstr "正在閱讀"
 
-#: common/templates/_sidebar.html:215
+#: common/templates/_sidebar.html:214
 msgid "Currently watching"
 msgstr "正在追看"
 
-#: common/templates/_sidebar.html:238 journal/forms.py:217
+#: common/templates/_sidebar.html:237 journal/forms.py:217
 #: journal/templates/user_tag_list.html:13
 #: journal/templates/user_tagmember_list.html:4
 msgid "Tags"
 msgstr "標籤"
 
-#: common/templates/_sidebar.html:244 journal/templates/user_tag_list.html:28
+#: common/templates/_sidebar.html:243 journal/templates/user_tag_list.html:28
 #: journal/templates/user_tagmember_list.html:10
 msgid "featured tag"
 msgstr "置頂標籤"
 
-#: common/templates/_sidebar.html:247 journal/templates/user_tag_list.html:31
+#: common/templates/_sidebar.html:246 journal/templates/user_tag_list.html:31
 #: journal/templates/user_tagmember_list.html:15
 msgid "personal tag"
 msgstr "個人標籤"
 
-#: common/templates/_sidebar.html:254 journal/templates/user_tag_list.html:39
+#: common/templates/_sidebar.html:253 journal/templates/user_tag_list.html:39
 msgid "no tags so far."
 msgstr "暫無標籤。"
 
-#: common/templates/_sidebar.html:258 common/templates/_sidebar.html:271
+#: common/templates/_sidebar.html:257 common/templates/_sidebar.html:270
 msgid "show all"
 msgstr "顯示全部"
 
-#: common/templates/_sidebar_anonymous.html:16
+#: common/templates/_sidebar_anonymous.html:15
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
 #| "        <h3>Welcome 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s "
-#| "is committed to creating a free, open, and interconnected space for "
-#| "collecting and reviewing books, movies, music, games, and podcasts. Here, "
-#| "you can document your collections and thoughts, discover new content, and "
-#| "connect with others.\n"
+#| "          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is committed to creating a free, open, and interconnected space for collecting and reviewing books, movies, music, games, and podcasts. Here, you can document your collections and thoughts, discover new content, and connect with others.\n"
 #| "        </p>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log "
-#| "in to %(site_name)s is through a Fediverse (a distributed social network, "
-#| "including Mastodon/Pleroma/etc) instance account. If you haven’t "
-#| "registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" "
-#| "target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
+#| "          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in to %(site_name)s is through a Fediverse (a distributed social network, including Mastodon/Pleroma/etc) instance account. If you haven’t registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
 #| "        </p>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not "
-#| "ready to join the Fediverse, that’s perfectly fine. You can create an "
-#| "account here using your email address, and link it to the Fediverse "
-#| "whenever you’re ready.\n"
+#| "          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready to join the Fediverse, that’s perfectly fine. You can create an account here using your email address, and link it to the Fediverse whenever you’re ready.\n"
 #| "        </p>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you "
-#| "have any questions or suggestions, feel free to contact us via <a "
-#| "href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a "
-#| "href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
+#| "          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have any questions or suggestions, feel free to contact us via <a href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 #| "        </p>\n"
 #| "        <p>\n"
-#| "          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-#| "href=\"%(login_url)s\">Click here</a> to register or log in.\n"
+#| "          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Click here</a> to register or log in.\n"
 #| "        </p>\n"
 #| "        "
 msgid ""
 "\n"
 "        <h3>Welcome 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is "
-"committed to creating a free, open, and interconnected space for collecting "
-"and reviewing books, movies, music, games, and podcasts. Here, you can "
-"manage your collections, share your thoughts, discover new content, and "
-"connect with others.\n"
+"          <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s is committed to creating a free, open, and interconnected space for collecting and reviewing books, movies, music, games, and podcasts. Here, you can manage your collections, share your thoughts, discover new content, and connect with others.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in "
-"to %(site_name)s is through a Fediverse (a distributed social network, "
-"including Mastodon/Pleroma/etc) instance account. If you haven’t registered "
-"yet, you can <a href=\"https://joinmastodon.org/en/servers\" "
-"target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
+"          <i class=\"fa-solid fa-globe\"></i> &nbsp; The best way to log in to %(site_name)s is through a Fediverse (a distributed social network, including Mastodon/Pleroma/etc) instance account. If you haven’t registered yet, you can <a href=\"https://joinmastodon.org/en/servers\" target=\"_blank\">choose a Fediverse instance and sign up</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log "
-"in is through a Bluesky (another distributed social network, also called "
-"ATProto) account. If you haven’t registered yet, you may <a href=\"https://"
-"bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
+"          <i class=\"fa-brands fa-bluesky\"></i> &nbsp; Another way to log in is through a Bluesky (another distributed social network, also called ATProto) account. If you haven’t registered yet, you may <a href=\"https://bsky.app\" target=\"_blank\">sign up via bsky.app</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready "
-"to join either Fediverse or Bluesky, that’s perfectly fine. You can create "
-"an account here using your email address, and link it to the Fediverse and "
-"Bluesky in settings whenever you’re ready.\n"
+"          <i class=\"fa-solid fa-envelope\"></i> &nbsp; If you’re not ready to join either Fediverse or Bluesky, that’s perfectly fine. You can create an account here using your email address, and link it to the Fediverse and Bluesky in settings whenever you’re ready.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have "
-"any questions or suggestions, please feel free to contact us via <a "
-"href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://"
-"discord.gg/uprvcH8gqD\">Discord</a>.\n"
+"          <i class=\"fa-solid fa-circle-question\"></i> &nbsp; If you have any questions or suggestions, please feel free to contact us via <a href=\"https://mastodon.social/@neodb\">Fediverse</a> or <a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>.\n"
 "        </p>\n"
 "        <p>\n"
-"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a "
-"href=\"%(login_url)s\">Click here</a> to register or log in.\n"
+"          <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">Click here</a> to register or log in.\n"
 "        </p>\n"
 "        "
 msgstr ""
 "\n"
 "<h3>歡迎 🙋🏻‍♀️ 🙋🏻 🙋🏻‍♂️</h3>\n"
 "<p>\n"
-"  <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s 致力於提供"
-"一個涵蓋書籍、影視、音樂、遊戲、播客的自由開放互聯的收藏評論空間。 你可以在這"
-"裏記錄你的收藏和想法，以及發現新的內容和朋友。\n"
+"  <i class=\"fa-solid fa-puzzle-piece\"></i> &nbsp; %(site_name)s 致力於提供一個涵蓋書籍、影視、音樂、遊戲、播客的自由開放互聯的收藏評論空間。 你可以在這裏記錄你的收藏和想法，以及發現新的內容和朋友。\n"
 "</p>\n"
 "<p>\n"
-"  <i class=\"fa-solid fa-globe\"></i> &nbsp; 登入%(site_name)s的最佳方式通過"
-"聯邦宇宙（Fediverse，有時也被稱爲<em data-tooltip=\"除了最常見的長毛象，另外"
-"也有Pleroma、GoToSocial、Takahē、Catodon等聯邦宇宙實例服務\">長毛象</em>，一"
-"種分佈式社交網絡）實例帳號，如果你還沒有註冊過，可先<a href=\"https://"
-"joinmastodon.org/zh/servers\" target=\"_blank\">選擇實例並註冊</a>。\n"
+"  <i class=\"fa-solid fa-globe\"></i> &nbsp; 登入%(site_name)s的最佳方式通過聯邦宇宙（Fediverse，有時也被稱爲<em data-tooltip=\"除了最常見的長毛象，另外也有Pleroma、GoToSocial、Takahē、Catodon等聯邦宇宙實例服務\">長毛象</em>，一種分佈式社交網絡）實例帳號，如果你還沒有註冊過，可先<a href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">選擇實例並註冊</a>。\n"
 "</p>\n"
 "<p>\n"
-"  <i class=\"fa-solid fa-envelope\"></i> &nbsp; 如果還沒準備好註冊聯邦宇宙也"
-"沒問題，你可以在登入頁面選擇電子郵件註冊，未來再連接到聯邦宇宙。\n"
+"  <i class=\"fa-solid fa-envelope\"></i> &nbsp; 如果還沒準備好註冊聯邦宇宙也沒問題，你可以在登入頁面選擇電子郵件註冊，未來再連接到聯邦宇宙。\n"
 "</p>\n"
 "<p>\n"
-"  <i class=\"fa-solid fa-circle-question\"></i> &nbsp; 如果有任何問題或建議，"
-"歡迎通過<a href=\"https://mastodon.social/@neodb\">聯邦宇宙</a>或<a "
-"href=\"https://discord.gg/uprvcH8gqD\">Discord</a>和我們聯繫。\n"
+"  <i class=\"fa-solid fa-circle-question\"></i> &nbsp; 如果有任何問題或建議，歡迎通過<a href=\"https://mastodon.social/@neodb\">聯邦宇宙</a>或<a href=\"https://discord.gg/uprvcH8gqD\">Discord</a>和我們聯繫。\n"
 "</p>\n"
 "<p>\n"
-"  <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">點"
-"擊這裏</a>註冊或登入。\n"
+"  <i class=\"fa-solid fa-door-open\"></i> &nbsp; <a href=\"%(login_url)s\">點擊這裏</a>註冊或登入。\n"
 "</p>\n"
 "        "
 
-#: common/templates/_sidebar_anonymous.html:43
+#: common/templates/_sidebar_anonymous.html:42
 #: users/templates/users/announcements.html:12
 #: users/templates/users/announcements.html:39
 msgid "Announcements"
@@ -4325,7 +4313,7 @@ msgstr "源代碼"
 msgid "Registration"
 msgstr "註冊失敗"
 
-#: common/templates/common/about.html:35 common/views_manage.py:493
+#: common/templates/common/about.html:35 common/views_manage.py:594
 #, fuzzy
 #| msgid "Mentioned Only"
 msgid "Invite Only"
@@ -4337,7 +4325,7 @@ msgstr "自己和提到的人"
 msgid "Open Registration"
 msgstr "註冊失敗"
 
-#: common/templates/common/about.html:40 common/views_manage.py:556
+#: common/templates/common/about.html:40 common/views_manage.py:657
 #, fuzzy
 #| msgid "Preferences"
 msgid "Preferred Languages"
@@ -4392,9 +4380,7 @@ msgid "Error"
 msgstr "錯誤"
 
 #: common/templates/common/scan.html:45
-msgid ""
-"Point the camera at a book ISBN or product barcode (EAN / UPC). You will be "
-"redirected to the search once a code is detected."
+msgid "Point the camera at a book ISBN or product barcode (EAN / UPC). You will be redirected to the search once a code is detected."
 msgstr ""
 
 #: common/templates/common/scan.html:50
@@ -4405,7 +4391,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:628
+#: common/templates/common/scan.html:60 common/views_manage.py:738
 #, fuzzy
 #| msgid "Search results"
 msgid "Search"
@@ -4439,21 +4425,33 @@ msgstr ""
 msgid "Camera unavailable. Use manual entry below."
 msgstr ""
 
-#: common/templates/manage/settings.html:9
+#: common/templates/manage/base.html:9
 #, fuzzy
 #| msgid "Additional Settings"
 msgid "Site Settings"
 msgstr "更多設定"
 
-#: common/templates/manage/settings.html:109
+#: common/templates/manage/base.html:127
 msgid "Takahe Admin"
 msgstr ""
 
-#: common/templates/manage/settings.html:112
+#: common/templates/manage/base.html:130
 #, fuzzy
 #| msgid "Database"
 msgid "Database Admin"
 msgstr "數據庫"
+
+#: common/templates/manage/environment.html:6
+msgid "These settings come from environment variables and cannot be changed here. Edit .env and restart the server to change them. Passwords and keys are hidden."
+msgstr ""
+
+#: common/templates/manage/environment.html:23
+msgid "(empty)"
+msgstr ""
+
+#: common/templates/manage/environment.html:26
+msgid "default"
+msgstr ""
 
 #: common/templatetags/duration.py:59
 msgid "just now"
@@ -4471,7 +4469,7 @@ msgstr "已關注"
 msgid "following you"
 msgstr "關注了你"
 
-#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:95
+#: common/templatetags/mastodon.py:53 social/templates/_event_post.html:90
 msgid "you"
 msgstr ""
 
@@ -4479,874 +4477,887 @@ msgstr ""
 msgid "unavailable"
 msgstr ""
 
-#: common/utils.py:126 common/utils.py:167 users/views/actions.py:134
+#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr "用戶不存在了"
 
-#: common/utils.py:133 common/utils.py:135 common/utils.py:138
-#: common/utils.py:174 common/utils.py:178 journal/views/profile.py:499
+#: common/utils.py:135 common/utils.py:137 common/utils.py:140
+#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
 msgid "Access denied"
 msgstr "訪問被拒絕"
 
-#: common/utils.py:141 common/utils.py:143 journal/views/article.py:204
+#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr "登入後訪問"
 
-#: common/views_manage.py:144 common/views_manage.py:295
+#: common/views_manage.py:34 common/views_manage.py:373
 #, fuzzy
 #| msgid "reading"
 msgid "Branding"
 msgstr "在讀"
 
-#: common/views_manage.py:146
+#: common/views_manage.py:37
 #, fuzzy
 #| msgid "comments"
 msgid "Recommendations"
 msgstr "短評"
 
-#: common/views_manage.py:147
+#: common/views_manage.py:38
 #, fuzzy
 #| msgid "Accept"
 msgid "Access"
 msgstr "接受"
 
-#: common/views_manage.py:148 common/views_manage.py:623
+#: common/views_manage.py:39 common/views_manage.py:733
 #, fuzzy
 #| msgid "duration"
 msgid "Federation"
 msgstr "時長"
 
-#: common/views_manage.py:149
+#: common/views_manage.py:40
 msgid "Catalog"
 msgstr ""
 
-#: common/views_manage.py:150
+#: common/views_manage.py:41
 msgid "API Keys"
 msgstr ""
 
-#: common/views_manage.py:151
+#: common/views_manage.py:42
 #, fuzzy
 #| msgid "Download"
 msgid "Downloader"
 msgstr "下載"
 
-#: common/views_manage.py:152 common/views_manage.py:303
+#: common/views_manage.py:43 common/views_manage.py:381
 #: users/templates/users/steam_import.html:113
 msgid "Advanced"
 msgstr ""
 
-#: common/views_manage.py:202
+#: common/views_manage.py:44
+msgid "Environment"
+msgstr ""
+
+#: common/views_manage.py:280
 #, fuzzy
 #| msgid "Invalid user."
 msgid "Invalid value."
 msgstr "無效用戶。"
 
-#: common/views_manage.py:206
+#: common/views_manage.py:284
 msgid "Invalid configuration. Please check your input."
 msgstr ""
 
-#: common/views_manage.py:211
+#: common/views_manage.py:289
 #, fuzzy
 #| msgid "Settings saved."
 msgid "Settings have been saved."
 msgstr "設定已儲存"
 
-#: common/views_manage.py:231
+#: common/views_manage.py:309
 msgid "Site Name"
 msgstr ""
 
-#: common/views_manage.py:234
+#: common/views_manage.py:312
 #, fuzzy
 #| msgid "Title and Description"
 msgid "Site Description"
 msgstr "標題和描述"
 
-#: common/views_manage.py:235
+#: common/views_manage.py:313
 msgid "Short description shown in metadata and about page."
 msgstr ""
 
-#: common/views_manage.py:238
+#: common/views_manage.py:316
 msgid "Site Logo URL"
 msgstr ""
 
-#: common/views_manage.py:239
+#: common/views_manage.py:317
 msgid "URL path to the site logo image."
 msgstr ""
 
-#: common/views_manage.py:242
+#: common/views_manage.py:320
 msgid "Site Icon URL"
 msgstr ""
 
-#: common/views_manage.py:243
+#: common/views_manage.py:321
 msgid "URL path to the site icon/favicon."
 msgstr ""
 
-#: common/views_manage.py:246
+#: common/views_manage.py:324
 msgid "Default User Avatar URL"
 msgstr ""
 
-#: common/views_manage.py:247
+#: common/views_manage.py:325
 msgid "URL path to the default user avatar."
 msgstr ""
 
-#: common/views_manage.py:250
+#: common/views_manage.py:328
 msgid "Site Color Theme"
 msgstr ""
 
-#: common/views_manage.py:251
+#: common/views_manage.py:329
 msgid "PicoCSS color theme."
 msgstr ""
 
-#: common/views_manage.py:276
+#: common/views_manage.py:354
 #, fuzzy
 #| msgid "Production"
 msgid "Site Introduction"
 msgstr "上演"
 
-#: common/views_manage.py:277
+#: common/views_manage.py:355
 msgid "URL path for the intro/welcome sidebar page."
 msgstr ""
 
-#: common/views_manage.py:280
+#: common/views_manage.py:358
 msgid "Custom HTML Head"
 msgstr ""
 
-#: common/views_manage.py:281
+#: common/views_manage.py:359
 msgid "Extra HTML injected into the <head> of all pages."
 msgstr ""
 
-#: common/views_manage.py:285
+#: common/views_manage.py:363
 msgid "Footer Links"
 msgstr ""
 
-#: common/views_manage.py:286
+#: common/views_manage.py:364
 msgid "Link title mapped to URL."
 msgstr ""
 
-#: common/views_manage.py:315
+#: common/views_manage.py:393
 msgid "Minimum Marks for Discover"
 msgstr ""
 
-#: common/views_manage.py:317
+#: common/views_manage.py:395
 msgid "Number of marks required for an item to appear in discover."
 msgstr ""
 
-#: common/views_manage.py:322
+#: common/views_manage.py:400
 msgid "Update Interval (minutes)"
 msgstr ""
 
-#: common/views_manage.py:323
+#: common/views_manage.py:401
 msgid "How often to refresh the popular items list."
 msgstr ""
 
-#: common/views_manage.py:327
+#: common/views_manage.py:405
 #, fuzzy
 #| msgid "filter by rating range"
 msgid "Filter by Preferred Languages"
 msgstr "篩選評分範圍"
 
-#: common/views_manage.py:328
+#: common/views_manage.py:406
 msgid "Only show items with titles in the preferred languages."
 msgstr ""
 
-#: common/views_manage.py:331
+#: common/views_manage.py:409
 #, fuzzy
 #| msgid "show all"
 msgid "Show Local Only"
 msgstr "顯示全部"
 
-#: common/views_manage.py:333
+#: common/views_manage.py:411
 msgid "Only show items marked by local users, not the entire network."
 msgstr ""
 
-#: common/views_manage.py:337
+#: common/views_manage.py:415
 #, fuzzy
 #| msgid "Popular Tags"
 msgid "Show Popular Posts"
 msgstr "熱門標籤"
 
-#: common/views_manage.py:338
+#: common/views_manage.py:416
 msgid "Show popular public posts instead of recent ones."
 msgstr ""
 
-#: common/views_manage.py:341
+#: common/views_manage.py:419
 #, fuzzy
 #| msgid "Popular Tags"
 msgid "Show Popular Tags"
 msgstr "熱門標籤"
 
-#: common/views_manage.py:342
+#: common/views_manage.py:420
 msgid "Show popular public tags on the discover page."
 msgstr ""
 
-#: common/views_manage.py:345
+#: common/views_manage.py:423
 #, fuzzy
 #| msgid "Spotify Podcast"
 msgid "Show Verified Podcasts"
 msgstr "Spotify播客"
 
-#: common/views_manage.py:347
-msgid ""
-"Show a shelf of recent episodes from podcasts with a verified creator on the "
-"discover page."
+#: common/views_manage.py:425
+msgid "Show a shelf of recent episodes from podcasts with a verified creator on the discover page."
 msgstr ""
 
-#: common/views_manage.py:386
+#: common/views_manage.py:447
+#, fuzzy
+#| msgid "your timeline"
+msgid "Show World Timeline"
+msgstr "你的貼文"
+
+#: common/views_manage.py:449
+msgid "Offer a tab with public posts from this site and every server it federates with."
+msgstr ""
+
+#: common/views_manage.py:454
+#, fuzzy
+#| msgid "show all"
+msgid "Show Local Timeline"
+msgstr "顯示全部"
+
+#: common/views_manage.py:455
+msgid "Offer a tab with public posts from this site only."
+msgstr ""
+
+#: common/views_manage.py:459
+#, fuzzy
+#| msgid "your timeline"
+msgid "Timelines"
+msgstr "你的貼文"
+
+#: common/views_manage.py:487
 msgid "Enable Recommendations"
 msgstr ""
 
-#: common/views_manage.py:388
-msgid ""
-"Master switch. When off, all recommendation surfaces are hidden and the cron "
-"jobs are not scheduled."
+#: common/views_manage.py:489
+msgid "Master switch. When off, all recommendation surfaces are hidden and the cron jobs are not scheduled."
 msgstr ""
 
-#: common/views_manage.py:393
+#: common/views_manage.py:494
 msgid "Source Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:395
-msgid ""
-"Minimum public marks an item needs before similarity rows are built for it."
+#: common/views_manage.py:496
+msgid "Minimum public marks an item needs before similarity rows are built for it."
 msgstr ""
 
-#: common/views_manage.py:401
+#: common/views_manage.py:502
 msgid "Target Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:403
-msgid ""
-"Minimum public marks an item needs to be eligible as a recommendation target."
+#: common/views_manage.py:504
+msgid "Minimum public marks an item needs to be eligible as a recommendation target."
 msgstr ""
 
-#: common/views_manage.py:409
+#: common/views_manage.py:510
 msgid "Top-K Similar Items per Source"
 msgstr ""
 
-#: common/views_manage.py:410
+#: common/views_manage.py:511
 msgid "Number of similar items stored per source item."
 msgstr ""
 
-#: common/views_manage.py:414
+#: common/views_manage.py:515
 msgid "Top-N Recommendations per User"
 msgstr ""
 
-#: common/views_manage.py:415
+#: common/views_manage.py:516
 msgid "Number of personalised rows stored per user."
 msgstr ""
 
-#: common/views_manage.py:419
+#: common/views_manage.py:520
 msgid "Dampen Heavy Shelvers"
 msgstr ""
 
-#: common/views_manage.py:421
-msgid ""
-"Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-"
-"shelvers in similarity scoring."
+#: common/views_manage.py:522
+msgid "Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-shelvers in similarity scoring."
 msgstr ""
 
-#: common/views_manage.py:426
+#: common/views_manage.py:527
 msgid "Per-User Mark Cap (training)"
 msgstr ""
 
-#: common/views_manage.py:428
-msgid ""
-"Truncate each user's contribution to their N most recent marks when building "
-"the similarity matrix."
+#: common/views_manage.py:529
+msgid "Truncate each user's contribution to their N most recent marks when building the similarity matrix."
 msgstr ""
 
-#: common/views_manage.py:434
+#: common/views_manage.py:535
 msgid "Active-User Window (days)"
 msgstr ""
 
-#: common/views_manage.py:436
-msgid ""
-"Refresh personalised recommendations for users with at least one public mark "
-"in the last N days."
+#: common/views_manage.py:537
+msgid "Refresh personalised recommendations for users with at least one public mark in the last N days."
 msgstr ""
 
-#: common/views_manage.py:442
+#: common/views_manage.py:543
 msgid "Per-User Seed Cap (serving)"
 msgstr ""
 
-#: common/views_manage.py:444
-msgid ""
-"Number of recent marks used as seeds when scoring personalised "
-"recommendations for one user."
+#: common/views_manage.py:545
+msgid "Number of recent marks used as seeds when scoring personalised recommendations for one user."
 msgstr ""
 
-#: common/views_manage.py:450
+#: common/views_manage.py:551
 msgid "Lazy Refresh TTL (days)"
 msgstr ""
 
-#: common/views_manage.py:452
-msgid ""
-"How long cached on-demand recommendations are valid before the next request "
-"triggers a refresh."
+#: common/views_manage.py:553
+msgid "How long cached on-demand recommendations are valid before the next request triggers a refresh."
 msgstr ""
 
-#: common/views_manage.py:458
+#: common/views_manage.py:559
 msgid "Circles Window (days)"
 msgstr ""
 
-#: common/views_manage.py:460
-msgid ""
-"Look back N days when finding items recently marked by people the viewer "
-"follows."
+#: common/views_manage.py:561
+msgid "Look back N days when finding items recently marked by people the viewer follows."
 msgstr ""
 
-#: common/views_manage.py:467
+#: common/views_manage.py:568
 msgid "Master Switch"
 msgstr ""
 
-#: common/views_manage.py:470
+#: common/views_manage.py:571
 msgid "Similarity Builder"
 msgstr ""
 
-#: common/views_manage.py:477
+#: common/views_manage.py:578
 #, fuzzy
 #| msgid "Personal"
 msgid "Personalisation"
 msgstr "個人"
 
-#: common/views_manage.py:495
-msgid ""
-"Require an invite token to register. Invite tokens can be generated with "
-"neodb-manage invite --create."
+#: common/views_manage.py:596
+msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
 msgstr ""
 
-#: common/views_manage.py:500
+#: common/views_manage.py:601
 msgid "Enable Local-Only Posting"
 msgstr ""
 
-#: common/views_manage.py:501
+#: common/views_manage.py:602
 msgid "Allow users to create posts visible only to local users."
 msgstr ""
 
-#: common/views_manage.py:504
+#: common/views_manage.py:605
 msgid "Mastodon Login Whitelist"
 msgstr ""
 
-#: common/views_manage.py:505
+#: common/views_manage.py:606
 msgid "One domain per line. Leave empty to allow any instance."
 msgstr ""
 
-#: common/views_manage.py:508
+#: common/views_manage.py:609
 #, fuzzy
 #| msgid "Registration failed"
 msgid "Registration Captcha Items"
 msgstr "註冊失敗"
 
-#: common/views_manage.py:512
-msgid ""
-"Number of item covers a new user must sort into two category rows before "
-"choosing a username. 0 disables the captcha; 5-6 is recommended. The covers "
-"carry no title text, so this cannot be solved with a screen reader: if you "
-"enable it, keep another way in, such as an invite link."
+#: common/views_manage.py:613
+msgid "Number of item covers a new user must sort into two category rows before choosing a username. 0 disables the captcha; 5-6 is recommended. The covers carry no title text, so this cannot be solved with a screen reader: if you enable it, keep another way in, such as an invite link."
 msgstr ""
 
-#: common/views_manage.py:520
+#: common/views_manage.py:621
 msgid "Registration Captcha Minimum Marks"
 msgstr ""
 
-#: common/views_manage.py:523
-msgid ""
-"Marks an item needs before the captcha treats it as well known enough to be "
-"recognizable. Categories with too few such items fall back to any item."
+#: common/views_manage.py:624
+msgid "Marks an item needs before the captcha treats it as well known enough to be recognizable. Categories with too few such items fall back to any item."
 msgstr ""
 
-#: common/views_manage.py:529
+#: common/views_manage.py:630
 msgid "Enable Mastodon Login"
 msgstr ""
 
-#: common/views_manage.py:532
+#: common/views_manage.py:633
 #, fuzzy
 #| msgid "Bluesky Login ID"
 msgid "Enable Bluesky Login"
 msgstr "Bluesky 登入名"
 
-#: common/views_manage.py:535
+#: common/views_manage.py:636
 msgid "Enable Threads Login"
 msgstr ""
 
-#: common/views_manage.py:538
+#: common/views_manage.py:639
 #, fuzzy
 #| msgid "Email"
 msgid "Email URL"
 msgstr "電子郵件"
 
-#: common/views_manage.py:540
+#: common/views_manage.py:641
 msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
 msgstr ""
 
-#: common/views_manage.py:544
+#: common/views_manage.py:645
 #, fuzzy
 #| msgid "Email"
 msgid "Email From"
 msgstr "電子郵件"
 
-#: common/views_manage.py:545
+#: common/views_manage.py:646
 msgid "Sender name and address for outgoing email."
 msgstr ""
 
-#: common/views_manage.py:548
+#: common/views_manage.py:649
 #, fuzzy
 #| msgid "Language"
 msgid "Default Language"
 msgstr "語言"
 
-#: common/views_manage.py:551
-msgid ""
-"Interface language for visitors and for users who have not chosen one "
-"themselves."
+#: common/views_manage.py:652
+msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:558
-msgid ""
-"Language codes, one per line (e.g. en, zh, ja). First language is the "
-"default."
+#: common/views_manage.py:659
+msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:564
+#: common/views_manage.py:665
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:571
+#: common/views_manage.py:672
 #, fuzzy
 #| msgid "Import Method"
 msgid "Login Methods"
 msgstr "匯入方式"
 
-#: common/views_manage.py:576 mastodon/models/common.py:28
+#: common/views_manage.py:677 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr "電子郵件"
 
-#: common/views_manage.py:580
+#: common/views_manage.py:681
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:591
+#: common/views_manage.py:692
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:593
-msgid ""
-"Disable relay.neodb.net federation for sharing public ratings across "
-"instances."
+#: common/views_manage.py:694
+msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:598
+#: common/views_manage.py:699
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:599
+#: common/views_manage.py:700
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:603
+#: common/views_manage.py:704
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:605
+#: common/views_manage.py:706
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:610
+#: common/views_manage.py:711
 #, fuzzy
 #| msgid "Search results"
 msgid "Search Sites"
 msgstr "搜索結果"
 
-#: common/views_manage.py:611
+#: common/views_manage.py:712
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:614
+#: common/views_manage.py:715
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:615
+#: common/views_manage.py:716
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:618
+#: common/views_manage.py:719
 #, fuzzy
 #| msgid "Add tv series"
 msgid "Hidden Categories"
 msgstr "添加電視劇集"
 
-#: common/views_manage.py:619
+#: common/views_manage.py:720
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:640
+#: common/views_manage.py:723
+msgid "Guest Search Page Limit"
+msgstr ""
+
+#: common/views_manage.py:725
+msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
+msgstr ""
+
+#: common/views_manage.py:751
 #, fuzzy
 #| msgid "Spotify Album"
 msgid "Spotify API Key"
 msgstr "Spotify專輯"
 
-#: common/views_manage.py:641
+#: common/views_manage.py:752
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:644
+#: common/views_manage.py:755
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:645
+#: common/views_manage.py:756
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:648
+#: common/views_manage.py:759
 #, fuzzy
 #| msgid "Google Books"
 msgid "Google Books API Key"
 msgstr "谷歌圖書"
 
-#: common/views_manage.py:649
+#: common/views_manage.py:760
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:652
+#: common/views_manage.py:763
 #, fuzzy
 #| msgid "Discogs"
 msgid "Discogs API Key"
 msgstr "Discogs"
 
-#: common/views_manage.py:654
+#: common/views_manage.py:765
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:658
+#: common/views_manage.py:769
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:770
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:662
+#: common/views_manage.py:773
 #, fuzzy
 #| msgid "client secret"
 msgid "IGDB Client Secret"
 msgstr "實例應用Client Secret"
 
-#: common/views_manage.py:665
+#: common/views_manage.py:776
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:667
-msgid ""
-"Bearer token from https://boardgamegeek.com/applications (see https://"
-"boardgamegeek.com/using_the_xml_api#toc9)."
+#: common/views_manage.py:778
+msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:672 users/templates/users/steam_import.html:26
+#: common/views_manage.py:783
+msgid "MyAnimeList Client ID"
+msgstr ""
+
+#: common/views_manage.py:785
+msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
+msgstr ""
+
+#: common/views_manage.py:790 users/templates/users/steam_import.html:26
 #, fuzzy
 #| msgid "Steam Game"
 msgid "Steam API Key"
 msgstr "Steam遊戲"
 
-#: common/views_manage.py:674
-msgid ""
-"https://steamcommunity.com/dev - fallback key for Steam importer. Users can "
-"provide their own key when importing."
+#: common/views_manage.py:792
+msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:679
+#: common/views_manage.py:797
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:680
+#: common/views_manage.py:798
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:683
+#: common/views_manage.py:801
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:686
+#: common/views_manage.py:804
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:689
+#: common/views_manage.py:807
 #, fuzzy
 #| msgid "Threads"
 msgid "Threads App ID"
 msgstr "Threads"
 
-#: common/views_manage.py:690
+#: common/views_manage.py:808
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:693
+#: common/views_manage.py:811
 #, fuzzy
 #| msgid "Threads.net"
 msgid "Threads App Secret"
 msgstr "Threads.net"
 
-#: common/views_manage.py:696
+#: common/views_manage.py:814
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:698
-msgid ""
-"Webhook URLs keyed by channel (default, report, audit, suggest, system). All "
-"channels must be Discord forum or media channels (thread mode) because "
-"notifications are posted as threads."
+#: common/views_manage.py:816
+msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:715
+#: common/views_manage.py:833
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:844
 #, fuzzy
 #| msgid "translator"
 msgid "Translation"
 msgstr "譯者"
 
-#: common/views_manage.py:730
+#: common/views_manage.py:849
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:734 social/templates/feed.html:27
+#: common/views_manage.py:853 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr "通知"
 
-#: common/views_manage.py:744
+#: common/views_manage.py:863
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:745
+#: common/views_manage.py:864
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:748
+#: common/views_manage.py:867
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:749
+#: common/views_manage.py:868
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:752
+#: common/views_manage.py:871
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:874
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:758
+#: common/views_manage.py:877
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:761
+#: common/views_manage.py:880
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:764
+#: common/views_manage.py:883
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:767
+#: common/views_manage.py:886
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:768
+#: common/views_manage.py:887
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:771
+#: common/views_manage.py:890
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:775
+#: common/views_manage.py:894
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:779
+#: common/views_manage.py:898
 #, fuzzy
 #| msgid "series"
 msgid "Retries"
 msgstr "叢書"
 
-#: common/views_manage.py:784
+#: common/views_manage.py:903
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:789
+#: common/views_manage.py:908
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:796
+#: common/views_manage.py:915
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:808
+#: common/views_manage.py:927
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:809
+#: common/views_manage.py:928
 #, fuzzy
 #| msgid "site domain name"
 msgid "One domain per line."
 msgstr "站點域名"
 
-#: common/views_manage.py:812
+#: common/views_manage.py:931
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:813
+#: common/views_manage.py:932
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:935
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:818
-msgid ""
-"Timeout for requests to Mastodon instances and remote fediverse servers."
+#: common/views_manage.py:937
+msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:824
+#: common/views_manage.py:943
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:825
+#: common/views_manage.py:944
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:828
+#: common/views_manage.py:947
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:829
+#: common/views_manage.py:948
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:839
+#: common/views_manage.py:958
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:841
-msgid ""
-"Delete import/export tasks and their files after this many days. Set to 0 to "
-"disable cleanup."
+#: common/views_manage.py:960
+msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:847
+#: common/views_manage.py:966
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:849
-msgid ""
-"Post-migration job keys to skip, one per line (e.g. normalize_genre). "
-"Checked by the worker at dequeue time; skipped jobs log a warning and notify "
-"the Discord system channel."
+#: common/views_manage.py:968
+msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:855
+#: common/views_manage.py:974
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:857
-msgid ""
-"Private key (JWK) identifying this site to ATProto authorization servers. "
-"Auto-generated on first Bluesky login; clear to regenerate."
+#: common/views_manage.py:976
+msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:983
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:986
 #, fuzzy
 #| msgid "optional"
 msgid "Operational"
 msgstr "可選"
 
-#: common/views_manage.py:883
+#: common/views_manage.py:1002
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:885
-msgid ""
-"Genre codes offered in the Movie edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1004
+msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:1009
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:892
-msgid ""
-"Genre codes offered in the TV edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1011
+msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:897
+#: common/views_manage.py:1016
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:899
-msgid ""
-"Genre codes offered in the Music edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1018
+msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:904
+#: common/views_manage.py:1023
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:906
-msgid ""
-"Genre codes offered in the Game edit dropdown, one per line. Leave empty to "
-"use the built-in default."
+#: common/views_manage.py:1025
+msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:911
+#: common/views_manage.py:1030
 #, fuzzy
 #| msgid "Podcast"
 msgid "Podcast Genres"
 msgstr "播客"
 
-#: common/views_manage.py:913
-msgid ""
-"Genre codes offered in the Podcast edit dropdown, one per line. Leave empty "
-"to use the built-in default."
+#: common/views_manage.py:1032
+msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:918
+#: common/views_manage.py:1037
 #, fuzzy
 #| msgid "Performance"
 msgid "Performance Genres"
 msgstr "演出"
 
-#: common/views_manage.py:920
-msgid ""
-"Genre codes offered in the Performance edit dropdown, one per line. Leave "
-"empty to use the built-in default."
+#: common/views_manage.py:1039
+msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:926
+#: common/views_manage.py:1045
 msgid "Genres by Category"
 msgstr ""
 
-#: journal/forms.py:12
-msgid ""
-"Tips: use >!text!< for spoilers; some instances may not be able to show "
-"posts longer than 360 charactors."
+#: common/views_manage.py:1069
+msgid "Site"
 msgstr ""
-"提示： 善用 >!文字!< 標記可隱藏劇透； 超過360字可能無法分享到聯邦宇宙實例時間"
-"軸。"
+
+#: common/views_manage.py:1079
+#, fuzzy
+#| msgid "Database"
+msgid "Database and Services"
+msgstr "數據庫"
+
+#: common/views_manage.py:1089
+msgid "Media and Files"
+msgstr ""
+
+#: common/views_manage.py:1098
+msgid "Monitoring"
+msgstr ""
+
+#: common/views_manage.py:1102
+msgid "Security"
+msgstr ""
+
+#: common/views_manage.py:1111
+msgid "Other Environment Variables"
+msgstr ""
+
+#: common/views_manage.py:1113
+msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
+msgstr ""
+
+#: journal/forms.py:12
+msgid "Tips: use >!text!< for spoilers; some instances may not be able to show posts longer than 360 charactors."
+msgstr "提示： 善用 >!文字!< 標記可隱藏劇透； 超過360字可能無法分享到聯邦宇宙實例時間軸。"
 
 #: journal/forms.py:29 journal/forms.py:31 journal/forms.py:80
 #: journal/forms.py:83 journal/forms.py:153
@@ -5360,14 +5371,14 @@ msgid "Content (Markdown)"
 msgstr "內容 （Markdown格式）"
 
 #: journal/forms.py:46 journal/forms.py:124 journal/forms.py:226
-#: journal/forms.py:288 journal/views/note.py:38
+#: journal/forms.py:288 journal/views/note.py:37
 #, fuzzy
 #| msgid "Crosspost to timeline"
 msgid "Crosspost"
 msgstr "轉發到時間軸"
 
 #: journal/forms.py:47 journal/forms.py:125 journal/forms.py:227
-#: journal/forms.py:289 journal/views/note.py:39
+#: journal/forms.py:289 journal/views/note.py:38
 #, fuzzy
 #| msgid "Turn on crosspost to other social networks by default"
 msgid "Crosspost to your connected social networks"
@@ -5384,10 +5395,10 @@ msgstr "保存時將行首空格替換爲全角"
 #: journal/forms.py:59 journal/forms.py:137 journal/forms.py:162
 #: journal/forms.py:219 journal/forms.py:281
 #: journal/templates/collection_share.html:24
-#: journal/templates/wrapped_share.html:36 journal/views/note.py:31
-#: users/templates/users/data.html:45 users/templates/users/data.html:98
-#: users/templates/users/data.html:155 users/templates/users/data.html:206
-#: users/templates/users/data.html:269 users/templates/users/data.html:328
+#: journal/templates/wrapped_share.html:36 journal/views/note.py:30
+#: users/templates/users/data.html:60 users/templates/users/data.html:113
+#: users/templates/users/data.html:170 users/templates/users/data.html:221
+#: users/templates/users/data.html:284 users/templates/users/data.html:346
 #: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
@@ -5434,7 +5445,6 @@ msgid "Collaborative editing"
 msgstr "協作編輯"
 
 #: journal/forms.py:204 users/templates/users/crossposts.html:51
-#: users/templates/users/data.html:483
 msgid "Status"
 msgstr "狀態"
 
@@ -5448,48 +5458,46 @@ msgstr "寫短評"
 msgid "Rating"
 msgstr "評分"
 
-#: journal/importers/goodreads.py:196 journal/importers/letterboxd.py:144
-#: journal/importers/rym.py:442 journal/importers/storygraph.py:500
+#: journal/importers/goodreads.py:198 journal/importers/letterboxd.py:147
+#: journal/importers/rym.py:444 journal/importers/storygraph.py:504
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr "關於 {item_title} 的評論"
 
-#: journal/importers/opml.py:45
+#: journal/importers/opml.py:49
 #, python-brace-format
 msgid "{username}'s podcast subscriptions"
 msgstr "{username} 的播客訂閱"
 
-#: journal/importers/rym.py:168 journal/importers/storygraph.py:128
+#: journal/importers/rym.py:170 journal/importers/storygraph.py:132
 #, python-brace-format
-msgid ""
-"Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
+msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:178 journal/importers/storygraph.py:138
+#: journal/importers/rym.py:180 journal/importers/storygraph.py:142
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/importers/rym.py:233 journal/importers/storygraph.py:184
+#: journal/importers/rym.py:235 journal/importers/storygraph.py:188
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:348 journal/importers/storygraph.py:389
+#: journal/importers/rym.py:350 journal/importers/storygraph.py:393
 msgid "Matched file missing; cannot import."
 msgstr ""
 
-#: journal/importers/rym.py:376 journal/importers/storygraph.py:412
+#: journal/importers/rym.py:378 journal/importers/storygraph.py:416
 #, python-brace-format
-msgid ""
-"Import complete: {imported} imported, {skipped} skipped, {failed} failed"
+msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:212 journal/views/article.py:218
+#: journal/models/article.py:215 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
-#: journal/models/collection.py:44 journal/templates/add_to_collection.html:39
+#: journal/models/collection.py:48 journal/templates/add_to_collection.html:39
 #: journal/templates/collection_edit.html:64
 #: journal/templates/collection_share.html:63
 #: journal/templates/collection_update_item_note.html:3
@@ -5497,67 +5505,67 @@ msgstr ""
 msgid "note"
 msgstr "備註"
 
-#: journal/models/collection.py:111
+#: journal/models/collection.py:115
 #, fuzzy
 #| msgid "shared {username}'s collection"
 msgid "search query for dynamic collection"
 msgstr "分享 {username} 的收藏單"
 
-#: journal/models/collection.py:524 journal/templatetags/collection.py:35
+#: journal/models/collection.py:566 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] "%(count)d 本書"
 
-#: journal/models/collection.py:529 journal/templatetags/collection.py:43
+#: journal/models/collection.py:571 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] "%(count)d 部電影"
 
-#: journal/models/collection.py:534 journal/templatetags/collection.py:51
+#: journal/models/collection.py:576 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] "%(count)d 部電視劇"
 
-#: journal/models/collection.py:539 journal/templatetags/collection.py:59
+#: journal/models/collection.py:581 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] "%(count)d 張專輯"
 
-#: journal/models/collection.py:544 journal/templatetags/collection.py:67
+#: journal/models/collection.py:586 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] "%(count)d 個遊戲"
 
-#: journal/models/collection.py:549 journal/templatetags/collection.py:75
+#: journal/models/collection.py:591 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] "%(count)d 個播客"
 
-#: journal/models/collection.py:555 journal/templatetags/collection.py:83
+#: journal/models/collection.py:597 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] "%(count)d 場演出"
 
-#: journal/models/collection.py:563 journal/templatetags/collection.py:91
+#: journal/models/collection.py:605 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] "%(count)d 個條目"
 
-#: journal/models/common.py:50 journal/templates/action_open_post.html:15
-#: journal/templates/collection_share.html:35 journal/templates/mark.html:84
+#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
-#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:54
-#: users/templates/users/data.html:107 users/templates/users/data.html:164
-#: users/templates/users/data.html:215 users/templates/users/data.html:277
-#: users/templates/users/data.html:337 users/templates/users/data.html:534
+#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
+#: users/templates/users/data.html:122 users/templates/users/data.html:179
+#: users/templates/users/data.html:230 users/templates/users/data.html:292
+#: users/templates/users/data.html:355 users/templates/users/data.html:534
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5565,13 +5573,13 @@ msgstr[0] "%(count)d 個條目"
 msgid "Public"
 msgstr "公開"
 
-#: journal/models/common.py:51 journal/templates/action_open_post.html:9
-#: journal/templates/collection_share.html:46 journal/templates/mark.html:91
+#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
-#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
-#: users/templates/users/data.html:115 users/templates/users/data.html:172
-#: users/templates/users/data.html:223 users/templates/users/data.html:285
-#: users/templates/users/data.html:345 users/templates/users/data.html:542
+#: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
+#: users/templates/users/data.html:130 users/templates/users/data.html:187
+#: users/templates/users/data.html:238 users/templates/users/data.html:300
+#: users/templates/users/data.html:363 users/templates/users/data.html:542
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5579,12 +5587,12 @@ msgstr "公開"
 msgid "Followers Only"
 msgstr "僅關注者"
 
-#: journal/models/common.py:52 journal/templates/collection_share.html:57
-#: journal/templates/mark.html:98 journal/templates/post_compose.html:72
-#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
-#: users/templates/users/data.html:123 users/templates/users/data.html:180
-#: users/templates/users/data.html:231 users/templates/users/data.html:293
-#: users/templates/users/data.html:353 users/templates/users/data.html:550
+#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/templates/mark.html:102 journal/templates/post_compose.html:72
+#: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
+#: users/templates/users/data.html:138 users/templates/users/data.html:195
+#: users/templates/users/data.html:246 users/templates/users/data.html:308
+#: users/templates/users/data.html:371 users/templates/users/data.html:550
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5592,33 +5600,31 @@ msgstr "僅關注者"
 msgid "Mentioned Only"
 msgstr "自己和提到的人"
 
-#: journal/models/common.py:790
-msgid ""
-"A recent post was not posted to Bluesky, please login NeoDB using ATProto "
-"again to re-authorize."
+#: journal/models/common.py:806
+msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr "帖文未能發佈到Bluesky，請重新用Bluesky驗證登入。"
 
-#: journal/models/common.py:987
+#: journal/models/common.py:1003
 msgid "A recent post was not posted to Threads."
 msgstr "帖文未能發佈到Threads。"
 
-#: journal/models/common.py:1020
+#: journal/models/common.py:1036
 #, fuzzy
 #| msgid "A recent post was not posted to Mastodon."
 msgid "A recent post was not boosted on Mastodon."
 msgstr "帖文未能發佈到聯邦實例。"
 
-#: journal/models/common.py:1030
+#: journal/models/common.py:1046
 #, fuzzy
 #| msgid "Item no longer exists"
 msgid "Original post no longer exists."
 msgstr "條目已不存在"
 
-#: journal/models/common.py:1044
+#: journal/models/common.py:1060
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr "帖文未能發佈到聯邦實例，請重新驗證登入。"
 
-#: journal/models/common.py:1053
+#: journal/models/common.py:1069
 msgid "A recent post was not posted to Mastodon."
 msgstr "帖文未能發佈到聯邦實例。"
 
@@ -5628,7 +5634,7 @@ msgstr "帖文未能發佈到聯邦實例。"
 msgid "Authorization expired"
 msgstr "認證失敗"
 
-#: journal/models/crosspost.py:17 users/models/task.py:24
+#: journal/models/crosspost.py:17 users/models/task.py:26
 msgid "Failed"
 msgstr "失敗"
 
@@ -5636,85 +5642,85 @@ msgstr "失敗"
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:469
+#: journal/models/mark.py:475
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:473
+#: journal/models/mark.py:479
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:480
+#: journal/models/mark.py:486
 #, fuzzy
 #| msgid "Invalid parameter"
 msgid "Invalid progress type."
 msgstr "無效參數"
 
-#: journal/models/mark.py:482
+#: journal/models/mark.py:488
 #, fuzzy
 #| msgid "Invalid response from Fediverse instance."
 msgid "Invalid progress type for this item."
 msgstr "聯邦實例返回信息無效"
 
-#: journal/models/note.py:34 users/templates/users/rym_import.html:73
+#: journal/models/note.py:47 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr "頁碼"
 
-#: journal/models/note.py:35
+#: journal/models/note.py:48
 msgid "Chapter"
 msgstr "章節"
 
-#: journal/models/note.py:38
+#: journal/models/note.py:51
 msgid "Part"
 msgstr "分部"
 
-#: journal/models/note.py:39
+#: journal/models/note.py:52
 msgid "Episode"
 msgstr "單集"
 
-#: journal/models/note.py:40
+#: journal/models/note.py:53
 msgid "Track"
 msgstr "曲目"
 
-#: journal/models/note.py:41
+#: journal/models/note.py:54
 msgid "Cycle"
 msgstr "周目"
 
-#: journal/models/note.py:42
+#: journal/models/note.py:55
 msgid "Timestamp"
 msgstr "時間戳"
 
-#: journal/models/note.py:43
+#: journal/models/note.py:56
 msgid "Percentage"
 msgstr "百分比"
 
-#: journal/models/note.py:60
+#: journal/models/note.py:77
 #, python-brace-format
 msgid "Page {value}"
 msgstr "第{value}頁"
 
-#: journal/models/note.py:61
+#: journal/models/note.py:78
 #, python-brace-format
 msgid "Chapter {value}"
 msgstr "第{value}章"
 
-#: journal/models/note.py:64
+#: journal/models/note.py:81
 #, python-brace-format
 msgid "Part {value}"
 msgstr "第{value}部"
 
-#: journal/models/note.py:65
+#: journal/models/note.py:82
 #, python-brace-format
 msgid "Episode {value}"
 msgstr "第{value}集"
 
-#: journal/models/note.py:66
+#: journal/models/note.py:83
 #, python-brace-format
 msgid "Track {value}"
 msgstr "第{value}首"
 
-#: journal/models/note.py:67
+#: journal/models/note.py:84
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr "{value}周目"
@@ -5724,445 +5730,445 @@ msgstr "{value}周目"
 msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr "關於 {item_title}，可能包含劇透或敏感內容"
 
-#: journal/models/review.py:78
+#: journal/models/review.py:79
 #, fuzzy, python-brace-format
 #| msgid "a review of {item_title}"
 msgid "a review of {title}"
 msgstr "關於 {item_title} 的評論"
 
-#: journal/models/review.py:80
+#: journal/models/review.py:81
 #, fuzzy
 #| msgid "Item contains sub-items."
 msgid "(may contain spoilers)"
 msgstr "條目下已有子項"
 
-#: journal/models/shelf.py:37
+#: journal/models/shelf.py:39
 msgid "WISHLIST"
 msgstr ""
 
-#: journal/models/shelf.py:38
+#: journal/models/shelf.py:40
 msgid "PROGRESS"
 msgstr ""
 
-#: journal/models/shelf.py:39
+#: journal/models/shelf.py:41
 msgid "COMPLETE"
 msgstr ""
 
-#: journal/models/shelf.py:40
+#: journal/models/shelf.py:42
 msgid "DROPPED"
 msgstr ""
 
-#: journal/models/shelf.py:49
+#: journal/models/shelf.py:51
 msgid "books to read"
 msgstr "想讀的書"
 
-#: journal/models/shelf.py:50
+#: journal/models/shelf.py:52
 msgid "want to read"
 msgstr "想讀"
 
-#: journal/models/shelf.py:51
+#: journal/models/shelf.py:53
 #, python-brace-format
 msgid "wants to read {item}"
 msgstr "想讀 {item}"
 
-#: journal/models/shelf.py:52
+#: journal/models/shelf.py:54
 msgid "to read"
 msgstr "想讀"
 
-#: journal/models/shelf.py:57
+#: journal/models/shelf.py:59
 msgid "books reading"
 msgstr "正在讀的書"
 
-#: journal/models/shelf.py:58
+#: journal/models/shelf.py:60
 msgid "start reading"
 msgstr "在讀"
 
-#: journal/models/shelf.py:59
+#: journal/models/shelf.py:61
 #, python-brace-format
 msgid "started reading {item}"
 msgstr "在讀 {item}"
 
-#: journal/models/shelf.py:60
+#: journal/models/shelf.py:62
 msgid "reading"
 msgstr "在讀"
 
-#: journal/models/shelf.py:65
+#: journal/models/shelf.py:67
 msgid "books completed"
 msgstr "讀過的書"
 
-#: journal/models/shelf.py:66
+#: journal/models/shelf.py:68
 msgid "finish reading"
 msgstr "讀過"
 
-#: journal/models/shelf.py:67
+#: journal/models/shelf.py:69
 #, python-brace-format
 msgid "finished reading {item}"
 msgstr "讀過 {item}"
 
-#: journal/models/shelf.py:68
+#: journal/models/shelf.py:70
 msgid "read"
 msgstr "已讀"
 
-#: journal/models/shelf.py:73
+#: journal/models/shelf.py:75
 msgid "books dropped"
 msgstr "不再讀的書"
 
-#: journal/models/shelf.py:74
+#: journal/models/shelf.py:76
 msgid "stop reading"
 msgstr "不讀了"
 
-#: journal/models/shelf.py:75
+#: journal/models/shelf.py:77
 #, python-brace-format
 msgid "stopped reading {item}"
 msgstr "不再讀 {item}"
 
-#: journal/models/shelf.py:76
+#: journal/models/shelf.py:78
 msgid "stopped reading"
 msgstr "不讀了"
 
-#: journal/models/shelf.py:81
+#: journal/models/shelf.py:83
 msgid "books reviewed"
 msgstr "評論過的書"
 
-#: journal/models/shelf.py:82 journal/models/shelf.py:122
-#: journal/models/shelf.py:162 journal/models/shelf.py:202
-#: journal/models/shelf.py:242 journal/models/shelf.py:282
-#: journal/models/shelf.py:316
+#: journal/models/shelf.py:84 journal/models/shelf.py:124
+#: journal/models/shelf.py:164 journal/models/shelf.py:204
+#: journal/models/shelf.py:244 journal/models/shelf.py:284
+#: journal/models/shelf.py:318
 msgid "review"
 msgstr "評論"
 
-#: journal/models/shelf.py:83 journal/models/shelf.py:123
-#: journal/models/shelf.py:163 journal/models/shelf.py:203
-#: journal/models/shelf.py:243 journal/models/shelf.py:283
-#: journal/models/shelf.py:317
+#: journal/models/shelf.py:85 journal/models/shelf.py:125
+#: journal/models/shelf.py:165 journal/models/shelf.py:205
+#: journal/models/shelf.py:245 journal/models/shelf.py:285
+#: journal/models/shelf.py:319
 #, python-brace-format
 msgid "wrote a review of {item}"
 msgstr "寫了關於 {item} 的評論"
 
-#: journal/models/shelf.py:89
+#: journal/models/shelf.py:91
 msgid "movies to watch"
 msgstr "想看的電影"
 
-#: journal/models/shelf.py:90 journal/models/shelf.py:130
+#: journal/models/shelf.py:92 journal/models/shelf.py:132
 msgid "want to watch"
 msgstr "想看"
 
-#: journal/models/shelf.py:91 journal/models/shelf.py:131
+#: journal/models/shelf.py:93 journal/models/shelf.py:133
 #, python-brace-format
 msgid "wants to watch {item}"
 msgstr "想看 {item}"
 
-#: journal/models/shelf.py:92 journal/models/shelf.py:132
+#: journal/models/shelf.py:94 journal/models/shelf.py:134
 msgid "to watch"
 msgstr "想看"
 
-#: journal/models/shelf.py:97
+#: journal/models/shelf.py:99
 msgid "movies watching"
 msgstr "正在看的電影"
 
-#: journal/models/shelf.py:98 journal/models/shelf.py:138
+#: journal/models/shelf.py:100 journal/models/shelf.py:140
 msgid "start watching"
 msgstr "在看"
 
-#: journal/models/shelf.py:99 journal/models/shelf.py:139
+#: journal/models/shelf.py:101 journal/models/shelf.py:141
 #, python-brace-format
 msgid "started watching {item}"
 msgstr "在看 {item}"
 
-#: journal/models/shelf.py:100 journal/models/shelf.py:140
+#: journal/models/shelf.py:102 journal/models/shelf.py:142
 msgid "watching"
 msgstr "在看"
 
-#: journal/models/shelf.py:105
+#: journal/models/shelf.py:107
 msgid "movies watched"
 msgstr "看過的電影"
 
-#: journal/models/shelf.py:106 journal/models/shelf.py:146
+#: journal/models/shelf.py:108 journal/models/shelf.py:148
 msgid "finish watching"
 msgstr "看過"
 
-#: journal/models/shelf.py:107 journal/models/shelf.py:147
+#: journal/models/shelf.py:109 journal/models/shelf.py:149
 #, python-brace-format
 msgid "finished watching {item}"
 msgstr "看過 {item}"
 
-#: journal/models/shelf.py:108 journal/models/shelf.py:148
+#: journal/models/shelf.py:110 journal/models/shelf.py:150
 msgid "watched"
 msgstr "看過"
 
-#: journal/models/shelf.py:113
+#: journal/models/shelf.py:115
 msgid "movies dropped"
 msgstr "不再看的電影"
 
-#: journal/models/shelf.py:114 journal/models/shelf.py:154
+#: journal/models/shelf.py:116 journal/models/shelf.py:156
 msgid "stop watching"
 msgstr "不看了"
 
-#: journal/models/shelf.py:115 journal/models/shelf.py:155
+#: journal/models/shelf.py:117 journal/models/shelf.py:157
 #, python-brace-format
 msgid "stopped watching {item}"
 msgstr "不再看 {item}"
 
-#: journal/models/shelf.py:116 journal/models/shelf.py:156
+#: journal/models/shelf.py:118 journal/models/shelf.py:158
 msgid "stopped watching"
 msgstr "不看了"
 
-#: journal/models/shelf.py:121
+#: journal/models/shelf.py:123
 msgid "movies reviewed"
 msgstr "評論過的電影"
 
-#: journal/models/shelf.py:129
+#: journal/models/shelf.py:131
 msgid "TV shows to watch"
 msgstr "想看的劇集"
 
-#: journal/models/shelf.py:137
+#: journal/models/shelf.py:139
 msgid "TV shows watching"
 msgstr "正在看的劇集"
 
-#: journal/models/shelf.py:145
+#: journal/models/shelf.py:147
 msgid "TV shows watched"
 msgstr "看過的劇集"
 
-#: journal/models/shelf.py:153
+#: journal/models/shelf.py:155
 msgid "TV shows dropped"
 msgstr "不再看的劇集"
 
-#: journal/models/shelf.py:161
+#: journal/models/shelf.py:163
 msgid "TV shows reviewed"
 msgstr "評論過的劇集"
 
-#: journal/models/shelf.py:169
+#: journal/models/shelf.py:171
 msgid "albums to listen"
 msgstr "想聽的專輯"
 
-#: journal/models/shelf.py:170 journal/models/shelf.py:250
+#: journal/models/shelf.py:172 journal/models/shelf.py:252
 msgid "want to listen"
 msgstr "想聽"
 
-#: journal/models/shelf.py:171 journal/models/shelf.py:251
+#: journal/models/shelf.py:173 journal/models/shelf.py:253
 #, python-brace-format
 msgid "wants to listen {item}"
 msgstr "想聽 {item}"
 
-#: journal/models/shelf.py:172 journal/models/shelf.py:252
+#: journal/models/shelf.py:174 journal/models/shelf.py:254
 msgid "to listen"
 msgstr "想聽"
 
-#: journal/models/shelf.py:177
+#: journal/models/shelf.py:179
 msgid "albums listening"
 msgstr "正在聽的專輯"
 
-#: journal/models/shelf.py:178 journal/models/shelf.py:258
+#: journal/models/shelf.py:180 journal/models/shelf.py:260
 msgid "start listening"
 msgstr "在聽"
 
-#: journal/models/shelf.py:179 journal/models/shelf.py:259
+#: journal/models/shelf.py:181 journal/models/shelf.py:261
 #, python-brace-format
 msgid "started listening {item}"
 msgstr "在聽 {item}"
 
-#: journal/models/shelf.py:180 journal/models/shelf.py:260
+#: journal/models/shelf.py:182 journal/models/shelf.py:262
 msgid "listening"
 msgstr "在聽"
 
-#: journal/models/shelf.py:185
+#: journal/models/shelf.py:187
 msgid "albums listened"
 msgstr "聽過的專輯"
 
-#: journal/models/shelf.py:186 journal/models/shelf.py:266
+#: journal/models/shelf.py:188 journal/models/shelf.py:268
 msgid "finish listening"
 msgstr "聽過"
 
-#: journal/models/shelf.py:187 journal/models/shelf.py:267
+#: journal/models/shelf.py:189 journal/models/shelf.py:269
 #, python-brace-format
 msgid "finished listening {item}"
 msgstr "聽過 {item}"
 
-#: journal/models/shelf.py:188 journal/models/shelf.py:268
+#: journal/models/shelf.py:190 journal/models/shelf.py:270
 msgid "listened"
 msgstr "聽過"
 
-#: journal/models/shelf.py:193
+#: journal/models/shelf.py:195
 msgid "albums dropped"
 msgstr "不再聽的專輯"
 
-#: journal/models/shelf.py:194 journal/models/shelf.py:274
+#: journal/models/shelf.py:196 journal/models/shelf.py:276
 msgid "stop listening"
 msgstr "不聽了"
 
-#: journal/models/shelf.py:195 journal/models/shelf.py:275
+#: journal/models/shelf.py:197 journal/models/shelf.py:277
 #, python-brace-format
 msgid "stopped listening {item}"
 msgstr "不聽了 {item}"
 
-#: journal/models/shelf.py:196 journal/models/shelf.py:276
+#: journal/models/shelf.py:198 journal/models/shelf.py:278
 msgid "stopped listening"
 msgstr "不聽了"
 
-#: journal/models/shelf.py:201
+#: journal/models/shelf.py:203
 msgid "albums reviewed"
 msgstr "評論過的專輯"
 
-#: journal/models/shelf.py:209
+#: journal/models/shelf.py:211
 msgid "games to play"
 msgstr "想玩的遊戲"
 
-#: journal/models/shelf.py:210
+#: journal/models/shelf.py:212
 msgid "want to play"
 msgstr "想玩"
 
-#: journal/models/shelf.py:211
+#: journal/models/shelf.py:213
 #, python-brace-format
 msgid "wants to play {item}"
 msgstr "想玩 {item}"
 
-#: journal/models/shelf.py:212
+#: journal/models/shelf.py:214
 msgid "to play"
 msgstr "想玩"
 
-#: journal/models/shelf.py:217
+#: journal/models/shelf.py:219
 msgid "games playing"
 msgstr "正在玩的遊戲"
 
-#: journal/models/shelf.py:218
+#: journal/models/shelf.py:220
 msgid "start playing"
 msgstr "在玩"
 
-#: journal/models/shelf.py:219
+#: journal/models/shelf.py:221
 #, python-brace-format
 msgid "started playing {item}"
 msgstr "在玩 {item}"
 
-#: journal/models/shelf.py:220
+#: journal/models/shelf.py:222
 msgid "playing"
 msgstr "在玩"
 
-#: journal/models/shelf.py:225
+#: journal/models/shelf.py:227
 msgid "games played"
 msgstr "玩過的遊戲"
 
-#: journal/models/shelf.py:226
+#: journal/models/shelf.py:228
 msgid "finish playing"
 msgstr "玩過"
 
-#: journal/models/shelf.py:227
+#: journal/models/shelf.py:229
 #, python-brace-format
 msgid "finished playing {item}"
 msgstr "玩過 {item}"
 
-#: journal/models/shelf.py:228
+#: journal/models/shelf.py:230
 msgid "played"
 msgstr "玩過"
 
-#: journal/models/shelf.py:233
+#: journal/models/shelf.py:235
 msgid "games dropped"
 msgstr "不再玩的遊戲"
 
-#: journal/models/shelf.py:234
+#: journal/models/shelf.py:236
 msgid "stop playing"
 msgstr "不玩了"
 
-#: journal/models/shelf.py:235
+#: journal/models/shelf.py:237
 #, python-brace-format
 msgid "stopped playing {item}"
 msgstr "不再玩 {item}"
 
-#: journal/models/shelf.py:236
+#: journal/models/shelf.py:238
 msgid "stopped playing"
 msgstr "不玩了"
 
-#: journal/models/shelf.py:241
+#: journal/models/shelf.py:243
 msgid "games reviewed"
 msgstr "評論過的遊戲"
 
-#: journal/models/shelf.py:249
+#: journal/models/shelf.py:251
 msgid "podcasts to listen"
 msgstr "想聽的播客"
 
-#: journal/models/shelf.py:257
+#: journal/models/shelf.py:259
 msgid "podcasts listening"
 msgstr "正在聽的播客"
 
-#: journal/models/shelf.py:265
+#: journal/models/shelf.py:267
 msgid "podcasts listened"
 msgstr "聽過的播客"
 
-#: journal/models/shelf.py:273
+#: journal/models/shelf.py:275
 msgid "podcasts dropped"
 msgstr "不再聽的播客"
 
-#: journal/models/shelf.py:281
+#: journal/models/shelf.py:283
 msgid "podcasts reviewed"
 msgstr "評論過的播客"
 
-#: journal/models/shelf.py:289
+#: journal/models/shelf.py:291
 msgid "performances to see"
 msgstr "想看的演出"
 
-#: journal/models/shelf.py:290
+#: journal/models/shelf.py:292
 msgid "want to see"
 msgstr "想看"
 
-#: journal/models/shelf.py:291
+#: journal/models/shelf.py:293
 #, python-brace-format
 msgid "wants to see {item}"
 msgstr "想看 {item}"
 
-#: journal/models/shelf.py:292
+#: journal/models/shelf.py:294
 msgid "to see"
 msgstr "想看"
 
-#: journal/models/shelf.py:299
+#: journal/models/shelf.py:301
 msgid "performances saw"
 msgstr "看過的演出"
 
-#: journal/models/shelf.py:300
+#: journal/models/shelf.py:302
 msgid "finish seeing"
 msgstr "看過"
 
-#: journal/models/shelf.py:301
+#: journal/models/shelf.py:303
 #, python-brace-format
 msgid "finished seeing {item}"
 msgstr "看過 {item}"
 
-#: journal/models/shelf.py:302
+#: journal/models/shelf.py:304
 msgid "seen"
 msgstr "看過"
 
-#: journal/models/shelf.py:307
+#: journal/models/shelf.py:309
 msgid "performances dropped"
 msgstr "不再看的演出"
 
-#: journal/models/shelf.py:308
+#: journal/models/shelf.py:310
 msgid "stop seeing"
 msgstr "不看了"
 
-#: journal/models/shelf.py:309
+#: journal/models/shelf.py:311
 #, python-brace-format
 msgid "stopped seeing {item}"
 msgstr "不再看 {item}"
 
-#: journal/models/shelf.py:310
+#: journal/models/shelf.py:312
 msgid "stopped seeing"
 msgstr "不看了"
 
-#: journal/models/shelf.py:315
+#: journal/models/shelf.py:317
 msgid "performances reviewed"
 msgstr "評論過的演出"
 
-#: journal/models/shelf.py:323
+#: journal/models/shelf.py:325
 #, fuzzy
 #| msgid "Users you are following"
 msgid "people following"
 msgstr "正在關注的用戶"
 
-#: journal/models/shelf.py:325
+#: journal/models/shelf.py:327
 #, fuzzy, python-brace-format
 #| msgid "started playing {item}"
 msgid "started following {item}"
 msgstr "在玩 {item}"
 
-#: journal/models/shelf.py:921
+#: journal/models/shelf.py:923
 msgid "removed mark"
 msgstr "移除標記"
 
@@ -6192,37 +6198,22 @@ msgstr ""
 msgid "Remove from collection"
 msgstr "從收藏單中移除"
 
-#: journal/templates/_list_item.html:34
-msgid "add mark"
-msgstr "添加標記"
-
-#: journal/templates/_list_item.html:42
-msgid "update mark"
-msgstr "更新標記"
-
-#: journal/templates/_list_item.html:60
+#: journal/templates/_list_item.html:43
 #: journal/templates/collection_update_item_note_ok.html:3
 msgid "Update note"
 msgstr "修改備註"
 
-#: journal/templates/_list_item.html:100 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:123
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
 msgstr "評論"
 
-#: journal/templates/_list_item.html:133
+#: journal/templates/_list_item.html:91
 #, fuzzy, python-format
-#| msgid ""
-#| " %(dups)s items are from the same work or have the same identifier, they "
-#| "are hidden from the search results, <a _=\"on click toggle .unfold on "
-#| "#dup\">click here to show them.</a> "
-msgid ""
-"%(dups)s item(s) are from the same work or have the same identifier, click "
-"here to display:"
-msgstr ""
-" 已從結果中略去了來自同一作品或有相同標識號的%(dups)s個條目，<a _=\"on click "
-"toggle .unfold on #dup\">點擊這裏可重新顯示</a> "
+#| msgid " %(dups)s items are from the same work or have the same identifier, they are hidden from the search results, <a _=\"on click toggle .unfold on #dup\">click here to show them.</a> "
+msgid "%(dups)s item(s) are from the same work or have the same identifier, click here to display:"
+msgstr " 已從結果中略去了來自同一作品或有相同標識號的%(dups)s個條目，<a _=\"on click toggle .unfold on #dup\">點擊這裏可重新顯示</a> "
 
 #: journal/templates/_sidebar_collection_filter.html:32
 #, fuzzy
@@ -6341,6 +6332,14 @@ msgstr "已喜歡"
 msgid "Like"
 msgstr ""
 
+#: journal/templates/action_mark_item.html:10
+msgid "add mark"
+msgstr "添加標記"
+
+#: journal/templates/action_mark_item.html:18
+msgid "update mark"
+msgstr "更新標記"
+
 #: journal/templates/action_open_post.html:7
 #, fuzzy
 #| msgid "Public"
@@ -6401,13 +6400,13 @@ msgstr "添加到收藏單"
 msgid "Create a new collection"
 msgstr "創建新收藏單"
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:81
+#: journal/templates/article.html:104 social/templates/_event_post.html:76
 #, fuzzy
 #| msgid "wrote a review of {item}"
 msgid "wrote a review"
 msgstr "寫了關於 {item} 的評論"
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:83
+#: journal/templates/article.html:106 social/templates/_event_post.html:78
 #, fuzzy
 #| msgid "wrote a note"
 msgid "wrote an article"
@@ -6527,19 +6526,19 @@ msgstr "分享播放位置"
 msgid "Mark"
 msgstr "標記"
 
-#: journal/templates/mark.html:50
+#: journal/templates/mark.html:54
 msgid "not rated"
 msgstr "未評分"
 
-#: journal/templates/mark.html:70
+#: journal/templates/mark.html:74
 msgid "add a tag and press Enter"
 msgstr "回車增加標籤"
 
-#: journal/templates/mark.html:122
+#: journal/templates/mark.html:126
 msgid "change mark date"
 msgstr "指定標記日期"
 
-#: journal/templates/mark.html:148
+#: journal/templates/mark.html:156
 msgid "Sure to delete mark, comment and tags for this item?"
 msgstr "確認刪除這條標記、短評和標籤？"
 
@@ -6559,15 +6558,13 @@ msgstr "Markdown語法參考"
 #| "\n"
 #| "  Paragraphs need to be separated by a blank line\n"
 #| "\n"
-#| "  Indentation at the beginning of the paragraph requires using a Unicode "
-#| "full-width space\n"
+#| "  Indentation at the beginning of the paragraph requires using a Unicode full-width space\n"
 #| "\n"
 #| "[Link](https://zh.wikipedia.org/wiki/Markdown)\n"
 #| "**Bold**  *Italic* ==Highlight== ~~Strikethrough~~\n"
 #| "^Super^script ~Sub~script [拼(pīn)音(yīn)]\n"
 #| "\n"
-#| "Drag and drop an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/"
-#| "Wikipedia-logo-v2.svg)\n"
+#| "Drag and drop an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 #| "\n"
 #| "> Quote\n"
 #| ">> Multi-level quote\n"
@@ -6627,8 +6624,7 @@ msgid ""
 "Content Cell  | Content Cell\n"
 "Content Cell  | Content Cell\n"
 "\n"
-"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/"
-"Wikipedia-logo-v2.svg)\n"
+"Paste or upload an image ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 "\n"
 msgstr ""
 "\n"
@@ -6655,8 +6651,7 @@ msgstr ""
 ">! 多行\n"
 ">! 劇透\n"
 "\n"
-"引用外部圖片 ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-"
-"logo-v2.svg)\n"
+"引用外部圖片 ![](https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg)\n"
 "\n"
 "上傳圖片可拖拽圖片文件到編輯框，或從剪貼板粘貼\n"
 "\n"
@@ -6678,7 +6673,7 @@ msgstr ""
 "Content Cell  | Content Cell\n"
 "\n"
 
-#: journal/templates/note.html:19 journal/views/note.py:23
+#: journal/templates/note.html:19 journal/views/note.py:22
 msgid "Note"
 msgstr "筆記"
 
@@ -6709,9 +6704,7 @@ msgid "Are you sure to delete this entire content?"
 msgstr "確認刪除這則內容嗎？"
 
 #: journal/templates/piece_delete.html:24
-msgid ""
-"By deleting it, you will also lose track of others' comments and feedbacks "
-"to your content."
+msgid "By deleting it, you will also lose track of others' comments and feedbacks to your content."
 msgstr "刪除後你將無法追溯其他用戶對此內容曾經作出的回應和互動。"
 
 #: journal/templates/piece_delete.html:25
@@ -6805,7 +6798,7 @@ msgstr "年度小結"
 msgid "Articles"
 msgstr ""
 
-#: journal/templates/profile.html:166 journal/views/collection.py:427
+#: journal/templates/profile.html:166 journal/views/collection.py:409
 #: journal/views/profile.py:401
 msgid "collection"
 msgstr "收藏單"
@@ -6841,12 +6834,8 @@ msgid "Personal"
 msgstr "個人"
 
 #: journal/templates/tag_edit.html:52
-msgid ""
-"Personal tags are not included in public index. However, if you use this tag "
-"when marking an item publicly, it might still be visible to others."
-msgstr ""
-"個人標籤不被包括在條目的公共索引中，但如果公開標記一個條目時使用這個標籤仍會"
-"被別人看到。"
+msgid "Personal tags are not included in public index. However, if you use this tag when marking an item publicly, it might still be visible to others."
+msgstr "個人標籤不被包括在條目的公共索引中，但如果公開標記一個條目時使用這個標籤仍會被別人看到。"
 
 #: journal/templates/tag_edit.html:55
 msgid "Delete this tag"
@@ -6921,123 +6910,124 @@ msgstr "{0} 的評論"
 msgid "Link invalid"
 msgstr "連結無效"
 
-#: journal/views/collection.py:58 journal/views/collection.py:96
+#: journal/views/collection.py:62 journal/views/collection.py:94
 #, python-brace-format
 msgid "Collection by {0}"
 msgstr "{0} 的收藏單"
 
-#: journal/views/collection.py:432
+#: journal/views/collection.py:414
 msgid "shared my collection"
 msgstr "分享我的收藏單"
 
-#: journal/views/collection.py:435
+#: journal/views/collection.py:417
 #, python-brace-format
 msgid "shared {username}'s collection"
 msgstr "分享 {username} 的收藏單"
 
-#: journal/views/collection.py:502 journal/views/collection.py:541
-#: journal/views/collection.py:553 journal/views/collection.py:579
+#: journal/views/collection.py:484 journal/views/collection.py:523
+#: journal/views/collection.py:535 journal/views/collection.py:561
 msgid "Dynamic collection is not editable"
 msgstr ""
 
-#: journal/views/collection.py:518
+#: journal/views/collection.py:500
 msgid "The item is already in the collection."
 msgstr "條目已在收藏單中。"
 
-#: journal/views/collection.py:520
+#: journal/views/collection.py:502
 msgid "Unable to find the item, please use item url from this site."
 msgstr "找不到條目，請使用本站條目網址。"
 
-#: journal/views/collection.py:566
+#: journal/views/collection.py:548
 msgid "Saved."
 msgstr "已保存"
 
-#: journal/views/common.py:119 journal/views/mark.py:225
-#: journal/views/mark.py:279 journal/views/note.py:175
+#: journal/views/common.py:126 journal/views/mark.py:273
+#: journal/views/mark.py:315 journal/views/note.py:167
 #: journal/views/profile.py:42 journal/views/review.py:59
 #: journal/views/review.py:79
 msgid "Content not found"
 msgstr "內容未找到"
 
-#: journal/views/common.py:174 journal/views/mark.py:159
+#: journal/views/common.py:184 journal/views/mark.py:210
 msgid "Data saved but unable to crosspost to Fediverse instance."
 msgstr "數據已保存但未能轉發到聯邦實例。"
 
-#: journal/views/common.py:176
+#: journal/views/common.py:186
 msgid "Redirecting to your Fediverse instance now to re-authenticate."
 msgstr "正在重定向到你的聯邦實例以重新認證。"
 
-#: journal/views/common.py:183
+#: journal/views/common.py:193
 msgid "List not found."
 msgstr "列表未找到"
 
-#: journal/views/mark.py:150
+#: journal/views/mark.py:206
 msgid "Content too long for your Fediverse instance."
 msgstr "內容過長，超出了你的聯邦實例的限制。"
 
-#: journal/views/mark.py:178 journal/views/mark.py:238
+#: journal/views/mark.py:224 journal/views/mark.py:226
+#: journal/views/mark.py:280
 #, fuzzy
 #| msgid "Invalid tag"
 msgid "Invalid input"
 msgstr "無效標籤"
 
-#: journal/views/note.py:23
+#: journal/views/note.py:22
 msgid "Progress"
 msgstr ""
 
-#: journal/views/note.py:28
+#: journal/views/note.py:27
 #, fuzzy
 #| msgid "Update note"
 msgid "Update progress"
 msgstr "修改備註"
 
-#: journal/views/note.py:59
+#: journal/views/note.py:58
 msgid "Progress (optional)"
 msgstr "進度（選填）"
 
-#: journal/views/note.py:61
+#: journal/views/note.py:60
 msgid "Note Content"
 msgstr "筆記內容"
 
-#: journal/views/note.py:63
+#: journal/views/note.py:62
 msgid "Content Warning (optional)"
 msgstr "劇透或敏感內容提示（選填）"
 
-#: journal/views/note.py:85
+#: journal/views/note.py:84
 msgid "Progress Type (optional)"
 msgstr "進度類型（選填）"
 
-#: journal/views/note.py:123 journal/views/note.py:183
+#: journal/views/note.py:115 journal/views/note.py:175
 msgid "Only in-progress items can have progress."
 msgstr ""
 
-#: journal/views/post.py:98 journal/views/post.py:392
+#: journal/views/post.py:100 journal/views/post.py:388
 msgid "Post not found"
 msgstr "帖文未找到"
 
-#: journal/views/post.py:189
+#: journal/views/post.py:191
 msgid "Visibility too high for quoting this post"
 msgstr ""
 
-#: journal/views/post.py:337 journal/views/post.py:418
+#: journal/views/post.py:339 journal/views/post.py:414
 #, fuzzy
 #| msgid "Item cannot be deleted."
 msgid "Content cannot be empty."
 msgstr "條目不可被刪除。"
 
-#: journal/views/post.py:396
+#: journal/views/post.py:392
 #, fuzzy
 #| msgid "This operation cannot be undone. Sure to merge?"
 msgid "This post cannot be edited here"
 msgstr "本操作不可撤銷。確認合併嗎？"
 
-#: journal/views/post.py:541
+#: journal/views/post.py:531
 #, fuzzy
 #| msgid "Invalid file."
 msgid "Invalid choices"
 msgstr "無效檔案。"
 
-#: journal/views/post.py:544
+#: journal/views/post.py:534
 #, fuzzy
 #| msgid "Invalid tag"
 msgid "Invalid post"
@@ -7059,60 +7049,57 @@ msgstr "{review_title} - 關於 {item_title} 的評論"
 msgid "may contain spoiler or triggering content"
 msgstr "關於 {item_title}，可能包含劇透或敏感內容"
 
-#: journal/views/tag.py:47 journal/views/tag.py:61
+#: journal/views/tag.py:46 journal/views/tag.py:60
 msgid "Invalid tag"
 msgstr "無效標籤"
 
-#: journal/views/tag.py:50
+#: journal/views/tag.py:49
 msgid "Tag not found"
 msgstr "標籤不存在"
 
-#: journal/views/tag.py:72
+#: journal/views/tag.py:65
 msgid "Tag deleted."
 msgstr "標籤已刪除"
 
-#: journal/views/tag.py:82
+#: journal/views/tag.py:75
 msgid "Duplicated tag."
 msgstr "重複標籤"
 
-#: journal/views/tag.py:96
+#: journal/views/tag.py:83
 msgid "Tag updated."
 msgstr "標籤已更新"
 
-#: journal/views/wrapped.py:160
+#: journal/views/wrapped.py:161
 msgid "Summary posted to timeline."
 msgstr "總結已發佈到時間軸"
 
-#: mastodon/models/common.py:29
+#: mastodon/models/common.py:31
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: mastodon/models/common.py:30 users/templates/users/login.html:120
+#: mastodon/models/common.py:32 users/templates/users/login.html:114
 msgid "Threads"
 msgstr "Threads"
 
-#: mastodon/models/common.py:31
+#: mastodon/models/common.py:33
 msgid "Bluesky"
 msgstr "Bluesky"
 
-#: mastodon/models/email.py:59
+#: mastodon/models/email.py:63
 msgid ""
 "\n"
 "\n"
-"If you did not mean to register or login, please ignore this email. If you "
-"are concerned with your account security, please change the email linked "
-"with your account, or contact us."
+"If you did not mean to register or login, please ignore this email. If you are concerned with your account security, please change the email linked with your account, or contact us."
 msgstr ""
 "\n"
 "\n"
-"如果你沒有打算用此電子郵件地址註冊或登入本站，請忽略此郵件；如果你確信帳號存"
-"在安全風險，請更改註冊郵件地址或與我們聯繫。"
+"如果你沒有打算用此電子郵件地址註冊或登入本站，請忽略此郵件；如果你確信帳號存在安全風險，請更改註冊郵件地址或與我們聯繫。"
 
-#: mastodon/models/email.py:64 mastodon/models/email.py:69
+#: mastodon/models/email.py:68 mastodon/models/email.py:73
 msgid "Verification Code"
 msgstr "驗證碼"
 
-#: mastodon/models/email.py:66
+#: mastodon/models/email.py:70
 #, python-brace-format
 msgid ""
 "Use this code to verify your email address {email}\n"
@@ -7124,7 +7111,7 @@ msgstr ""
 "\n"
 "{code}"
 
-#: mastodon/models/email.py:70
+#: mastodon/models/email.py:74
 #, python-brace-format
 msgid ""
 "Use this code to login as {email}\n"
@@ -7136,29 +7123,26 @@ msgstr ""
 "\n"
 "{code}"
 
-#: mastodon/models/email.py:74 users/templates/users/captcha.html:13
+#: mastodon/models/email.py:78 users/templates/users/captcha.html:13
 #: users/templates/users/captcha_solved.html:9
 #: users/templates/users/login.html:20 users/templates/users/register.html:9
 #: users/templates/users/welcome.html:10
 msgid "Register"
 msgstr "註冊"
 
-#: mastodon/models/email.py:76
+#: mastodon/models/email.py:80
 #, python-brace-format
 msgid ""
 "There is no account registered with this email address yet: {email}\n"
 "\n"
-"If you already have an account with us, just login and add this email to you "
-"account.\n"
+"If you already have an account with us, just login and add this email to you account.\n"
 "\n"
-"If you prefer to register a new account with this email, please use this "
-"verification code: {code}"
+"If you prefer to register a new account with this email, please use this verification code: {code}"
 msgstr ""
 "你好，\n"
 "本站沒有與{email}關聯的帳號。你希望註冊一個新帳號嗎？\n"
 "\n"
-"如果你已註冊過本站或某個聯邦宇宙（長毛象）實例，不必重新註冊，只要用聯邦宇宙"
-"身份登入本站，再關聯這個電子郵件地址，即可通過郵件登入。\n"
+"如果你已註冊過本站或某個聯邦宇宙（長毛象）實例，不必重新註冊，只要用聯邦宇宙身份登入本站，再關聯這個電子郵件地址，即可通過郵件登入。\n"
 "\n"
 "如果你確認要使用電子郵件新註冊帳號，請輸入如下驗證碼： {code}"
 
@@ -7202,56 +7186,61 @@ msgstr "帖文長度限制"
 msgid "New Post"
 msgstr "新帖文"
 
-#: mastodon/views/bluesky.py:26 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:32 mastodon/views/bluesky.py:93
 #, fuzzy
 #| msgid "Bluesky Login ID"
 msgid "Bluesky login is disabled."
 msgstr "Bluesky 登入名"
 
-#: mastodon/views/bluesky.py:28 mastodon/views/email.py:35
-#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:29
-#: users/templates/users/login.html:6 users/views/webauthn.py:133
+#: mastodon/views/bluesky.py:47 mastodon/views/bluesky.py:59
+#: mastodon/views/bluesky.py:65 mastodon/views/bluesky.py:98
+#: mastodon/views/bluesky.py:106 mastodon/views/bluesky.py:112
+#: mastodon/views/common.py:36 mastodon/views/mastodon.py:62
+#: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
+#: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
+#: mastodon/views/threads.py:57 mastodon/views/threads.py:65
+#: mastodon/views/threads.py:71 users/views/account.py:256
+#: users/views/account.py:375
+msgid "Authentication failed"
+msgstr "認證失敗"
+
+#: mastodon/views/bluesky.py:47 mastodon/views/common.py:103
+msgid "Identity not found."
+msgstr "身份未找到"
+
+#: mastodon/views/bluesky.py:53 mastodon/views/email.py:35
+#: mastodon/views/mastodon.py:36 mastodon/views/threads.py:31
+#: users/templates/users/login.html:6 users/views/webauthn.py:136
 #, fuzzy
 #| msgid "Export file expired. Please export again."
 msgid "Security check failed. Please try again."
 msgstr "匯出文件已失效，請重新匯出"
 
-#: mastodon/views/bluesky.py:34 mastodon/views/bluesky.py:40
-#: mastodon/views/bluesky.py:64 mastodon/views/bluesky.py:72
-#: mastodon/views/bluesky.py:78 mastodon/views/common.py:36
-#: mastodon/views/mastodon.py:62 mastodon/views/mastodon.py:70
-#: mastodon/views/mastodon.py:77 mastodon/views/mastodon.py:87
-#: mastodon/views/mastodon.py:94 mastodon/views/threads.py:55
-#: mastodon/views/threads.py:63 mastodon/views/threads.py:69
-#: users/views/account.py:254 users/views/account.py:373
-msgid "Authentication failed"
-msgstr "認證失敗"
-
-#: mastodon/views/bluesky.py:35 mastodon/views/email.py:66
+#: mastodon/views/bluesky.py:60 mastodon/views/email.py:66
 #, fuzzy
 #| msgid "System busy, please try again in a minute."
 msgid "Too many attempts, please try again later."
 msgstr "系統繁忙，請稍等幾秒鐘再搜索。"
 
-#: mastodon/views/bluesky.py:40
+#: mastodon/views/bluesky.py:65
 #, fuzzy
 #| msgid "ATProto handle"
 msgid "ATProto handle is required."
 msgstr "ATProto 用戶標識"
 
-#: mastodon/views/bluesky.py:50
+#: mastodon/views/bluesky.py:84
 #, fuzzy
 #| msgid "Error connecting to instance"
 msgid "Error connecting to your ATProto server"
 msgstr "無法連接實例"
 
-#: mastodon/views/bluesky.py:73
+#: mastodon/views/bluesky.py:107
 #, fuzzy
 #| msgid "Invalid response from Fediverse instance."
 msgid "Invalid response from ATProto authorization server."
 msgstr "聯邦實例返回信息無效"
 
-#: mastodon/views/bluesky.py:78
+#: mastodon/views/bluesky.py:112
 msgid "Invalid account data from Bluesky."
 msgstr "Bluesky返回了無效的帳號數據。"
 
@@ -7259,7 +7248,7 @@ msgstr "Bluesky返回了無效的帳號數據。"
 msgid "Invalid user."
 msgstr "無效用戶。"
 
-#: mastodon/views/common.py:52 users/views/account.py:414
+#: mastodon/views/common.py:52 users/views/account.py:416
 msgid "Registration failed"
 msgstr "註冊失敗"
 
@@ -7290,10 +7279,6 @@ msgstr "登入信息已更新爲{handle}。"
 #: mastodon/views/common.py:116
 msgid "Disconnect identity failed"
 msgstr "未能取消身份關聯"
-
-#: mastodon/views/common.py:103
-msgid "Identity not found."
-msgstr "身份未找到"
 
 #: mastodon/views/common.py:117
 msgid "You cannot disconnect last login identity."
@@ -7336,7 +7321,7 @@ msgstr "無法連接實例"
 msgid "Invalid response from Fediverse instance."
 msgstr "聯邦實例返回信息無效"
 
-#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:64
+#: mastodon/views/mastodon.py:71 mastodon/views/threads.py:66
 msgid "Invalid OAuth state. Please try again."
 msgstr ""
 
@@ -7356,19 +7341,17 @@ msgstr "聯邦實例返回了無效的認證令牌。"
 msgid "Invalid account data from Fediverse instance."
 msgstr "聯邦實例返回了無效的帳號資料。"
 
-#: mastodon/views/threads.py:69
+#: mastodon/views/threads.py:71
 msgid "Invalid account data from Threads."
 msgstr "Threads返回了無效的帳號資料。"
 
-#: mastodon/views/threads.py:147
+#: mastodon/views/threads.py:149
 msgid "Data deletion completed"
 msgstr ""
 
-#: mastodon/views/threads.py:149
+#: mastodon/views/threads.py:151
 #, python-brace-format
-msgid ""
-"Data linked to your Threads account has been deleted. Confirmation code: "
-"{code}"
+msgid "Data linked to your Threads account has been deleted. Confirmation code: {code}"
 msgstr ""
 
 #: social/templates/_article_teaser.html:10
@@ -7405,15 +7388,11 @@ msgstr "轉播了"
 msgid "play"
 msgstr "播放"
 
-#: social/templates/_event_post.html:50
-msgid "mark"
-msgstr "標記"
-
-#: social/templates/_event_post.html:79
+#: social/templates/_event_post.html:74
 msgid "wrote a note"
 msgstr "寫了筆記"
 
-#: social/templates/_event_post.html:88
+#: social/templates/_event_post.html:83
 #, fuzzy
 #| msgid "playing"
 msgid "replying to"
@@ -7428,7 +7407,7 @@ msgstr ""
 msgid "Untitled article"
 msgstr ""
 
-#: social/templates/event/boosted.html:3
+#: social/templates/event/boosted.html:2
 msgid "boosted your post"
 msgstr "轉播了你的帖文"
 
@@ -7484,12 +7463,10 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"boosted your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"轉播了你對 <a href=\"%(item_url)s\">%(item_title)s</a> 的評論 <a "
-"href=\"%(piece_url)s\">%(piece_title)s</a>\n"
+"轉播了你對 <a href=\"%(item_url)s\">%(item_title)s</a> 的評論 <a href=\"%(piece_url)s\">%(piece_title)s</a>\n"
 
 #: social/templates/event/boosted_shelfmember.html:3
 #, python-format
@@ -7508,7 +7485,7 @@ msgstr "請求關注你"
 msgid "followed you"
 msgstr "關注了你"
 
-#: social/templates/event/liked.html:3
+#: social/templates/event/liked.html:2
 msgid "liked your post"
 msgstr "讚了你的帖文"
 
@@ -7564,12 +7541,10 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"liked your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"讚了你對 <a href=\"%(item_url)s\">%(item_title)s</a> 的評論 <a "
-"href=\"%(piece_url)s\">%(piece_title)s</a>\n"
+"讚了你對 <a href=\"%(item_url)s\">%(item_title)s</a> 的評論 <a href=\"%(piece_url)s\">%(piece_title)s</a>\n"
 
 #: social/templates/event/liked_shelfmember.html:3
 #, python-format
@@ -7580,7 +7555,7 @@ msgstr ""
 "\n"
 "讚了你對 <a href=\"%(item_url)s\">%(item_title)s</a> 的標記\n"
 
-#: social/templates/event/mentioned.html:3
+#: social/templates/event/mentioned.html:2
 msgid "mentioned you"
 msgstr "提到了你"
 
@@ -7636,12 +7611,10 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a "
-"href=\"%(item_url)s\">%(item_title)s</a>\n"
+"replied to your review <a href=\"%(piece_url)s\">%(piece_title)s</a> on <a href=\"%(item_url)s\">%(item_title)s</a>\n"
 msgstr ""
 "\n"
-"回應了你對 <a href=\"%(item_url)s\">%(item_title)s</a> 的評論 <a "
-"href=\"%(piece_url)s\">%(piece_title)s</a>\n"
+"回應了你對 <a href=\"%(item_url)s\">%(item_title)s</a> 的評論 <a href=\"%(piece_url)s\">%(piece_title)s</a>\n"
 
 #: social/templates/event/mentioned_shelfmember.html:3
 #, python-format
@@ -7652,32 +7625,46 @@ msgstr ""
 "\n"
 "回應了你對 <a href=\"%(item_url)s\">%(item_title)s</a> 的標記\n"
 
-#: social/templates/feed.html:12 social/templates/feed.html:39
-#: social/templates/search_feed.html:12
-msgid "Activities from those you follow"
-msgstr "好友動態"
+#: social/templates/feed.html:39 users/templates/users/preferences.html:40
+msgid "Activities"
+msgstr "動態"
 
-#: social/templates/feed.html:42 social/templates/feed.html:44
+#: social/templates/feed.html:43 social/templates/feed.html:45
+msgid "world"
+msgstr ""
+
+#: social/templates/feed.html:51 social/templates/feed.html:53
+#, fuzzy
+#| msgid "locale"
+msgid "local"
+msgstr "區域語言"
+
+#: social/templates/feed.html:58 social/templates/feed.html:60
+#, fuzzy
+#| msgid "sure to follow?"
+msgid "those you follow"
+msgstr "確定關注該用戶嗎？"
+
+#: social/templates/feed.html:64 social/templates/feed.html:66
 #, fuzzy
 #| msgid "What they read/watch/..."
 msgid "what they read/watch/..."
 msgstr "僅書影音"
 
-#: social/templates/feed_events.html:30
+#: social/templates/feed_events.html:29
 msgid "no matching activities."
 msgstr "無匹配動態。"
 
-#: social/templates/feed_events.html:33
+#: social/templates/feed_events.html:31
+#, fuzzy
+#| msgid "no matching activities."
+msgid "no public activities yet."
+msgstr "無匹配動態。"
+
+#: social/templates/feed_events.html:34
 #, python-format
-msgid ""
-"Find and mark some books/movies/podcasts/games, <a "
-"href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/"
-"Douban, follow some fellow %(site_name)s users on the fediverse, so their "
-"recent activities and yours will show up here."
-msgstr ""
-"搜索並標記一些書影音/播客/遊戲，<a href=\"%(import_url)s\">匯入你的豆瓣、"
-"Letterboxd或Goodreads記錄</a>，去聯邦宇宙（長毛象）關注一些正在使"
-"用%(site_name)s的用戶，這裏就會顯示你和她們的近期動態。"
+msgid "Find and mark some books/movies/podcasts/games, <a href=\"%(import_url)s\">import your data</a> from Goodreads/Letterboxd/Douban, follow some fellow %(site_name)s users on the fediverse, so their recent activities and yours will show up here."
+msgstr "搜索並標記一些書影音/播客/遊戲，<a href=\"%(import_url)s\">匯入你的豆瓣、Letterboxd或Goodreads記錄</a>，去聯邦宇宙（長毛象）關注一些正在使用%(site_name)s的用戶，這裏就會顯示你和她們的近期動態。"
 
 #: social/templates/notification.html:58
 msgid "mention"
@@ -7713,6 +7700,10 @@ msgstr ""
 msgid "Poll ending at %(end_time)s"
 msgstr ""
 
+#: social/templates/search_feed.html:12 social/views.py:57 social/views.py:58
+msgid "Activities from those you follow"
+msgstr "好友動態"
+
 #: social/templates/single_post.html:13 social/templates/single_post.html:32
 #, fuzzy
 #| msgid "Posts"
@@ -7727,59 +7718,69 @@ msgstr ""
 msgid "Poll"
 msgstr ""
 
-#: takahe/models.py:453
+#: social/views.py:59
+#, fuzzy
+#| msgid "Activities from those you follow"
+msgid "Activities on this site"
+msgstr "好友動態"
+
+#: social/views.py:60
+#, fuzzy
+#| msgid "Activities from those you follow"
+msgid "Activities from the fediverse"
+msgstr "好友動態"
+
+#: takahe/models.py:445
 msgid "Display Name"
 msgstr "暱稱"
 
-#: takahe/models.py:455
+#: takahe/models.py:447
 msgid "Bio"
 msgstr "簡介"
 
-#: takahe/models.py:457
+#: takahe/models.py:449
 msgid "Manually approve new followers"
 msgstr "手工審覈關注者"
 
-#: takahe/models.py:461
+#: takahe/models.py:453
 #, fuzzy
 #| msgid "Include profile and posts in discovery"
 msgid "Include profile, marks and posts in discovery"
 msgstr "允許個人資料和帖文包含在發現中"
 
-#: takahe/models.py:464
+#: takahe/models.py:456
 msgid "Include posts in search results"
 msgstr "允許個人帖文包含在搜索結果中"
 
-#: takahe/models.py:482
+#: takahe/models.py:474
 msgid "Profile picture"
 msgstr "頭像"
 
-#: takahe/models.py:489
+#: takahe/models.py:481
 msgid "Header picture"
 msgstr "背景圖片"
 
-#: users/models/task.py:22
+#: users/models/task.py:24
 msgid "Started"
 msgstr "已開始"
 
-#: users/models/task.py:23
+#: users/models/task.py:25
 msgid "Complete"
 msgstr "完成"
 
-#: users/models/user.py:69
-msgid ""
-"Enter a valid username. This value may contain only unaccented lowercase a-z "
-"and uppercase A-Z letters, numbers, and _ characters."
+#: users/models/user.py:71
+msgid "Enter a valid username. This value may contain only unaccented lowercase a-z and uppercase A-Z letters, numbers, and _ characters."
 msgstr "輸入用戶名，限英文字母數字下劃線，最多30個字符。"
 
-#: users/models/user.py:130
+#: users/models/user.py:132
 msgid "username"
 msgstr "用戶名"
 
-#: users/models/user.py:135
+#: users/models/user.py:137
 msgid "Required. 50 characters or fewer. Letters, digits and _ only."
 msgstr "必填，限英文字母數字下劃線，最多30個字符。"
 
-#: users/models/user.py:138
+#: users/models/user.py:140
 msgid "A user with that username already exists."
 msgstr "使用該用戶名的用戶已存在。"
 
@@ -7934,9 +7935,7 @@ msgid "Cancel import"
 msgstr "取消"
 
 #: users/templates/users/_rym_section.html:29
-msgid ""
-"On RateYourMusic, go to your profile and use the <b>Export your music "
-"catalog</b> option to download your library as a CSV file."
+msgid "On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:31
@@ -7945,18 +7944,12 @@ msgid "Upload the downloaded CSV file below."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:33
-msgid ""
-"Albums are matched by title + artist (and year if present) — first against "
-"the local catalog, then MusicBrainz, then Spotify. After auto-matching, "
-"you'll preview the matches in a table, edit any link or shelf status, and "
-"confirm the import."
+msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:36
 #: users/templates/users/_storygraph_section.html:38
-msgid ""
-"You can also re-upload a previously-downloaded matched CSV — the existing "
-"<code>link</code> column will be honoured as the default match."
+msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:40
@@ -7987,18 +7980,11 @@ msgid "Cancel the StoryGraph import? Progress will be discarded."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:31
-msgid ""
-"On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to "
-"download your library as a CSV file."
+msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/_storygraph_section.html:35
-msgid ""
-"Books are matched by ISBN — first against the local catalog, then Google "
-"Books and OpenLibrary — with a title + author search as fallback. After auto-"
-"matching, you'll preview the matches in a table, edit any link or shelf "
-"status, and confirm the import."
+msgid "Books are matched by ISBN — first against the local catalog, then Google Books and OpenLibrary — with a title + author search as fallback. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/account.html:11
@@ -8010,9 +7996,7 @@ msgid "Display name, avatar and other information"
 msgstr "暱稱、頭像與其它個人信息"
 
 #: users/templates/users/account.html:23
-msgid ""
-"Updating profile information here will turn off automatic sync of display "
-"name, bio and avatar from your Mastodon instance. Sure to continue?"
+msgid "Updating profile information here will turn off automatic sync of display name, bio and avatar from your Mastodon instance. Sure to continue?"
 msgstr "在這裏更新個人資料會停止從關聯實例自動同步暱稱等個人信息，確定繼續嗎？"
 
 #: users/templates/users/account.html:26
@@ -8025,18 +8009,11 @@ msgstr "電子郵件地址"
 
 #: users/templates/users/account.html:59 users/templates/users/register.html:47
 #, python-format
-msgid ""
-"Please click the confirmation link in the email sent to %(pending_email)s; "
-"if you haven't received it for more than a few minutes, please input and "
-"save again."
-msgstr ""
-"當前待確認的電子郵件地址爲%(pending_email)s，請查收郵件並點擊確認連結；如長時"
-"間未收到可重新輸入並保存。"
+msgid "Please click the confirmation link in the email sent to %(pending_email)s; if you haven't received it for more than a few minutes, please input and save again."
+msgstr "當前待確認的電子郵件地址爲%(pending_email)s，請查收郵件並點擊確認連結；如長時間未收到可重新輸入並保存。"
 
 #: users/templates/users/account.html:61 users/templates/users/register.html:50
-msgid ""
-"Email is recommended as a backup login method, if you log in via a Fediverse "
-"instance"
+msgid "Email is recommended as a backup login method, if you log in via a Fediverse instance"
 msgstr "推薦輸入電子郵件地址作爲備用登入方式。"
 
 #: users/templates/users/account.html:73 users/templates/users/login.html:84
@@ -8054,25 +8031,15 @@ msgid "Last updated"
 msgstr "最近更新"
 
 #: users/templates/users/account.html:92
-msgid ""
-"If you have not yet registered with any Federated instance, you may <a "
-"href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an "
-"instance</a> and register."
-msgstr ""
-"如果你還沒有在任何<em data-tooltip=\"聯邦宇宙(Fediverse 有時也被稱爲長毛象)是"
-"一種分佈式社交網絡\">聯邦宇宙</em>實例註冊過，可先<a href=\"https://"
-"joinmastodon.org/zh/servers\" target=\"_blank\">選擇實例並註冊</a>。"
+msgid "If you have not yet registered with any Federated instance, you may <a href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">choose an instance</a> and register."
+msgstr "如果你還沒有在任何<em data-tooltip=\"聯邦宇宙(Fediverse 有時也被稱爲長毛象)是一種分佈式社交網絡\">聯邦宇宙</em>實例註冊過，可先<a href=\"https://joinmastodon.org/zh/servers\" target=\"_blank\">選擇實例並註冊</a>。"
 
 #: users/templates/users/account.html:97
-msgid ""
-"To associate with another federated identity, please enter the domain name "
-"of the instance where the new identity is located."
+msgid "To associate with another federated identity, please enter the domain name of the instance where the new identity is located."
 msgstr "如需關聯到另一個聯邦宇宙社交身份，請輸入新身份所在的實例域名"
 
 #: users/templates/users/account.html:99
-msgid ""
-"If you have registered with a Federated instance, please enter the instance "
-"domain name."
+msgid "If you have registered with a Federated instance, please enter the instance domain name."
 msgstr "如果你已經註冊過聯邦宇宙實例，請輸入實例域名"
 
 #: users/templates/users/account.html:104
@@ -8086,26 +8053,17 @@ msgid "Go to target instance and authorize with the identity"
 msgstr "登入實例並關聯"
 
 #: users/templates/users/account.html:113
-msgid ""
-"After replacing the association, you may use the new Fediverse identity to "
-"log in and control data visibility. Existing data such as tags, comments, "
-"and collections will not be affected."
-msgstr ""
-"替換關聯後可使用新的聯邦宇宙身份來登入本站和控制數據可見性，已有的標記評論收"
-"藏單等數據不受影響。"
+msgid "After replacing the association, you may use the new Fediverse identity to log in and control data visibility. Existing data such as tags, comments, and collections will not be affected."
+msgstr "替換關聯後可使用新的聯邦宇宙身份來登入本站和控制數據可見性，已有的標記評論收藏單等數據不受影響。"
 
 #: users/templates/users/account.html:115
-msgid ""
-"Once associated with Fediverse identity, you can discover more users and use "
-"the full features of this site."
+msgid "Once associated with Fediverse identity, you can discover more users and use the full features of this site."
 msgstr "關聯聯邦宇宙身份後可發現更多用戶，並使用本站完整功能。"
 
 #: users/templates/users/account.html:123
 #: users/templates/users/account.html:160
 #: users/templates/users/account.html:206
-msgid ""
-"Once disconnected, you will no longer be able login with this identity. Are "
-"you sure to continue?"
+msgid "Once disconnected, you will no longer be able login with this identity. Are you sure to continue?"
 msgstr "取消關聯後將無法使用這個身份登入本站，確認繼續嗎？"
 
 #: users/templates/users/account.html:126
@@ -8132,7 +8090,7 @@ msgstr "關聯一個threads.net帳號"
 msgid "Disconnect with Threads"
 msgstr "取消關聯"
 
-#: users/templates/users/account.html:173 users/templates/users/login.html:112
+#: users/templates/users/account.html:173 users/templates/users/login.html:106
 msgid "Bluesky (ATProto)"
 msgstr "Bluesky (ATProto)"
 
@@ -8140,7 +8098,7 @@ msgstr "Bluesky (ATProto)"
 msgid "Verified ATProto identity"
 msgstr "已驗證的ATProto身份"
 
-#: users/templates/users/account.html:194 users/templates/users/login.html:216
+#: users/templates/users/account.html:194 users/templates/users/login.html:210
 msgid "ATProto handle"
 msgstr "ATProto 用戶標識"
 
@@ -8165,7 +8123,7 @@ msgid "Name this passkey:"
 msgstr ""
 
 #: users/templates/users/account.html:227 users/templates/users/login.html:69
-#: users/templates/users/welcome.html:33 users/views/webauthn.py:106
+#: users/templates/users/welcome.html:33 users/views/webauthn.py:109
 msgid "Passkey"
 msgstr ""
 
@@ -8214,13 +8172,8 @@ msgid "Save sync settings"
 msgstr "保存同步設定"
 
 #: users/templates/users/account.html:297
-msgid ""
-"New follow, mute and blocks in the associated identity may be automatically "
-"imported; removal has to be done manually."
-msgstr ""
-"本站會按照以上設定每天自動匯入你在聯邦宇宙實例等社交網絡中新增的關注、屏蔽和"
-"隱藏列表；如果你在聯邦宇宙實例中關注的用戶加入了本站，你會自動關注她；如果你"
-"在聯邦宇宙實例中取消了關注、屏蔽或隱藏，本站不會自動取消，但你可以手動移除。"
+msgid "New follow, mute and blocks in the associated identity may be automatically imported; removal has to be done manually."
+msgstr "本站會按照以上設定每天自動匯入你在聯邦宇宙實例等社交網絡中新增的關注、屏蔽和隱藏列表；如果你在聯邦宇宙實例中關注的用戶加入了本站，你會自動關注她；如果你在聯邦宇宙實例中取消了關注、屏蔽或隱藏，本站不會自動取消，但你可以手動移除。"
 
 #: users/templates/users/account.html:304
 msgid "Click button below to start sync now."
@@ -8256,15 +8209,11 @@ msgid "Log out everywhere"
 msgstr ""
 
 #: users/templates/users/account.html:365
-msgid ""
-"This will log you out of all browsers and devices (including the current "
-"one), and revoke all API tokens. Continue?"
+msgid "This will log you out of all browsers and devices (including the current one), and revoke all API tokens. Continue?"
 msgstr ""
 
 #: users/templates/users/account.html:368
-msgid ""
-"If you notice any suspicious activity or have logged in on a shared "
-"computer, you can log out of all sessions and revoke all API tokens."
+msgid "If you notice any suspicious activity or have logged in on a shared computer, you can log out of all sessions and revoke all API tokens."
 msgstr ""
 
 #: users/templates/users/account.html:378
@@ -8339,10 +8288,10 @@ msgstr "想聽"
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:74
-#: users/templates/users/data.html:126 users/templates/users/data.html:183
-#: users/templates/users/data.html:234 users/templates/users/data.html:298
-#: users/templates/users/data.html:358 users/templates/users/data.html:553
+#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/data.html:141 users/templates/users/data.html:198
+#: users/templates/users/data.html:249 users/templates/users/data.html:313
+#: users/templates/users/data.html:376 users/templates/users/data.html:553
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr "匯入"
@@ -8371,9 +8320,7 @@ msgid "Migrate Account"
 msgstr "遷移帳號"
 
 #: users/templates/users/account.html:488
-msgid ""
-"Linking an email to your account is highly recommended before migrating from "
-"another Fediverse instance."
+msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
 msgstr "建議關聯電子郵件後再從其他實例遷入。"
 
 #: users/templates/users/account.html:491
@@ -8399,12 +8346,8 @@ msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
 msgstr "帳號數據一旦刪除後將無法恢復，確定繼續嗎？"
 
 #: users/templates/users/account.html:507
-msgid ""
-"Enter full <code>username@instance.social</code> or <code>email@domain.com</"
-"code> to confirm deletion."
-msgstr ""
-"輸入完整的登入用 <code>用戶名@實例名</code> 或 <code>電子郵件地址</code> 以確"
-"認刪除"
+msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
+msgstr "輸入完整的登入用 <code>用戶名@實例名</code> 或 <code>電子郵件地址</code> 以確認刪除"
 
 #: users/templates/users/account.html:517
 msgid "Once deleted, account data cannot be recovered."
@@ -8465,9 +8408,7 @@ msgid "Token Created"
 msgstr "未評分"
 
 #: users/templates/users/authorized_app_created.html:22
-msgid ""
-"Your new personal access token has been created. Copy it now -- you will not "
-"be able to see it again."
+msgid "Your new personal access token has been created. Copy it now -- you will not be able to see it again."
 msgstr ""
 
 #: users/templates/users/authorized_app_created.html:25
@@ -8495,9 +8436,7 @@ msgid "One quick check"
 msgstr ""
 
 #: users/templates/users/captcha.html:28
-msgid ""
-"Put every cover into the row it belongs to. Drag it, or select a cover and "
-"then select a row."
+msgid "Put every cover into the row it belongs to. Drag it, or select a cover and then select a row."
 msgstr ""
 
 #: users/templates/users/captcha.html:41 users/templates/users/captcha.html:43
@@ -8531,7 +8470,7 @@ msgstr ""
 msgid "That is all we needed. Let's get you a username."
 msgstr ""
 
-#: users/templates/users/captcha_solved.html:34
+#: users/templates/users/captcha_solved.html:32
 #: users/templates/users/login.html:63
 #: users/templates/users/verify_email.html:25
 #: users/templates/users/welcome.html:51
@@ -8551,10 +8490,7 @@ msgid "Failed Crossposts"
 msgstr ""
 
 #: users/templates/users/crossposts.html:42
-msgid ""
-"These posts could not be crossposted to your linked social accounts. Re-"
-"authorize the account if needed, then retry. In rare cases retrying may "
-"create a duplicate post."
+msgid "These posts could not be crossposted to your linked social accounts. Re-authorize the account if needed, then retry. In rare cases retrying may create a duplicate post."
 msgstr ""
 
 #: users/templates/users/crossposts.html:48
@@ -8577,262 +8513,191 @@ msgstr ""
 msgid "Data Management"
 msgstr "數據管理"
 
-#: users/templates/users/data.html:27
+#: users/templates/users/data.html:39
 msgid "Import Marks and Reviews from Douban"
 msgstr "匯入豆瓣標記和評論"
 
-#: users/templates/users/data.html:31
-msgid ""
-"Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
-"target=\"_blank\" rel=\"noopener\">Doufen</a>"
-msgstr ""
-"在<a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">豆伴(豆"
-"墳)</a>導出時勾選<mark>書影音遊劇</mark>和<mark>評論</mark>。<br>選擇從豆伴"
-"(豆墳)導出的<code>.xlsx</code>文件"
+#: users/templates/users/data.html:43
+msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
+msgstr "在<a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">豆伴(豆墳)</a>導出時勾選<mark>書影音遊劇</mark>和<mark>評論</mark>。<br>選擇從豆伴(豆墳)導出的<code>.xlsx</code>文件"
 
 #: users/templates/users/data.html:45
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
-"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
-"NeoDB Archive</a> below."
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON format instead; upload it under <a href=\"#import-neodb-archive\">Import NeoDB Archive</a> below."
 msgstr ""
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:256
+#: users/templates/users/data.html:49 users/templates/users/data.html:271
 msgid "Import Method"
 msgstr "匯入方式"
 
-#: users/templates/users/data.html:37
-msgid ""
-"Merge: only update when status changes from wishlist to in-progress, or from "
-"in-progress to complete."
-msgstr ""
-"自動合併：僅更新正向變化(未標->想讀->在讀->已讀)標記，不更新其它標記和現有評"
-"論（推薦）"
+#: users/templates/users/data.html:52
+msgid "Merge: only update when status changes from wishlist to in-progress, or from in-progress to complete."
+msgstr "自動合併：僅更新正向變化(未標->想讀->在讀->已讀)標記，不更新其它標記和現有評論（推薦）"
 
-#: users/templates/users/data.html:41
+#: users/templates/users/data.html:56
 msgid "Overwrite: update all imported status."
-msgstr ""
-"強制覆蓋：覆蓋已存在的標記和評論，匯入文件中未涉及的條目標記和評論不會被改"
-"動。"
+msgstr "強制覆蓋：覆蓋已存在的標記和評論，匯入文件中未涉及的條目標記和評論不會被改動。"
 
-#: users/templates/users/data.html:74
-msgid ""
-"Another import is in progress, starting a new import may cause issues, sure "
-"to import?"
+#: users/templates/users/data.html:89
+msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
 msgstr "短期重複上傳可能有無法預期的效果，確定現在上傳匯入嗎？"
 
-#: users/templates/users/data.html:74
+#: users/templates/users/data.html:89 users/views/data.py:1130
 msgid "Import in progress, please wait"
 msgstr "備份文件已上傳，請等待匯入完成或刷新頁面查看最新進度"
 
-#: users/templates/users/data.html:81
+#: users/templates/users/data.html:96
 #, fuzzy
 #| msgid "Import Shelf or List from Goodreads"
 msgid "Import from Goodreads"
 msgstr "匯入Goodreads書架或書單"
 
-#: users/templates/users/data.html:87
-msgid ""
-"On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" "
-"target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download "
-"your library as a CSV file."
+#: users/templates/users/data.html:102
+msgid "On Goodreads, click <a href=\"https://www.goodreads.com/review/import\" target=\"_blank\" rel=\"noopener\"><b>Export Library</b></a> to download your library as a CSV file."
 msgstr ""
 
-#: users/templates/users/data.html:90
-msgid ""
-"Upload the downloaded <code>goodreads_library_export.csv</code> file below."
+#: users/templates/users/data.html:105
+msgid "Upload the downloaded <code>goodreads_library_export.csv</code> file below."
 msgstr ""
 
-#: users/templates/users/data.html:93
+#: users/templates/users/data.html:108
 #, fuzzy
-#| msgid ""
-#| "want-to-read / currently-reading / read books and their reviews will be "
-#| "imported."
-msgid ""
-"want-to-read / currently-reading / read / did-not-finish books and their "
-"reviews will be imported."
-msgstr ""
-"提交Goodreads用戶主頁連結將匯入想讀、在讀、已讀列表，每本書的評論匯入爲本站短"
-"評。"
+#| msgid "want-to-read / currently-reading / read books and their reviews will be imported."
+msgid "want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported."
+msgstr "提交Goodreads用戶主頁連結將匯入想讀、在讀、已讀列表，每本書的評論匯入爲本站短評。"
 
-#: users/templates/users/data.html:134
+#: users/templates/users/data.html:149
 msgid "Import from Letterboxd"
 msgstr "匯入Letterboxd標記"
 
-#: users/templates/users/data.html:140
-msgid ""
-"on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" "
-"target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap "
-"Advanced Settings in Settings, tap EXPORT YOUR DATA"
+#: users/templates/users/data.html:155
+msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
 msgstr ""
 
-#: users/templates/users/data.html:143
-msgid ""
-"download file with name like <code>letterboxd-username-2018-03-11-07-52-"
-"utc.zip</code>, do not unzip"
+#: users/templates/users/data.html:158
+msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
 msgstr ""
 
-#: users/templates/users/data.html:146
-msgid ""
-"the following files in the zip file will be processed: <code>reviews.csv</"
-"code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</"
-"code> <code>lists/*.csv</code>"
+#: users/templates/users/data.html:161
+msgid "the following files in the zip file will be processed: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
 msgstr ""
 
-#: users/templates/users/data.html:149
-msgid ""
-"exported file does not indicate whether a list is private, unlisted or "
-"public, so all imported marks, reviews and collections will be created with "
-"the visibility selected below"
+#: users/templates/users/data.html:164
+msgid "exported file does not indicate whether a list is private, unlisted or public, so all imported marks, reviews and collections will be created with the visibility selected below"
 msgstr ""
 
-#: users/templates/users/data.html:184 users/templates/users/data.html:235
+#: users/templates/users/data.html:199 users/templates/users/data.html:250
 msgid "Only forward changes(none->to-watch->watched) will be imported."
-msgstr ""
-"匯入時僅更新正向變化(未標->想看->已看)標記；不足360字符的評論會作爲短評添加。"
+msgstr "匯入時僅更新正向變化(未標->想看->已看)標記；不足360字符的評論會作爲短評添加。"
 
-#: users/templates/users/data.html:191
+#: users/templates/users/data.html:206
 #, fuzzy
 #| msgid "Import from Letterboxd"
 msgid "Import from Trakt"
 msgstr "匯入Letterboxd標記"
 
-#: users/templates/users/data.html:197
-msgid ""
-"On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" "
-"rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait "
-"for the download link to appear."
+#: users/templates/users/data.html:212
+msgid "On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait for the download link to appear."
 msgstr ""
 
-#: users/templates/users/data.html:200
+#: users/templates/users/data.html:215
 msgid "Upload the downloaded <code>.zip</code> file below, do not unzip."
 msgstr ""
 
-#: users/templates/users/data.html:202
+#: users/templates/users/data.html:217
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:243
+#: users/templates/users/data.html:258
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr ""
 
-#: users/templates/users/data.html:246
+#: users/templates/users/data.html:261
 msgid "Login with Steam"
 msgstr ""
 
-#: users/templates/users/data.html:252
+#: users/templates/users/data.html:267
 msgid "Import Podcast Subscriptions"
 msgstr "匯入播客訂閱列表 (OPML)"
 
-#: users/templates/users/data.html:263
+#: users/templates/users/data.html:278
 msgid "Mark as listening"
 msgstr "標記爲在聽"
 
-#: users/templates/users/data.html:267
+#: users/templates/users/data.html:282
 msgid "Import as a new collection"
 msgstr "匯入爲新收藏單"
 
-#: users/templates/users/data.html:296
+#: users/templates/users/data.html:311
 msgid "Select OPML file"
 msgstr "選擇OPML文件"
 
-#: users/templates/users/data.html:306
+#: users/templates/users/data.html:321
 msgid "Import NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:312
-msgid ""
-"Upload a <code>.zip</code> file containing <code>.csv</code> or "
-"<code>.ndjson</code> files exported from NeoDB."
+#: users/templates/users/data.html:327
+msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr ""
 
 #: users/templates/users/data.html:330
 #, fuzzy
-#| msgid ""
-#| "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
-#| "target=\"_blank\" rel=\"noopener\">Doufen</a>"
-msgid ""
-"A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
-"imported here."
-msgstr ""
-"在<a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">豆伴(豆"
-"墳)</a>導出時勾選<mark>書影音遊劇</mark>和<mark>評論</mark>。<br>選擇從豆伴"
-"(豆墳)導出的<code>.xlsx</code>文件"
+#| msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is imported here."
+msgstr "在<a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">豆伴(豆墳)</a>導出時勾選<mark>書影音遊劇</mark>和<mark>評論</mark>。<br>選擇從豆伴(豆墳)導出的<code>.xlsx</code>文件"
 
-#: users/templates/users/data.html:314
+#: users/templates/users/data.html:332
 #, fuzzy
 #| msgid "Existing metadata might get overwritten, sure to proceed?"
 msgid "Existing data may be overwritten."
 msgstr "現有信息可能會被覆蓋。確認重新獲取嗎？"
 
-#: users/templates/users/data.html:324
+#: users/templates/users/data.html:342
 msgid "Detected format"
 msgstr ""
 
-#: users/templates/users/data.html:385
+#: users/templates/users/data.html:403
 msgid "Detecting format..."
 msgstr ""
 
-#: users/templates/users/data.html:411
+#: users/templates/users/data.html:429
 #, fuzzy
 #| msgid "Unknown or Other"
 msgid "Unknown format"
 msgstr "未知或其它"
 
-#: users/templates/users/data.html:436
+#: users/templates/users/data.html:454
 #, fuzzy
 #| msgid "Error connecting to instance"
 msgid "Error detecting format"
 msgstr "無法連接實例"
 
-#: users/templates/users/data.html:460
+#: users/templates/users/data.html:478
 msgid "Export NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:464
+#: users/templates/users/data.html:482
 msgid "Export marks, reviews and notes in CSV"
 msgstr "匯出標記、短評和評論 （CSV格式）"
 
-#: users/templates/users/data.html:471
+#: users/templates/users/data.html:489
 msgid "Export everything in NDJSON"
 msgstr "匯出標記、短評和評論 （NDJSON格式）"
-
-#: users/templates/users/data.html:479
-msgid "Export marks and reviews in XLSX (Doufen format)"
-msgstr "匯出標記、短評和評論 （豆墳xlsx格式）"
-
-#: users/templates/users/data.html:482
-msgid "Last export"
-msgstr "最近匯出"
-
-#: users/templates/users/data.html:487
-msgid "Download"
-msgstr "下載"
 
 #: users/templates/users/data.html:496
 msgid "Import and Export Articles (WordPress)"
 msgstr ""
 
 #: users/templates/users/data.html:499
-msgid ""
-"Your articles are exchanged as WordPress posts in the WXR format, which "
-"WordPress and most blogging tools can read and write. Marks, reviews and "
-"notes are not included: use the NeoDB archive above for those."
+msgid "Your articles are exchanged as WordPress posts in the WXR format, which WordPress and most blogging tools can read and write. Marks, reviews and notes are not included: use the NeoDB archive above for those."
 msgstr ""
 
 #: users/templates/users/data.html:502
-msgid ""
-"Article title, body, excerpt, tags, dates and featured image are exchanged. "
-"Comments and custom fields are ignored."
+msgid "Article title, body, excerpt, tags, dates and featured image are exchanged. Comments and custom fields are ignored."
 msgstr ""
 
 #: users/templates/users/data.html:505
-msgid ""
-"The body is converted between Markdown and HTML, so formatting is kept but "
-"the text is not character-for-character identical."
+msgid "The body is converted between Markdown and HTML, so formatting is kept but the text is not character-for-character identical."
 msgstr ""
 
 #: users/templates/users/data.html:512
@@ -8842,16 +8707,11 @@ msgid "Export articles in WordPress format"
 msgstr "匯出標記、短評和評論 （豆墳xlsx格式）"
 
 #: users/templates/users/data.html:519
-msgid ""
-"In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download "
-"an <code>.xml</code> file, then upload it below."
+msgid "In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download an <code>.xml</code> file, then upload it below."
 msgstr ""
 
 #: users/templates/users/data.html:522
-msgid ""
-"Only published posts use the visibility below. Drafts, pending, private and "
-"password-protected posts are always imported as mentioned-only, so nothing "
-"unpublished becomes public."
+msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
 #: users/templates/users/data.html:560
@@ -8859,9 +8719,7 @@ msgid "View Annual Summary"
 msgstr "查看年度小結"
 
 #: users/templates/users/fetch_identity_failed.html:4
-msgid ""
-"Unable to find the user, please check your spelling; or the server may be "
-"busy, please try again later."
+msgid "Unable to find the user, please check your spelling; or the server may be busy, please try again later."
 msgstr "無法找到用戶，請確認拼寫正確；也可能伺服器正忙，請稍後再嘗試。"
 
 #: users/templates/users/fetch_identity_pending.html:13
@@ -8881,107 +8739,78 @@ msgstr "登入"
 msgid "logo"
 msgstr ""
 
-#: users/templates/users/login.html:127
-msgid ""
-"Sign in with a passkey saved on this device or in your password manager."
+#: users/templates/users/login.html:121
+msgid "Sign in with a passkey saved on this device or in your password manager."
 msgstr ""
 
-#: users/templates/users/login.html:132
+#: users/templates/users/login.html:126
 msgid "Sign in with Passkey"
 msgstr ""
 
-#: users/templates/users/login.html:148
+#: users/templates/users/login.html:142
 msgid "Enter your email address"
 msgstr "輸入電子郵件地址"
 
-#: users/templates/users/login.html:152
+#: users/templates/users/login.html:146
 msgid "Send verification code"
 msgstr "發送驗證碼"
 
-#: users/templates/users/login.html:171
+#: users/templates/users/login.html:165
 msgid "Domain of your instance, e.g. mastodon.social"
 msgstr "實例域名(不含@和@之前的部分)，如mastodon.social"
 
-#: users/templates/users/login.html:177
-msgid ""
-"Please enter domain of your instance; e.g. if your id is "
-"<i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
-msgstr ""
-"請輸入你的實例域名(不含@和@之前的部分)；如果你的聯邦帳號是"
-"<i>@neodb@mastodon.social</i>，只需要在此輸入<i>mastodon.social</i>。"
+#: users/templates/users/login.html:171
+msgid "Please enter domain of your instance; e.g. if your id is <i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
+msgstr "請輸入你的實例域名(不含@和@之前的部分)；如果你的聯邦帳號是<i>@neodb@mastodon.social</i>，只需要在此輸入<i>mastodon.social</i>。"
 
-#: users/templates/users/login.html:182 users/templates/users/login.html:246
+#: users/templates/users/login.html:176 users/templates/users/login.html:240
 msgid "Authorize via Fediverse instance"
 msgstr "去聯邦實例授權註冊或登入"
 
-#: users/templates/users/login.html:187
-msgid ""
-"If you don't have a <a href=\"https://joinmastodon.org/servers\" "
-"target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or "
-"login with Email first, and link it with Fediverse (Mastodon) later in "
-"account settings."
-msgstr ""
-"如果你還沒有或不便註冊<a href=\"https://joinmastodon.org/servers\" "
-"target=\"_blank\">聯邦實例</a>帳號，也可先通過電子郵件或其它平臺註冊登入，未"
-"來再作關聯。"
+#: users/templates/users/login.html:181
+msgid "If you don't have a <a href=\"https://joinmastodon.org/servers\" target=\"_blank\">Fediverse (Mastodon) account</a> yet, you may register or login with Email first, and link it with Fediverse (Mastodon) later in account settings."
+msgstr "如果你還沒有或不便註冊<a href=\"https://joinmastodon.org/servers\" target=\"_blank\">聯邦實例</a>帳號，也可先通過電子郵件或其它平臺註冊登入，未來再作關聯。"
 
-#: users/templates/users/login.html:200
+#: users/templates/users/login.html:194
 msgid "Authorize via Threads"
 msgstr "去Threads授權註冊或登入"
 
-#: users/templates/users/login.html:221
-msgid ""
-"Please input your ATProto handle (e.g. neodb.bsky.social, without the "
-"leading @), do not use email. If you changed handle recently, just use the "
-"latest one."
-msgstr ""
-"請輸入你的ATProto用戶標識（例如neodb.bsky.social，不包含開頭的@），不要輸入電"
-"子郵件地址。如果你最近更改過標識，請使用最新的那一個。"
+#: users/templates/users/login.html:215
+msgid "Please input your ATProto handle (e.g. neodb.bsky.social, without the leading @), do not use email. If you changed handle recently, just use the latest one."
+msgstr "請輸入你的ATProto用戶標識（例如neodb.bsky.social，不包含開頭的@），不要輸入電子郵件地址。如果你最近更改過標識，請使用最新的那一個。"
 
-#: users/templates/users/login.html:224
+#: users/templates/users/login.html:218
 #, fuzzy
 #| msgid "Authorize via Threads"
 msgid "Authorize via ATProto server"
 msgstr "去Threads授權註冊或登入"
 
-#: users/templates/users/login.html:231
+#: users/templates/users/login.html:225
 #, python-format
-msgid ""
-"Please choose one to register or login %(site_name)s. Have more than one of "
-"these identities? Don't worry, you may link them in account settings once "
-"logged in."
-msgstr ""
-"請選擇一種方式註冊或登入 %(site_name)s。如果你有多個社交身份，登入後可在帳號"
-"設定中添加綁定。"
+msgid "Please choose one to register or login %(site_name)s. Have more than one of these identities? Don't worry, you may link them in account settings once logged in."
+msgstr "請選擇一種方式註冊或登入 %(site_name)s。如果你有多個社交身份，登入後可在帳號設定中添加綁定。"
 
-#: users/templates/users/login.html:255
+#: users/templates/users/login.html:249
 msgid "Valid invitation code, please login or register."
 msgstr "邀請連結有效，可註冊新用戶"
 
-#: users/templates/users/login.html:257
-msgid ""
-"Please use invitation link to register a new account; existing user may "
-"login."
+#: users/templates/users/login.html:251
+msgid "Please use invitation link to register a new account; existing user may login."
 msgstr "本站目前爲邀請註冊，已有帳號可直接登入，新用戶請使用有效邀請連結註冊"
 
-#: users/templates/users/login.html:259
+#: users/templates/users/login.html:253
 msgid "Invitation code invalid or expired."
 msgstr "邀請連結無效，已有賬戶可直接登入，新用戶請使用有效邀請連結註冊"
 
-#: users/templates/users/login.html:267
+#: users/templates/users/login.html:261
 msgid "Loading timed out, please check your network (VPN) settings."
 msgstr "部分模塊加載超時，請檢查網絡（翻牆）設定。"
 
-#: users/templates/users/login.html:273
-msgid ""
-"Continue using this site implies consent to our <a href=\"/pages/rules/"
-"\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using "
-"cookies to provide necessary functionality."
-msgstr ""
-"繼續訪問或註冊視爲同意<a href=\"/pages/rules/\">站規</a>與<a href=\"/pages/"
-"terms/\">協議</a>，及使用cookie提供必要功能"
+#: users/templates/users/login.html:267
+msgid "Continue using this site implies consent to our <a href=\"/pages/rules/\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using cookies to provide necessary functionality."
+msgstr "繼續訪問或註冊視爲同意<a href=\"/pages/rules/\">站規</a>與<a href=\"/pages/terms/\">協議</a>，及使用cookie提供必要功能"
 
-#: users/templates/users/login.html:287
+#: users/templates/users/login.html:281
 msgid "Domain of your instance (excl. @)"
 msgstr "實例域名(不含@和@之前的部分)"
 
@@ -8991,9 +8820,7 @@ msgid "Migrate Here"
 msgstr ""
 
 #: users/templates/users/migrate_in.html:22
-msgid ""
-"To move another account to this one, first add it as an alias here, and then "
-"go to the server where it is hosted and initiate the move."
+msgid "To move another account to this one, first add it as an alias here, and then go to the server where it is hosted and initiate the move."
 msgstr ""
 
 #: users/templates/users/migrate_in.html:27
@@ -9049,16 +8876,11 @@ msgstr ""
 
 #: users/templates/users/migrate_out.html:46
 #, python-format
-msgid ""
-"To migrate to another account, first add <code>@%(handle)s</code> as an "
-"alias on the target server, and then type the target account below to start "
-"the migration."
+msgid "To migrate to another account, first add <code>@%(handle)s</code> as an alias on the target server, and then type the target account below to start the migration."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:50
-msgid ""
-"Are you sure you want to migrate your account? Your followers will be moved "
-"to the target account."
+msgid "Are you sure you want to migrate your account? Your followers will be moved to the target account."
 msgstr ""
 
 #: users/templates/users/migrate_out.html:53
@@ -9076,10 +8898,6 @@ msgstr "在讀"
 #: users/templates/users/preferences.html:28
 msgid "Default view once logged in"
 msgstr "登入後預設顯示"
-
-#: users/templates/users/preferences.html:40
-msgid "Activities"
-msgstr "動態"
 
 #: users/templates/users/preferences.html:49
 msgid "Default visibility"
@@ -9108,9 +8926,7 @@ msgstr "發表時預設轉發到社交網絡時間軸"
 
 #: users/templates/users/preferences.html:111
 #: users/templates/users/register.html:88
-msgid ""
-"If a Mastodon account is linked with this identity, boosting a post will "
-"also make the same post boosted with that Mastodon account."
+msgid "If a Mastodon account is linked with this identity, boosting a post will also make the same post boosted with that Mastodon account."
 msgstr ""
 
 #: users/templates/users/preferences.html:115
@@ -9126,16 +8942,12 @@ msgid "Create a new post"
 msgstr "另發新帖文"
 
 #: users/templates/users/preferences.html:130
-msgid ""
-"this method is less optimal, may generate duplicated posts and miss "
-"reactions."
+msgid "this method is less optimal, may generate duplicated posts and miss reactions."
 msgstr "這種方式可能產生重複帖文，且其他人對新帖的回應、點贊不會被記錄"
 
 #: users/templates/users/preferences.html:140
 #: users/templates/users/register.html:97
-msgid ""
-"Always publish my public marks, reviews and articles as data records to my "
-"PDS."
+msgid "Always publish my public marks, reviews and articles as data records to my PDS."
 msgstr ""
 
 #: users/templates/users/preferences.html:145
@@ -9155,16 +8967,8 @@ msgid "Automatic bookmark for these categories"
 msgstr "以下類型自動加入書籤"
 
 #: users/templates/users/preferences.html:175
-msgid ""
-"When start to read/watch/play/... an item in these categories, a bookmark "
-"will be created automatically. Bookmarks can be viewed and managed in most "
-"<a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon "
-"compatible apps</a>; your replies to these posts will automatically become "
-"notes for the item."
-msgstr ""
-"將這些類型的條目標記爲在讀/在看/在玩/...時，自動把相應帖文添加爲書籤。這些書"
-"籤帖文可使用<a href=\"https://joinmastodon.org/apps\" target=\"_blank\">應用"
-"程序</a>查看和管理，你對這些帖文的回覆會自動成爲該條目的筆記。"
+msgid "When start to read/watch/play/... an item in these categories, a bookmark will be created automatically. Bookmarks can be viewed and managed in most <a href=\"https://joinmastodon.org/apps\" target=\"_blank\">Mastodon compatible apps</a>; your replies to these posts will automatically become notes for the item."
+msgstr "將這些類型的條目標記爲在讀/在看/在玩/...時，自動把相應帖文添加爲書籤。這些書籤帖文可使用<a href=\"https://joinmastodon.org/apps\" target=\"_blank\">應用程序</a>查看和管理，你對這些帖文的回覆會自動成爲該條目的筆記。"
 
 #: users/templates/users/preferences.html:183
 msgid "Turn replies to my own catalog item posts into notes for the item"
@@ -9183,12 +8987,8 @@ msgid "Profile visible to anonymous web visitors and search engines"
 msgstr "匿名訪客和搜索引擎可以查看你的個人主頁"
 
 #: users/templates/users/preferences.html:217
-msgid ""
-"this option limits web visits only; to limit fediverse visibility, choose "
-"followers only or mentioned only when posting"
-msgstr ""
-"此選項僅針對網頁訪客，如果不希望被聯邦網路用戶看到請在發表時選擇僅關注者或本"
-"人"
+msgid "this option limits web visits only; to limit fediverse visibility, choose followers only or mentioned only when posting"
+msgstr "此選項僅針對網頁訪客，如果不希望被聯邦網路用戶看到請在發表時選擇僅關注者或本人"
 
 #: users/templates/users/preferences.html:225
 msgid "Show your name on item page if you recently edited it"
@@ -9199,17 +8999,7 @@ msgid "Do not show me item recommendations"
 msgstr ""
 
 #: users/templates/users/preferences.html:237
-msgid ""
-"Recommendations are generated only from public marks, processed in batch on "
-"this server. Your private and follower-only marks are never used as a signal "
-"for anyone, and we never share your data with third parties for this "
-"feature. When you share marks publicly and keep your profile discoverable, "
-"your marks help others here and across the Fediverse find things they might "
-"enjoy -- that voluntary contribution is what makes the feature work for "
-"everyone. If you'd rather not contribute, uncheck \"Include profile, marks "
-"and posts in discovery\" on your account page; this setting is published "
-"over ActivityPub, so other servers will also stop including you in their "
-"discovery features."
+msgid "Recommendations are generated only from public marks, processed in batch on this server. Your private and follower-only marks are never used as a signal for anyone, and we never share your data with third parties for this feature. When you share marks publicly and keep your profile discoverable, your marks help others here and across the Fediverse find things they might enjoy -- that voluntary contribution is what makes the feature work for everyone. If you'd rather not contribute, uncheck \"Include profile, marks and posts in discovery\" on your account page; this setting is published over ActivityPub, so other servers will also stop including you in their discovery features."
 msgstr ""
 
 #: users/templates/users/profile_actions.html:12
@@ -9310,20 +9100,12 @@ msgid "2-30 alphabets, numbers or underscore, can't be changed once saved"
 msgstr "2-30個字符，限英文字母數字下劃線，儲存後不可更改"
 
 #: users/templates/users/register.html:72
-msgid ""
-"Use display name, bio and avatar from the social network you authenticated "
-"with"
+msgid "Use display name, bio and avatar from the social network you authenticated with"
 msgstr "自動同步用戶暱稱等基本資訊"
 
 #: users/templates/users/register.html:80
-msgid ""
-"Add follow, mute and block list from the social network you authenticated "
-"with"
+msgid "Add follow, mute and block list from the social network you authenticated with"
 msgstr "自動匯入新增的關注、屏蔽和隱藏列表"
-
-#: users/templates/users/register.html:104
-msgid "Confirm and save"
-msgstr "確認並儲存"
 
 #: users/templates/users/register.html:106
 msgid "Close"
@@ -9351,8 +9133,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"              Matched %(local)s locally, %(external)s externally, "
-"%(unmatched)s unmatched out of %(total)s rows.\n"
+"              Matched %(local)s locally, %(external)s externally, %(unmatched)s unmatched out of %(total)s rows.\n"
 "            "
 msgstr ""
 
@@ -9487,9 +9268,7 @@ msgid "Played"
 msgstr "玩過"
 
 #: users/templates/users/steam_import.html:90
-msgid ""
-"Games in wishlist; or purchased in library but never played, mark date will "
-"be set as today"
+msgid "Games in wishlist; or purchased in library but never played, mark date will be set as today"
 msgstr ""
 
 #: users/templates/users/steam_import.html:91
@@ -9533,15 +9312,11 @@ msgid "Comma-separated Steam AppIDs"
 msgstr ""
 
 #: users/templates/users/steam_import.html:121
-msgid ""
-"Allow reverse override of status (e.g. playing -> want to, or played -> "
-"playing)"
+msgid "Allow reverse override of status (e.g. playing -> want to, or played -> playing)"
 msgstr ""
 
 #: users/templates/users/steam_import.html:139
-msgid ""
-"To import from Steam, your game details must be visible to public in Steam "
-"privacy settings."
+msgid "To import from Steam, your game details must be visible to public in Steam privacy settings."
 msgstr ""
 
 #: users/templates/users/storygraph_import.html:9
@@ -9588,31 +9363,19 @@ msgstr "歡迎"
 #, python-format
 msgid ""
 "\n"
-"              %(site_name)s is flourishing because of collaborations and "
-"contributions from users like you. Please read our <a href=\"/pages/"
-"rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</"
-"a> if you have any question or feedback.\n"
+"              %(site_name)s is flourishing because of collaborations and contributions from users like you. Please read our <a href=\"/pages/rules\">rules</a>, and feel free to <a href=\"%(support_link)s\">contact us</a> if you have any question or feedback.\n"
 "        "
 msgstr ""
 "\n"
-"              %(site_name)s還在不斷完善中。 豐富的內容需要大家共同創造，試圖"
-"添加垃圾資料（如添加信息混亂或缺失的書籍、以推廣爲主要目的的評論）將會受到嚴"
-"肅處理。 本站爲非盈利站點，cookie和其它資料保管使用原則請參閱<a href=\"/"
-"pages/rules\">站內公告</a>。 本站提供API和導出功能，請妥善備份您的數據，使用"
-"過程中遇到的問題或者錯誤歡迎向<a href=\"%(support_link)s\">維護者</a>提出。感"
-"謝理解和支持！\n"
+"              %(site_name)s還在不斷完善中。 豐富的內容需要大家共同創造，試圖添加垃圾資料（如添加信息混亂或缺失的書籍、以推廣爲主要目的的評論）將會受到嚴肅處理。 本站爲非盈利站點，cookie和其它資料保管使用原則請參閱<a href=\"/pages/rules\">站內公告</a>。 本站提供API和導出功能，請妥善備份您的數據，使用過程中遇到的問題或者錯誤歡迎向<a href=\"%(support_link)s\">維護者</a>提出。感謝理解和支持！\n"
 "        "
 
 #: users/templates/users/welcome.html:37
-msgid ""
-"Set up a passkey to sign in quickly next time using your fingerprint, face, "
-"or screen lock."
+msgid "Set up a passkey to sign in quickly next time using your fingerprint, face, or screen lock."
 msgstr ""
 
 #: users/templates/users/welcome.html:39
-msgid ""
-"Creating a passkey is highly recommended, as the website or email you use to "
-"create this account may not be always available."
+msgid "Creating a passkey is highly recommended, as the website or email you use to create this account may not be always available."
 msgstr ""
 
 #: users/templates/users/welcome.html:43
@@ -9629,339 +9392,244 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:124
+#: users/views/account.py:126
 msgid "This username is already in use."
 msgstr "用戶名已被使用"
 
-#: users/views/account.py:135
+#: users/views/account.py:137
 msgid "This email address is already in use."
 msgstr "此電子郵件地址已被使用"
 
-#: users/views/account.py:255 users/views/account.py:374
+#: users/views/account.py:257 users/views/account.py:376
 msgid "Registration is for invitation only"
 msgstr "本站僅限邀請註冊"
 
-#: users/views/account.py:266 users/views/account.py:338
+#: users/views/account.py:268 users/views/account.py:340
 #, fuzzy
 #| msgid "Timestamp"
 msgid "Time is up"
 msgstr "時間戳"
 
-#: users/views/account.py:267 users/views/account.py:310
-#: users/views/account.py:339
+#: users/views/account.py:269 users/views/account.py:312
+#: users/views/account.py:341
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:313
+#: users/views/account.py:315
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:325
+#: users/views/account.py:327
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:326
+#: users/views/account.py:328
 #, fuzzy
 #| msgid "System busy, please try again in a minute."
 msgid "Please try again later."
 msgstr "系統繁忙，請稍等幾秒鐘再搜索。"
 
-#: users/views/account.py:415
+#: users/views/account.py:417
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:445
+#: users/views/account.py:447
 msgid "Valid username required"
 msgstr "請輸入有效的用戶名"
 
-#: users/views/account.py:526
+#: users/views/account.py:518
 msgid "Account is being deleted."
 msgstr "帳號刪除進行中。"
 
-#: users/views/account.py:529
+#: users/views/account.py:521
 msgid "Account mismatch."
 msgstr "帳號資訊不符合。"
 
-#: users/views/data.py:262 users/views/data.py:294
+#: users/views/data.py:264 users/views/data.py:296
 msgid "Export file not available."
 msgstr "匯出檔案不可用"
 
-#: users/views/data.py:288
+#: users/views/data.py:290
 msgid "Generating exports."
 msgstr "正在產生匯出檔案文件。"
 
-#: users/views/data.py:306
+#: users/views/data.py:308
 msgid "Export file expired. Please export again."
 msgstr "匯出文件已失效，請重新匯出"
 
-#: users/views/data.py:321 users/views/data.py:342 users/views/data.py:363
+#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
 msgid "Recent export still in progress."
 msgstr "正在匯入"
 
-#: users/views/data.py:379 users/views/data.py:513 users/views/data.py:547
-#: users/views/data.py:772 users/views/data.py:989 users/views/data.py:1015
-#: users/views/data.py:1040 users/views/data.py:1065
+#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
+#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
+#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
 msgid "Invalid file."
 msgstr "無效檔案。"
 
-#: users/views/data.py:403
+#: users/views/data.py:405
 msgid "Sync in progress."
 msgstr "正在同步。"
 
-#: users/views/data.py:417
+#: users/views/data.py:419
 msgid "Settings saved."
 msgstr "設定已儲存"
 
-#: users/views/data.py:472
+#: users/views/data.py:474
 #, fuzzy
 #| msgid "Account is being deleted."
 msgid "Account no longer linked."
 msgstr "帳號刪除進行中。"
 
-#: users/views/data.py:475
+#: users/views/data.py:477
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:503
+#: users/views/data.py:505
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:583 users/views/data.py:808
+#: users/views/data.py:585 users/views/data.py:810
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:608 users/views/data.py:837
+#: users/views/data.py:610 users/views/data.py:839
 #, fuzzy
 #| msgid "Cancel"
 msgid "Cancelled."
 msgstr "取消"
 
-#: users/views/data.py:628
+#: users/views/data.py:630
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:636 users/views/data.py:746 users/views/data.py:867
-#: users/views/data.py:972
+#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
+#: users/views/data.py:974
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:732 users/views/data.py:958
+#: users/views/data.py:734 users/views/data.py:960
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:742 users/views/data.py:968
+#: users/views/data.py:744 users/views/data.py:970
 #, fuzzy
 #| msgid "Export file not available."
 msgid "No matched file available."
 msgstr "匯出檔案不可用"
 
-#: users/views/data.py:859
+#: users/views/data.py:861
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1188
+#: users/views/data.py:1226
 #, fuzzy
 #| msgid "Login required"
 msgid "Name is required."
 msgstr "登入後訪問"
 
-#: users/views/data.py:1210
+#: users/views/data.py:1248
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1264
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1231
+#: users/views/data.py:1269
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1241 users/views/data.py:1292
+#: users/views/data.py:1279 users/views/data.py:1330
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:1248
+#: users/views/data.py:1286
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:1253
+#: users/views/data.py:1291
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:1279
+#: users/views/data.py:1317
 #, fuzzy
 #| msgid "Registration failed"
 msgid "Migration cancelled."
 msgstr "註冊失敗"
 
-#: users/views/data.py:1284
+#: users/views/data.py:1322
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:1297
+#: users/views/data.py:1335
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:1308
+#: users/views/data.py:1346
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:1314
+#: users/views/data.py:1352
 #, fuzzy, python-brace-format
 #| msgid "Continue login as {handle}."
 msgid "Start moving to {handle}."
 msgstr "繼續以 {handle} 登入。"
 
-#: users/views/data.py:1372
+#: users/views/data.py:1410
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1388
+#: users/views/data.py:1426
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1392
+#: users/views/data.py:1430
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1402
+#: users/views/data.py:1440
 #, python-brace-format
-msgid ""
-"Import of {count} entries received. They will be processed in the background."
+msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""
 
-#: users/views/webauthn.py:103
+#: users/views/webauthn.py:106
 #, fuzzy
 #| msgid "Registration failed"
 msgid "Passkey registration failed"
 msgstr "註冊失敗"
 
-#: users/views/webauthn.py:123
+#: users/views/webauthn.py:126
 msgid "Credential already registered"
 msgstr ""
 
-#: users/views/webauthn.py:165 users/views/webauthn.py:172
-#: users/views/webauthn.py:181
+#: users/views/webauthn.py:168 users/views/webauthn.py:175
+#: users/views/webauthn.py:184
 msgid "Passkey not recognized"
 msgstr ""
 
-#: users/views/webauthn.py:186
+#: users/views/webauthn.py:189
 #, fuzzy
 #| msgid "Account is being deleted."
 msgid "Account is inactive"
 msgstr "帳號刪除進行中。"
 
-#: users/views/webauthn.py:202
+#: users/views/webauthn.py:205
 #, fuzzy
 #| msgid "Send verification code"
 msgid "Passkey verification failed"
 msgstr "發送驗證碼"
 
-#: users/views/webauthn.py:228 users/views/webauthn.py:250
+#: users/views/webauthn.py:231 users/views/webauthn.py:253
 #, fuzzy
 #| msgid "User not found"
 msgid "Passkey not found"
 msgstr "用戶不存在"
 
-#: users/views/webauthn.py:244
+#: users/views/webauthn.py:247
 #, fuzzy
 #| msgid "Login required"
 msgid "Name is required"
 msgstr "登入後訪問"
-
-#~ msgid "FanFic"
-#~ msgstr "網文"
-
-#~ msgid "year of publication"
-#~ msgstr "發行年份"
-
-#~ msgid "YYYY-MM-DD"
-#~ msgstr "YYYY-MM-DD"
-
-#~ msgid "region or event"
-#~ msgstr "地區或類型"
-
-#~ msgid "Germany or Toronto International Film Festival"
-#~ msgstr "德國或多倫多國際電影節"
-
-#~ msgid "year"
-#~ msgstr "年份"
-
-#~ msgctxt "music"
-#~ msgid "genre"
-#~ msgstr "風格"
-
-#~ msgid "my notes"
-#~ msgstr "我的筆記"
-
-#~ msgid "release year"
-#~ msgstr "發行年份"
-
-#~ msgid "episode Length"
-#~ msgstr "單集時長"
-
-#~ msgid "show time"
-#~ msgstr "上映時間"
-
-#~ msgid "Region or Event"
-#~ msgstr "地區或場合"
-
-#~ msgid "Addtional filters may be added to query"
-#~ msgstr "可使用額外的篩選條件"
-
-#~ msgid "boost"
-#~ msgstr "轉播"
-
-#~ msgid "Invalid form data"
-#~ msgstr "無效表單信息。"
-
-#~ msgid "Username and app password is required."
-#~ msgstr "請輸入用戶名和密碼。"
-
-#~ msgid "All"
-#~ msgstr "全部"
-
-#~ msgid "Bluesky app password"
-#~ msgstr "Bluesky 應用密碼"
-
-#~ msgid ""
-#~ "App password can be created on <a href=\"https://bsky.app/settings/app-"
-#~ "passwords\" target=\"_blank\">bsky.app</a>."
-#~ msgstr ""
-#~ "應用密碼可在 <a href=\"https://bsky.app/settings/app-passwords\" "
-#~ "target=\"_blank\">bsky.app</a> 創建管理。"
-
-#~ msgid "Link to Goodreads Profile / Shelf / List"
-#~ msgstr "Goodreads個人主頁、書架或書單連結"
-
-#~ msgid "Last import started"
-#~ msgstr "最近匯入時間"
-
-#~ msgid "Shelf will be imported as a new collection."
-#~ msgstr "Goodreads書架將被匯入爲收藏單，每本書的評論匯入爲收藏單條目備註。"
-
-#~ msgid "List will be imported as a new collection."
-#~ msgstr "Goodreads書單將被匯入爲收藏單，每本書的評論匯入爲收藏單條目備註。"
-
-#~ msgid ""
-#~ "Failed links, likely due to Letterboxd error, you may have to mark them "
-#~ "manually"
-#~ msgstr "匯入失敗的連結（通常由於Letterboxd的信息錯誤，請手工添加標記）"
-
-#~ msgid "Export Data"
-#~ msgstr "匯出資料"
-
-#~ msgid "Turn on crosspost to timeline by default"
-#~ msgstr "發表時預設轉發到時間軸"
-
-#~ msgid "Username in use"
-#~ msgstr "用戶名已被使用"
-
-#~ msgid "Invalid URL."
-#~ msgstr "無效網址。"
-
-#~ msgid "File is uploaded and will be imported soon."
-#~ msgstr "檔案已上傳，等待後臺匯入。"


### PR DESCRIPTION
Follow-up to #1859. This is the commit Weblate's "Update PO files to match POT (msgmerge)" add-on produced after #1859 landed, pushed automatically to the fork's `weblate` branch by the new push-on-commit setting.

It rewrites the 14 non-zh_Hans locales into the `--no-wrap` form that `makemessages` uses, msgmerged against the current POT, with obsolete `#~` entries removed. `zh_Hans` is untouched, which confirms the Weblate component settings now match `makemessages` output.

Checked on `de`: `msgfmt -c` passes, and re-emitting the file with `msgcat --no-wrap` or translate-toolkit at Weblate's wrap setting is byte-identical.

Land with "Create a merge commit" so Weblate's commit stays in the history.
