### PR TITLE
fix(catalog): keep external search results from breaking the label sort

### DIFF
--- a/neodb/catalog/search/external.py
+++ b/neodb/catalog/search/external.py
@@ -1,16 +1,35 @@
 import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
 from urllib.parse import quote_plus
 
 from django.core.cache import cache
 
 from catalog.models import ItemCategory, SiteName
 
+if TYPE_CHECKING:
+    from django_stubs_ext import StrOrPromise
+
+
+@dataclass
+class ExternalSearchResource:
+    """Stand-in for the ExternalResource of an item not saved locally yet.
+
+    Carries what _site_labels.html and ExternalResource.sort_for_display read.
+    """
+
+    url: str
+    site_name: SiteName
+    site_label: "StrOrPromise"
+    pk: int | None = None
+    id_value: str = ""
+
 
 class ExternalSearchResultItem:
     def __init__(
         self,
         category: ItemCategory | None,
-        source_site: SiteName,
+        source_site: "SiteName | str",
         source_url: str,
         title: str,
         subtitle: str,
@@ -19,14 +38,13 @@ class ExternalSearchResultItem:
     ):
         self.class_name = "base"
         self.category = category
+        if isinstance(source_site, SiteName):
+            site_name, site_label = source_site, source_site.label
+        else:
+            # federated search passes the peer's hostname as its source site
+            site_name, site_label = SiteName.Fediverse, source_site
         self.external_resources = {
-            "all": [
-                {
-                    "url": source_url,
-                    "site_name": source_site,
-                    "site_label": source_site,
-                }
-            ]
+            "all": [ExternalSearchResource(source_url, site_name, site_label)]
         }
         self.source_site = source_site
         self.source_url = source_url

--- a/neodb/tests/catalog/test_site_labels.py
+++ b/neodb/tests/catalog/test_site_labels.py
@@ -2,8 +2,11 @@ import re
 
 import pytest
 from django.test import Client
+from django.urls import reverse
 
-from catalog.models import Edition, ExternalResource, IdType
+from catalog.models import Edition, ExternalResource, IdType, ItemCategory, SiteName
+from catalog.search.external import ExternalSearchResultItem, ExternalSources
+from users.models import User
 
 
 def _edition_with_resources(title: str, id_types: list[IdType]) -> Edition:
@@ -82,3 +85,42 @@ def test_labels_order_priority_sites_first_and_fediverse_last():
         "fedi extra",
         "more",
     ]
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_external_search_results_render_site_labels(monkeypatch):
+    """Results not saved locally carry a stand-in resource, not a plain dict."""
+    results = [
+        ExternalSearchResultItem(
+            ItemCategory.Movie,
+            SiteName.TMDB,
+            "https://www.themoviedb.org/movie/1",
+            "Ext Movie",
+            "",
+            "brief",
+            "",
+        ),
+        ExternalSearchResultItem(
+            ItemCategory.Movie,
+            "peer.example",
+            "https://peer.example/movies/2",
+            "Peer Movie",
+            "",
+            "brief",
+            "",
+        ),
+    ]
+    monkeypatch.setattr(
+        ExternalSources, "search", classmethod(lambda cls, *a, **kw: results)
+    )
+    user = User.register(email="ext@example.com", username="extuser")
+    client = Client()
+    client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+    response = client.get(reverse("catalog:external_search"), {"q": "movie"})
+    assert response.status_code == 200
+    html = response.content.decode()
+    assert '<a href="https://www.themoviedb.org/movie/1"' in html
+    assert 'class="tmdb"' in html
+    assert ">TMDB</a>" in html
+    assert 'class="fedi"' in html
+    assert ">peer.example</a>" in html

--- a/neodb/tests/journal/test_attachment.py
+++ b/neodb/tests/journal/test_attachment.py
@@ -255,6 +255,11 @@ class TestTakaheAttachmentUrls:
     # Real (unsaved) PostAttachments rather than stubs, so the production
     # signature stays honest and the storage plumbing is the real one.
 
