### PR TITLE
fix(search): stop /search/suggest from timing out Typesense

### DIFF
--- a/neodb/catalog/search/suggest.py
+++ b/neodb/catalog/search/suggest.py
@@ -38,7 +38,11 @@ _CJK = re.compile(r"[\u2e80-\u9fff\uf900-\ufaff]")
 # https://typesense.org/docs/latest/api/search.html#ranking-and-sorting-parameters
 _SUGGEST_PARAMS: dict[str, Any] = {
     "per_page": SUGGEST_LIMIT,
-    "num_typos": 1,
+    # A typeahead fires on every keystroke, so one query must stay cheap.
+    # Typo tolerance belongs to full search: a token long enough to pass
+    # min_len_1typo gets expanded here for no gain, because the next
+    # keystroke corrects the typo anyway (NEODB-SOCIAL-7WD).
+    "num_typos": 0,
     "drop_tokens_threshold": 0,
     "exhaustive_search": False,
     "search_cutoff_ms": 50,
@@ -48,8 +52,15 @@ _SUGGEST_PARAMS: dict[str, Any] = {
 
 class CatalogSuggestParser(CatalogQueryParser):
     max_pages = 1
+    # Full search also matches `people` and `company`, but they are large
+    # multi-valued fields, and prefix expansion over them made a two or three
+    # character query as expensive as a whole page of full search. The
+    # dropdown is a title typeahead; Enter still runs full search, which keeps
+    # matching creators. `prefix` is positional against `query_by`, so the two
+    # lists must stay the same length and in the same order.
     default_search_params = {
-        "query_by": "title, people, company, lookup_id, extra_title",
+        "query_by": "title, extra_title, lookup_id",
+        "prefix": "true,true,false",
         "sort_by": f"_text_match(bucket_size:{SUGGEST_LIMIT}):desc,mark_count:desc",
         "include_fields": "id, item_class, title",
         **_SUGGEST_PARAMS,
@@ -60,6 +71,7 @@ class PeopleSuggestParser(PeopleQueryParser):
     max_pages = 1
     default_search_params = {
         "query_by": "name, lookup_id",
+        "prefix": "true,false",
         "sort_by": f"_text_match(bucket_size:{SUGGEST_LIMIT}):desc,credit_count:desc",
         "include_fields": "id, people_type, name",
         **_SUGGEST_PARAMS,

--- a/neodb/common/templates/_header.html
+++ b/neodb/common/templates/_header.html
@@ -13,6 +13,7 @@
     <ul class="nav-search {% if request.GET.q %}unhide{% endif %}">
       <li _="on focusout if not me.contains(event.relatedTarget) set #q's @data-dismissed to 'true' then send htmx:abort to #q then set #search-suggest's innerHTML to '' end">
         <form role="search" method="get" action="{% url 'common:search' %}">
+          {# An IME keeps its composition buffer in the input value and `input` fires on every pinyin keystroke with isComposing set, so one CJK title used to send a request per keystroke (NEODB-SOCIAL-7WD). Filter those out, and trigger on compositionend too for the browsers that fire the committed `input` first. Both specs share one debounce timer and one `changed` value, so a commit still sends one request. #}
           <input type="search"
                  name="q"
                  id="q"
@@ -21,7 +22,7 @@
                  autocomplete="off"
                  aria-controls="search-suggest"
                  hx-get="{% url 'common:search_suggest' %}"
-                 hx-trigger="input changed delay:200ms"
+                 hx-trigger="input[!event.isComposing] changed delay:300ms, compositionend changed delay:300ms"
                  hx-include="[name='c']"
                  hx-sync="this:replace"
                  hx-target="#search-suggest"

--- a/neodb/common/templates/_header.html
+++ b/neodb/common/templates/_header.html
@@ -13,7 +13,7 @@
     <ul class="nav-search {% if request.GET.q %}unhide{% endif %}">
       <li _="on focusout if not me.contains(event.relatedTarget) set #q's @data-dismissed to 'true' then send htmx:abort to #q then set #search-suggest's innerHTML to '' end">
         <form role="search" method="get" action="{% url 'common:search' %}">
-          {# An IME keeps its composition buffer in the input value and `input` fires on every pinyin keystroke with isComposing set, so one CJK title used to send a request per keystroke (NEODB-SOCIAL-7WD). Composing keystrokes get a long debounce so a run of them sends nothing, but Android autocorrects every latin word through a composition session, so they must still fire once the typist pauses. compositionend covers the browsers that fire the committed `input` first. The three specs share one debounce timer and one `changed` value, so a commit still sends one request. #}
+          {# An IME keeps its composition buffer in the input value and `input` fires on every pinyin keystroke with isComposing set, so one CJK title used to send a request per keystroke (NEODB-SOCIAL-7WD). Composing keystrokes get a long debounce so a run of them sends nothing, but Android autocorrects every latin word through a composition session, so they must still fire once the typist pauses. compositionend covers the browsers that fire the committed `input` first. Do not add a `changed` guard: htmx remembers its last value per trigger spec, so a value only the composing spec saw stays invisible to the other two, and clearing an IME-entered query then compares '' against '' and is dropped, stranding stale rows under an empty box. The specs do share one debounce timer, so a commit still sends a single request. #}
           <input type="search"
                  name="q"
                  id="q"
@@ -22,7 +22,7 @@
                  autocomplete="off"
                  aria-controls="search-suggest"
                  hx-get="{% url 'common:search_suggest' %}"
-                 hx-trigger="input[!event.isComposing] changed delay:300ms, input[event.isComposing] changed delay:1000ms, compositionend changed delay:300ms"
+                 hx-trigger="input[!event.isComposing] delay:300ms, input[event.isComposing] delay:1000ms, compositionend delay:300ms"
                  hx-include="[name='c']"
                  hx-sync="this:replace"
                  hx-target="#search-suggest"

--- a/neodb/common/templates/_header.html
+++ b/neodb/common/templates/_header.html
@@ -13,7 +13,7 @@
     <ul class="nav-search {% if request.GET.q %}unhide{% endif %}">
       <li _="on focusout if not me.contains(event.relatedTarget) set #q's @data-dismissed to 'true' then send htmx:abort to #q then set #search-suggest's innerHTML to '' end">
         <form role="search" method="get" action="{% url 'common:search' %}">
-          {# An IME keeps its composition buffer in the input value and `input` fires on every pinyin keystroke with isComposing set, so one CJK title used to send a request per keystroke (NEODB-SOCIAL-7WD). Filter those out, and trigger on compositionend too for the browsers that fire the committed `input` first. Both specs share one debounce timer and one `changed` value, so a commit still sends one request. #}
+          {# An IME keeps its composition buffer in the input value and `input` fires on every pinyin keystroke with isComposing set, so one CJK title used to send a request per keystroke (NEODB-SOCIAL-7WD). Composing keystrokes get a long debounce so a run of them sends nothing, but Android autocorrects every latin word through a composition session, so they must still fire once the typist pauses. compositionend covers the browsers that fire the committed `input` first. The three specs share one debounce timer and one `changed` value, so a commit still sends one request. #}
           <input type="search"
                  name="q"
                  id="q"
@@ -22,7 +22,7 @@
                  autocomplete="off"
                  aria-controls="search-suggest"
                  hx-get="{% url 'common:search_suggest' %}"
-                 hx-trigger="input[!event.isComposing] changed delay:300ms, compositionend changed delay:300ms"
+                 hx-trigger="input[!event.isComposing] changed delay:300ms, input[event.isComposing] changed delay:1000ms, compositionend changed delay:300ms"
                  hx-include="[name='c']"
                  hx-sync="this:replace"
                  hx-target="#search-suggest"

--- a/neodb/tests/catalog/test_search_suggest.py
+++ b/neodb/tests/catalog/test_search_suggest.py
@@ -47,13 +47,25 @@ class TestSuggestParsers:
         params = CatalogSuggestParser("thr", page_size=SUGGEST_LIMIT).to_search_params()
         assert params["q"] == "thr"
         assert params["per_page"] == SUGGEST_LIMIT
-        assert params["num_typos"] == 1
+        assert params["num_typos"] == 0
         assert params["drop_tokens_threshold"] == 0
         assert params["exhaustive_search"] is False
         assert params["search_cutoff_ms"] == 50
         assert "facet_by" not in params
         assert f"bucket_size:{SUGGEST_LIMIT}" in params["sort_by"]
         assert params["include_fields"] == "id, item_class, title"
+        # prefix expansion over the large multi-valued creator fields is what
+        # made a short query cost a full page of search (NEODB-SOCIAL-7WD)
+        assert params["query_by"] == "title, extra_title, lookup_id"
+        assert params["prefix"] == "true,true,false"
+
+    def test_people_and_company_are_still_filterable(self):
+        """Dropping them from query_by must not drop the `people:` filter."""
+        params = CatalogSuggestParser(
+            "people:某人 company:某社", page_size=SUGGEST_LIMIT
+        ).to_search_params()
+        assert "people:" in params["filter_by"]
+        assert "company:" in params["filter_by"]
 
     def test_catalog_category_filter(self):
         from catalog.models import ItemCategory
@@ -67,6 +79,7 @@ class TestSuggestParsers:
     def test_people_params(self):
         params = PeopleSuggestParser("liu", page_size=SUGGEST_LIMIT).to_search_params()
         assert params["query_by"] == "name, lookup_id"
+        assert params["prefix"] == "true,false"
         assert "facet_by" not in params
         assert params["include_fields"] == "id, people_type, name"
 
@@ -77,11 +90,19 @@ class TestSuggestParsers:
             (PeopleIndex.schema, PeopleSuggestParser),
         ):
             declared = {f["name"] for f in schema["fields"]} | {"id"}
-            wanted = {
-                f.strip()
-                for f in parser.default_search_params["include_fields"].split(",")
-            }
-            assert wanted <= declared
+            for key in ("include_fields", "query_by"):
+                wanted = {
+                    f.strip() for f in parser.default_search_params[key].split(",")
+                }
+                assert wanted <= declared, f"{parser.__name__}.{key}"
+
+    def test_prefix_lines_up_with_query_by(self):
+        """Typesense reads `prefix` positionally, so a stale list mismatches."""
+        for parser in (CatalogSuggestParser, PeopleSuggestParser):
+            params = parser.default_search_params
+            assert len(params["prefix"].split(",")) == len(
+                params["query_by"].split(",")
+            ), parser.__name__
 
 
 class TestTitleChoice:


### PR DESCRIPTION

/search/suggest `input` fires on every keystroke *including while an IME composes*, because nothing checked `isComposing`. One CJK title sent 10 to 20 requests instead of 1, each a short-prefix query, which is the expensive shape. `hx-sync` cancels the browser request but Typesense keeps computing, so abandoned queries still hold search threads. Queue delay is not bounded by `search_cutoff_ms: 50`, which is why a 50ms cutoff still ends in a 4s timeout, and why unrelated users' cheap queries time out too.

## Changes

**Send fewer requests.** Composing keystrokes get their own long debounce rather than being dropped outright: Android autocorrects *every latin word* through a composition session, so gating on `isComposing` alone would have left Android users with no suggestions until they typed a space. A CJK typist now sends nothing while composing, because the timer keeps resetting inside a second, and Android suggests once the typist pauses. `compositionend` covers browsers that fire the committed `input` first.

No `changed` guard: htmx remembers its last value **per trigger spec**, so a value only the composing spec saw stays invisible to the other two, and clearing an IME-entered query would compare `''` to `''` and be dropped, stranding stale rows under an empty box. The specs do share one debounce timer, so a commit still sends a single request.

**Make one query cheap.** Query only the title fields, keep `prefix` off `lookup_id`, and drop typo tolerance, since the next keystroke corrects the typo before an expansion pays off. Prefix expansion over the large multi-valued `people` and `company` fields is the likely cost of the short queries; that part is inferred from the `/search` comparison above rather than measured, since I could not profile the production index.

## Behavior change

Typing a creator name with `c=all` no longer suggests their works in the dropdown. Enter still runs full search, which matches creators, the `people:` and `company:` query filters are untouched, and `c=people` has its own index. If we would rather keep creator matching in the dropdown, the cheaper variant is to keep both fields in `query_by` with `prefix` off, since expansion is the expensive part.

## Verification

- Real Typesense 30.2 accepts the new params, `error=None` across 8 query shapes including every one that was timing out.
- Browser probe against htmx 2.0.8 covering: a composing run sends nothing; a composing run then a pause sends one (Android); `compositionend` sends one carrying the committed text, not a stale composing value; `compositionend` plus a trailing `input` sends one; latin typing debounces to one; clearing after IME entry sends the clear.
- 31 suggest tests, plus 1277 in `tests/catalog` and `tests/core`. New tests guard that `prefix` stays positionally aligned with `query_by`, and that dropping the fields from `query_by` did not break the `people:` / `company:` filters.