+    # Patch atta.file.storage, not storages["takahe"]: the field resolved its
+    # storage callable once at import, and any override_settings of STORAGES,
+    # STATIC_ROOT or STATIC_URL empties the handler cache, after which
+    # storages["takahe"] hands out a second instance the field never reads.
+
     def test_relative_urls_become_absolute(self):
         atta = PostAttachment(
             pk=7,
@@ -262,7 +267,7 @@ class TestTakaheAttachmentUrls:
             file="attachments/a.png",
             thumbnail="attachment_thumbnails/a.png",
         )
-        with mock.patch.object(storages["takahe"], "base_url", "/media/"):
+        with mock.patch.object(atta.file.storage, "base_url", "/media/"):
             full, preview = takahe_attachment_urls(atta)
         assert full.startswith("http")
         assert full.endswith("/media/attachments/a.png")
@@ -270,7 +275,7 @@ class TestTakaheAttachmentUrls:
 
     def test_absolute_urls_pass_through(self):
         atta = PostAttachment(pk=7, mimetype="image/png", file="attachments/a.png")
-        with mock.patch.object(storages["takahe"], "base_url", "https://cdn.example/"):
+        with mock.patch.object(atta.file.storage, "base_url", "https://cdn.example/"):
             full, preview = takahe_attachment_urls(atta)
         assert full == "https://cdn.example/attachments/a.png"
         # no thumbnail: preview falls back to the full file
@@ -777,13 +782,13 @@ class TestSyncFromPost:
         compose.yml sets an absolute one, which is why this hid locally --
         pinning it here rather than relying on the ambient config."""
         note, post = self._note_with_post(local=False)
-        PostAttachment.objects.create(
+        atta = PostAttachment.objects.create(
             post=post,
             author_id=self.identity.pk,
             mimetype="image/png",
             file=ContentFile(_png_bytes(), name="rel.png"),
         )
-        with mock.patch.object(storages["takahe"], "base_url", "/media/"):
+        with mock.patch.object(atta.file.storage, "base_url", "/media/"):
             rows = Attachment.sync_from_post(note, post)
         assert len(rows) == 1
         # resolved to an absolute URL rather than raising


### PR DESCRIPTION
Fixes the `AttributeError: 'dict' object has no attribute 'site_name'` that every `/search/external` request has raised since the site label restyle in f37d9224.

`ExternalSearchResultItem` carried its single resource as a plain dict. The old inline label loop in `_item_card.html` could read it, because Django template lookup resolves dict keys as well as attributes. The shared `_site_labels.html` now sorts through `ExternalResource.sort_for_display`, which does real attribute access on `site_name` and `pk`, so the render fails for any item that is not saved locally yet.

The fake item now carries a small `ExternalSearchResource` dataclass, keeping the outer `{"all": [...]}` shape the template reads. `sort_for_display` stays strict; the synthetic item is the odd one out, so it should carry the shape the template contract needs.

Two label details come along, since the dataclass is built from the site anyway:

- external results show the proper label (`TMDB`) like saved items, instead of the raw `tmdb` value that `TextChoices.__str__` produces
- a federated peer, which `FediverseInstance` passes as a bare hostname rather than a `SiteName`, gets the `fedi` label class with its hostname as the label, matching how a saved Fediverse resource renders

Nothing else in the tree builds a synthetic `external_resources`, and the only other consumer of `ExternalSources.search` (the `catalog search` management command) prints `__repr__` only.

## Test

`tests/catalog/test_site_labels.py` gets a view-level test that hits `catalog:external_search` with `ExternalSources.search` patched to return one `SiteName` result and one peer-hostname result, asserting the rendered anchors. Reverting the fix makes it fail with the exact traceback from the report; with the fix, all 884 tests in `tests/catalog/` pass.
