### PR TITLE
Update translation files

### DIFF
--- a/neodb/locale/da_DK/LC_MESSAGES/django.po
+++ b/neodb/locale/da_DK/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neodb-test\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 20:04-0400\n"
+"POT-Creation-Date: 2026-09-07 14:56-0400\n"
 "PO-Revision-Date: 2026-08-09 06:31+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Danish <https://hosted.weblate.org/projects/neodb/neodb/da/>\n"
@@ -61,15 +61,15 @@ msgstr "Forenklet kinesisk"
 msgid "Traditional Chinese"
 msgstr "Traditionelt kinesisk"
 
-#: catalog/forms.py:35 catalog/models/item.py:307
+#: catalog/forms.py:35 catalog/models/item.py:412
 msgid "Primary ID Type"
 msgstr "Primær ID-type"
 
-#: catalog/forms.py:40 catalog/models/item.py:310
+#: catalog/forms.py:40 catalog/models/item.py:415
 msgid "Primary ID Value"
 msgstr "Primær ID-værdi"
 
-#: catalog/forms.py:176
+#: catalog/forms.py:177
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
@@ -130,11 +130,11 @@ msgid "other title"
 msgstr "anden titel"
 
 #: catalog/models/book.py:282 catalog/models/book.py:566
-#: catalog/models/item.py:119
+#: catalog/models/item.py:224
 msgid "author"
 msgstr "forfatter"
 
-#: catalog/models/book.py:289 catalog/models/item.py:120
+#: catalog/models/book.py:289 catalog/models/item.py:225
 msgid "translator"
 msgstr "oversætter"
 
@@ -145,7 +145,7 @@ msgid "book format"
 msgstr "bøger der skal læses"
 
 #: catalog/models/book.py:303 catalog/models/game.py:135
-#: catalog/models/item.py:134 catalog/models/music.py:142
+#: catalog/models/item.py:239 catalog/models/music.py:142
 msgid "publisher"
 msgstr "forlag"
 
@@ -177,7 +177,7 @@ msgstr "indhold"
 msgid "price"
 msgstr "pris"
 
-#: catalog/models/book.py:326 catalog/models/item.py:145
+#: catalog/models/book.py:326 catalog/models/item.py:250
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr "kolofon"
@@ -604,7 +604,7 @@ msgid "Exhibition"
 msgstr "Udstilling"
 
 #: catalog/models/common.py:174 catalog/models/common.py:191
-#: journal/templates/collection.html:29 journal/templates/collection.html:40
+#: journal/templates/collection.html:30 journal/templates/collection.html:41
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
@@ -734,16 +734,16 @@ msgstr "Nyfortolkning"
 msgid "Special Edition"
 msgstr "Særlig udgave"
 
-#: catalog/models/game.py:111 catalog/models/item.py:126
+#: catalog/models/game.py:111 catalog/models/item.py:231
 msgid "designer"
 msgstr "designer"
 
-#: catalog/models/game.py:119 catalog/models/item.py:125
+#: catalog/models/game.py:119 catalog/models/item.py:230
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr "kunstner"
 
-#: catalog/models/game.py:127 catalog/models/item.py:135
+#: catalog/models/game.py:127 catalog/models/item.py:240
 msgid "developer"
 msgstr "udvikler"
 
@@ -773,147 +773,147 @@ msgstr "udgivelsestype"
 msgid "website"
 msgstr "websted"
 
-#: catalog/models/item.py:121 catalog/models/movie.py:123
+#: catalog/models/item.py:226 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
 #: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr "instruktør"
 
-#: catalog/models/item.py:122 catalog/models/movie.py:130
+#: catalog/models/item.py:227 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
 #: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr "skuespilforfatter"
 
-#: catalog/models/item.py:123 catalog/models/movie.py:137
+#: catalog/models/item.py:228 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
 #: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr "skuespiller"
 
-#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/item.py:229 catalog/models/movie.py:144
 #: catalog/models/tv.py:237 catalog/models/tv.py:463
 #, fuzzy
 #| msgid "production"
 msgid "producer"
 msgstr "produktion"
 
-#: catalog/models/item.py:127 catalog/models/performance.py:203
+#: catalog/models/item.py:232 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr "komponist"
 
-#: catalog/models/item.py:128 catalog/models/performance.py:210
+#: catalog/models/item.py:233 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr "koreograf"
 
-#: catalog/models/item.py:129 catalog/models/performance.py:224
+#: catalog/models/item.py:234 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr "udøvende kunstner"
 
-#: catalog/models/item.py:130 catalog/models/podcast.py:80
+#: catalog/models/item.py:235 catalog/models/podcast.py:80
 msgid "host"
 msgstr "vært"
 
-#: catalog/models/item.py:131 catalog/models/performance.py:196
+#: catalog/models/item.py:236 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr "oprindelig ophavsmand"
 
-#: catalog/models/item.py:132 catalog/models/performance.py:238
+#: catalog/models/item.py:237 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr "produktionshold"
 
-#: catalog/models/item.py:136
+#: catalog/models/item.py:241
 #, fuzzy
 #| msgid "production"
 msgid "production company"
 msgstr "produktion"
 
-#: catalog/models/item.py:137
+#: catalog/models/item.py:242
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:138
+#: catalog/models/item.py:243
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:139
+#: catalog/models/item.py:244
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:140 catalog/models/performance.py:231
+#: catalog/models/item.py:245 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr "trup"
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:248
 #, fuzzy
 #| msgid "director"
 msgid "voice actor"
 msgstr "instruktør"
 
-#: catalog/models/item.py:144 catalog/templates/edition.html:30
+#: catalog/models/item.py:249 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr "forlag"
 
-#: catalog/models/item.py:169 catalog/models/people.py:476
+#: catalog/models/item.py:274 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr "rolle"
 
-#: catalog/models/item.py:170 catalog/models/people.py:155
+#: catalog/models/item.py:275 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr "navn"
 
-#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:277 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:304 catalog/models/item.py:336
-#: journal/models/collection.py:100
+#: catalog/models/item.py:409 catalog/models/item.py:441
+#: journal/models/collection.py:101
 msgid "title"
 msgstr "titel"
 
-#: catalog/models/item.py:305 catalog/models/item.py:344
-#: journal/models/collection.py:101
+#: catalog/models/item.py:410 catalog/models/item.py:449
+#: journal/models/collection.py:102
 msgid "description"
 msgstr "beskrivelse"
 
-#: catalog/models/item.py:316 catalog/models/people.py:484
+#: catalog/models/item.py:421 catalog/models/people.py:484
 msgid "metadata"
 msgstr "metadata"
 
-#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:423 catalog/templates/_item_card.html:28
 msgid "cover"
 msgstr "omslag"
 
-#: catalog/models/item.py:1526
+#: catalog/models/item.py:1612
 msgid "source site"
 msgstr "kilde-site"
 
-#: catalog/models/item.py:1528
+#: catalog/models/item.py:1614
 msgid "ID on source site"
 msgstr "ID på kilde-site"
 
-#: catalog/models/item.py:1530
+#: catalog/models/item.py:1616
 msgid "source url"
 msgstr "kilde url"
 
-#: catalog/models/item.py:1546
+#: catalog/models/item.py:1632
 msgid "IdType of the source site"
 msgstr "IdType for kilde-sitet"
 
-#: catalog/models/item.py:1552
+#: catalog/models/item.py:1638
 msgid "Primary Id on the source site"
 msgstr "Primært ID på kilde-sitet"
 
-#: catalog/models/item.py:1555
+#: catalog/models/item.py:1641
 msgid "url to the resource"
 msgstr "url til ressourcen"
 
@@ -1244,12 +1244,12 @@ msgstr "Kan ikke hente fra linket, tjek venligst igen. Nogle websteder kræver m
 #: catalog/templates/_item_card_metadata_tvseason.html:7
 #: catalog/templates/_item_card_metadata_tvshow.html:7
 #: catalog/templates/_item_card_metadata_work.html:7
-#: catalog/templates/item_base.html:201
+#: catalog/templates/item_base.html:186
 msgid "ratings"
 msgstr "bedømmelser"
 
-#: catalog/templates/_item_card_metadata_base.html:34
-#: catalog/templates/item_base.html:256
+#: catalog/templates/_item_card_metadata_base.html:28
+#: catalog/templates/item_base.html:241
 msgid "part of"
 msgstr "del af"
 
@@ -1269,7 +1269,7 @@ msgid "hide this tooltip"
 msgstr "skjul dette værktøjstip"
 
 #: catalog/templates/_item_comments.html:58
-#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:83
+#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:81
 #, fuzzy
 #| msgid "translator"
 msgid "translate"
@@ -1278,7 +1278,7 @@ msgstr "oversætter"
 #: catalog/templates/_item_comments.html:92
 #: catalog/templates/_item_comments_by_episode.html:80
 #: catalog/templates/_item_notes.html:88
-#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:284
+#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:269
 #: catalog/templates/podcast_episode_data.html:41
 msgid "show more"
 msgstr "vis mere"
@@ -1399,8 +1399,8 @@ msgstr "Synkronisering i gang."
 #: catalog/templates/_item_user_pieces.html:101
 #: catalog/templates/catalog_edit.html:12
 #: journal/templates/action_edit_post.html:6
-#: journal/templates/action_edit_post.html:8 journal/templates/article.html:196
-#: journal/templates/collection.html:185 journal/templates/collection.html:193
+#: journal/templates/action_edit_post.html:8 journal/templates/article.html:194
+#: journal/templates/collection.html:186 journal/templates/collection.html:194
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_edit.html:26
 #: journal/templates/post_compose.html:16 journal/templates/tag_edit.html:16
@@ -1444,7 +1444,7 @@ msgstr "tilbage til element"
 #: catalog/templates/_sidebar_edit.html:20
 #: catalog/templates/catalog_verify.html:11
 #: catalog/templates/catalog_verify.html:17
-#: catalog/templates/item_base.html:182
+#: catalog/templates/item_base.html:167
 #, fuzzy
 #| msgid "Verification"
 msgid "Creator verification"
@@ -1454,7 +1454,7 @@ msgstr "Bekræftelse"
 msgid "Edit Options"
 msgstr "Rediger Indstillinger"
 
-#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
+#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:163
 #: catalog/views/edit.py:160 catalog/views/edit.py:221
 #: catalog/views/edit.py:288 catalog/views/edit.py:309
 #: catalog/views/edit.py:364 catalog/views/edit.py:471
@@ -1628,7 +1628,7 @@ msgstr "flet til et andet element"
 #: catalog/templates/_sidebar_edit.html:265
 #: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
-#: journal/templates/article.html:199 journal/templates/collection.html:188
+#: journal/templates/article.html:197 journal/templates/collection.html:189
 #: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
@@ -1825,7 +1825,7 @@ msgstr ""
 msgid "Remove my verification"
 msgstr "Fjern fra samling"
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:311
+#: catalog/templates/_verify_status.html:31 users/views/account.py:312
 #, fuzzy
 #| msgid "Verification"
 msgid "Verification failed"
@@ -2019,7 +2019,7 @@ msgstr "Populære tags"
 
 #: catalog/templates/discover.html:229
 #: catalog/templates/discover_original_podcasts.html:25
-#: catalog/templates/item_base.html:282
+#: catalog/templates/item_base.html:267
 #: catalog/templates/item_mark_list.html:71
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
@@ -2089,67 +2089,67 @@ msgstr "Henter fra %(site_label)s"
 msgid "System busy, please try again in a minute."
 msgstr "System er optaget, prøv venligst igen om et øjeblik."
 
-#: catalog/templates/item_base.html:95
+#: catalog/templates/item_base.html:80
 msgid "select one of the seasons to comment"
 msgstr "vælg en sæson for at skal kommente"
 
-#: catalog/templates/item_base.html:129
+#: catalog/templates/item_base.html:114
 msgid "mark, comment and collect"
 msgstr "marker, kommenter og indsaml"
 
-#: catalog/templates/item_base.html:142
+#: catalog/templates/item_base.html:127
 msgid "Login or register to review or add this item to your collection."
 msgstr "Log ind eller registrer dig for at anmelde eller tilføje dette element til din samling."
 
-#: catalog/templates/item_base.html:151
+#: catalog/templates/item_base.html:136
 msgid "Related Collections"
 msgstr "Relaterede samlinger"
 
-#: catalog/templates/item_base.html:166
+#: catalog/templates/item_base.html:151
 msgid "Unsupported item type."
 msgstr "Filtype ikke understøttet."
 
-#: catalog/templates/item_base.html:176
+#: catalog/templates/item_base.html:161
 msgid "Edit this item"
 msgstr "Rediger dette element"
 
-#: catalog/templates/item_base.html:187
+#: catalog/templates/item_base.html:172
 msgid "Last edited"
 msgstr "Sidst redigeret"
 
-#: catalog/templates/item_base.html:230
+#: catalog/templates/item_base.html:215
 msgid "No enough ratings"
 msgstr "Ingen nok bedømmelser"
 
-#: catalog/templates/item_base.html:274
+#: catalog/templates/item_base.html:259
 msgid "overview"
 msgstr "overblik"
 
-#: catalog/templates/item_base.html:305
+#: catalog/templates/item_base.html:290
 msgid "comments"
 msgstr "kommentarer"
 
-#: catalog/templates/item_base.html:308
+#: catalog/templates/item_base.html:293
 #: catalog/templates/item_mark_list.html:22
 #: catalog/templates/item_mark_list.html:25
 #: catalog/templates/item_review_list.html:21
 msgid "marks"
 msgstr "markeringer"
 
-#: catalog/templates/item_base.html:309
+#: catalog/templates/item_base.html:294
 #: catalog/templates/item_mark_list.html:23
 #: catalog/templates/item_mark_list.html:26
 #: catalog/templates/item_review_list.html:22
 msgid "marks from who you follow"
 msgstr "markeringer fra folk du følger"
 
-#: catalog/templates/item_base.html:323
+#: catalog/templates/item_base.html:308
 #: catalog/templates/item_mark_list.html:28
 #: catalog/templates/item_review_list.html:23
 msgid "reviews"
 msgstr "anmeldelser"
 
-#: catalog/templates/item_base.html:333
+#: catalog/templates/item_base.html:318
 #, fuzzy
 #| msgid "note"
 msgid "notes"
@@ -2564,7 +2564,7 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
+#: catalog/views/verify.py:164 common/utils.py:148 common/utils.py:189
 #: journal/views/article.py:186 journal/views/review.py:182
 #: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
@@ -4342,7 +4342,7 @@ msgstr "Kun Omtalte"
 msgid "Open Registration"
 msgstr "Registrering mislykkedes"
 
-#: common/templates/common/about.html:40 common/views_manage.py:657
+#: common/templates/common/about.html:40 common/views_manage.py:671
 #, fuzzy
 #| msgid "Preferences"
 msgid "Preferred Languages"
@@ -4408,7 +4408,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:738
+#: common/templates/common/scan.html:60 common/views_manage.py:756
 #, fuzzy
 #| msgid "Search results"
 msgid "Search"
@@ -4494,16 +4494,16 @@ msgstr ""
 msgid "unavailable"
 msgstr ""
 
-#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
+#: common/utils.py:152 common/utils.py:193 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr "Brugeren findes ikke længere"
 
-#: common/utils.py:135 common/utils.py:137 common/utils.py:140
-#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
+#: common/utils.py:159 common/utils.py:161 common/utils.py:164
+#: common/utils.py:200 common/utils.py:204 journal/views/profile.py:499
 msgid "Access denied"
 msgstr "Adgang nægtet"
 
-#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
+#: common/utils.py:167 common/utils.py:169 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr "Login påkrævet"
@@ -4526,7 +4526,7 @@ msgstr "kommentarer"
 msgid "Access"
 msgstr "Adgang nægtet"
 
-#: common/views_manage.py:39 common/views_manage.py:733
+#: common/views_manage.py:39 common/views_manage.py:751
 #, fuzzy
 #| msgid "duration"
 msgid "Federation"
@@ -4910,465 +4910,495 @@ msgid "Sender name and address for outgoing email."
 msgstr ""
 
 #: common/views_manage.py:649
+msgid "Enable Twitter / X Archive Import"
+msgstr ""
+
+#: common/views_manage.py:651
+msgid "Show the Twitter / X archive import on the data page. Imported tweets become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:656
+msgid "Enable Mastodon Archive Import"
+msgstr ""
+
+#: common/views_manage.py:658
+msgid "Show the Mastodon archive import on the data page. Imported posts become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:663
 #, fuzzy
 #| msgid "Language"
 msgid "Default Language"
 msgstr "Sprog"
 
-#: common/views_manage.py:652
+#: common/views_manage.py:666
 msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:673
 msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:665
+#: common/views_manage.py:679
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:672
+#: common/views_manage.py:686
 #, fuzzy
 #| msgid "Import Method"
 msgid "Login Methods"
 msgstr "Importeringsmetode"
 
-#: common/views_manage.py:677 mastodon/models/common.py:30
+#: common/views_manage.py:691 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr "E-mail"
 
-#: common/views_manage.py:681
+#: common/views_manage.py:695
+#, fuzzy
+#| msgid "Import"
+msgid "Data Import"
+msgstr "Import"
+
+#: common/views_manage.py:699
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:692
+#: common/views_manage.py:710
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:694
+#: common/views_manage.py:712
 msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:699
+#: common/views_manage.py:717
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:700
+#: common/views_manage.py:718
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:704
+#: common/views_manage.py:722
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:706
+#: common/views_manage.py:724
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:711
+#: common/views_manage.py:729
 #, fuzzy
 #| msgid "Search results"
 msgid "Search Sites"
 msgstr "Søgeresultater"
 
-#: common/views_manage.py:712
+#: common/views_manage.py:730
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:715
+#: common/views_manage.py:733
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:716
+#: common/views_manage.py:734
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:719
+#: common/views_manage.py:737
 #, fuzzy
 #| msgid "Add tv series"
 msgid "Hidden Categories"
 msgstr "Tilføj tv-serier"
 
-#: common/views_manage.py:720
+#: common/views_manage.py:738
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:723
+#: common/views_manage.py:741
 msgid "Guest Search Page Limit"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:743
 msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
 msgstr ""
 
-#: common/views_manage.py:751
+#: common/views_manage.py:769
 #, fuzzy
 #| msgid "Spotify Album"
 msgid "Spotify API Key"
 msgstr "Spotify album"
 
-#: common/views_manage.py:752
+#: common/views_manage.py:770
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:773
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:756
+#: common/views_manage.py:774
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:759
+#: common/views_manage.py:777
 #, fuzzy
 #| msgid "Google Books"
 msgid "Google Books API Key"
 msgstr "Google Bøger"
 
-#: common/views_manage.py:760
+#: common/views_manage.py:778
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:763
+#: common/views_manage.py:781
 #, fuzzy
 #| msgid "Discogs"
 msgid "Discogs API Key"
 msgstr "Discogs"
 
-#: common/views_manage.py:765
+#: common/views_manage.py:783
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:769
+#: common/views_manage.py:787
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:770
+#: common/views_manage.py:788
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:773
+#: common/views_manage.py:791
 #, fuzzy
 #| msgid "client secret"
 msgid "IGDB Client Secret"
 msgstr "klienthemmelighed"
 
-#: common/views_manage.py:776
+#: common/views_manage.py:794
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:778
+#: common/views_manage.py:796
 msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:783
+#: common/views_manage.py:801
 msgid "MyAnimeList Client ID"
 msgstr ""
 
-#: common/views_manage.py:785
+#: common/views_manage.py:803
 msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
 msgstr ""
 
-#: common/views_manage.py:790 users/templates/users/steam_import.html:26
+#: common/views_manage.py:808 users/templates/users/steam_import.html:26
 #, fuzzy
 #| msgid "Steam Game"
 msgid "Steam API Key"
 msgstr "Steam spil"
 
-#: common/views_manage.py:792
+#: common/views_manage.py:810
 msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:797
+#: common/views_manage.py:815
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:798
+#: common/views_manage.py:816
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:801
+#: common/views_manage.py:819
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:804
+#: common/views_manage.py:822
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:807
+#: common/views_manage.py:825
 #, fuzzy
 #| msgid "Threads"
 msgid "Threads App ID"
 msgstr "Threads"
 
-#: common/views_manage.py:808
+#: common/views_manage.py:826
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:811
+#: common/views_manage.py:829
 #, fuzzy
 #| msgid "Threads.net"
 msgid "Threads App Secret"
 msgstr "Threads.net"
 
-#: common/views_manage.py:814
+#: common/views_manage.py:832
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:834
 msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:833
+#: common/views_manage.py:851
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:844
+#: common/views_manage.py:862
 #, fuzzy
 #| msgid "translator"
 msgid "Translation"
 msgstr "oversætter"
 
-#: common/views_manage.py:849
+#: common/views_manage.py:867
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:853 social/templates/feed.html:27
+#: common/views_manage.py:871 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr "Notifikationer"
 
-#: common/views_manage.py:863
+#: common/views_manage.py:881
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:882
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:885
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:868
+#: common/views_manage.py:886
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:871
+#: common/views_manage.py:889
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:874
+#: common/views_manage.py:892
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:877
+#: common/views_manage.py:895
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:880
+#: common/views_manage.py:898
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:883
+#: common/views_manage.py:901
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:886
+#: common/views_manage.py:904
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:887
+#: common/views_manage.py:905
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:908
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:894
+#: common/views_manage.py:912
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:898
+#: common/views_manage.py:916
 #, fuzzy
 #| msgid "series"
 msgid "Retries"
 msgstr "serie"
 
-#: common/views_manage.py:903
+#: common/views_manage.py:921
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:908
+#: common/views_manage.py:926
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:915
+#: common/views_manage.py:933
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:927
+#: common/views_manage.py:945
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:928
+#: common/views_manage.py:946
 #, fuzzy
 #| msgid "site domain name"
 msgid "One domain per line."
 msgstr "websteds domænenavn"
 
-#: common/views_manage.py:931
+#: common/views_manage.py:949
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:932
+#: common/views_manage.py:950
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:935
+#: common/views_manage.py:953
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:937
+#: common/views_manage.py:955
 msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:943
+#: common/views_manage.py:961
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:944
+#: common/views_manage.py:962
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:947
+#: common/views_manage.py:965
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:948
+#: common/views_manage.py:966
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:958
+#: common/views_manage.py:976
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:960
+#: common/views_manage.py:978
 msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:966
+#: common/views_manage.py:984
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:968
+#: common/views_manage.py:986
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:974
+#: common/views_manage.py:992
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:976
+#: common/views_manage.py:994
 msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:983
+#: common/views_manage.py:1000
+msgid "Webhook Timeout (milliseconds)"
+msgstr ""
+
+#: common/views_manage.py:1001
+msgid "Timeout for delivering webhook requests to applications."
+msgstr ""
+
+#: common/views_manage.py:1006
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:986
+#: common/views_manage.py:1009
 #, fuzzy
 #| msgid "optional"
 msgid "Operational"
 msgstr "valgfrit"
 
-#: common/views_manage.py:1002
+#: common/views_manage.py:1026
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:1004
+#: common/views_manage.py:1028
 msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1009
+#: common/views_manage.py:1033
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:1011
+#: common/views_manage.py:1035
 msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1016
+#: common/views_manage.py:1040
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:1018
+#: common/views_manage.py:1042
 msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1023
+#: common/views_manage.py:1047
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:1025
+#: common/views_manage.py:1049
 msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1030
+#: common/views_manage.py:1054
 #, fuzzy
 #| msgid "Podcast"
 msgid "Podcast Genres"
 msgstr "Podcast"
 
-#: common/views_manage.py:1032
+#: common/views_manage.py:1056
 msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1037
+#: common/views_manage.py:1061
 #, fuzzy
 #| msgid "Performance"
 msgid "Performance Genres"
 msgstr "Forestilling"
 
-#: common/views_manage.py:1039
+#: common/views_manage.py:1063
 msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1045
+#: common/views_manage.py:1069
 msgid "Genres by Category"
 msgstr ""
 
-#: common/views_manage.py:1069
+#: common/views_manage.py:1093
 msgid "Site"
 msgstr ""
 
-#: common/views_manage.py:1079
+#: common/views_manage.py:1103
 #, fuzzy
 #| msgid "Database"
 msgid "Database and Services"
 msgstr "Database"
 
-#: common/views_manage.py:1089
+#: common/views_manage.py:1113
 msgid "Media and Files"
 msgstr ""
 
-#: common/views_manage.py:1098
+#: common/views_manage.py:1122
 msgid "Monitoring"
 msgstr ""
 
-#: common/views_manage.py:1102
+#: common/views_manage.py:1126
 msgid "Security"
 msgstr ""
 
-#: common/views_manage.py:1111
+#: common/views_manage.py:1135
 msgid "Other Environment Variables"
 msgstr ""
 
-#: common/views_manage.py:1113
+#: common/views_manage.py:1137
 msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
 msgstr ""
 
@@ -5416,7 +5446,8 @@ msgstr "Udskift indledende mellemrum med mellemrum med fuld bredde ved lagring"
 #: users/templates/users/data.html:60 users/templates/users/data.html:113
 #: users/templates/users/data.html:170 users/templates/users/data.html:221
 #: users/templates/users/data.html:284 users/templates/users/data.html:346
-#: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
+#: users/templates/users/data.html:525 users/templates/users/data.html:578
+#: users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
 msgid "Visibility"
@@ -5456,8 +5487,8 @@ msgstr "kun ejeren"
 msgid "owner and their local mutuals"
 msgstr "ejeren og deres gensidige følgere"
 
-#: journal/forms.py:169 journal/templates/collection.html:193
-#: journal/templates/collection.html:202
+#: journal/forms.py:169 journal/templates/collection.html:194
+#: journal/templates/collection.html:203
 msgid "Collaborative editing"
 msgstr "Kollaborativ redigering"
 
@@ -5510,7 +5541,7 @@ msgstr ""
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:215 journal/views/article.py:218
+#: journal/models/article.py:224 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
@@ -5522,75 +5553,76 @@ msgstr ""
 msgid "note"
 msgstr "note"
 
-#: journal/models/collection.py:115
+#: journal/models/collection.py:116
 #, fuzzy
 #| msgid "shared {username}'s collection"
 msgid "search query for dynamic collection"
 msgstr "delte {username}'s samling"
 
-#: journal/models/collection.py:566 journal/templatetags/collection.py:35
+#: journal/models/collection.py:575 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] "%(count)d bog"
 msgstr[1] "%(count)d bøger"
 
-#: journal/models/collection.py:571 journal/templatetags/collection.py:43
+#: journal/models/collection.py:580 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] "%(count)d film"
 msgstr[1] "%(count)d film"
 
-#: journal/models/collection.py:576 journal/templatetags/collection.py:51
+#: journal/models/collection.py:585 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] "%(count)d tv-serie"
 msgstr[1] "%(count)d tv-serier"
 
-#: journal/models/collection.py:581 journal/templatetags/collection.py:59
+#: journal/models/collection.py:590 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] "%(count)d album"
 msgstr[1] "%(count)d albums"
 
-#: journal/models/collection.py:586 journal/templatetags/collection.py:67
+#: journal/models/collection.py:595 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] "%(count)d spil"
 msgstr[1] "%(count)d spil"
 
-#: journal/models/collection.py:591 journal/templatetags/collection.py:75
+#: journal/models/collection.py:600 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] "%(count)d podcast"
 msgstr[1] "%(count)d podcasts"
 
-#: journal/models/collection.py:597 journal/templatetags/collection.py:83
+#: journal/models/collection.py:606 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] "%(count)d forestilling"
 msgstr[1] "%(count)d forestillinger"
 
-#: journal/models/collection.py:605 journal/templatetags/collection.py:91
+#: journal/models/collection.py:614 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] "%(count)d element"
 msgstr[1] "%(count)d elementer"
 
-#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/models/common.py:59 journal/templates/action_open_post.html:15
 #: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
 #: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
 #: users/templates/users/data.html:122 users/templates/users/data.html:179
 #: users/templates/users/data.html:230 users/templates/users/data.html:292
 #: users/templates/users/data.html:355 users/templates/users/data.html:534
+#: users/templates/users/data.html:587
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5598,13 +5630,14 @@ msgstr[1] "%(count)d elementer"
 msgid "Public"
 msgstr "Offentlig"
 
-#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/models/common.py:60 journal/templates/action_open_post.html:9
 #: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
 #: users/templates/users/data.html:130 users/templates/users/data.html:187
 #: users/templates/users/data.html:238 users/templates/users/data.html:300
 #: users/templates/users/data.html:363 users/templates/users/data.html:542
+#: users/templates/users/data.html:595
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5612,12 +5645,13 @@ msgstr "Offentlig"
 msgid "Followers Only"
 msgstr "Kun Følgere"
 
-#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/models/common.py:61 journal/templates/collection_share.html:57
 #: journal/templates/mark.html:102 journal/templates/post_compose.html:72
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
 #: users/templates/users/data.html:138 users/templates/users/data.html:195
 #: users/templates/users/data.html:246 users/templates/users/data.html:308
 #: users/templates/users/data.html:371 users/templates/users/data.html:550
+#: users/templates/users/data.html:603
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5625,33 +5659,33 @@ msgstr "Kun Følgere"
 msgid "Mentioned Only"
 msgstr "Kun Omtalte"
 
-#: journal/models/common.py:806
+#: journal/models/common.py:851
 #, fuzzy
 #| msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr "Et nyligt indlæg blev ikke sendt til Mastodon, prøv venligst at autorisere igen."
 
-#: journal/models/common.py:1003
+#: journal/models/common.py:1048
 msgid "A recent post was not posted to Threads."
 msgstr "Et nyligt indlæg blev ikke sendt til Threads."
 
-#: journal/models/common.py:1036
+#: journal/models/common.py:1081
 #, fuzzy
 #| msgid "A recent post was not posted to Mastodon."
 msgid "A recent post was not boosted on Mastodon."
 msgstr "Et nyligt indlæg blev ikke sendt til Mastodon."
 
-#: journal/models/common.py:1046
+#: journal/models/common.py:1091
 #, fuzzy
 #| msgid "Item no longer exists"
 msgid "Original post no longer exists."
 msgstr "Elementet findes ikke længere"
 
-#: journal/models/common.py:1060
+#: journal/models/common.py:1105
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr "Et nyligt indlæg blev ikke sendt til Mastodon, prøv venligst at autorisere igen."
 
-#: journal/models/common.py:1069
+#: journal/models/common.py:1114
 msgid "A recent post was not posted to Mastodon."
 msgstr "Et nyligt indlæg blev ikke sendt til Mastodon."
 
@@ -5669,85 +5703,85 @@ msgstr "Mislykket"
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:475
+#: journal/models/mark.py:477
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:479
+#: journal/models/mark.py:481
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:486
+#: journal/models/mark.py:488
 #, fuzzy
 #| msgid "Invalid parameter"
 msgid "Invalid progress type."
 msgstr "Ugyldig parameter"
 
-#: journal/models/mark.py:488
+#: journal/models/mark.py:490
 #, fuzzy
 #| msgid "Invalid response from Fediverse instance."
 msgid "Invalid progress type for this item."
 msgstr "Ugyldigt svar fra Fødivers instans."
 
-#: journal/models/note.py:47 users/templates/users/rym_import.html:73
+#: journal/models/note.py:48 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr "Side"
 
-#: journal/models/note.py:48
+#: journal/models/note.py:49
 msgid "Chapter"
 msgstr "Kapitel"
 
-#: journal/models/note.py:51
+#: journal/models/note.py:52
 msgid "Part"
 msgstr "Del"
 
-#: journal/models/note.py:52
+#: journal/models/note.py:53
 msgid "Episode"
 msgstr "Afsnit"
 
-#: journal/models/note.py:53
+#: journal/models/note.py:54
 msgid "Track"
 msgstr "Nummer"
 
-#: journal/models/note.py:54
+#: journal/models/note.py:55
 msgid "Cycle"
 msgstr "Cyklus"
 
-#: journal/models/note.py:55
+#: journal/models/note.py:56
 msgid "Timestamp"
 msgstr "Tidsmærke"
 
-#: journal/models/note.py:56
+#: journal/models/note.py:57
 msgid "Percentage"
 msgstr "Procent"
 
-#: journal/models/note.py:77
+#: journal/models/note.py:78
 #, python-brace-format
 msgid "Page {value}"
 msgstr "Side {value}"
 
-#: journal/models/note.py:78
+#: journal/models/note.py:79
 #, python-brace-format
 msgid "Chapter {value}"
 msgstr "Kapitel {value}"
 
-#: journal/models/note.py:81
+#: journal/models/note.py:82
 #, python-brace-format
 msgid "Part {value}"
 msgstr "Del {value}"
 
-#: journal/models/note.py:82
+#: journal/models/note.py:83
 #, python-brace-format
 msgid "Episode {value}"
 msgstr "Afsnit {value}"
 
-#: journal/models/note.py:83
+#: journal/models/note.py:84
 #, python-brace-format
 msgid "Track {value}"
 msgstr "Nummer {value}"
 
-#: journal/models/note.py:84
+#: journal/models/note.py:85
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr "Cyklus {value}"
@@ -5757,13 +5791,13 @@ msgstr "Cyklus {value}"
 msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr "vedrørende {item_title}, kan indeholde spoilers eller provokerende/triggerende indhold"
 
-#: journal/models/review.py:79
+#: journal/models/review.py:80
 #, fuzzy, python-brace-format
 #| msgid "a review of {item_title}"
 msgid "a review of {title}"
 msgstr "en anmeldelse af {item_title}"
 
-#: journal/models/review.py:81
+#: journal/models/review.py:82
 #, fuzzy
 #| msgid "Item contains sub-items."
 msgid "(may contain spoilers)"
@@ -6195,7 +6229,7 @@ msgstr "Brugere du følger"
 msgid "started following {item}"
 msgstr "begyndte at spille {item}"
 
-#: journal/models/shelf.py:923
+#: journal/models/shelf.py:925
 msgid "removed mark"
 msgstr "fjernet markering"
 
@@ -6230,7 +6264,7 @@ msgstr "Fjern fra samling"
 msgid "Update note"
 msgstr "Opdater note"
 
-#: journal/templates/_list_item.html:71 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:121
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
@@ -6399,7 +6433,7 @@ msgid "View post"
 msgstr ""
 
 #: journal/templates/action_quote_post.html:3
-#: journal/templates/article.html:190 journal/templates/collection.html:174
+#: journal/templates/article.html:188 journal/templates/collection.html:175
 msgid "Quote"
 msgstr ""
 
@@ -6408,7 +6442,7 @@ msgid "reply"
 msgstr "svar"
 
 #: journal/templates/action_reply_post.html:3
-#: journal/templates/article.html:181 journal/templates/collection.html:165
+#: journal/templates/article.html:179 journal/templates/collection.html:166
 msgid "Reply"
 msgstr "Svar"
 
@@ -6427,23 +6461,23 @@ msgstr "Føj til samling"
 msgid "Create a new collection"
 msgstr "Opret ny samling"
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:76
+#: journal/templates/article.html:102 social/templates/_event_post.html:76
 #, fuzzy
 #| msgid "wrote a review of {item}"
 msgid "wrote a review"
 msgstr "skrev en anmeldelse af {item}"
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:78
+#: journal/templates/article.html:104 social/templates/_event_post.html:78
 #, fuzzy
 #| msgid "wrote a note"
 msgid "wrote an article"
 msgstr "skrev en note"
 
-#: journal/templates/article.html:136
+#: journal/templates/article.html:134
 msgid "This article may contain sensitive content. Click to reveal."
 msgstr ""
 
-#: journal/templates/article.html:155
+#: journal/templates/article.html:153
 msgid "The author has set it to be viewable only by logged-in users."
 msgstr "Forfatteren har sat den til kun at kunne ses af indloggede brugere."
 
@@ -6508,20 +6542,20 @@ msgstr "NOV"
 msgid "DEC"
 msgstr "DEC"
 
-#: journal/templates/collection.html:71
+#: journal/templates/collection.html:72
 #: journal/templates/collection_share.html:12
 #: journal/templates/collection_share.html:66
 #: journal/templates/wrapped_share.html:59
 msgid "Share"
 msgstr "Del"
 
-#: journal/templates/collection.html:86
+#: journal/templates/collection.html:87
 #, fuzzy
 #| msgid "created collection"
 msgid "created a collection"
 msgstr "oprettede samling"
 
-#: journal/templates/collection.html:181
+#: journal/templates/collection.html:182
 msgid "Query"
 msgstr ""
 
@@ -6874,14 +6908,14 @@ msgid "Liked Collections"
 msgstr "Samlinger som nogen synes godt om"
 
 #: journal/templates/user_follow_list.html:23 journal/views/profile.py:507
-#: users/templates/users/account.html:443
+#: users/templates/users/account.html:455
 #, fuzzy
 #| msgid "following you"
 msgid "Following"
 msgstr "følger dig"
 
 #: journal/templates/user_follow_list.html:28 journal/views/profile.py:511
-#: users/templates/users/account.html:452
+#: users/templates/users/account.html:464
 #, fuzzy
 #| msgid "Followers Only"
 msgid "Followers"
@@ -7231,8 +7265,8 @@ msgstr "Bluesky Login ID"
 #: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
 #: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
 #: mastodon/views/threads.py:57 mastodon/views/threads.py:65
-#: mastodon/views/threads.py:71 users/views/account.py:256
-#: users/views/account.py:375
+#: mastodon/views/threads.py:71 users/views/account.py:257
+#: users/views/account.py:376
 msgid "Authentication failed"
 msgstr "Godkendelse mislykkedes"
 
@@ -7280,7 +7314,7 @@ msgstr "Ugyldige kontodata fra Bluesky."
 msgid "Invalid user."
 msgstr "Ugyldig bruger."
 
-#: mastodon/views/common.py:52 users/views/account.py:416
+#: mastodon/views/common.py:52 users/views/account.py:417
 msgid "Registration failed"
 msgstr "Registrering mislykkedes"
 
@@ -8270,146 +8304,161 @@ msgstr "udgivelsesår"
 msgid "Scopes"
 msgstr ""
 
-#: users/templates/users/account.html:398
+#: users/templates/users/account.html:386
+msgid "Webhook"
+msgstr ""
+
+#: users/templates/users/account.html:400
+msgid "disabled"
+msgstr ""
+
+#: users/templates/users/account.html:402
+#, fuzzy
+#| msgid "Activities"
+msgid "active"
+msgstr "Aktiviteter"
+
+#: users/templates/users/account.html:410
 msgid "Revoke access for this application?"
 msgstr ""
 
-#: users/templates/users/account.html:401
+#: users/templates/users/account.html:413
 msgid "Revoke"
 msgstr ""
 
-#: users/templates/users/account.html:409
+#: users/templates/users/account.html:421
 #, fuzzy
 #| msgid "View authorized applications"
 msgid "No authorized applications."
 msgstr "Vis godkendte programmer"
 
-#: users/templates/users/account.html:412
+#: users/templates/users/account.html:424
 #: users/templates/users/authorized_app_create.html:9
 #: users/templates/users/authorized_app_create.html:19
 msgid "Create Personal Token"
 msgstr ""
 
-#: users/templates/users/account.html:418
+#: users/templates/users/account.html:430
 msgid "Import/Export Social Graph"
 msgstr ""
 
-#: users/templates/users/account.html:419
+#: users/templates/users/account.html:431
 msgid "Upload a CSV file exported from Mastodon or compatible services."
 msgstr ""
 
-#: users/templates/users/account.html:425
+#: users/templates/users/account.html:437
 #, fuzzy
 #| msgid "Import"
 msgid "Import type"
 msgstr "Import"
 
-#: users/templates/users/account.html:427
+#: users/templates/users/account.html:439
 #, fuzzy
 #| msgid "following you"
 msgid "Following list"
 msgstr "følger dig"
 
-#: users/templates/users/account.html:428
+#: users/templates/users/account.html:440
 #, fuzzy
 #| msgid "to listen"
 msgid "Block list"
 msgstr "skal lyttes til"
 
-#: users/templates/users/account.html:429
+#: users/templates/users/account.html:441
 #, fuzzy
 #| msgid "to listen"
 msgid "Mute list"
 msgstr "skal lyttes til"
 
-#: users/templates/users/account.html:433
+#: users/templates/users/account.html:445
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/account.html:448 users/templates/users/data.html:89
 #: users/templates/users/data.html:141 users/templates/users/data.html:198
 #: users/templates/users/data.html:249 users/templates/users/data.html:313
 #: users/templates/users/data.html:376 users/templates/users/data.html:553
+#: users/templates/users/data.html:606 users/templates/users/data.html:631
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr "Import"
 
-#: users/templates/users/account.html:447
-#: users/templates/users/account.html:456
-#: users/templates/users/account.html:465
-#: users/templates/users/account.html:474
+#: users/templates/users/account.html:459
+#: users/templates/users/account.html:468
+#: users/templates/users/account.html:477
+#: users/templates/users/account.html:486
 #, fuzzy
 #| msgid "Download"
 msgid "Download CSV"
 msgstr "Download"
 
-#: users/templates/users/account.html:461
+#: users/templates/users/account.html:473
 #, fuzzy
 #| msgid "blocked"
 msgid "Blocks"
 msgstr "blokeret"
 
-#: users/templates/users/account.html:470
+#: users/templates/users/account.html:482
 msgid "Mutes"
 msgstr ""
 
-#: users/templates/users/account.html:484
+#: users/templates/users/account.html:496
 #, fuzzy
 #| msgid "Migrate account"
 msgid "Migrate Account"
 msgstr "Overflyt konto"
 
-#: users/templates/users/account.html:488
+#: users/templates/users/account.html:500
 #, fuzzy
 #| msgid "Link an email so that you can migrate followers from other Fediverse instances."
 msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
 msgstr "Link en e-mail, så du kan overflytte tilhængere fra andre Fødivers-instanser."
 
-#: users/templates/users/account.html:491
+#: users/templates/users/account.html:503
 #, fuzzy
 #| msgid "Migrate account"
 msgid "Migrate another account here"
 msgstr "Overflyt konto"
 
-#: users/templates/users/account.html:494
+#: users/templates/users/account.html:506
 #, fuzzy
 #| msgid "Migrate account"
 msgid "Migrate to another account"
 msgstr "Overflyt konto"
 
-#: users/templates/users/account.html:501
+#: users/templates/users/account.html:513
 msgid "Delete Account"
 msgstr "Slet Konto"
 
-#: users/templates/users/account.html:504
+#: users/templates/users/account.html:516
 msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
 msgstr "Når kontodata er slettet, kan de ikke gendannes. Er du sikker på at du vil fortsætte?"
 
-#: users/templates/users/account.html:507
+#: users/templates/users/account.html:519
 msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
 msgstr "Indtast fuld <code>brugernavn@instance.social</code> eller <code>email@domain.com</code> for at bekræfte sletning."
 
-#: users/templates/users/account.html:517
+#: users/templates/users/account.html:529
 msgid "Once deleted, account data cannot be recovered."
 msgstr "Når kontodata er slettet, kan de ikke gendannes."
 
-#: users/templates/users/account.html:520
+#: users/templates/users/account.html:532
 #, fuzzy
 #| msgid "Importing in progress, can't delete now."
 msgid "Task in progress, can't delete now."
 msgstr "Importering i gang, kan ikke slette nu."
 
-#: users/templates/users/account.html:524
+#: users/templates/users/account.html:536
 msgid "Permanently Delete"
 msgstr "Slet permanent"
 
-#: users/templates/users/account.html:565
+#: users/templates/users/account.html:577
 #, fuzzy
 #| msgid "Delete this tag"
 msgid "Delete this passkey?"
 msgstr "Slet dette tag"
 
-#: users/templates/users/account.html:585
+#: users/templates/users/account.html:597
 msgid "Rename passkey:"
 msgstr ""
 
@@ -8433,12 +8482,10 @@ msgstr ""
 
 #: users/templates/users/authorized_app_create.html:48
 #: users/templates/users/authorized_app_created.html:39
-#: users/templates/users/migrate_in.html:70
-#: users/templates/users/migrate_out.html:67
 #, fuzzy
-#| msgid "Preferences"
-msgid "Back to Preferences"
-msgstr "Brugerindstillinger"
+#| msgid "Migrate account"
+msgid "Back to Account"
+msgstr "Overflyt konto"
 
 #: users/templates/users/authorized_app_created.html:9
 #: users/templates/users/authorized_app_created.html:19
@@ -8582,7 +8629,7 @@ msgstr "Overskriv: Opdater alle importerede statusser."
 msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
 msgstr "En anden import er i gang. Det kan forårsage problemer at starte en ny import. Er du sikker på at du vil fortsætte?"
 
-#: users/templates/users/data.html:89 users/views/data.py:1130
+#: users/templates/users/data.html:89 users/views/data.py:1194
 msgid "Import in progress, please wait"
 msgstr "Import i gang, vent venligst"
 
@@ -8757,7 +8804,41 @@ msgstr ""
 msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
-#: users/templates/users/data.html:560
+#: users/templates/users/data.html:561
+msgid "Import Twitter / X Archive"
+msgstr ""
+
+#: users/templates/users/data.html:567
+msgid "On X, go to <b>Settings</b> - <b>Your account</b> - <b>Download an archive of your data</b>. Upload the <code>.zip</code> you receive, or only the <code>data/tweets.js</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:570
+msgid "Each tweet becomes a post with its original date, text, links and photos. Replies to your own tweets are kept as a thread. A retweet becomes a short post that links to the original tweet. Videos are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:573
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Tweets that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:615
+#, fuzzy
+#| msgid "Import Method"
+msgid "Import Mastodon Archive"
+msgstr "Importeringsmetode"
+
+#: users/templates/users/data.html:621
+msgid "On your Mastodon server, go to <b>Preferences</b> - <b>Import and export</b> - <b>Request your archive</b>. Upload the <code>.zip</code> you receive, or only the <code>outbox.json</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:624
+msgid "Each post is imported with its original date, text, links, photos, content warning and visibility, so a followers-only post or a direct message stays that way. Replies to your own posts are kept as a thread. A boost becomes a short post that links to the original post. Videos, favourites and bookmarks are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:627
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Posts that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:639
 msgid "View Annual Summary"
 msgstr "Vis Årlig Sammenfatning"
 
@@ -8887,6 +8968,13 @@ msgstr "Aktuelle Mål"
 #: users/templates/users/migrate_in.html:64
 msgid "No aliases configured."
 msgstr ""
+
+#: users/templates/users/migrate_in.html:70
+#: users/templates/users/migrate_out.html:67
+#, fuzzy
+#| msgid "Preferences"
+msgid "Back to Preferences"
+msgstr "Brugerindstillinger"
 
 #: users/templates/users/migrate_out.html:9
 #: users/templates/users/migrate_out.html:43
@@ -9445,205 +9533,206 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:126
+#: users/views/account.py:127
 msgid "This username is already in use."
 msgstr "Dette brugernavn er allerede i brug."
 
-#: users/views/account.py:137
+#: users/views/account.py:138
 msgid "This email address is already in use."
 msgstr "Denne e-mailadresse er allerede i brug."
 
-#: users/views/account.py:257 users/views/account.py:376
+#: users/views/account.py:258 users/views/account.py:377
 msgid "Registration is for invitation only"
 msgstr "Tilmelding er kun for inviterede"
 
-#: users/views/account.py:268 users/views/account.py:340
+#: users/views/account.py:269 users/views/account.py:341
 #, fuzzy
 #| msgid "Timestamp"
 msgid "Time is up"
 msgstr "Tidsmærke"
 
-#: users/views/account.py:269 users/views/account.py:312
-#: users/views/account.py:341
+#: users/views/account.py:270 users/views/account.py:313
+#: users/views/account.py:342
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:315
+#: users/views/account.py:316
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:327
+#: users/views/account.py:328
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:328
+#: users/views/account.py:329
 #, fuzzy
 #| msgid "System busy, please try again in a minute."
 msgid "Please try again later."
 msgstr "System er optaget, prøv venligst igen om et øjeblik."
 
-#: users/views/account.py:417
+#: users/views/account.py:418
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:447
+#: users/views/account.py:448
 msgid "Valid username required"
 msgstr "Gyldigt brugernavn kræves"
 
-#: users/views/account.py:518
+#: users/views/account.py:519
 msgid "Account is being deleted."
 msgstr "Kontoen bliver slettet."
 
-#: users/views/account.py:521
+#: users/views/account.py:522
 msgid "Account mismatch."
 msgstr "Konto matcher ikke."
 
-#: users/views/data.py:264 users/views/data.py:296
+#: users/views/data.py:276 users/views/data.py:308
 msgid "Export file not available."
 msgstr ""
 
-#: users/views/data.py:290
+#: users/views/data.py:302
 msgid "Generating exports."
 msgstr "Genererer eksport."
 
-#: users/views/data.py:308
+#: users/views/data.py:320
 msgid "Export file expired. Please export again."
 msgstr "Eksport fil udløbet. Eksporter venligst igen."
 
-#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
+#: users/views/data.py:335 users/views/data.py:356 users/views/data.py:377
 #, fuzzy
 #| msgid "Export in progress"
 msgid "Recent export still in progress."
 msgstr "Eksport er i gang"
 
-#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
-#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
-#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
+#: users/views/data.py:393 users/views/data.py:419 users/views/data.py:447
+#: users/views/data.py:579 users/views/data.py:613 users/views/data.py:838
+#: users/views/data.py:1055 users/views/data.py:1081 users/views/data.py:1106
+#: users/views/data.py:1131 users/views/data.py:1201
 msgid "Invalid file."
 msgstr "Ugyldig fil."
 
-#: users/views/data.py:405
+#: users/views/data.py:469
 msgid "Sync in progress."
 msgstr "Synkronisering i gang."
 
-#: users/views/data.py:419
+#: users/views/data.py:483
 msgid "Settings saved."
 msgstr "Indstillinger gemt."
 
-#: users/views/data.py:474
+#: users/views/data.py:538
 #, fuzzy
 #| msgid "Account is being deleted."
 msgid "Account no longer linked."
 msgstr "Kontoen bliver slettet."
 
-#: users/views/data.py:477
+#: users/views/data.py:541
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:505
+#: users/views/data.py:569
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:585 users/views/data.py:810
+#: users/views/data.py:649 users/views/data.py:874
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:610 users/views/data.py:839
+#: users/views/data.py:674 users/views/data.py:903
 #, fuzzy
 #| msgid "Cancel"
 msgid "Cancelled."
 msgstr "Annuller"
 
-#: users/views/data.py:630
+#: users/views/data.py:694
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
-#: users/views/data.py:974
+#: users/views/data.py:702 users/views/data.py:812 users/views/data.py:933
+#: users/views/data.py:1038
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:734 users/views/data.py:960
+#: users/views/data.py:798 users/views/data.py:1024
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:744 users/views/data.py:970
+#: users/views/data.py:808 users/views/data.py:1034
 msgid "No matched file available."
 msgstr ""
 
-#: users/views/data.py:861
+#: users/views/data.py:925
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1290
 #, fuzzy
 #| msgid "Login required"
 msgid "Name is required."
 msgstr "Login påkrævet"
 
-#: users/views/data.py:1248
+#: users/views/data.py:1314
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1264
+#: users/views/data.py:1330
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1269
+#: users/views/data.py:1335
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1279 users/views/data.py:1330
+#: users/views/data.py:1345 users/views/data.py:1396
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:1286
+#: users/views/data.py:1352
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:1291
+#: users/views/data.py:1357
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:1317
+#: users/views/data.py:1383
 #, fuzzy
 #| msgid "Registration failed"
 msgid "Migration cancelled."
 msgstr "Registrering mislykkedes"
 
-#: users/views/data.py:1322
+#: users/views/data.py:1388
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:1335
+#: users/views/data.py:1401
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:1346
+#: users/views/data.py:1412
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:1352
+#: users/views/data.py:1418
 #, fuzzy, python-brace-format
 #| msgid "Continue login as {handle}."
 msgid "Start moving to {handle}."
 msgstr "Fortsæt login som {handle}."
 
-#: users/views/data.py:1410
+#: users/views/data.py:1476
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1426
+#: users/views/data.py:1492
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1430
+#: users/views/data.py:1496
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1440
+#: users/views/data.py:1506
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""

--- a/neodb/locale/de/LC_MESSAGES/django.po
+++ b/neodb/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 20:04-0400\n"
+"POT-Creation-Date: 2026-09-07 14:56-0400\n"
 "PO-Revision-Date: 2026-08-09 06:31+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/neodb/neodb/de/>\n"
@@ -61,15 +61,15 @@ msgstr "Chinesisch (vereinfacht)"
 msgid "Traditional Chinese"
 msgstr "Chinesisch (traditionell)"
 
-#: catalog/forms.py:35 catalog/models/item.py:307
+#: catalog/forms.py:35 catalog/models/item.py:412
 msgid "Primary ID Type"
 msgstr "primärer ID Typ"
 
-#: catalog/forms.py:40 catalog/models/item.py:310
+#: catalog/forms.py:40 catalog/models/item.py:415
 msgid "Primary ID Value"
 msgstr "primärer ID Wert"
 
-#: catalog/forms.py:176
+#: catalog/forms.py:177
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
@@ -122,11 +122,11 @@ msgid "other title"
 msgstr "anderer Titel"
 
 #: catalog/models/book.py:282 catalog/models/book.py:566
-#: catalog/models/item.py:119
+#: catalog/models/item.py:224
 msgid "author"
 msgstr "Autor/in"
 
-#: catalog/models/book.py:289 catalog/models/item.py:120
+#: catalog/models/book.py:289 catalog/models/item.py:225
 msgid "translator"
 msgstr "Übersetzer/in"
 
@@ -135,7 +135,7 @@ msgid "book format"
 msgstr "Buchformat"
 
 #: catalog/models/book.py:303 catalog/models/game.py:135
-#: catalog/models/item.py:134 catalog/models/music.py:142
+#: catalog/models/item.py:239 catalog/models/music.py:142
 msgid "publisher"
 msgstr "Publisher"
 
@@ -167,7 +167,7 @@ msgstr "Inhalt"
 msgid "price"
 msgstr "Preis"
 
-#: catalog/models/book.py:326 catalog/models/item.py:145
+#: catalog/models/book.py:326 catalog/models/item.py:250
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr "Impressum"
@@ -594,7 +594,7 @@ msgid "Exhibition"
 msgstr "Ausstellung"
 
 #: catalog/models/common.py:174 catalog/models/common.py:191
-#: journal/templates/collection.html:29 journal/templates/collection.html:40
+#: journal/templates/collection.html:30 journal/templates/collection.html:41
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
@@ -724,16 +724,16 @@ msgstr "Remake"
 msgid "Special Edition"
 msgstr "Special Edition"
 
-#: catalog/models/game.py:111 catalog/models/item.py:126
+#: catalog/models/game.py:111 catalog/models/item.py:231
 msgid "designer"
 msgstr "Designer/in"
 
-#: catalog/models/game.py:119 catalog/models/item.py:125
+#: catalog/models/game.py:119 catalog/models/item.py:230
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr "Künstler/in"
 
-#: catalog/models/game.py:127 catalog/models/item.py:135
+#: catalog/models/game.py:127 catalog/models/item.py:240
 msgid "developer"
 msgstr "Entwickler/in"
 
@@ -763,147 +763,147 @@ msgstr "Veröffentlichungs-Typ"
 msgid "website"
 msgstr "Webseite"
 
-#: catalog/models/item.py:121 catalog/models/movie.py:123
+#: catalog/models/item.py:226 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
 #: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr "Regisseur/in"
 
-#: catalog/models/item.py:122 catalog/models/movie.py:130
+#: catalog/models/item.py:227 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
 #: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr "Dramatiker"
 
-#: catalog/models/item.py:123 catalog/models/movie.py:137
+#: catalog/models/item.py:228 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
 #: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr "Schauspieler/in"
 
-#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/item.py:229 catalog/models/movie.py:144
 #: catalog/models/tv.py:237 catalog/models/tv.py:463
 #, fuzzy
 #| msgid "production"
 msgid "producer"
 msgstr "Produktion"
 
-#: catalog/models/item.py:127 catalog/models/performance.py:203
+#: catalog/models/item.py:232 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr "Komponist/in"
 
-#: catalog/models/item.py:128 catalog/models/performance.py:210
+#: catalog/models/item.py:233 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr "Choreograph/in"
 
-#: catalog/models/item.py:129 catalog/models/performance.py:224
+#: catalog/models/item.py:234 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr "Künstler/in"
 
-#: catalog/models/item.py:130 catalog/models/podcast.py:80
+#: catalog/models/item.py:235 catalog/models/podcast.py:80
 msgid "host"
 msgstr "Gastgeber"
 
-#: catalog/models/item.py:131 catalog/models/performance.py:196
+#: catalog/models/item.py:236 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr "originaler Ersteller"
 
-#: catalog/models/item.py:132 catalog/models/performance.py:238
+#: catalog/models/item.py:237 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr "Besatzung"
 
-#: catalog/models/item.py:136
+#: catalog/models/item.py:241
 #, fuzzy
 #| msgid "production"
 msgid "production company"
 msgstr "Produktion"
 
-#: catalog/models/item.py:137
+#: catalog/models/item.py:242
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:138
+#: catalog/models/item.py:243
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:139
+#: catalog/models/item.py:244
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:140 catalog/models/performance.py:231
+#: catalog/models/item.py:245 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr "Gruppe"
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:248
 #, fuzzy
 #| msgid "director"
 msgid "voice actor"
 msgstr "Regisseur/in"
 
-#: catalog/models/item.py:144 catalog/templates/edition.html:30
+#: catalog/models/item.py:249 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr "Verlag"
 
-#: catalog/models/item.py:169 catalog/models/people.py:476
+#: catalog/models/item.py:274 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr "Rolle"
 
-#: catalog/models/item.py:170 catalog/models/people.py:155
+#: catalog/models/item.py:275 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr "Name"
 
-#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:277 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:304 catalog/models/item.py:336
-#: journal/models/collection.py:100
+#: catalog/models/item.py:409 catalog/models/item.py:441
+#: journal/models/collection.py:101
 msgid "title"
 msgstr "Titel"
 
-#: catalog/models/item.py:305 catalog/models/item.py:344
-#: journal/models/collection.py:101
+#: catalog/models/item.py:410 catalog/models/item.py:449
+#: journal/models/collection.py:102
 msgid "description"
 msgstr "Beschreibung"
 
-#: catalog/models/item.py:316 catalog/models/people.py:484
+#: catalog/models/item.py:421 catalog/models/people.py:484
 msgid "metadata"
 msgstr "Metadaten"
 
-#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:423 catalog/templates/_item_card.html:28
 msgid "cover"
 msgstr "Cover"
 
-#: catalog/models/item.py:1526
+#: catalog/models/item.py:1612
 msgid "source site"
 msgstr "Quellseite"
 
-#: catalog/models/item.py:1528
+#: catalog/models/item.py:1614
 msgid "ID on source site"
 msgstr "ID der Quellseite"
 
-#: catalog/models/item.py:1530
+#: catalog/models/item.py:1616
 msgid "source url"
 msgstr "Quell-URL"
 
-#: catalog/models/item.py:1546
+#: catalog/models/item.py:1632
 msgid "IdType of the source site"
 msgstr "ID-Typ der Quellseite"
 
-#: catalog/models/item.py:1552
+#: catalog/models/item.py:1638
 msgid "Primary Id on the source site"
 msgstr "primäre ID der Quellseite"
 
-#: catalog/models/item.py:1555
+#: catalog/models/item.py:1641
 msgid "url to the resource"
 msgstr "URL der Ressource"
 
@@ -1234,12 +1234,12 @@ msgstr "Der Abruf des Links ist fehlgeschlagen, bitte versuche es nochmal. Einig
 #: catalog/templates/_item_card_metadata_tvseason.html:7
 #: catalog/templates/_item_card_metadata_tvshow.html:7
 #: catalog/templates/_item_card_metadata_work.html:7
-#: catalog/templates/item_base.html:201
+#: catalog/templates/item_base.html:186
 msgid "ratings"
 msgstr "Bewertungen"
 
-#: catalog/templates/_item_card_metadata_base.html:34
-#: catalog/templates/item_base.html:256
+#: catalog/templates/_item_card_metadata_base.html:28
+#: catalog/templates/item_base.html:241
 msgid "part of"
 msgstr "Teil von"
 
@@ -1259,7 +1259,7 @@ msgid "hide this tooltip"
 msgstr "diesen Tooltip ausblenden"
 
 #: catalog/templates/_item_comments.html:58
-#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:83
+#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:81
 #, fuzzy
 #| msgid "translator"
 msgid "translate"
@@ -1268,7 +1268,7 @@ msgstr "Übersetzer/in"
 #: catalog/templates/_item_comments.html:92
 #: catalog/templates/_item_comments_by_episode.html:80
 #: catalog/templates/_item_notes.html:88
-#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:284
+#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:269
 #: catalog/templates/podcast_episode_data.html:41
 msgid "show more"
 msgstr "mehr anzeigen"
@@ -1389,8 +1389,8 @@ msgstr "Synchronisation läuft."
 #: catalog/templates/_item_user_pieces.html:101
 #: catalog/templates/catalog_edit.html:12
 #: journal/templates/action_edit_post.html:6
-#: journal/templates/action_edit_post.html:8 journal/templates/article.html:196
-#: journal/templates/collection.html:185 journal/templates/collection.html:193
+#: journal/templates/action_edit_post.html:8 journal/templates/article.html:194
+#: journal/templates/collection.html:186 journal/templates/collection.html:194
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_edit.html:26
 #: journal/templates/post_compose.html:16 journal/templates/tag_edit.html:16
@@ -1434,7 +1434,7 @@ msgstr "zurück zum Artikel"
 #: catalog/templates/_sidebar_edit.html:20
 #: catalog/templates/catalog_verify.html:11
 #: catalog/templates/catalog_verify.html:17
-#: catalog/templates/item_base.html:182
+#: catalog/templates/item_base.html:167
 #, fuzzy
 #| msgid "Verification"
 msgid "Creator verification"
@@ -1444,7 +1444,7 @@ msgstr "Verifikation"
 msgid "Edit Options"
 msgstr "bearbeite Optionen"
 
-#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
+#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:163
 #: catalog/views/edit.py:160 catalog/views/edit.py:221
 #: catalog/views/edit.py:288 catalog/views/edit.py:309
 #: catalog/views/edit.py:364 catalog/views/edit.py:471
@@ -1618,7 +1618,7 @@ msgstr "mit anderem Artikel zusammenfügen"
 #: catalog/templates/_sidebar_edit.html:265
 #: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
-#: journal/templates/article.html:199 journal/templates/collection.html:188
+#: journal/templates/article.html:197 journal/templates/collection.html:189
 #: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
@@ -1815,7 +1815,7 @@ msgstr ""
 msgid "Remove my verification"
 msgstr "von Sammlung entfernen"
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:311
+#: catalog/templates/_verify_status.html:31 users/views/account.py:312
 #, fuzzy
 #| msgid "Verification Code"
 msgid "Verification failed"
@@ -2009,7 +2009,7 @@ msgstr "Beliebte Tags"
 
 #: catalog/templates/discover.html:229
 #: catalog/templates/discover_original_podcasts.html:25
-#: catalog/templates/item_base.html:282
+#: catalog/templates/item_base.html:267
 #: catalog/templates/item_mark_list.html:71
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
@@ -2079,67 +2079,67 @@ msgstr "Abrufen von %(site_label)s"
 msgid "System busy, please try again in a minute."
 msgstr "System ist beschäftigt, versuche es in einer Minute erneut."
 
-#: catalog/templates/item_base.html:95
+#: catalog/templates/item_base.html:80
 msgid "select one of the seasons to comment"
 msgstr "Wähle zum Kommentieren eine der Staffeln aus"
 
-#: catalog/templates/item_base.html:129
+#: catalog/templates/item_base.html:114
 msgid "mark, comment and collect"
 msgstr "markieren, kommentieren und sammeln"
 
-#: catalog/templates/item_base.html:142
+#: catalog/templates/item_base.html:127
 msgid "Login or register to review or add this item to your collection."
 msgstr "Zum Bewerten, Kommentieren oder Hinzufügen des Artikels zu deiner Sammlung, musst du dich anmelden oder registrieren."
 
-#: catalog/templates/item_base.html:151
+#: catalog/templates/item_base.html:136
 msgid "Related Collections"
 msgstr "Verwandte Sammlungen"
 
-#: catalog/templates/item_base.html:166
+#: catalog/templates/item_base.html:151
 msgid "Unsupported item type."
 msgstr "Nicht-Unterstützter Artikel Typ."
 
-#: catalog/templates/item_base.html:176
+#: catalog/templates/item_base.html:161
 msgid "Edit this item"
 msgstr "Bearbeite diesen Artikel"
 
-#: catalog/templates/item_base.html:187
+#: catalog/templates/item_base.html:172
 msgid "Last edited"
 msgstr "zuletzt bearbeitet"
 
-#: catalog/templates/item_base.html:230
+#: catalog/templates/item_base.html:215
 msgid "No enough ratings"
 msgstr "Nicht genug Bewertungen"
 
-#: catalog/templates/item_base.html:274
+#: catalog/templates/item_base.html:259
 msgid "overview"
 msgstr "Übersicht"
 
-#: catalog/templates/item_base.html:305
+#: catalog/templates/item_base.html:290
 msgid "comments"
 msgstr "Kommentare"
 
-#: catalog/templates/item_base.html:308
+#: catalog/templates/item_base.html:293
 #: catalog/templates/item_mark_list.html:22
 #: catalog/templates/item_mark_list.html:25
 #: catalog/templates/item_review_list.html:21
 msgid "marks"
 msgstr "Markierungen"
 
-#: catalog/templates/item_base.html:309
+#: catalog/templates/item_base.html:294
 #: catalog/templates/item_mark_list.html:23
 #: catalog/templates/item_mark_list.html:26
 #: catalog/templates/item_review_list.html:22
 msgid "marks from who you follow"
 msgstr "Markierungen von Leuten denen du folgst"
 
-#: catalog/templates/item_base.html:323
+#: catalog/templates/item_base.html:308
 #: catalog/templates/item_mark_list.html:28
 #: catalog/templates/item_review_list.html:23
 msgid "reviews"
 msgstr "Rezensionen"
 
-#: catalog/templates/item_base.html:333
+#: catalog/templates/item_base.html:318
 #, fuzzy
 #| msgid "note"
 msgid "notes"
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
+#: catalog/views/verify.py:164 common/utils.py:148 common/utils.py:189
 #: journal/views/article.py:186 journal/views/review.py:182
 #: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
@@ -4324,7 +4324,7 @@ msgstr "nur Erwähnte"
 msgid "Open Registration"
 msgstr "Registrierung fehlgeschlagen"
 
-#: common/templates/common/about.html:40 common/views_manage.py:657
+#: common/templates/common/about.html:40 common/views_manage.py:671
 #, fuzzy
 #| msgid "Preferences"
 msgid "Preferred Languages"
@@ -4390,7 +4390,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:738
+#: common/templates/common/scan.html:60 common/views_manage.py:756
 #, fuzzy
 #| msgid "Search results"
 msgid "Search"
@@ -4476,16 +4476,16 @@ msgstr "Du"
 msgid "unavailable"
 msgstr "nicht verfügbar"
 
-#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
+#: common/utils.py:152 common/utils.py:193 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr "Benutzer existiert nicht mehr"
 
-#: common/utils.py:135 common/utils.py:137 common/utils.py:140
-#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
+#: common/utils.py:159 common/utils.py:161 common/utils.py:164
+#: common/utils.py:200 common/utils.py:204 journal/views/profile.py:499
 msgid "Access denied"
 msgstr "Zugriff verweigert"
 
-#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
+#: common/utils.py:167 common/utils.py:169 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr "Anmeldung erforderlich"
@@ -4508,7 +4508,7 @@ msgstr "Kommentare"
 msgid "Access"
 msgstr "Zugriff verweigert"
 
-#: common/views_manage.py:39 common/views_manage.py:733
+#: common/views_manage.py:39 common/views_manage.py:751
 #, fuzzy
 #| msgid "duration"
 msgid "Federation"
@@ -4892,465 +4892,495 @@ msgid "Sender name and address for outgoing email."
 msgstr ""
 
 #: common/views_manage.py:649
+msgid "Enable Twitter / X Archive Import"
+msgstr ""
+
+#: common/views_manage.py:651
+msgid "Show the Twitter / X archive import on the data page. Imported tweets become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:656
+msgid "Enable Mastodon Archive Import"
+msgstr ""
+
+#: common/views_manage.py:658
+msgid "Show the Mastodon archive import on the data page. Imported posts become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:663
 #, fuzzy
 #| msgid "Language"
 msgid "Default Language"
 msgstr "Sprache"
 
-#: common/views_manage.py:652
+#: common/views_manage.py:666
 msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:673
 msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:665
+#: common/views_manage.py:679
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:672
+#: common/views_manage.py:686
 #, fuzzy
 #| msgid "Import Method"
 msgid "Login Methods"
 msgstr "Importier-Methode"
 
-#: common/views_manage.py:677 mastodon/models/common.py:30
+#: common/views_manage.py:691 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr "E-Mail"
 
-#: common/views_manage.py:681
+#: common/views_manage.py:695
+#, fuzzy
+#| msgid "Import"
+msgid "Data Import"
+msgstr "importieren"
+
+#: common/views_manage.py:699
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:692
+#: common/views_manage.py:710
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:694
+#: common/views_manage.py:712
 msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:699
+#: common/views_manage.py:717
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:700
+#: common/views_manage.py:718
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:704
+#: common/views_manage.py:722
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:706
+#: common/views_manage.py:724
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:711
+#: common/views_manage.py:729
 #, fuzzy
 #| msgid "Search results"
 msgid "Search Sites"
 msgstr "Suchergebnisse"
 
-#: common/views_manage.py:712
+#: common/views_manage.py:730
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:715
+#: common/views_manage.py:733
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:716
+#: common/views_manage.py:734
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:719
+#: common/views_manage.py:737
 #, fuzzy
 #| msgid "Add tv series"
 msgid "Hidden Categories"
 msgstr "Serie hinzufügen"
 
-#: common/views_manage.py:720
+#: common/views_manage.py:738
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:723
+#: common/views_manage.py:741
 msgid "Guest Search Page Limit"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:743
 msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
 msgstr ""
 
-#: common/views_manage.py:751
+#: common/views_manage.py:769
 #, fuzzy
 #| msgid "Spotify Album"
 msgid "Spotify API Key"
 msgstr "Spotify Album"
 
-#: common/views_manage.py:752
+#: common/views_manage.py:770
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:773
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:756
+#: common/views_manage.py:774
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:759
+#: common/views_manage.py:777
 #, fuzzy
 #| msgid "Google Books"
 msgid "Google Books API Key"
 msgstr "Google Books"
 
-#: common/views_manage.py:760
+#: common/views_manage.py:778
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:763
+#: common/views_manage.py:781
 #, fuzzy
 #| msgid "Discogs"
 msgid "Discogs API Key"
 msgstr "Discogs"
 
-#: common/views_manage.py:765
+#: common/views_manage.py:783
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:769
+#: common/views_manage.py:787
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:770
+#: common/views_manage.py:788
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:773
+#: common/views_manage.py:791
 #, fuzzy
 #| msgid "client secret"
 msgid "IGDB Client Secret"
 msgstr "Client Geheimnis"
 
-#: common/views_manage.py:776
+#: common/views_manage.py:794
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:778
+#: common/views_manage.py:796
 msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:783
+#: common/views_manage.py:801
 msgid "MyAnimeList Client ID"
 msgstr ""
 
-#: common/views_manage.py:785
+#: common/views_manage.py:803
 msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
 msgstr ""
 
-#: common/views_manage.py:790 users/templates/users/steam_import.html:26
+#: common/views_manage.py:808 users/templates/users/steam_import.html:26
 #, fuzzy
 #| msgid "Steam Game"
 msgid "Steam API Key"
 msgstr "Steam Spiel"
 
-#: common/views_manage.py:792
+#: common/views_manage.py:810
 msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:797
+#: common/views_manage.py:815
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:798
+#: common/views_manage.py:816
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:801
+#: common/views_manage.py:819
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:804
+#: common/views_manage.py:822
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:807
+#: common/views_manage.py:825
 #, fuzzy
 #| msgid "Threads"
 msgid "Threads App ID"
 msgstr "Threads"
 
-#: common/views_manage.py:808
+#: common/views_manage.py:826
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:811
+#: common/views_manage.py:829
 #, fuzzy
 #| msgid "Threads.net"
 msgid "Threads App Secret"
 msgstr "Threads.net"
 
-#: common/views_manage.py:814
+#: common/views_manage.py:832
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:834
 msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:833
+#: common/views_manage.py:851
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:844
+#: common/views_manage.py:862
 #, fuzzy
 #| msgid "translator"
 msgid "Translation"
 msgstr "Übersetzer/in"
 
-#: common/views_manage.py:849
+#: common/views_manage.py:867
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:853 social/templates/feed.html:27
+#: common/views_manage.py:871 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr "Benachrichtigungen"
 
-#: common/views_manage.py:863
+#: common/views_manage.py:881
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:882
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:885
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:868
+#: common/views_manage.py:886
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:871
+#: common/views_manage.py:889
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:874
+#: common/views_manage.py:892
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:877
+#: common/views_manage.py:895
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:880
+#: common/views_manage.py:898
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:883
+#: common/views_manage.py:901
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:886
+#: common/views_manage.py:904
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:887
+#: common/views_manage.py:905
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:908
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:894
+#: common/views_manage.py:912
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:898
+#: common/views_manage.py:916
 #, fuzzy
 #| msgid "series"
 msgid "Retries"
 msgstr "Serie"
 
-#: common/views_manage.py:903
+#: common/views_manage.py:921
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:908
+#: common/views_manage.py:926
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:915
+#: common/views_manage.py:933
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:927
+#: common/views_manage.py:945
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:928
+#: common/views_manage.py:946
 #, fuzzy
 #| msgid "site domain name"
 msgid "One domain per line."
 msgstr "Seiten Domäne Name"
 
-#: common/views_manage.py:931
+#: common/views_manage.py:949
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:932
+#: common/views_manage.py:950
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:935
+#: common/views_manage.py:953
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:937
+#: common/views_manage.py:955
 msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:943
+#: common/views_manage.py:961
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:944
+#: common/views_manage.py:962
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:947
+#: common/views_manage.py:965
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:948
+#: common/views_manage.py:966
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:958
+#: common/views_manage.py:976
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:960
+#: common/views_manage.py:978
 msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:966
+#: common/views_manage.py:984
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:968
+#: common/views_manage.py:986
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:974
+#: common/views_manage.py:992
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:976
+#: common/views_manage.py:994
 msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:983
+#: common/views_manage.py:1000
+msgid "Webhook Timeout (milliseconds)"
+msgstr ""
+
+#: common/views_manage.py:1001
+msgid "Timeout for delivering webhook requests to applications."
+msgstr ""
+
+#: common/views_manage.py:1006
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:986
+#: common/views_manage.py:1009
 #, fuzzy
 #| msgid "optional"
 msgid "Operational"
 msgstr "optional"
 
-#: common/views_manage.py:1002
+#: common/views_manage.py:1026
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:1004
+#: common/views_manage.py:1028
 msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1009
+#: common/views_manage.py:1033
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:1011
+#: common/views_manage.py:1035
 msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1016
+#: common/views_manage.py:1040
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:1018
+#: common/views_manage.py:1042
 msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1023
+#: common/views_manage.py:1047
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:1025
+#: common/views_manage.py:1049
 msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1030
+#: common/views_manage.py:1054
 #, fuzzy
 #| msgid "Podcast"
 msgid "Podcast Genres"
 msgstr "Podcasts"
 
-#: common/views_manage.py:1032
+#: common/views_manage.py:1056
 msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1037
+#: common/views_manage.py:1061
 #, fuzzy
 #| msgid "Performance"
 msgid "Performance Genres"
 msgstr "Aufführung"
 
-#: common/views_manage.py:1039
+#: common/views_manage.py:1063
 msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1045
+#: common/views_manage.py:1069
 msgid "Genres by Category"
 msgstr ""
 
-#: common/views_manage.py:1069
+#: common/views_manage.py:1093
 msgid "Site"
 msgstr ""
 
-#: common/views_manage.py:1079
+#: common/views_manage.py:1103
 #, fuzzy
 #| msgid "Database"
 msgid "Database and Services"
 msgstr "Datenbank"
 
-#: common/views_manage.py:1089
+#: common/views_manage.py:1113
 msgid "Media and Files"
 msgstr ""
 
-#: common/views_manage.py:1098
+#: common/views_manage.py:1122
 msgid "Monitoring"
 msgstr ""
 
-#: common/views_manage.py:1102
+#: common/views_manage.py:1126
 msgid "Security"
 msgstr ""
 
-#: common/views_manage.py:1111
+#: common/views_manage.py:1135
 msgid "Other Environment Variables"
 msgstr ""
 
-#: common/views_manage.py:1113
+#: common/views_manage.py:1137
 msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
 msgstr ""
 
@@ -5398,7 +5428,8 @@ msgstr "Nach dem Speichern, führende Leerzeichen durch Leerzeichen voller Breit
 #: users/templates/users/data.html:60 users/templates/users/data.html:113
 #: users/templates/users/data.html:170 users/templates/users/data.html:221
 #: users/templates/users/data.html:284 users/templates/users/data.html:346
-#: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
+#: users/templates/users/data.html:525 users/templates/users/data.html:578
+#: users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
 msgid "Visibility"
@@ -5438,8 +5469,8 @@ msgstr "nur Ersteller"
 msgid "owner and their local mutuals"
 msgstr "Ersteller und ihre gegenseitigen Follows"
 
-#: journal/forms.py:169 journal/templates/collection.html:193
-#: journal/templates/collection.html:202
+#: journal/forms.py:169 journal/templates/collection.html:194
+#: journal/templates/collection.html:203
 msgid "Collaborative editing"
 msgstr "gemeinsames Bearbeiten"
 
@@ -5492,7 +5523,7 @@ msgstr ""
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:215 journal/views/article.py:218
+#: journal/models/article.py:224 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
@@ -5504,75 +5535,76 @@ msgstr ""
 msgid "note"
 msgstr "Notiz"
 
-#: journal/models/collection.py:115
+#: journal/models/collection.py:116
 #, fuzzy
 #| msgid "shared {username}'s collection"
 msgid "search query for dynamic collection"
 msgstr "{username}'s geteilte Sammlung"
 
-#: journal/models/collection.py:566 journal/templatetags/collection.py:35
+#: journal/models/collection.py:575 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] "%(count)d Buch"
 msgstr[1] "%(count)d Bücher"
 
-#: journal/models/collection.py:571 journal/templatetags/collection.py:43
+#: journal/models/collection.py:580 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] "%(count)d Film"
 msgstr[1] "%(count)d Filme"
 
-#: journal/models/collection.py:576 journal/templatetags/collection.py:51
+#: journal/models/collection.py:585 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] "%(count)d Serie"
 msgstr[1] "%(count)d Serien"
 
-#: journal/models/collection.py:581 journal/templatetags/collection.py:59
+#: journal/models/collection.py:590 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] "%(count)d Album"
 msgstr[1] "%(count)d Alben"
 
-#: journal/models/collection.py:586 journal/templatetags/collection.py:67
+#: journal/models/collection.py:595 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] "%(count)d Spiel"
 msgstr[1] "%(count)d Spiele"
 
-#: journal/models/collection.py:591 journal/templatetags/collection.py:75
+#: journal/models/collection.py:600 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] "%(count)d Podcast"
 msgstr[1] "%(count)d Podcasts"
 
-#: journal/models/collection.py:597 journal/templatetags/collection.py:83
+#: journal/models/collection.py:606 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] "%(count)d Aufführung"
 msgstr[1] "%(count)d Aufführungen"
 
-#: journal/models/collection.py:605 journal/templatetags/collection.py:91
+#: journal/models/collection.py:614 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] "%(count)d Artikel"
 msgstr[1] "%(count)d Artikel"
 
-#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/models/common.py:59 journal/templates/action_open_post.html:15
 #: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
 #: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
 #: users/templates/users/data.html:122 users/templates/users/data.html:179
 #: users/templates/users/data.html:230 users/templates/users/data.html:292
 #: users/templates/users/data.html:355 users/templates/users/data.html:534
+#: users/templates/users/data.html:587
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5580,13 +5612,14 @@ msgstr[1] "%(count)d Artikel"
 msgid "Public"
 msgstr "Öffentlich"
 
-#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/models/common.py:60 journal/templates/action_open_post.html:9
 #: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
 #: users/templates/users/data.html:130 users/templates/users/data.html:187
 #: users/templates/users/data.html:238 users/templates/users/data.html:300
 #: users/templates/users/data.html:363 users/templates/users/data.html:542
+#: users/templates/users/data.html:595
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5594,12 +5627,13 @@ msgstr "Öffentlich"
 msgid "Followers Only"
 msgstr "nur Follower"
 
-#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/models/common.py:61 journal/templates/collection_share.html:57
 #: journal/templates/mark.html:102 journal/templates/post_compose.html:72
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
 #: users/templates/users/data.html:138 users/templates/users/data.html:195
 #: users/templates/users/data.html:246 users/templates/users/data.html:308
 #: users/templates/users/data.html:371 users/templates/users/data.html:550
+#: users/templates/users/data.html:603
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5607,33 +5641,33 @@ msgstr "nur Follower"
 msgid "Mentioned Only"
 msgstr "nur Erwähnte"
 
-#: journal/models/common.py:806
+#: journal/models/common.py:851
 #, fuzzy
 #| msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr "Ein kürzlicher Beitrag wurde nicht auf Mastodon veröffentlicht, bitte autorisiere dein Konto erneut."
 
-#: journal/models/common.py:1003
+#: journal/models/common.py:1048
 msgid "A recent post was not posted to Threads."
 msgstr "Ein kürzlicher Beitrag wurde nicht auf Threads veröffentlicht."
 
-#: journal/models/common.py:1036
+#: journal/models/common.py:1081
 #, fuzzy
 #| msgid "A recent post was not posted to Mastodon."
 msgid "A recent post was not boosted on Mastodon."
 msgstr "Ein kürzlicher Beitrag wurde nicht auf Mastodon veröffentlicht."
 
-#: journal/models/common.py:1046
+#: journal/models/common.py:1091
 #, fuzzy
 #| msgid "Item no longer exists"
 msgid "Original post no longer exists."
 msgstr "Artikel existiert nicht mehr"
 
-#: journal/models/common.py:1060
+#: journal/models/common.py:1105
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr "Ein kürzlicher Beitrag wurde nicht auf Mastodon veröffentlicht, bitte autorisiere dein Konto erneut."
 
-#: journal/models/common.py:1069
+#: journal/models/common.py:1114
 msgid "A recent post was not posted to Mastodon."
 msgstr "Ein kürzlicher Beitrag wurde nicht auf Mastodon veröffentlicht."
 
@@ -5651,85 +5685,85 @@ msgstr "abgebrochen"
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:475
+#: journal/models/mark.py:477
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:479
+#: journal/models/mark.py:481
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:486
+#: journal/models/mark.py:488
 #, fuzzy
 #| msgid "Invalid parameter"
 msgid "Invalid progress type."
 msgstr "Ungültige Parameter"
 
-#: journal/models/mark.py:488
+#: journal/models/mark.py:490
 #, fuzzy
 #| msgid "Invalid response from Fediverse instance."
 msgid "Invalid progress type for this item."
 msgstr "Ungültige Antwort der Fediverse Instanz."
 
-#: journal/models/note.py:47 users/templates/users/rym_import.html:73
+#: journal/models/note.py:48 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr "Seite"
 
-#: journal/models/note.py:48
+#: journal/models/note.py:49
 msgid "Chapter"
 msgstr "Kapitel"
 
-#: journal/models/note.py:51
+#: journal/models/note.py:52
 msgid "Part"
 msgstr "Teil"
 
-#: journal/models/note.py:52
+#: journal/models/note.py:53
 msgid "Episode"
 msgstr "Folge"
 
-#: journal/models/note.py:53
+#: journal/models/note.py:54
 msgid "Track"
 msgstr "Titel"
 
-#: journal/models/note.py:54
+#: journal/models/note.py:55
 msgid "Cycle"
 msgstr "Wiederholungen"
 
-#: journal/models/note.py:55
+#: journal/models/note.py:56
 msgid "Timestamp"
 msgstr "Zeitstempel"
 
-#: journal/models/note.py:56
+#: journal/models/note.py:57
 msgid "Percentage"
 msgstr "Prozent"
 
-#: journal/models/note.py:77
+#: journal/models/note.py:78
 #, python-brace-format
 msgid "Page {value}"
 msgstr "Seite {value}"
 
-#: journal/models/note.py:78
+#: journal/models/note.py:79
 #, python-brace-format
 msgid "Chapter {value}"
 msgstr "Kapitel {value}"
 
-#: journal/models/note.py:81
+#: journal/models/note.py:82
 #, python-brace-format
 msgid "Part {value}"
 msgstr "Teil {value}"
 
-#: journal/models/note.py:82
+#: journal/models/note.py:83
 #, python-brace-format
 msgid "Episode {value}"
 msgstr "Folge {value}"
 
-#: journal/models/note.py:83
+#: journal/models/note.py:84
 #, python-brace-format
 msgid "Track {value}"
 msgstr "Titel {value}"
 
-#: journal/models/note.py:84
+#: journal/models/note.py:85
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr "Wiederholungen {value}"
@@ -5739,13 +5773,13 @@ msgstr "Wiederholungen {value}"
 msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr "{item_title} enhält eventuell Spoiler oder triggernden Inhalt"
 
-#: journal/models/review.py:79
+#: journal/models/review.py:80
 #, fuzzy, python-brace-format
 #| msgid "a review of {item_title}"
 msgid "a review of {title}"
 msgstr "eine Rezension über {item_title}"
 
-#: journal/models/review.py:81
+#: journal/models/review.py:82
 #, fuzzy
 #| msgid "Item contains sub-items."
 msgid "(may contain spoilers)"
@@ -6177,7 +6211,7 @@ msgstr "Leuten denen du folgst"
 msgid "started following {item}"
 msgstr "hat angefangen {item} zu spielen"
 
-#: journal/models/shelf.py:923
+#: journal/models/shelf.py:925
 msgid "removed mark"
 msgstr "gelöschte Markierungen"
 
@@ -6212,7 +6246,7 @@ msgstr "von Sammlung entfernen"
 msgid "Update note"
 msgstr "Notiz aktuallisieren"
 
-#: journal/templates/_list_item.html:71 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:121
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
@@ -6381,7 +6415,7 @@ msgid "View post"
 msgstr ""
 
 #: journal/templates/action_quote_post.html:3
-#: journal/templates/article.html:190 journal/templates/collection.html:174
+#: journal/templates/article.html:188 journal/templates/collection.html:175
 msgid "Quote"
 msgstr ""
 
@@ -6390,7 +6424,7 @@ msgid "reply"
 msgstr "antworten"
 
 #: journal/templates/action_reply_post.html:3
-#: journal/templates/article.html:181 journal/templates/collection.html:165
+#: journal/templates/article.html:179 journal/templates/collection.html:166
 msgid "Reply"
 msgstr "antworten"
 
@@ -6409,23 +6443,23 @@ msgstr "zur Sammlung hinzufügen"
 msgid "Create a new collection"
 msgstr "neue Sammlung erstellen"
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:76
+#: journal/templates/article.html:102 social/templates/_event_post.html:76
 #, fuzzy
 #| msgid "wrote a review of {item}"
 msgid "wrote a review"
 msgstr "hat eine Rezension über {item} verfasst"
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:78
+#: journal/templates/article.html:104 social/templates/_event_post.html:78
 #, fuzzy
 #| msgid "wrote a note"
 msgid "wrote an article"
 msgstr "schrieb eine Notiz"
 
-#: journal/templates/article.html:136
+#: journal/templates/article.html:134
 msgid "This article may contain sensitive content. Click to reveal."
 msgstr ""
 
-#: journal/templates/article.html:155
+#: journal/templates/article.html:153
 msgid "The author has set it to be viewable only by logged-in users."
 msgstr "Der Autor hat diesen Inhalt nur für eingeloggte Nutzer sichtbar gemacht."
 
@@ -6490,20 +6524,20 @@ msgstr "NOV"
 msgid "DEC"
 msgstr "DEC"
 
-#: journal/templates/collection.html:71
+#: journal/templates/collection.html:72
 #: journal/templates/collection_share.html:12
 #: journal/templates/collection_share.html:66
 #: journal/templates/wrapped_share.html:59
 msgid "Share"
 msgstr "teilen"
 
-#: journal/templates/collection.html:86
+#: journal/templates/collection.html:87
 #, fuzzy
 #| msgid "created collection"
 msgid "created a collection"
 msgstr "erstellte Sammlung"
 
-#: journal/templates/collection.html:181
+#: journal/templates/collection.html:182
 msgid "Query"
 msgstr ""
 
@@ -6856,14 +6890,14 @@ msgid "Liked Collections"
 msgstr "Favorisierte Sammlungen"
 
 #: journal/templates/user_follow_list.html:23 journal/views/profile.py:507
-#: users/templates/users/account.html:443
+#: users/templates/users/account.html:455
 #, fuzzy
 #| msgid "following you"
 msgid "Following"
 msgstr "folgt dir"
 
 #: journal/templates/user_follow_list.html:28 journal/views/profile.py:511
-#: users/templates/users/account.html:452
+#: users/templates/users/account.html:464
 #, fuzzy
 #| msgid "Followers Only"
 msgid "Followers"
@@ -7205,8 +7239,8 @@ msgstr "Bluesky Anmelde-ID"
 #: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
 #: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
 #: mastodon/views/threads.py:57 mastodon/views/threads.py:65
-#: mastodon/views/threads.py:71 users/views/account.py:256
-#: users/views/account.py:375
+#: mastodon/views/threads.py:71 users/views/account.py:257
+#: users/views/account.py:376
 msgid "Authentication failed"
 msgstr "Authentifikation fehlgeschlagen"
 
@@ -7254,7 +7288,7 @@ msgstr "Ungültige Konto-Daten von Bluesky."
 msgid "Invalid user."
 msgstr "Ungültiger Benutzer."
 
-#: mastodon/views/common.py:52 users/views/account.py:416
+#: mastodon/views/common.py:52 users/views/account.py:417
 msgid "Registration failed"
 msgstr "Registrierung fehlgeschlagen"
 
@@ -8242,146 +8276,161 @@ msgstr "Veröffentlichungsjahr"
 msgid "Scopes"
 msgstr ""
 
-#: users/templates/users/account.html:398
+#: users/templates/users/account.html:386
+msgid "Webhook"
+msgstr ""
+
+#: users/templates/users/account.html:400
+msgid "disabled"
+msgstr ""
+
+#: users/templates/users/account.html:402
+#, fuzzy
+#| msgid "Activities"
+msgid "active"
+msgstr "Aktivitäten"
+
+#: users/templates/users/account.html:410
 msgid "Revoke access for this application?"
 msgstr ""
 
-#: users/templates/users/account.html:401
+#: users/templates/users/account.html:413
 msgid "Revoke"
 msgstr ""
 
-#: users/templates/users/account.html:409
+#: users/templates/users/account.html:421
 #, fuzzy
 #| msgid "View authorized applications"
 msgid "No authorized applications."
 msgstr "authorisierte Plattformen ansehen"
 
-#: users/templates/users/account.html:412
+#: users/templates/users/account.html:424
 #: users/templates/users/authorized_app_create.html:9
 #: users/templates/users/authorized_app_create.html:19
 msgid "Create Personal Token"
 msgstr ""
 
-#: users/templates/users/account.html:418
+#: users/templates/users/account.html:430
 msgid "Import/Export Social Graph"
 msgstr ""
 
-#: users/templates/users/account.html:419
+#: users/templates/users/account.html:431
 msgid "Upload a CSV file exported from Mastodon or compatible services."
 msgstr ""
 
-#: users/templates/users/account.html:425
+#: users/templates/users/account.html:437
 #, fuzzy
 #| msgid "Import"
 msgid "Import type"
 msgstr "importieren"
 
-#: users/templates/users/account.html:427
+#: users/templates/users/account.html:439
 #, fuzzy
 #| msgid "following you"
 msgid "Following list"
 msgstr "folgt dir"
 
-#: users/templates/users/account.html:428
+#: users/templates/users/account.html:440
 #, fuzzy
 #| msgid "to listen"
 msgid "Block list"
 msgstr "zu hören"
 
-#: users/templates/users/account.html:429
+#: users/templates/users/account.html:441
 #, fuzzy
 #| msgid "to listen"
 msgid "Mute list"
 msgstr "zu hören"
 
-#: users/templates/users/account.html:433
+#: users/templates/users/account.html:445
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/account.html:448 users/templates/users/data.html:89
 #: users/templates/users/data.html:141 users/templates/users/data.html:198
 #: users/templates/users/data.html:249 users/templates/users/data.html:313
 #: users/templates/users/data.html:376 users/templates/users/data.html:553
+#: users/templates/users/data.html:606 users/templates/users/data.html:631
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr "importieren"
 
-#: users/templates/users/account.html:447
-#: users/templates/users/account.html:456
-#: users/templates/users/account.html:465
-#: users/templates/users/account.html:474
+#: users/templates/users/account.html:459
+#: users/templates/users/account.html:468
+#: users/templates/users/account.html:477
+#: users/templates/users/account.html:486
 #, fuzzy
 #| msgid "Download"
 msgid "Download CSV"
 msgstr "Herunterladen"
 
-#: users/templates/users/account.html:461
+#: users/templates/users/account.html:473
 #, fuzzy
 #| msgid "blocked"
 msgid "Blocks"
 msgstr "blockiert"
 
-#: users/templates/users/account.html:470
+#: users/templates/users/account.html:482
 msgid "Mutes"
 msgstr ""
 
-#: users/templates/users/account.html:484
+#: users/templates/users/account.html:496
 #, fuzzy
 #| msgid "Migrate account"
 msgid "Migrate Account"
 msgstr "Konto migrieren"
 
-#: users/templates/users/account.html:488
+#: users/templates/users/account.html:500
 #, fuzzy
 #| msgid "Link an email so that you can migrate followers from other Fediverse instances."
 msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
 msgstr "Verbinde eine E-Mail, damit du deine Follower von anderen Fediverse Instanzen migrieren kannst."
 
-#: users/templates/users/account.html:491
+#: users/templates/users/account.html:503
 #, fuzzy
 #| msgid "Migrate account"
 msgid "Migrate another account here"
 msgstr "Konto migrieren"
 
-#: users/templates/users/account.html:494
+#: users/templates/users/account.html:506
 #, fuzzy
 #| msgid "Migrate account"
 msgid "Migrate to another account"
 msgstr "Konto migrieren"
 
-#: users/templates/users/account.html:501
+#: users/templates/users/account.html:513
 msgid "Delete Account"
 msgstr "Konto löschen"
 
-#: users/templates/users/account.html:504
+#: users/templates/users/account.html:516
 msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
 msgstr "Einmal gelöscht, kann dein Konto nicht wieder hergestellt werden. Möchtest du fortfahren?"
 
-#: users/templates/users/account.html:507
+#: users/templates/users/account.html:519
 msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
 msgstr "Gib deinen vollen <code>benutzername@fediverse.instanz</code> oder <code>benutzername@e-mail.konto</code> an, um die Löschung durchzuführen."
 
-#: users/templates/users/account.html:517
+#: users/templates/users/account.html:529
 msgid "Once deleted, account data cannot be recovered."
 msgstr "Einmal gelöscht, können deine Kontodaten nicht wieder hergestellt werden."
 
-#: users/templates/users/account.html:520
+#: users/templates/users/account.html:532
 #, fuzzy
 #| msgid "Importing in progress, can't delete now."
 msgid "Task in progress, can't delete now."
 msgstr "Importierung läuft derzeitig. Konto kann gerade nicht gelöscht werden."
 
-#: users/templates/users/account.html:524
+#: users/templates/users/account.html:536
 msgid "Permanently Delete"
 msgstr "permanent löschen"
 
-#: users/templates/users/account.html:565
+#: users/templates/users/account.html:577
 #, fuzzy
 #| msgid "Delete this tag"
 msgid "Delete this passkey?"
 msgstr "Diesen Tag löschen"
 
-#: users/templates/users/account.html:585
+#: users/templates/users/account.html:597
 msgid "Rename passkey:"
 msgstr ""
 
@@ -8405,12 +8454,10 @@ msgstr ""
 
 #: users/templates/users/authorized_app_create.html:48
 #: users/templates/users/authorized_app_created.html:39
-#: users/templates/users/migrate_in.html:70
-#: users/templates/users/migrate_out.html:67
 #, fuzzy
-#| msgid "Preferences"
-msgid "Back to Preferences"
-msgstr "Einstellungen"
+#| msgid "Migrate account"
+msgid "Back to Account"
+msgstr "Konto migrieren"
 
 #: users/templates/users/authorized_app_created.html:9
 #: users/templates/users/authorized_app_created.html:19
@@ -8554,7 +8601,7 @@ msgstr "Überschreiben: Aktuallisiere jeden importierten Status."
 msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
 msgstr "Eine andere Importierung ist im Gange. Einen neuen Import zu starten könnte Probleme verursachen. Möchtest du fortfahren?"
 
-#: users/templates/users/data.html:89 users/views/data.py:1130
+#: users/templates/users/data.html:89 users/views/data.py:1194
 msgid "Import in progress, please wait"
 msgstr "Importierung läuft, bitte warten"
 
@@ -8729,7 +8776,41 @@ msgstr ""
 msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
-#: users/templates/users/data.html:560
+#: users/templates/users/data.html:561
+msgid "Import Twitter / X Archive"
+msgstr ""
+
+#: users/templates/users/data.html:567
+msgid "On X, go to <b>Settings</b> - <b>Your account</b> - <b>Download an archive of your data</b>. Upload the <code>.zip</code> you receive, or only the <code>data/tweets.js</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:570
+msgid "Each tweet becomes a post with its original date, text, links and photos. Replies to your own tweets are kept as a thread. A retweet becomes a short post that links to the original tweet. Videos are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:573
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Tweets that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:615
+#, fuzzy
+#| msgid "Import Method"
+msgid "Import Mastodon Archive"
+msgstr "Importier-Methode"
+
+#: users/templates/users/data.html:621
+msgid "On your Mastodon server, go to <b>Preferences</b> - <b>Import and export</b> - <b>Request your archive</b>. Upload the <code>.zip</code> you receive, or only the <code>outbox.json</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:624
+msgid "Each post is imported with its original date, text, links, photos, content warning and visibility, so a followers-only post or a direct message stays that way. Replies to your own posts are kept as a thread. A boost becomes a short post that links to the original post. Videos, favourites and bookmarks are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:627
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Posts that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:639
 msgid "View Annual Summary"
 msgstr "Jahresübersicht ansehen"
 
@@ -8859,6 +8940,13 @@ msgstr "Aktuelle Ziele"
 #: users/templates/users/migrate_in.html:64
 msgid "No aliases configured."
 msgstr ""
+
+#: users/templates/users/migrate_in.html:70
+#: users/templates/users/migrate_out.html:67
+#, fuzzy
+#| msgid "Preferences"
+msgid "Back to Preferences"
+msgstr "Einstellungen"
 
 #: users/templates/users/migrate_out.html:9
 #: users/templates/users/migrate_out.html:43
@@ -9415,207 +9503,208 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:126
+#: users/views/account.py:127
 msgid "This username is already in use."
 msgstr "Dieser Benutzername wird bereits verwendet."
 
-#: users/views/account.py:137
+#: users/views/account.py:138
 msgid "This email address is already in use."
 msgstr "Diese E-Mail Adresse wird bereits verwendet."
 
-#: users/views/account.py:257 users/views/account.py:376
+#: users/views/account.py:258 users/views/account.py:377
 msgid "Registration is for invitation only"
 msgstr "Registrierungen sind nur mit einem Einladungslink möglich"
 
-#: users/views/account.py:268 users/views/account.py:340
+#: users/views/account.py:269 users/views/account.py:341
 #, fuzzy
 #| msgid "Timestamp"
 msgid "Time is up"
 msgstr "Zeitstempel"
 
-#: users/views/account.py:269 users/views/account.py:312
-#: users/views/account.py:341
+#: users/views/account.py:270 users/views/account.py:313
+#: users/views/account.py:342
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:315
+#: users/views/account.py:316
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:327
+#: users/views/account.py:328
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:328
+#: users/views/account.py:329
 #, fuzzy
 #| msgid "System busy, please try again in a minute."
 msgid "Please try again later."
 msgstr "System ist beschäftigt, versuche es in einer Minute erneut."
 
-#: users/views/account.py:417
+#: users/views/account.py:418
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:447
+#: users/views/account.py:448
 msgid "Valid username required"
 msgstr "gültiger Benutzername erforderlich"
 
-#: users/views/account.py:518
+#: users/views/account.py:519
 msgid "Account is being deleted."
 msgstr "Konto wurde gelöscht."
 
-#: users/views/account.py:521
+#: users/views/account.py:522
 msgid "Account mismatch."
 msgstr "Konten stimmen nicht überein."
 
-#: users/views/data.py:264 users/views/data.py:296
+#: users/views/data.py:276 users/views/data.py:308
 msgid "Export file not available."
 msgstr "Export-Datei nicht verfügbar."
 
-#: users/views/data.py:290
+#: users/views/data.py:302
 msgid "Generating exports."
 msgstr "Exporte werden generiert."
 
-#: users/views/data.py:308
+#: users/views/data.py:320
 msgid "Export file expired. Please export again."
 msgstr "Export-Datei abgelaufen. Bitte erneut exportieren."
 
-#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
+#: users/views/data.py:335 users/views/data.py:356 users/views/data.py:377
 #, fuzzy
 #| msgid "Import in progress."
 msgid "Recent export still in progress."
 msgstr "Import läuft."
 
-#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
-#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
-#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
+#: users/views/data.py:393 users/views/data.py:419 users/views/data.py:447
+#: users/views/data.py:579 users/views/data.py:613 users/views/data.py:838
+#: users/views/data.py:1055 users/views/data.py:1081 users/views/data.py:1106
+#: users/views/data.py:1131 users/views/data.py:1201
 msgid "Invalid file."
 msgstr "Ungültige Datei."
 
-#: users/views/data.py:405
+#: users/views/data.py:469
 msgid "Sync in progress."
 msgstr "Synchronisation läuft."
 
-#: users/views/data.py:419
+#: users/views/data.py:483
 msgid "Settings saved."
 msgstr "Einstellungen gespeichert."
 
-#: users/views/data.py:474
+#: users/views/data.py:538
 #, fuzzy
 #| msgid "Account is being deleted."
 msgid "Account no longer linked."
 msgstr "Konto wurde gelöscht."
 
-#: users/views/data.py:477
+#: users/views/data.py:541
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:505
+#: users/views/data.py:569
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:585 users/views/data.py:810
+#: users/views/data.py:649 users/views/data.py:874
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:610 users/views/data.py:839
+#: users/views/data.py:674 users/views/data.py:903
 #, fuzzy
 #| msgid "Cancel"
 msgid "Cancelled."
 msgstr "Abbrechen"
 
-#: users/views/data.py:630
+#: users/views/data.py:694
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
-#: users/views/data.py:974
+#: users/views/data.py:702 users/views/data.py:812 users/views/data.py:933
+#: users/views/data.py:1038
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:734 users/views/data.py:960
+#: users/views/data.py:798 users/views/data.py:1024
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:744 users/views/data.py:970
+#: users/views/data.py:808 users/views/data.py:1034
 #, fuzzy
 #| msgid "Export file not available."
 msgid "No matched file available."
 msgstr "Export-Datei nicht verfügbar."
 
-#: users/views/data.py:861
+#: users/views/data.py:925
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1290
 #, fuzzy
 #| msgid "Login required"
 msgid "Name is required."
 msgstr "Anmeldung erforderlich"
 
-#: users/views/data.py:1248
+#: users/views/data.py:1314
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1264
+#: users/views/data.py:1330
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1269
+#: users/views/data.py:1335
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1279 users/views/data.py:1330
+#: users/views/data.py:1345 users/views/data.py:1396
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:1286
+#: users/views/data.py:1352
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:1291
+#: users/views/data.py:1357
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:1317
+#: users/views/data.py:1383
 #, fuzzy
 #| msgid "Registration failed"
 msgid "Migration cancelled."
 msgstr "Registrierung fehlgeschlagen"
 
-#: users/views/data.py:1322
+#: users/views/data.py:1388
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:1335
+#: users/views/data.py:1401
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:1346
+#: users/views/data.py:1412
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:1352
+#: users/views/data.py:1418
 #, fuzzy, python-brace-format
 #| msgid "Continue login as {handle}."
 msgid "Start moving to {handle}."
 msgstr "Anmeldung als {handle} fortfahren."
 
-#: users/views/data.py:1410
+#: users/views/data.py:1476
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1426
+#: users/views/data.py:1492
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1430
+#: users/views/data.py:1496
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1440
+#: users/views/data.py:1506
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""

--- a/neodb/locale/es/LC_MESSAGES/django.po
+++ b/neodb/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 20:04-0400\n"
+"POT-Creation-Date: 2026-09-07 14:56-0400\n"
 "PO-Revision-Date: 2026-08-09 06:31+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/neodb/neodb/es/>\n"
@@ -61,15 +61,15 @@ msgstr "Chino simplificado"
 msgid "Traditional Chinese"
 msgstr "Chino tradicional"
 
-#: catalog/forms.py:35 catalog/models/item.py:307
+#: catalog/forms.py:35 catalog/models/item.py:412
 msgid "Primary ID Type"
 msgstr "Tipo de identificador principal"
 
-#: catalog/forms.py:40 catalog/models/item.py:310
+#: catalog/forms.py:40 catalog/models/item.py:415
 msgid "Primary ID Value"
 msgstr "Valor de identificador principal"
 
-#: catalog/forms.py:176
+#: catalog/forms.py:177
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
@@ -122,11 +122,11 @@ msgid "other title"
 msgstr "otro título"
 
 #: catalog/models/book.py:282 catalog/models/book.py:566
-#: catalog/models/item.py:119
+#: catalog/models/item.py:224
 msgid "author"
 msgstr "autor"
 
-#: catalog/models/book.py:289 catalog/models/item.py:120
+#: catalog/models/book.py:289 catalog/models/item.py:225
 msgid "translator"
 msgstr "traductor"
 
@@ -135,7 +135,7 @@ msgid "book format"
 msgstr "formato del libro"
 
 #: catalog/models/book.py:303 catalog/models/game.py:135
-#: catalog/models/item.py:134 catalog/models/music.py:142
+#: catalog/models/item.py:239 catalog/models/music.py:142
 msgid "publisher"
 msgstr "editor"
 
@@ -167,7 +167,7 @@ msgstr "contenidos"
 msgid "price"
 msgstr "precio"
 
-#: catalog/models/book.py:326 catalog/models/item.py:145
+#: catalog/models/book.py:326 catalog/models/item.py:250
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr "impresión"
@@ -590,7 +590,7 @@ msgid "Exhibition"
 msgstr "Exhibición"
 
 #: catalog/models/common.py:174 catalog/models/common.py:191
-#: journal/templates/collection.html:29 journal/templates/collection.html:40
+#: journal/templates/collection.html:30 journal/templates/collection.html:41
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
@@ -718,16 +718,16 @@ msgstr "Remake"
 msgid "Special Edition"
 msgstr "Edición Especial"
 
-#: catalog/models/game.py:111 catalog/models/item.py:126
+#: catalog/models/game.py:111 catalog/models/item.py:231
 msgid "designer"
 msgstr "diseñador"
 
-#: catalog/models/game.py:119 catalog/models/item.py:125
+#: catalog/models/game.py:119 catalog/models/item.py:230
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr "artista"
 
-#: catalog/models/game.py:127 catalog/models/item.py:135
+#: catalog/models/game.py:127 catalog/models/item.py:240
 msgid "developer"
 msgstr "desarrollador"
 
@@ -757,147 +757,147 @@ msgstr "tipo de lanzamiento"
 msgid "website"
 msgstr "sitio web"
 
-#: catalog/models/item.py:121 catalog/models/movie.py:123
+#: catalog/models/item.py:226 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
 #: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr "director"
 
-#: catalog/models/item.py:122 catalog/models/movie.py:130
+#: catalog/models/item.py:227 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
 #: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr "guión"
 
-#: catalog/models/item.py:123 catalog/models/movie.py:137
+#: catalog/models/item.py:228 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
 #: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr "actor"
 
-#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/item.py:229 catalog/models/movie.py:144
 #: catalog/models/tv.py:237 catalog/models/tv.py:463
 #, fuzzy
 #| msgid "production"
 msgid "producer"
 msgstr "producción"
 
-#: catalog/models/item.py:127 catalog/models/performance.py:203
+#: catalog/models/item.py:232 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr "compositor"
 
-#: catalog/models/item.py:128 catalog/models/performance.py:210
+#: catalog/models/item.py:233 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr "coreógrafo"
 
-#: catalog/models/item.py:129 catalog/models/performance.py:224
+#: catalog/models/item.py:234 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr "intérprete"
 
-#: catalog/models/item.py:130 catalog/models/podcast.py:80
+#: catalog/models/item.py:235 catalog/models/podcast.py:80
 msgid "host"
 msgstr "anfitrión"
 
-#: catalog/models/item.py:131 catalog/models/performance.py:196
+#: catalog/models/item.py:236 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr "creador original"
 
-#: catalog/models/item.py:132 catalog/models/performance.py:238
+#: catalog/models/item.py:237 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr "personal"
 
-#: catalog/models/item.py:136
+#: catalog/models/item.py:241
 #, fuzzy
 #| msgid "production"
 msgid "production company"
 msgstr "producción"
 
-#: catalog/models/item.py:137
+#: catalog/models/item.py:242
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:138
+#: catalog/models/item.py:243
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:139
+#: catalog/models/item.py:244
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:140 catalog/models/performance.py:231
+#: catalog/models/item.py:245 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr "elenco"
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:248
 #, fuzzy
 #| msgid "director"
 msgid "voice actor"
 msgstr "director"
 
-#: catalog/models/item.py:144 catalog/templates/edition.html:30
+#: catalog/models/item.py:249 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr "editorial"
 
-#: catalog/models/item.py:169 catalog/models/people.py:476
+#: catalog/models/item.py:274 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr "rol"
 
-#: catalog/models/item.py:170 catalog/models/people.py:155
+#: catalog/models/item.py:275 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr "nombre"
 
-#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:277 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:304 catalog/models/item.py:336
-#: journal/models/collection.py:100
+#: catalog/models/item.py:409 catalog/models/item.py:441
+#: journal/models/collection.py:101
 msgid "title"
 msgstr "título"
 
-#: catalog/models/item.py:305 catalog/models/item.py:344
-#: journal/models/collection.py:101
+#: catalog/models/item.py:410 catalog/models/item.py:449
+#: journal/models/collection.py:102
 msgid "description"
 msgstr "descripción"
 
-#: catalog/models/item.py:316 catalog/models/people.py:484
+#: catalog/models/item.py:421 catalog/models/people.py:484
 msgid "metadata"
 msgstr "metadatos"
 
-#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:423 catalog/templates/_item_card.html:28
 msgid "cover"
 msgstr "cubierta"
 
-#: catalog/models/item.py:1526
+#: catalog/models/item.py:1612
 msgid "source site"
 msgstr "fuente"
 
-#: catalog/models/item.py:1528
+#: catalog/models/item.py:1614
 msgid "ID on source site"
 msgstr "ID de la fuente"
 
-#: catalog/models/item.py:1530
+#: catalog/models/item.py:1616
 msgid "source url"
 msgstr "URL de la fuente"
 
-#: catalog/models/item.py:1546
+#: catalog/models/item.py:1632
 msgid "IdType of the source site"
 msgstr "IdType de la fuente"
 
-#: catalog/models/item.py:1552
+#: catalog/models/item.py:1638
 msgid "Primary Id on the source site"
 msgstr "Identificador principal de la fuente"
 
-#: catalog/models/item.py:1555
+#: catalog/models/item.py:1641
 msgid "url to the resource"
 msgstr "URL del recurso"
 
@@ -1224,12 +1224,12 @@ msgstr "No se ha podido obtener la información del enlace, por favor inténtalo
 #: catalog/templates/_item_card_metadata_tvseason.html:7
 #: catalog/templates/_item_card_metadata_tvshow.html:7
 #: catalog/templates/_item_card_metadata_work.html:7
-#: catalog/templates/item_base.html:201
+#: catalog/templates/item_base.html:186
 msgid "ratings"
 msgstr "puntuación"
 
-#: catalog/templates/_item_card_metadata_base.html:34
-#: catalog/templates/item_base.html:256
+#: catalog/templates/_item_card_metadata_base.html:28
+#: catalog/templates/item_base.html:241
 msgid "part of"
 msgstr "parte de"
 
@@ -1247,7 +1247,7 @@ msgid "hide this tooltip"
 msgstr "oculta esta sugerencia"
 
 #: catalog/templates/_item_comments.html:58
-#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:83
+#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:81
 #, fuzzy
 #| msgid "translator"
 msgid "translate"
@@ -1256,7 +1256,7 @@ msgstr "traductor"
 #: catalog/templates/_item_comments.html:92
 #: catalog/templates/_item_comments_by_episode.html:80
 #: catalog/templates/_item_notes.html:88
-#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:284
+#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:269
 #: catalog/templates/podcast_episode_data.html:41
 msgid "show more"
 msgstr "ver más"
@@ -1375,8 +1375,8 @@ msgstr ""
 #: catalog/templates/_item_user_pieces.html:101
 #: catalog/templates/catalog_edit.html:12
 #: journal/templates/action_edit_post.html:6
-#: journal/templates/action_edit_post.html:8 journal/templates/article.html:196
-#: journal/templates/collection.html:185 journal/templates/collection.html:193
+#: journal/templates/action_edit_post.html:8 journal/templates/article.html:194
+#: journal/templates/collection.html:186 journal/templates/collection.html:194
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_edit.html:26
 #: journal/templates/post_compose.html:16 journal/templates/tag_edit.html:16
@@ -1420,7 +1420,7 @@ msgstr "volver al elemento"
 #: catalog/templates/_sidebar_edit.html:20
 #: catalog/templates/catalog_verify.html:11
 #: catalog/templates/catalog_verify.html:17
-#: catalog/templates/item_base.html:182
+#: catalog/templates/item_base.html:167
 #, fuzzy
 #| msgid "Notification"
 msgid "Creator verification"
@@ -1430,7 +1430,7 @@ msgstr "Notificaciones"
 msgid "Edit Options"
 msgstr "Editar Opciones"
 
-#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
+#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:163
 #: catalog/views/edit.py:160 catalog/views/edit.py:221
 #: catalog/views/edit.py:288 catalog/views/edit.py:309
 #: catalog/views/edit.py:364 catalog/views/edit.py:471
@@ -1604,7 +1604,7 @@ msgstr "fusionar con otro elemento"
 #: catalog/templates/_sidebar_edit.html:265
 #: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
-#: journal/templates/article.html:199 journal/templates/collection.html:188
+#: journal/templates/article.html:197 journal/templates/collection.html:189
 #: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
@@ -1795,7 +1795,7 @@ msgstr ""
 msgid "Remove my verification"
 msgstr ""
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:311
+#: catalog/templates/_verify_status.html:31 users/views/account.py:312
 msgid "Verification failed"
 msgstr ""
 
@@ -1987,7 +1987,7 @@ msgstr "Etiquetas destacadas"
 
 #: catalog/templates/discover.html:229
 #: catalog/templates/discover_original_podcasts.html:25
-#: catalog/templates/item_base.html:282
+#: catalog/templates/item_base.html:267
 #: catalog/templates/item_mark_list.html:71
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
@@ -2055,67 +2055,67 @@ msgstr "Recuperando desde %(site_label)s"
 msgid "System busy, please try again in a minute."
 msgstr "El sistema está ocupado, por favor inténtalo de nuevo en un minuto."
 
-#: catalog/templates/item_base.html:95
+#: catalog/templates/item_base.html:80
 msgid "select one of the seasons to comment"
 msgstr "elige una de las temporadas para comentar"
 
-#: catalog/templates/item_base.html:129
+#: catalog/templates/item_base.html:114
 msgid "mark, comment and collect"
 msgstr "marcar, comentar y coleccionar"
 
-#: catalog/templates/item_base.html:142
+#: catalog/templates/item_base.html:127
 msgid "Login or register to review or add this item to your collection."
 msgstr "Inicia sesión o regístrate para reseñar o añadir este elemento a tu colección."
 
-#: catalog/templates/item_base.html:151
+#: catalog/templates/item_base.html:136
 msgid "Related Collections"
 msgstr "Colecciones relacionadas"
 
-#: catalog/templates/item_base.html:166
+#: catalog/templates/item_base.html:151
 msgid "Unsupported item type."
 msgstr "Tipo de obra no soportado."
 
-#: catalog/templates/item_base.html:176
+#: catalog/templates/item_base.html:161
 msgid "Edit this item"
 msgstr "Modificar esta obra"
 
-#: catalog/templates/item_base.html:187
+#: catalog/templates/item_base.html:172
 msgid "Last edited"
 msgstr "Última modificación"
 
-#: catalog/templates/item_base.html:230
+#: catalog/templates/item_base.html:215
 msgid "No enough ratings"
 msgstr "No hay suficientes evaluaciones"
 
-#: catalog/templates/item_base.html:274
+#: catalog/templates/item_base.html:259
 msgid "overview"
 msgstr "sinopsis"
 
-#: catalog/templates/item_base.html:305
+#: catalog/templates/item_base.html:290
 msgid "comments"
 msgstr "comentarios"
 
-#: catalog/templates/item_base.html:308
+#: catalog/templates/item_base.html:293
 #: catalog/templates/item_mark_list.html:22
 #: catalog/templates/item_mark_list.html:25
 #: catalog/templates/item_review_list.html:21
 msgid "marks"
 msgstr "marcas"
 
-#: catalog/templates/item_base.html:309
+#: catalog/templates/item_base.html:294
 #: catalog/templates/item_mark_list.html:23
 #: catalog/templates/item_mark_list.html:26
 #: catalog/templates/item_review_list.html:22
 msgid "marks from who you follow"
 msgstr "marcas de usuarios a los que sigues"
 
-#: catalog/templates/item_base.html:323
+#: catalog/templates/item_base.html:308
 #: catalog/templates/item_mark_list.html:28
 #: catalog/templates/item_review_list.html:23
 msgid "reviews"
 msgstr "reseñas"
 
-#: catalog/templates/item_base.html:333
+#: catalog/templates/item_base.html:318
 #, fuzzy
 #| msgid "note"
 msgid "notes"
@@ -2524,7 +2524,7 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
+#: catalog/views/verify.py:164 common/utils.py:148 common/utils.py:189
 #: journal/views/article.py:186 journal/views/review.py:182
 #: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
@@ -4241,7 +4241,7 @@ msgstr "Solo cuentas mencionadas"
 msgid "Open Registration"
 msgstr ""
 
-#: common/templates/common/about.html:40 common/views_manage.py:657
+#: common/templates/common/about.html:40 common/views_manage.py:671
 #, fuzzy
 #| msgid "Preferences"
 msgid "Preferred Languages"
@@ -4301,7 +4301,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:738
+#: common/templates/common/scan.html:60 common/views_manage.py:756
 #, fuzzy
 #| msgid "Search results"
 msgid "Search"
@@ -4385,16 +4385,16 @@ msgstr "tú"
 msgid "unavailable"
 msgstr "no disponible"
 
-#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
+#: common/utils.py:152 common/utils.py:193 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr "Este usuario ya no existe"
 
-#: common/utils.py:135 common/utils.py:137 common/utils.py:140
-#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
+#: common/utils.py:159 common/utils.py:161 common/utils.py:164
+#: common/utils.py:200 common/utils.py:204 journal/views/profile.py:499
 msgid "Access denied"
 msgstr "Acceso denegado"
 
-#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
+#: common/utils.py:167 common/utils.py:169 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr ""
@@ -4417,7 +4417,7 @@ msgstr "comentarios"
 msgid "Access"
 msgstr "Acceso denegado"
 
-#: common/views_manage.py:39 common/views_manage.py:733
+#: common/views_manage.py:39 common/views_manage.py:751
 #, fuzzy
 #| msgid "duration"
 msgid "Federation"
@@ -4795,455 +4795,483 @@ msgid "Sender name and address for outgoing email."
 msgstr ""
 
 #: common/views_manage.py:649
+msgid "Enable Twitter / X Archive Import"
+msgstr ""
+
+#: common/views_manage.py:651
+msgid "Show the Twitter / X archive import on the data page. Imported tweets become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:656
+msgid "Enable Mastodon Archive Import"
+msgstr ""
+
+#: common/views_manage.py:658
+msgid "Show the Mastodon archive import on the data page. Imported posts become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:663
 #, fuzzy
 #| msgid "language"
 msgid "Default Language"
 msgstr "idioma"
 
-#: common/views_manage.py:652
+#: common/views_manage.py:666
 msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:673
 msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:665
+#: common/views_manage.py:679
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:672
+#: common/views_manage.py:686
 msgid "Login Methods"
 msgstr ""
 
-#: common/views_manage.py:677 mastodon/models/common.py:30
+#: common/views_manage.py:691 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr ""
 
-#: common/views_manage.py:681
-msgid "Localization"
-msgstr ""
-
-#: common/views_manage.py:692
-msgid "Disable Default Relay"
-msgstr ""
-
-#: common/views_manage.py:694
-msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
+#: common/views_manage.py:695
+msgid "Data Import"
 msgstr ""
 
 #: common/views_manage.py:699
+msgid "Localization"
+msgstr ""
+
+#: common/views_manage.py:710
+msgid "Disable Default Relay"
+msgstr ""
+
+#: common/views_manage.py:712
+msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
+msgstr ""
+
+#: common/views_manage.py:717
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:700
+#: common/views_manage.py:718
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:704
+#: common/views_manage.py:722
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:706
+#: common/views_manage.py:724
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:711
+#: common/views_manage.py:729
 #, fuzzy
 #| msgid "Search results"
 msgid "Search Sites"
 msgstr "Resultados de la búsqueda"
 
-#: common/views_manage.py:712
+#: common/views_manage.py:730
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:715
+#: common/views_manage.py:733
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:716
+#: common/views_manage.py:734
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:719
+#: common/views_manage.py:737
 #, fuzzy
 #| msgid "Add tv series"
 msgid "Hidden Categories"
 msgstr "Añadir series de tv"
 
-#: common/views_manage.py:720
+#: common/views_manage.py:738
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:723
+#: common/views_manage.py:741
 msgid "Guest Search Page Limit"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:743
 msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
 msgstr ""
 
-#: common/views_manage.py:751
+#: common/views_manage.py:769
 #, fuzzy
 #| msgid "Spotify Album"
 msgid "Spotify API Key"
 msgstr "Álbum de Spotify"
 
-#: common/views_manage.py:752
+#: common/views_manage.py:770
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:773
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:756
+#: common/views_manage.py:774
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:759
+#: common/views_manage.py:777
 #, fuzzy
 #| msgid "Google Books"
 msgid "Google Books API Key"
 msgstr "Google Books"
 
-#: common/views_manage.py:760
+#: common/views_manage.py:778
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:763
+#: common/views_manage.py:781
 #, fuzzy
 #| msgid "Discogs"
 msgid "Discogs API Key"
 msgstr "Discogs"
 
-#: common/views_manage.py:765
+#: common/views_manage.py:783
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:769
+#: common/views_manage.py:787
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:770
+#: common/views_manage.py:788
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:773
+#: common/views_manage.py:791
 msgid "IGDB Client Secret"
 msgstr ""
 
-#: common/views_manage.py:776
+#: common/views_manage.py:794
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:778
+#: common/views_manage.py:796
 msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:783
+#: common/views_manage.py:801
 msgid "MyAnimeList Client ID"
 msgstr ""
 
-#: common/views_manage.py:785
+#: common/views_manage.py:803
 msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
 msgstr ""
 
-#: common/views_manage.py:790 users/templates/users/steam_import.html:26
+#: common/views_manage.py:808 users/templates/users/steam_import.html:26
 #, fuzzy
 #| msgid "Steam Game"
 msgid "Steam API Key"
 msgstr "Juego de Steam"
 
-#: common/views_manage.py:792
+#: common/views_manage.py:810
 msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:797
+#: common/views_manage.py:815
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:798
+#: common/views_manage.py:816
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:801
+#: common/views_manage.py:819
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:804
+#: common/views_manage.py:822
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:807
+#: common/views_manage.py:825
 msgid "Threads App ID"
 msgstr ""
 
-#: common/views_manage.py:808
+#: common/views_manage.py:826
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:811
+#: common/views_manage.py:829
 msgid "Threads App Secret"
 msgstr ""
 
-#: common/views_manage.py:814
+#: common/views_manage.py:832
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:834
 msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:833
+#: common/views_manage.py:851
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:844
+#: common/views_manage.py:862
 #, fuzzy
 #| msgid "translator"
 msgid "Translation"
 msgstr "traductor"
 
-#: common/views_manage.py:849
+#: common/views_manage.py:867
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:853 social/templates/feed.html:27
+#: common/views_manage.py:871 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr ""
 
-#: common/views_manage.py:863
+#: common/views_manage.py:881
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:882
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:885
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:868
+#: common/views_manage.py:886
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:871
+#: common/views_manage.py:889
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:874
+#: common/views_manage.py:892
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:877
+#: common/views_manage.py:895
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:880
+#: common/views_manage.py:898
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:883
+#: common/views_manage.py:901
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:886
+#: common/views_manage.py:904
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:887
+#: common/views_manage.py:905
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:908
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:894
+#: common/views_manage.py:912
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:898
+#: common/views_manage.py:916
 #, fuzzy
 #| msgid "series"
 msgid "Retries"
 msgstr "serie"
 
-#: common/views_manage.py:903
+#: common/views_manage.py:921
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:908
+#: common/views_manage.py:926
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:915
+#: common/views_manage.py:933
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:927
+#: common/views_manage.py:945
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:928
+#: common/views_manage.py:946
 msgid "One domain per line."
 msgstr ""
 
-#: common/views_manage.py:931
+#: common/views_manage.py:949
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:932
+#: common/views_manage.py:950
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:935
+#: common/views_manage.py:953
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:937
+#: common/views_manage.py:955
 msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:943
+#: common/views_manage.py:961
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:944
+#: common/views_manage.py:962
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:947
+#: common/views_manage.py:965
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:948
+#: common/views_manage.py:966
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:958
+#: common/views_manage.py:976
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:960
+#: common/views_manage.py:978
 msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:966
+#: common/views_manage.py:984
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:968
+#: common/views_manage.py:986
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:974
+#: common/views_manage.py:992
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:976
+#: common/views_manage.py:994
 msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:983
+#: common/views_manage.py:1000
+msgid "Webhook Timeout (milliseconds)"
+msgstr ""
+
+#: common/views_manage.py:1001
+msgid "Timeout for delivering webhook requests to applications."
+msgstr ""
+
+#: common/views_manage.py:1006
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:986
+#: common/views_manage.py:1009
 #, fuzzy
 #| msgid "optional"
 msgid "Operational"
 msgstr "opcional"
 
-#: common/views_manage.py:1002
+#: common/views_manage.py:1026
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:1004
+#: common/views_manage.py:1028
 msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1009
+#: common/views_manage.py:1033
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:1011
+#: common/views_manage.py:1035
 msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1016
+#: common/views_manage.py:1040
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:1018
+#: common/views_manage.py:1042
 msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1023
+#: common/views_manage.py:1047
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:1025
+#: common/views_manage.py:1049
 msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1030
+#: common/views_manage.py:1054
 #, fuzzy
 #| msgid "Podcast"
 msgid "Podcast Genres"
 msgstr "Podcast"
 
-#: common/views_manage.py:1032
+#: common/views_manage.py:1056
 msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1037
+#: common/views_manage.py:1061
 #, fuzzy
 #| msgid "Performance"
 msgid "Performance Genres"
 msgstr "Espectáculo"
 
-#: common/views_manage.py:1039
+#: common/views_manage.py:1063
 msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1045
+#: common/views_manage.py:1069
 msgid "Genres by Category"
 msgstr ""
 
-#: common/views_manage.py:1069
+#: common/views_manage.py:1093
 msgid "Site"
 msgstr ""
 
-#: common/views_manage.py:1079
+#: common/views_manage.py:1103
 #, fuzzy
 #| msgid "Database"
 msgid "Database and Services"
 msgstr "Base de datos"
 
-#: common/views_manage.py:1089
+#: common/views_manage.py:1113
 msgid "Media and Files"
 msgstr ""
 
-#: common/views_manage.py:1098
+#: common/views_manage.py:1122
 msgid "Monitoring"
 msgstr ""
 
-#: common/views_manage.py:1102
+#: common/views_manage.py:1126
 msgid "Security"
 msgstr ""
 
-#: common/views_manage.py:1111
+#: common/views_manage.py:1135
 msgid "Other Environment Variables"
 msgstr ""
 
-#: common/views_manage.py:1113
+#: common/views_manage.py:1137
 msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
 msgstr ""
 
@@ -5289,7 +5317,8 @@ msgstr ""
 #: users/templates/users/data.html:60 users/templates/users/data.html:113
 #: users/templates/users/data.html:170 users/templates/users/data.html:221
 #: users/templates/users/data.html:284 users/templates/users/data.html:346
-#: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
+#: users/templates/users/data.html:525 users/templates/users/data.html:578
+#: users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
 msgid "Visibility"
@@ -5321,8 +5350,8 @@ msgstr ""
 msgid "owner and their local mutuals"
 msgstr ""
 
-#: journal/forms.py:169 journal/templates/collection.html:193
-#: journal/templates/collection.html:202
+#: journal/forms.py:169 journal/templates/collection.html:194
+#: journal/templates/collection.html:203
 msgid "Collaborative editing"
 msgstr "Edición colaborativa"
 
@@ -5375,7 +5404,7 @@ msgstr ""
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:215 journal/views/article.py:218
+#: journal/models/article.py:224 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
@@ -5387,73 +5416,74 @@ msgstr ""
 msgid "note"
 msgstr "nota"
 
-#: journal/models/collection.py:115
+#: journal/models/collection.py:116
 msgid "search query for dynamic collection"
 msgstr ""
 
-#: journal/models/collection.py:566 journal/templatetags/collection.py:35
+#: journal/models/collection.py:575 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:571 journal/templatetags/collection.py:43
+#: journal/models/collection.py:580 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:576 journal/templatetags/collection.py:51
+#: journal/models/collection.py:585 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:581 journal/templatetags/collection.py:59
+#: journal/models/collection.py:590 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:586 journal/templatetags/collection.py:67
+#: journal/models/collection.py:595 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:591 journal/templatetags/collection.py:75
+#: journal/models/collection.py:600 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:597 journal/templatetags/collection.py:83
+#: journal/models/collection.py:606 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:605 journal/templatetags/collection.py:91
+#: journal/models/collection.py:614 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/models/common.py:59 journal/templates/action_open_post.html:15
 #: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
 #: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
 #: users/templates/users/data.html:122 users/templates/users/data.html:179
 #: users/templates/users/data.html:230 users/templates/users/data.html:292
 #: users/templates/users/data.html:355 users/templates/users/data.html:534
+#: users/templates/users/data.html:587
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5461,13 +5491,14 @@ msgstr[1] ""
 msgid "Public"
 msgstr "Público"
 
-#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/models/common.py:60 journal/templates/action_open_post.html:9
 #: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
 #: users/templates/users/data.html:130 users/templates/users/data.html:187
 #: users/templates/users/data.html:238 users/templates/users/data.html:300
 #: users/templates/users/data.html:363 users/templates/users/data.html:542
+#: users/templates/users/data.html:595
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5475,12 +5506,13 @@ msgstr "Público"
 msgid "Followers Only"
 msgstr "Solo seguidores"
 
-#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/models/common.py:61 journal/templates/collection_share.html:57
 #: journal/templates/mark.html:102 journal/templates/post_compose.html:72
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
 #: users/templates/users/data.html:138 users/templates/users/data.html:195
 #: users/templates/users/data.html:246 users/templates/users/data.html:308
 #: users/templates/users/data.html:371 users/templates/users/data.html:550
+#: users/templates/users/data.html:603
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5488,31 +5520,31 @@ msgstr "Solo seguidores"
 msgid "Mentioned Only"
 msgstr "Solo cuentas mencionadas"
 
-#: journal/models/common.py:806
+#: journal/models/common.py:851
 msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr "Una publicación reciente no se publicó en Bluesky. Por favor, vuelve a iniciar sesión en NeoDB con ATProto para renovar la autorización."
 
-#: journal/models/common.py:1003
+#: journal/models/common.py:1048
 msgid "A recent post was not posted to Threads."
 msgstr "Falló la publicación en Threads."
 
-#: journal/models/common.py:1036
+#: journal/models/common.py:1081
 #, fuzzy
 #| msgid "A recent post was not posted to Mastodon."
 msgid "A recent post was not boosted on Mastodon."
 msgstr "Falló la publicación en Mastodon."
 
-#: journal/models/common.py:1046
+#: journal/models/common.py:1091
 #, fuzzy
 #| msgid "Item no longer exists"
 msgid "Original post no longer exists."
 msgstr "El elemento ya no existe."
 
-#: journal/models/common.py:1060
+#: journal/models/common.py:1105
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr "Falló la publicación en Mastodon. Por favor, renueva la autorización."
 
-#: journal/models/common.py:1069
+#: journal/models/common.py:1114
 msgid "A recent post was not posted to Mastodon."
 msgstr "Falló la publicación en Mastodon."
 
@@ -5528,83 +5560,83 @@ msgstr ""
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:475
+#: journal/models/mark.py:477
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:479
+#: journal/models/mark.py:481
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:486
+#: journal/models/mark.py:488
 #, fuzzy
 #| msgid "Invalid parameter"
 msgid "Invalid progress type."
 msgstr "Parámetro no válido"
 
-#: journal/models/mark.py:488
+#: journal/models/mark.py:490
 msgid "Invalid progress type for this item."
 msgstr ""
 
-#: journal/models/note.py:47 users/templates/users/rym_import.html:73
+#: journal/models/note.py:48 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr "Página"
 
-#: journal/models/note.py:48
+#: journal/models/note.py:49
 msgid "Chapter"
 msgstr "Capítulo"
 
-#: journal/models/note.py:51
+#: journal/models/note.py:52
 msgid "Part"
 msgstr "Parte"
 
-#: journal/models/note.py:52
+#: journal/models/note.py:53
 msgid "Episode"
 msgstr "Episodio"
 
-#: journal/models/note.py:53
+#: journal/models/note.py:54
 msgid "Track"
 msgstr "Pista"
 
-#: journal/models/note.py:54
+#: journal/models/note.py:55
 msgid "Cycle"
 msgstr "Ciclo"
 
-#: journal/models/note.py:55
+#: journal/models/note.py:56
 msgid "Timestamp"
 msgstr "Marca de tiempo"
 
-#: journal/models/note.py:56
+#: journal/models/note.py:57
 msgid "Percentage"
 msgstr "Porcentaje"
 
-#: journal/models/note.py:77
+#: journal/models/note.py:78
 #, python-brace-format
 msgid "Page {value}"
 msgstr "Página {value}"
 
-#: journal/models/note.py:78
+#: journal/models/note.py:79
 #, python-brace-format
 msgid "Chapter {value}"
 msgstr "Capítulo {value}"
 
-#: journal/models/note.py:81
+#: journal/models/note.py:82
 #, python-brace-format
 msgid "Part {value}"
 msgstr "Parte {value}"
 
-#: journal/models/note.py:82
+#: journal/models/note.py:83
 #, python-brace-format
 msgid "Episode {value}"
 msgstr "Episodio {value}"
 
-#: journal/models/note.py:83
+#: journal/models/note.py:84
 #, python-brace-format
 msgid "Track {value}"
 msgstr "Pista {value}"
 
-#: journal/models/note.py:84
+#: journal/models/note.py:85
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr "Ciclo {value}"
@@ -5614,13 +5646,13 @@ msgstr "Ciclo {value}"
 msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr "acerca de {item_title}, puede contener espoilers o contenido chocante"
 
-#: journal/models/review.py:79
+#: journal/models/review.py:80
 #, fuzzy, python-brace-format
 #| msgid "a review of {item_title}"
 msgid "a review of {title}"
 msgstr "reseña de {item_title}"
 
-#: journal/models/review.py:81
+#: journal/models/review.py:82
 #, fuzzy
 #| msgid "Item contains sub-items."
 msgid "(may contain spoilers)"
@@ -6052,7 +6084,7 @@ msgstr "te sigue"
 msgid "started following {item}"
 msgstr "comenzó a jugar {item}"
 
-#: journal/models/shelf.py:923
+#: journal/models/shelf.py:925
 msgid "removed mark"
 msgstr ""
 
@@ -6087,7 +6119,7 @@ msgstr ""
 msgid "Update note"
 msgstr ""
 
-#: journal/templates/_list_item.html:71 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:121
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
@@ -6247,7 +6279,7 @@ msgid "View post"
 msgstr ""
 
 #: journal/templates/action_quote_post.html:3
-#: journal/templates/article.html:190 journal/templates/collection.html:174
+#: journal/templates/article.html:188 journal/templates/collection.html:175
 msgid "Quote"
 msgstr ""
 
@@ -6256,7 +6288,7 @@ msgid "reply"
 msgstr ""
 
 #: journal/templates/action_reply_post.html:3
-#: journal/templates/article.html:181 journal/templates/collection.html:165
+#: journal/templates/article.html:179 journal/templates/collection.html:166
 msgid "Reply"
 msgstr ""
 
@@ -6275,21 +6307,21 @@ msgstr ""
 msgid "Create a new collection"
 msgstr ""
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:76
+#: journal/templates/article.html:102 social/templates/_event_post.html:76
 #, fuzzy
 #| msgid "wrote a review of {item}"
 msgid "wrote a review"
 msgstr "escribió una reseña de {item}"
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:78
+#: journal/templates/article.html:104 social/templates/_event_post.html:78
 msgid "wrote an article"
 msgstr ""
 
-#: journal/templates/article.html:136
+#: journal/templates/article.html:134
 msgid "This article may contain sensitive content. Click to reveal."
 msgstr ""
 
-#: journal/templates/article.html:155
+#: journal/templates/article.html:153
 msgid "The author has set it to be viewable only by logged-in users."
 msgstr ""
 
@@ -6354,20 +6386,20 @@ msgstr ""
 msgid "DEC"
 msgstr ""
 
-#: journal/templates/collection.html:71
+#: journal/templates/collection.html:72
 #: journal/templates/collection_share.html:12
 #: journal/templates/collection_share.html:66
 #: journal/templates/wrapped_share.html:59
 msgid "Share"
 msgstr ""
 
-#: journal/templates/collection.html:86
+#: journal/templates/collection.html:87
 #, fuzzy
 #| msgid "created collection"
 msgid "created a collection"
 msgstr "colección creada"
 
-#: journal/templates/collection.html:181
+#: journal/templates/collection.html:182
 msgid "Query"
 msgstr ""
 
@@ -6626,14 +6658,14 @@ msgid "Liked Collections"
 msgstr ""
 
 #: journal/templates/user_follow_list.html:23 journal/views/profile.py:507
-#: users/templates/users/account.html:443
+#: users/templates/users/account.html:455
 #, fuzzy
 #| msgid "following you"
 msgid "Following"
 msgstr "te sigue"
 
 #: journal/templates/user_follow_list.html:28 journal/views/profile.py:511
-#: users/templates/users/account.html:452
+#: users/templates/users/account.html:464
 #, fuzzy
 #| msgid "Followers Only"
 msgid "Followers"
@@ -6954,8 +6986,8 @@ msgstr ""
 #: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
 #: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
 #: mastodon/views/threads.py:57 mastodon/views/threads.py:65
-#: mastodon/views/threads.py:71 users/views/account.py:256
-#: users/views/account.py:375
+#: mastodon/views/threads.py:71 users/views/account.py:257
+#: users/views/account.py:376
 msgid "Authentication failed"
 msgstr ""
 
@@ -6995,7 +7027,7 @@ msgstr ""
 msgid "Invalid user."
 msgstr ""
 
-#: mastodon/views/common.py:52 users/views/account.py:416
+#: mastodon/views/common.py:52 users/views/account.py:417
 msgid "Registration failed"
 msgstr ""
 
@@ -7897,130 +7929,143 @@ msgstr "año de publicación"
 msgid "Scopes"
 msgstr ""
 
-#: users/templates/users/account.html:398
+#: users/templates/users/account.html:386
+msgid "Webhook"
+msgstr ""
+
+#: users/templates/users/account.html:400
+msgid "disabled"
+msgstr ""
+
+#: users/templates/users/account.html:402
+msgid "active"
+msgstr ""
+
+#: users/templates/users/account.html:410
 msgid "Revoke access for this application?"
 msgstr ""
 
-#: users/templates/users/account.html:401
+#: users/templates/users/account.html:413
 msgid "Revoke"
 msgstr ""
 
-#: users/templates/users/account.html:409
+#: users/templates/users/account.html:421
 msgid "No authorized applications."
 msgstr ""
 
-#: users/templates/users/account.html:412
+#: users/templates/users/account.html:424
 #: users/templates/users/authorized_app_create.html:9
 #: users/templates/users/authorized_app_create.html:19
 msgid "Create Personal Token"
 msgstr ""
 
-#: users/templates/users/account.html:418
+#: users/templates/users/account.html:430
 msgid "Import/Export Social Graph"
 msgstr ""
 
-#: users/templates/users/account.html:419
+#: users/templates/users/account.html:431
 msgid "Upload a CSV file exported from Mastodon or compatible services."
 msgstr ""
 
-#: users/templates/users/account.html:425
+#: users/templates/users/account.html:437
 msgid "Import type"
 msgstr ""
 
-#: users/templates/users/account.html:427
+#: users/templates/users/account.html:439
 #, fuzzy
 #| msgid "following you"
 msgid "Following list"
 msgstr "te sigue"
 
-#: users/templates/users/account.html:428
+#: users/templates/users/account.html:440
 #, fuzzy
 #| msgid "to listen"
 msgid "Block list"
 msgstr "escuchar"
 
-#: users/templates/users/account.html:429
+#: users/templates/users/account.html:441
 #, fuzzy
 #| msgid "to listen"
 msgid "Mute list"
 msgstr "escuchar"
 
-#: users/templates/users/account.html:433
+#: users/templates/users/account.html:445
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/account.html:448 users/templates/users/data.html:89
 #: users/templates/users/data.html:141 users/templates/users/data.html:198
 #: users/templates/users/data.html:249 users/templates/users/data.html:313
 #: users/templates/users/data.html:376 users/templates/users/data.html:553
+#: users/templates/users/data.html:606 users/templates/users/data.html:631
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr ""
 
-#: users/templates/users/account.html:447
-#: users/templates/users/account.html:456
-#: users/templates/users/account.html:465
-#: users/templates/users/account.html:474
+#: users/templates/users/account.html:459
+#: users/templates/users/account.html:468
+#: users/templates/users/account.html:477
+#: users/templates/users/account.html:486
 #, fuzzy
 #| msgid "Downloadable Content"
 msgid "Download CSV"
 msgstr "Contenido descargable"
 
-#: users/templates/users/account.html:461
+#: users/templates/users/account.html:473
 msgid "Blocks"
 msgstr ""
 
-#: users/templates/users/account.html:470
+#: users/templates/users/account.html:482
 msgid "Mutes"
 msgstr ""
 
-#: users/templates/users/account.html:484
+#: users/templates/users/account.html:496
 msgid "Migrate Account"
 msgstr ""
 
-#: users/templates/users/account.html:488
+#: users/templates/users/account.html:500
 msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
 msgstr ""
 
-#: users/templates/users/account.html:491
+#: users/templates/users/account.html:503
 msgid "Migrate another account here"
 msgstr ""
 
-#: users/templates/users/account.html:494
+#: users/templates/users/account.html:506
 #, fuzzy
 #| msgid "merge to another item"
 msgid "Migrate to another account"
 msgstr "fusionar con otro elemento"
 
-#: users/templates/users/account.html:501
+#: users/templates/users/account.html:513
 msgid "Delete Account"
 msgstr ""
 
-#: users/templates/users/account.html:504
+#: users/templates/users/account.html:516
 msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
 msgstr ""
 
-#: users/templates/users/account.html:507
+#: users/templates/users/account.html:519
 msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
 msgstr ""
 
-#: users/templates/users/account.html:517
+#: users/templates/users/account.html:529
 msgid "Once deleted, account data cannot be recovered."
 msgstr ""
 
-#: users/templates/users/account.html:520
+#: users/templates/users/account.html:532
 msgid "Task in progress, can't delete now."
 msgstr ""
 
-#: users/templates/users/account.html:524
+#: users/templates/users/account.html:536
 msgid "Permanently Delete"
 msgstr ""
 
-#: users/templates/users/account.html:565
+#: users/templates/users/account.html:577
 msgid "Delete this passkey?"
 msgstr ""
 
-#: users/templates/users/account.html:585
+#: users/templates/users/account.html:597
 msgid "Rename passkey:"
 msgstr ""
 
@@ -8044,12 +8089,10 @@ msgstr ""
 
 #: users/templates/users/authorized_app_create.html:48
 #: users/templates/users/authorized_app_created.html:39
-#: users/templates/users/migrate_in.html:70
-#: users/templates/users/migrate_out.html:67
 #, fuzzy
-#| msgid "Preferences"
-msgid "Back to Preferences"
-msgstr "Preferencias"
+#| msgid "Account"
+msgid "Back to Account"
+msgstr "Cuenta"
 
 #: users/templates/users/authorized_app_created.html:9
 #: users/templates/users/authorized_app_created.html:19
@@ -8191,7 +8234,7 @@ msgstr ""
 msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
 msgstr ""
 
-#: users/templates/users/data.html:89 users/views/data.py:1130
+#: users/templates/users/data.html:89 users/views/data.py:1194
 msgid "Import in progress, please wait"
 msgstr ""
 
@@ -8354,7 +8397,39 @@ msgstr ""
 msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
-#: users/templates/users/data.html:560
+#: users/templates/users/data.html:561
+msgid "Import Twitter / X Archive"
+msgstr ""
+
+#: users/templates/users/data.html:567
+msgid "On X, go to <b>Settings</b> - <b>Your account</b> - <b>Download an archive of your data</b>. Upload the <code>.zip</code> you receive, or only the <code>data/tweets.js</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:570
+msgid "Each tweet becomes a post with its original date, text, links and photos. Replies to your own tweets are kept as a thread. A retweet becomes a short post that links to the original tweet. Videos are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:573
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Tweets that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:615
+msgid "Import Mastodon Archive"
+msgstr ""
+
+#: users/templates/users/data.html:621
+msgid "On your Mastodon server, go to <b>Preferences</b> - <b>Import and export</b> - <b>Request your archive</b>. Upload the <code>.zip</code> you receive, or only the <code>outbox.json</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:624
+msgid "Each post is imported with its original date, text, links, photos, content warning and visibility, so a followers-only post or a direct message stays that way. Replies to your own posts are kept as a thread. A boost becomes a short post that links to the original post. Videos, favourites and bookmarks are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:627
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Posts that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:639
 msgid "View Annual Summary"
 msgstr ""
 
@@ -8482,6 +8557,13 @@ msgstr "Metas actuales"
 #: users/templates/users/migrate_in.html:64
 msgid "No aliases configured."
 msgstr ""
+
+#: users/templates/users/migrate_in.html:70
+#: users/templates/users/migrate_out.html:67
+#, fuzzy
+#| msgid "Preferences"
+msgid "Back to Preferences"
+msgstr "Preferencias"
 
 #: users/templates/users/migrate_out.html:9
 #: users/templates/users/migrate_out.html:43
@@ -9009,198 +9091,199 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:126
+#: users/views/account.py:127
 msgid "This username is already in use."
 msgstr ""
 
-#: users/views/account.py:137
+#: users/views/account.py:138
 msgid "This email address is already in use."
 msgstr ""
 
-#: users/views/account.py:257 users/views/account.py:376
+#: users/views/account.py:258 users/views/account.py:377
 msgid "Registration is for invitation only"
 msgstr ""
 
-#: users/views/account.py:268 users/views/account.py:340
+#: users/views/account.py:269 users/views/account.py:341
 #, fuzzy
 #| msgid "Timestamp"
 msgid "Time is up"
 msgstr "Marca de tiempo"
 
-#: users/views/account.py:269 users/views/account.py:312
-#: users/views/account.py:341
+#: users/views/account.py:270 users/views/account.py:313
+#: users/views/account.py:342
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:315
+#: users/views/account.py:316
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:327
+#: users/views/account.py:328
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:328
+#: users/views/account.py:329
 #, fuzzy
 #| msgid "System busy, please try again in a minute."
 msgid "Please try again later."
 msgstr "El sistema está ocupado, por favor inténtalo de nuevo en un minuto."
 
-#: users/views/account.py:417
+#: users/views/account.py:418
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:447
+#: users/views/account.py:448
 msgid "Valid username required"
 msgstr ""
 
-#: users/views/account.py:518
+#: users/views/account.py:519
 msgid "Account is being deleted."
 msgstr ""
 
-#: users/views/account.py:521
+#: users/views/account.py:522
 msgid "Account mismatch."
 msgstr ""
 
-#: users/views/data.py:264 users/views/data.py:296
+#: users/views/data.py:276 users/views/data.py:308
 msgid "Export file not available."
 msgstr ""
 
-#: users/views/data.py:290
+#: users/views/data.py:302
 msgid "Generating exports."
 msgstr ""
 
-#: users/views/data.py:308
+#: users/views/data.py:320
 msgid "Export file expired. Please export again."
 msgstr ""
 
-#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
+#: users/views/data.py:335 users/views/data.py:356 users/views/data.py:377
 msgid "Recent export still in progress."
 msgstr ""
 
-#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
-#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
-#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
+#: users/views/data.py:393 users/views/data.py:419 users/views/data.py:447
+#: users/views/data.py:579 users/views/data.py:613 users/views/data.py:838
+#: users/views/data.py:1055 users/views/data.py:1081 users/views/data.py:1106
+#: users/views/data.py:1131 users/views/data.py:1201
 msgid "Invalid file."
 msgstr ""
 
-#: users/views/data.py:405
+#: users/views/data.py:469
 msgid "Sync in progress."
 msgstr ""
 
-#: users/views/data.py:419
+#: users/views/data.py:483
 msgid "Settings saved."
 msgstr ""
 
-#: users/views/data.py:474
+#: users/views/data.py:538
 msgid "Account no longer linked."
 msgstr ""
 
-#: users/views/data.py:477
+#: users/views/data.py:541
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:505
+#: users/views/data.py:569
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:585 users/views/data.py:810
+#: users/views/data.py:649 users/views/data.py:874
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:610 users/views/data.py:839
+#: users/views/data.py:674 users/views/data.py:903
 #, fuzzy
 #| msgid "Cancel"
 msgid "Cancelled."
 msgstr "Cancelar"
 
-#: users/views/data.py:630
+#: users/views/data.py:694
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
-#: users/views/data.py:974
+#: users/views/data.py:702 users/views/data.py:812 users/views/data.py:933
+#: users/views/data.py:1038
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:734 users/views/data.py:960
+#: users/views/data.py:798 users/views/data.py:1024
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:744 users/views/data.py:970
+#: users/views/data.py:808 users/views/data.py:1034
 msgid "No matched file available."
 msgstr ""
 
-#: users/views/data.py:861
+#: users/views/data.py:925
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1290
 #, fuzzy
 #| msgid "games reviewed"
 msgid "Name is required."
 msgstr "juegos reseñados"
 
-#: users/views/data.py:1248
+#: users/views/data.py:1314
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1264
+#: users/views/data.py:1330
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1269
+#: users/views/data.py:1335
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1279 users/views/data.py:1330
+#: users/views/data.py:1345 users/views/data.py:1396
 msgid "Looking up the account. Please try again in a few seconds."
-msgstr ""
-
-#: users/views/data.py:1286
-#, python-brace-format
-msgid "Alias to {handle} removed."
-msgstr ""
-
-#: users/views/data.py:1291
-#, python-brace-format
-msgid "Alias to {handle} added."
-msgstr ""
-
-#: users/views/data.py:1317
-msgid "Migration cancelled."
-msgstr ""
-
-#: users/views/data.py:1322
-msgid "No target account specified."
-msgstr ""
-
-#: users/views/data.py:1335
-msgid "Cannot migrate to a local account."
-msgstr ""
-
-#: users/views/data.py:1346
-msgid "You must set up an alias in the target account first."
 msgstr ""
 
 #: users/views/data.py:1352
 #, python-brace-format
+msgid "Alias to {handle} removed."
+msgstr ""
+
+#: users/views/data.py:1357
+#, python-brace-format
+msgid "Alias to {handle} added."
+msgstr ""
+
+#: users/views/data.py:1383
+msgid "Migration cancelled."
+msgstr ""
+
+#: users/views/data.py:1388
+msgid "No target account specified."
+msgstr ""
+
+#: users/views/data.py:1401
+msgid "Cannot migrate to a local account."
+msgstr ""
+
+#: users/views/data.py:1412
+msgid "You must set up an alias in the target account first."
+msgstr ""
+
+#: users/views/data.py:1418
+#, python-brace-format
 msgid "Start moving to {handle}."
 msgstr ""
 
-#: users/views/data.py:1410
+#: users/views/data.py:1476
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1426
+#: users/views/data.py:1492
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1430
+#: users/views/data.py:1496
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1440
+#: users/views/data.py:1506
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""

--- a/neodb/locale/eu/LC_MESSAGES/django.po
+++ b/neodb/locale/eu/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 20:04-0400\n"
+"POT-Creation-Date: 2026-09-07 14:56-0400\n"
 "PO-Revision-Date: 2026-08-09 06:31+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Basque <https://hosted.weblate.org/projects/neodb/neodb/eu/>\n"
@@ -59,15 +59,15 @@ msgstr "Txinera sinplifikatua"
 msgid "Traditional Chinese"
 msgstr "Txinera Tradizionala"
 
-#: catalog/forms.py:35 catalog/models/item.py:307
+#: catalog/forms.py:35 catalog/models/item.py:412
 msgid "Primary ID Type"
 msgstr ""
 
-#: catalog/forms.py:40 catalog/models/item.py:310
+#: catalog/forms.py:40 catalog/models/item.py:415
 msgid "Primary ID Value"
 msgstr ""
 
-#: catalog/forms.py:176
+#: catalog/forms.py:177
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
@@ -120,11 +120,11 @@ msgid "other title"
 msgstr "beste izenburua"
 
 #: catalog/models/book.py:282 catalog/models/book.py:566
-#: catalog/models/item.py:119
+#: catalog/models/item.py:224
 msgid "author"
 msgstr "autorea"
 
-#: catalog/models/book.py:289 catalog/models/item.py:120
+#: catalog/models/book.py:289 catalog/models/item.py:225
 msgid "translator"
 msgstr "itzultzailea"
 
@@ -133,7 +133,7 @@ msgid "book format"
 msgstr "liburu formatua"
 
 #: catalog/models/book.py:303 catalog/models/game.py:135
-#: catalog/models/item.py:134 catalog/models/music.py:142
+#: catalog/models/item.py:239 catalog/models/music.py:142
 msgid "publisher"
 msgstr ""
 
@@ -165,7 +165,7 @@ msgstr "edukiak"
 msgid "price"
 msgstr "prezioa"
 
-#: catalog/models/book.py:326 catalog/models/item.py:145
+#: catalog/models/book.py:326 catalog/models/item.py:250
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr ""
@@ -580,7 +580,7 @@ msgid "Exhibition"
 msgstr ""
 
 #: catalog/models/common.py:174 catalog/models/common.py:191
-#: journal/templates/collection.html:29 journal/templates/collection.html:40
+#: journal/templates/collection.html:30 journal/templates/collection.html:41
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
@@ -706,16 +706,16 @@ msgstr ""
 msgid "Special Edition"
 msgstr "Edizio Berezia"
 
-#: catalog/models/game.py:111 catalog/models/item.py:126
+#: catalog/models/game.py:111 catalog/models/item.py:231
 msgid "designer"
 msgstr "diseinatzailea"
 
-#: catalog/models/game.py:119 catalog/models/item.py:125
+#: catalog/models/game.py:119 catalog/models/item.py:230
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr "artista"
 
-#: catalog/models/game.py:127 catalog/models/item.py:135
+#: catalog/models/game.py:127 catalog/models/item.py:240
 msgid "developer"
 msgstr "garatzailea"
 
@@ -745,147 +745,147 @@ msgstr ""
 msgid "website"
 msgstr "webgunea"
 
-#: catalog/models/item.py:121 catalog/models/movie.py:123
+#: catalog/models/item.py:226 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
 #: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr "zuzendaria"
 
-#: catalog/models/item.py:122 catalog/models/movie.py:130
+#: catalog/models/item.py:227 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
 #: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr ""
 
-#: catalog/models/item.py:123 catalog/models/movie.py:137
+#: catalog/models/item.py:228 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
 #: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr "aktorea"
 
-#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/item.py:229 catalog/models/movie.py:144
 #: catalog/models/tv.py:237 catalog/models/tv.py:463
 #, fuzzy
 #| msgid "production"
 msgid "producer"
 msgstr "produkzioa"
 
-#: catalog/models/item.py:127 catalog/models/performance.py:203
+#: catalog/models/item.py:232 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr "konpositorea"
 
-#: catalog/models/item.py:128 catalog/models/performance.py:210
+#: catalog/models/item.py:233 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr "koreografo"
 
-#: catalog/models/item.py:129 catalog/models/performance.py:224
+#: catalog/models/item.py:234 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr ""
 
-#: catalog/models/item.py:130 catalog/models/podcast.py:80
+#: catalog/models/item.py:235 catalog/models/podcast.py:80
 msgid "host"
 msgstr ""
 
-#: catalog/models/item.py:131 catalog/models/performance.py:196
+#: catalog/models/item.py:236 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr "sortzaile originala"
 
-#: catalog/models/item.py:132 catalog/models/performance.py:238
+#: catalog/models/item.py:237 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr "krew"
 
-#: catalog/models/item.py:136
+#: catalog/models/item.py:241
 #, fuzzy
 #| msgid "production"
 msgid "production company"
 msgstr "produkzioa"
 
-#: catalog/models/item.py:137
+#: catalog/models/item.py:242
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:138
+#: catalog/models/item.py:243
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:139
+#: catalog/models/item.py:244
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:140 catalog/models/performance.py:231
+#: catalog/models/item.py:245 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr ""
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:248
 #, fuzzy
 #| msgid "director"
 msgid "voice actor"
 msgstr "zuzendaria"
 
-#: catalog/models/item.py:144 catalog/templates/edition.html:30
+#: catalog/models/item.py:249 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr ""
 
-#: catalog/models/item.py:169 catalog/models/people.py:476
+#: catalog/models/item.py:274 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr "rola"
 
-#: catalog/models/item.py:170 catalog/models/people.py:155
+#: catalog/models/item.py:275 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr "izena"
 
-#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:277 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:304 catalog/models/item.py:336
-#: journal/models/collection.py:100
+#: catalog/models/item.py:409 catalog/models/item.py:441
+#: journal/models/collection.py:101
 msgid "title"
 msgstr "izenburua"
 
-#: catalog/models/item.py:305 catalog/models/item.py:344
-#: journal/models/collection.py:101
+#: catalog/models/item.py:410 catalog/models/item.py:449
+#: journal/models/collection.py:102
 msgid "description"
 msgstr "deskribapena"
 
-#: catalog/models/item.py:316 catalog/models/people.py:484
+#: catalog/models/item.py:421 catalog/models/people.py:484
 msgid "metadata"
 msgstr "metadatua"
 
-#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:423 catalog/templates/_item_card.html:28
 msgid "cover"
 msgstr "azala"
 
-#: catalog/models/item.py:1526
+#: catalog/models/item.py:1612
 msgid "source site"
 msgstr "jatorrizko gunea"
 
-#: catalog/models/item.py:1528
+#: catalog/models/item.py:1614
 msgid "ID on source site"
 msgstr "IDa jatorrizko gunean"
 
-#: catalog/models/item.py:1530
+#: catalog/models/item.py:1616
 msgid "source url"
 msgstr "jatorrizko url-a"
 
-#: catalog/models/item.py:1546
+#: catalog/models/item.py:1632
 msgid "IdType of the source site"
 msgstr ""
 
-#: catalog/models/item.py:1552
+#: catalog/models/item.py:1638
 msgid "Primary Id on the source site"
 msgstr ""
 
-#: catalog/models/item.py:1555
+#: catalog/models/item.py:1641
 msgid "url to the resource"
 msgstr ""
 
@@ -1198,12 +1198,12 @@ msgstr ""
 #: catalog/templates/_item_card_metadata_tvseason.html:7
 #: catalog/templates/_item_card_metadata_tvshow.html:7
 #: catalog/templates/_item_card_metadata_work.html:7
-#: catalog/templates/item_base.html:201
+#: catalog/templates/item_base.html:186
 msgid "ratings"
 msgstr ""
 
-#: catalog/templates/_item_card_metadata_base.html:34
-#: catalog/templates/item_base.html:256
+#: catalog/templates/_item_card_metadata_base.html:28
+#: catalog/templates/item_base.html:241
 msgid "part of"
 msgstr ""
 
@@ -1221,14 +1221,14 @@ msgid "hide this tooltip"
 msgstr ""
 
 #: catalog/templates/_item_comments.html:58
-#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:83
+#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:81
 msgid "translate"
 msgstr ""
 
 #: catalog/templates/_item_comments.html:92
 #: catalog/templates/_item_comments_by_episode.html:80
 #: catalog/templates/_item_notes.html:88
-#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:284
+#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:269
 #: catalog/templates/podcast_episode_data.html:41
 msgid "show more"
 msgstr ""
@@ -1337,8 +1337,8 @@ msgstr ""
 #: catalog/templates/_item_user_pieces.html:101
 #: catalog/templates/catalog_edit.html:12
 #: journal/templates/action_edit_post.html:6
-#: journal/templates/action_edit_post.html:8 journal/templates/article.html:196
-#: journal/templates/collection.html:185 journal/templates/collection.html:193
+#: journal/templates/action_edit_post.html:8 journal/templates/article.html:194
+#: journal/templates/collection.html:186 journal/templates/collection.html:194
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_edit.html:26
 #: journal/templates/post_compose.html:16 journal/templates/tag_edit.html:16
@@ -1380,7 +1380,7 @@ msgstr ""
 #: catalog/templates/_sidebar_edit.html:20
 #: catalog/templates/catalog_verify.html:11
 #: catalog/templates/catalog_verify.html:17
-#: catalog/templates/item_base.html:182
+#: catalog/templates/item_base.html:167
 #, fuzzy
 #| msgid "year of publication"
 msgid "Creator verification"
@@ -1390,7 +1390,7 @@ msgstr "publikatutako urtea"
 msgid "Edit Options"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
+#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:163
 #: catalog/views/edit.py:160 catalog/views/edit.py:221
 #: catalog/views/edit.py:288 catalog/views/edit.py:309
 #: catalog/views/edit.py:364 catalog/views/edit.py:471
@@ -1550,7 +1550,7 @@ msgstr ""
 #: catalog/templates/_sidebar_edit.html:265
 #: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
-#: journal/templates/article.html:199 journal/templates/collection.html:188
+#: journal/templates/article.html:197 journal/templates/collection.html:189
 #: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
@@ -1735,7 +1735,7 @@ msgstr ""
 msgid "Remove my verification"
 msgstr ""
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:311
+#: catalog/templates/_verify_status.html:31 users/views/account.py:312
 msgid "Verification failed"
 msgstr ""
 
@@ -1923,7 +1923,7 @@ msgstr ""
 
 #: catalog/templates/discover.html:229
 #: catalog/templates/discover_original_podcasts.html:25
-#: catalog/templates/item_base.html:282
+#: catalog/templates/item_base.html:267
 #: catalog/templates/item_mark_list.html:71
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
@@ -1991,67 +1991,67 @@ msgstr ""
 msgid "System busy, please try again in a minute."
 msgstr ""
 
-#: catalog/templates/item_base.html:95
+#: catalog/templates/item_base.html:80
 msgid "select one of the seasons to comment"
 msgstr ""
 
-#: catalog/templates/item_base.html:129
+#: catalog/templates/item_base.html:114
 msgid "mark, comment and collect"
 msgstr ""
 
-#: catalog/templates/item_base.html:142
+#: catalog/templates/item_base.html:127
 msgid "Login or register to review or add this item to your collection."
 msgstr ""
 
-#: catalog/templates/item_base.html:151
+#: catalog/templates/item_base.html:136
 msgid "Related Collections"
 msgstr ""
 
-#: catalog/templates/item_base.html:166
+#: catalog/templates/item_base.html:151
 msgid "Unsupported item type."
 msgstr ""
 
-#: catalog/templates/item_base.html:176
+#: catalog/templates/item_base.html:161
 msgid "Edit this item"
 msgstr ""
 
-#: catalog/templates/item_base.html:187
+#: catalog/templates/item_base.html:172
 msgid "Last edited"
 msgstr ""
 
-#: catalog/templates/item_base.html:230
+#: catalog/templates/item_base.html:215
 msgid "No enough ratings"
 msgstr ""
 
-#: catalog/templates/item_base.html:274
+#: catalog/templates/item_base.html:259
 msgid "overview"
 msgstr ""
 
-#: catalog/templates/item_base.html:305
+#: catalog/templates/item_base.html:290
 msgid "comments"
 msgstr ""
 
-#: catalog/templates/item_base.html:308
+#: catalog/templates/item_base.html:293
 #: catalog/templates/item_mark_list.html:22
 #: catalog/templates/item_mark_list.html:25
 #: catalog/templates/item_review_list.html:21
 msgid "marks"
 msgstr ""
 
-#: catalog/templates/item_base.html:309
+#: catalog/templates/item_base.html:294
 #: catalog/templates/item_mark_list.html:23
 #: catalog/templates/item_mark_list.html:26
 #: catalog/templates/item_review_list.html:22
 msgid "marks from who you follow"
 msgstr ""
 
-#: catalog/templates/item_base.html:323
+#: catalog/templates/item_base.html:308
 #: catalog/templates/item_mark_list.html:28
 #: catalog/templates/item_review_list.html:23
 msgid "reviews"
 msgstr "kritikak"
 
-#: catalog/templates/item_base.html:333
+#: catalog/templates/item_base.html:318
 msgid "notes"
 msgstr "oharrak"
 
@@ -2430,7 +2430,7 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
+#: catalog/views/verify.py:164 common/utils.py:148 common/utils.py:189
 #: journal/views/article.py:186 journal/views/review.py:182
 #: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
@@ -4120,7 +4120,7 @@ msgstr ""
 msgid "Open Registration"
 msgstr ""
 
-#: common/templates/common/about.html:40 common/views_manage.py:657
+#: common/templates/common/about.html:40 common/views_manage.py:671
 msgid "Preferred Languages"
 msgstr ""
 
@@ -4176,7 +4176,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:738
+#: common/templates/common/scan.html:60 common/views_manage.py:756
 #, fuzzy
 #| msgid "Search results"
 msgid "Search"
@@ -4258,16 +4258,16 @@ msgstr ""
 msgid "unavailable"
 msgstr ""
 
-#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
+#: common/utils.py:152 common/utils.py:193 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr ""
 
-#: common/utils.py:135 common/utils.py:137 common/utils.py:140
-#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
+#: common/utils.py:159 common/utils.py:161 common/utils.py:164
+#: common/utils.py:200 common/utils.py:204 journal/views/profile.py:499
 msgid "Access denied"
 msgstr ""
 
-#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
+#: common/utils.py:167 common/utils.py:169 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr ""
@@ -4284,7 +4284,7 @@ msgstr ""
 msgid "Access"
 msgstr ""
 
-#: common/views_manage.py:39 common/views_manage.py:733
+#: common/views_manage.py:39 common/views_manage.py:751
 #, fuzzy
 #| msgid "duration"
 msgid "Federation"
@@ -4644,451 +4644,479 @@ msgid "Sender name and address for outgoing email."
 msgstr ""
 
 #: common/views_manage.py:649
+msgid "Enable Twitter / X Archive Import"
+msgstr ""
+
+#: common/views_manage.py:651
+msgid "Show the Twitter / X archive import on the data page. Imported tweets become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:656
+msgid "Enable Mastodon Archive Import"
+msgstr ""
+
+#: common/views_manage.py:658
+msgid "Show the Mastodon archive import on the data page. Imported posts become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:663
 #, fuzzy
 #| msgid "language"
 msgid "Default Language"
 msgstr "hizkuntza"
 
-#: common/views_manage.py:652
+#: common/views_manage.py:666
 msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:673
 msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:665
+#: common/views_manage.py:679
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:672
+#: common/views_manage.py:686
 msgid "Login Methods"
 msgstr ""
 
-#: common/views_manage.py:677 mastodon/models/common.py:30
+#: common/views_manage.py:691 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr ""
 
-#: common/views_manage.py:681
-msgid "Localization"
-msgstr ""
-
-#: common/views_manage.py:692
-msgid "Disable Default Relay"
-msgstr ""
-
-#: common/views_manage.py:694
-msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
+#: common/views_manage.py:695
+msgid "Data Import"
 msgstr ""
 
 #: common/views_manage.py:699
+msgid "Localization"
+msgstr ""
+
+#: common/views_manage.py:710
+msgid "Disable Default Relay"
+msgstr ""
+
+#: common/views_manage.py:712
+msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
+msgstr ""
+
+#: common/views_manage.py:717
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:700
+#: common/views_manage.py:718
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:704
+#: common/views_manage.py:722
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:706
+#: common/views_manage.py:724
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:711
+#: common/views_manage.py:729
 #, fuzzy
 #| msgid "Search results"
 msgid "Search Sites"
 msgstr "Emaitzak bilatu"
 
-#: common/views_manage.py:712
+#: common/views_manage.py:730
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:715
+#: common/views_manage.py:733
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:716
+#: common/views_manage.py:734
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:719
+#: common/views_manage.py:737
 msgid "Hidden Categories"
 msgstr ""
 
-#: common/views_manage.py:720
+#: common/views_manage.py:738
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:723
+#: common/views_manage.py:741
 msgid "Guest Search Page Limit"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:743
 msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
 msgstr ""
 
-#: common/views_manage.py:751
+#: common/views_manage.py:769
 #, fuzzy
 #| msgid "Spotify Album"
 msgid "Spotify API Key"
 msgstr "Spotify Albuma"
 
-#: common/views_manage.py:752
+#: common/views_manage.py:770
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:773
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:756
+#: common/views_manage.py:774
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:759
+#: common/views_manage.py:777
 #, fuzzy
 #| msgid "Google Books"
 msgid "Google Books API Key"
 msgstr "Google Liburuak"
 
-#: common/views_manage.py:760
+#: common/views_manage.py:778
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:763
+#: common/views_manage.py:781
 #, fuzzy
 #| msgid "Discogs"
 msgid "Discogs API Key"
 msgstr "Discogs"
 
-#: common/views_manage.py:765
+#: common/views_manage.py:783
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:769
+#: common/views_manage.py:787
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:770
+#: common/views_manage.py:788
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:773
+#: common/views_manage.py:791
 msgid "IGDB Client Secret"
 msgstr ""
 
-#: common/views_manage.py:776
+#: common/views_manage.py:794
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:778
+#: common/views_manage.py:796
 msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:783
+#: common/views_manage.py:801
 msgid "MyAnimeList Client ID"
 msgstr ""
 
-#: common/views_manage.py:785
+#: common/views_manage.py:803
 msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
 msgstr ""
 
-#: common/views_manage.py:790 users/templates/users/steam_import.html:26
+#: common/views_manage.py:808 users/templates/users/steam_import.html:26
 #, fuzzy
 #| msgid "Steam Game"
 msgid "Steam API Key"
 msgstr "Steam Jokoa"
 
-#: common/views_manage.py:792
+#: common/views_manage.py:810
 msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:797
+#: common/views_manage.py:815
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:798
+#: common/views_manage.py:816
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:801
+#: common/views_manage.py:819
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:804
+#: common/views_manage.py:822
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:807
+#: common/views_manage.py:825
 msgid "Threads App ID"
 msgstr ""
 
-#: common/views_manage.py:808
+#: common/views_manage.py:826
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:811
+#: common/views_manage.py:829
 msgid "Threads App Secret"
 msgstr ""
 
-#: common/views_manage.py:814
+#: common/views_manage.py:832
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:834
 msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:833
+#: common/views_manage.py:851
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:844
+#: common/views_manage.py:862
 #, fuzzy
 #| msgid "translator"
 msgid "Translation"
 msgstr "itzultzailea"
 
-#: common/views_manage.py:849
+#: common/views_manage.py:867
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:853 social/templates/feed.html:27
+#: common/views_manage.py:871 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr ""
 
-#: common/views_manage.py:863
+#: common/views_manage.py:881
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:882
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:885
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:868
+#: common/views_manage.py:886
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:871
+#: common/views_manage.py:889
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:874
+#: common/views_manage.py:892
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:877
+#: common/views_manage.py:895
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:880
+#: common/views_manage.py:898
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:883
+#: common/views_manage.py:901
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:886
+#: common/views_manage.py:904
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:887
+#: common/views_manage.py:905
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:908
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:894
+#: common/views_manage.py:912
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:898
+#: common/views_manage.py:916
 #, fuzzy
 #| msgid "series"
 msgid "Retries"
 msgstr "telesailak"
 
-#: common/views_manage.py:903
+#: common/views_manage.py:921
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:908
+#: common/views_manage.py:926
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:915
+#: common/views_manage.py:933
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:927
+#: common/views_manage.py:945
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:928
+#: common/views_manage.py:946
 msgid "One domain per line."
 msgstr ""
 
-#: common/views_manage.py:931
+#: common/views_manage.py:949
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:932
+#: common/views_manage.py:950
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:935
+#: common/views_manage.py:953
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:937
+#: common/views_manage.py:955
 msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:943
+#: common/views_manage.py:961
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:944
+#: common/views_manage.py:962
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:947
+#: common/views_manage.py:965
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:948
+#: common/views_manage.py:966
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:958
+#: common/views_manage.py:976
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:960
+#: common/views_manage.py:978
 msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:966
+#: common/views_manage.py:984
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:968
+#: common/views_manage.py:986
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:974
+#: common/views_manage.py:992
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:976
+#: common/views_manage.py:994
 msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:983
+#: common/views_manage.py:1000
+msgid "Webhook Timeout (milliseconds)"
+msgstr ""
+
+#: common/views_manage.py:1001
+msgid "Timeout for delivering webhook requests to applications."
+msgstr ""
+
+#: common/views_manage.py:1006
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:986
+#: common/views_manage.py:1009
 #, fuzzy
 #| msgid "optional"
 msgid "Operational"
 msgstr "aukerakoa"
 
-#: common/views_manage.py:1002
+#: common/views_manage.py:1026
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:1004
+#: common/views_manage.py:1028
 msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1009
+#: common/views_manage.py:1033
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:1011
+#: common/views_manage.py:1035
 msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1016
+#: common/views_manage.py:1040
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:1018
+#: common/views_manage.py:1042
 msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1023
+#: common/views_manage.py:1047
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:1025
+#: common/views_manage.py:1049
 msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1030
+#: common/views_manage.py:1054
 #, fuzzy
 #| msgid "Podcast"
 msgid "Podcast Genres"
 msgstr "Podkasta"
 
-#: common/views_manage.py:1032
+#: common/views_manage.py:1056
 msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1037
+#: common/views_manage.py:1061
 #, fuzzy
 #| msgid "performances"
 msgid "Performance Genres"
 msgstr "ikuskizunak"
 
-#: common/views_manage.py:1039
+#: common/views_manage.py:1063
 msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1045
+#: common/views_manage.py:1069
 msgid "Genres by Category"
 msgstr ""
 
-#: common/views_manage.py:1069
+#: common/views_manage.py:1093
 msgid "Site"
 msgstr ""
 
-#: common/views_manage.py:1079
+#: common/views_manage.py:1103
 msgid "Database and Services"
 msgstr ""
 
-#: common/views_manage.py:1089
+#: common/views_manage.py:1113
 msgid "Media and Files"
 msgstr ""
 
-#: common/views_manage.py:1098
+#: common/views_manage.py:1122
 msgid "Monitoring"
 msgstr ""
 
-#: common/views_manage.py:1102
+#: common/views_manage.py:1126
 msgid "Security"
 msgstr ""
 
-#: common/views_manage.py:1111
+#: common/views_manage.py:1135
 msgid "Other Environment Variables"
 msgstr ""
 
-#: common/views_manage.py:1113
+#: common/views_manage.py:1137
 msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
 msgstr ""
 
@@ -5132,7 +5160,8 @@ msgstr ""
 #: users/templates/users/data.html:60 users/templates/users/data.html:113
 #: users/templates/users/data.html:170 users/templates/users/data.html:221
 #: users/templates/users/data.html:284 users/templates/users/data.html:346
-#: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
+#: users/templates/users/data.html:525 users/templates/users/data.html:578
+#: users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
 msgid "Visibility"
@@ -5164,8 +5193,8 @@ msgstr ""
 msgid "owner and their local mutuals"
 msgstr ""
 
-#: journal/forms.py:169 journal/templates/collection.html:193
-#: journal/templates/collection.html:202
+#: journal/forms.py:169 journal/templates/collection.html:194
+#: journal/templates/collection.html:203
 msgid "Collaborative editing"
 msgstr ""
 
@@ -5216,7 +5245,7 @@ msgstr ""
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:215 journal/views/article.py:218
+#: journal/models/article.py:224 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
@@ -5228,73 +5257,74 @@ msgstr ""
 msgid "note"
 msgstr ""
 
-#: journal/models/collection.py:115
+#: journal/models/collection.py:116
 msgid "search query for dynamic collection"
 msgstr ""
 
-#: journal/models/collection.py:566 journal/templatetags/collection.py:35
+#: journal/models/collection.py:575 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:571 journal/templatetags/collection.py:43
+#: journal/models/collection.py:580 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:576 journal/templatetags/collection.py:51
+#: journal/models/collection.py:585 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:581 journal/templatetags/collection.py:59
+#: journal/models/collection.py:590 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:586 journal/templatetags/collection.py:67
+#: journal/models/collection.py:595 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:591 journal/templatetags/collection.py:75
+#: journal/models/collection.py:600 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:597 journal/templatetags/collection.py:83
+#: journal/models/collection.py:606 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:605 journal/templatetags/collection.py:91
+#: journal/models/collection.py:614 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/models/common.py:59 journal/templates/action_open_post.html:15
 #: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
 #: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
 #: users/templates/users/data.html:122 users/templates/users/data.html:179
 #: users/templates/users/data.html:230 users/templates/users/data.html:292
 #: users/templates/users/data.html:355 users/templates/users/data.html:534
+#: users/templates/users/data.html:587
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5302,13 +5332,14 @@ msgstr[1] ""
 msgid "Public"
 msgstr ""
 
-#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/models/common.py:60 journal/templates/action_open_post.html:9
 #: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
 #: users/templates/users/data.html:130 users/templates/users/data.html:187
 #: users/templates/users/data.html:238 users/templates/users/data.html:300
 #: users/templates/users/data.html:363 users/templates/users/data.html:542
+#: users/templates/users/data.html:595
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5316,12 +5347,13 @@ msgstr ""
 msgid "Followers Only"
 msgstr ""
 
-#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/models/common.py:61 journal/templates/collection_share.html:57
 #: journal/templates/mark.html:102 journal/templates/post_compose.html:72
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
 #: users/templates/users/data.html:138 users/templates/users/data.html:195
 #: users/templates/users/data.html:246 users/templates/users/data.html:308
 #: users/templates/users/data.html:371 users/templates/users/data.html:550
+#: users/templates/users/data.html:603
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5329,27 +5361,27 @@ msgstr ""
 msgid "Mentioned Only"
 msgstr ""
 
-#: journal/models/common.py:806
+#: journal/models/common.py:851
 msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr ""
 
-#: journal/models/common.py:1003
+#: journal/models/common.py:1048
 msgid "A recent post was not posted to Threads."
 msgstr ""
 
-#: journal/models/common.py:1036
+#: journal/models/common.py:1081
 msgid "A recent post was not boosted on Mastodon."
 msgstr ""
 
-#: journal/models/common.py:1046
+#: journal/models/common.py:1091
 msgid "Original post no longer exists."
 msgstr ""
 
-#: journal/models/common.py:1060
+#: journal/models/common.py:1105
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr ""
 
-#: journal/models/common.py:1069
+#: journal/models/common.py:1114
 msgid "A recent post was not posted to Mastodon."
 msgstr ""
 
@@ -5365,81 +5397,81 @@ msgstr ""
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:475
+#: journal/models/mark.py:477
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:479
+#: journal/models/mark.py:481
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:486
+#: journal/models/mark.py:488
 msgid "Invalid progress type."
 msgstr ""
 
-#: journal/models/mark.py:488
+#: journal/models/mark.py:490
 msgid "Invalid progress type for this item."
 msgstr ""
 
-#: journal/models/note.py:47 users/templates/users/rym_import.html:73
+#: journal/models/note.py:48 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr ""
 
-#: journal/models/note.py:48
+#: journal/models/note.py:49
 msgid "Chapter"
 msgstr ""
 
-#: journal/models/note.py:51
+#: journal/models/note.py:52
 msgid "Part"
 msgstr ""
 
-#: journal/models/note.py:52
+#: journal/models/note.py:53
 msgid "Episode"
 msgstr ""
 
-#: journal/models/note.py:53
+#: journal/models/note.py:54
 msgid "Track"
 msgstr ""
 
-#: journal/models/note.py:54
+#: journal/models/note.py:55
 msgid "Cycle"
 msgstr ""
 
-#: journal/models/note.py:55
+#: journal/models/note.py:56
 msgid "Timestamp"
 msgstr ""
 
-#: journal/models/note.py:56
+#: journal/models/note.py:57
 msgid "Percentage"
-msgstr ""
-
-#: journal/models/note.py:77
-#, python-brace-format
-msgid "Page {value}"
 msgstr ""
 
 #: journal/models/note.py:78
 #, python-brace-format
-msgid "Chapter {value}"
+msgid "Page {value}"
 msgstr ""
 
-#: journal/models/note.py:81
+#: journal/models/note.py:79
 #, python-brace-format
-msgid "Part {value}"
+msgid "Chapter {value}"
 msgstr ""
 
 #: journal/models/note.py:82
 #, python-brace-format
-msgid "Episode {value}"
+msgid "Part {value}"
 msgstr ""
 
 #: journal/models/note.py:83
 #, python-brace-format
-msgid "Track {value}"
+msgid "Episode {value}"
 msgstr ""
 
 #: journal/models/note.py:84
+#, python-brace-format
+msgid "Track {value}"
+msgstr ""
+
+#: journal/models/note.py:85
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr ""
@@ -5449,12 +5481,12 @@ msgstr ""
 msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr ""
 
-#: journal/models/review.py:79
+#: journal/models/review.py:80
 #, python-brace-format
 msgid "a review of {title}"
 msgstr ""
 
-#: journal/models/review.py:81
+#: journal/models/review.py:82
 msgid "(may contain spoilers)"
 msgstr ""
 
@@ -5881,7 +5913,7 @@ msgstr ""
 msgid "started following {item}"
 msgstr ""
 
-#: journal/models/shelf.py:923
+#: journal/models/shelf.py:925
 msgid "removed mark"
 msgstr ""
 
@@ -5914,7 +5946,7 @@ msgstr ""
 msgid "Update note"
 msgstr ""
 
-#: journal/templates/_list_item.html:71 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:121
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
@@ -6064,7 +6096,7 @@ msgid "View post"
 msgstr ""
 
 #: journal/templates/action_quote_post.html:3
-#: journal/templates/article.html:190 journal/templates/collection.html:174
+#: journal/templates/article.html:188 journal/templates/collection.html:175
 msgid "Quote"
 msgstr ""
 
@@ -6073,7 +6105,7 @@ msgid "reply"
 msgstr ""
 
 #: journal/templates/action_reply_post.html:3
-#: journal/templates/article.html:181 journal/templates/collection.html:165
+#: journal/templates/article.html:179 journal/templates/collection.html:166
 msgid "Reply"
 msgstr ""
 
@@ -6092,23 +6124,23 @@ msgstr ""
 msgid "Create a new collection"
 msgstr ""
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:76
+#: journal/templates/article.html:102 social/templates/_event_post.html:76
 #, fuzzy
 #| msgid "write a review"
 msgid "wrote a review"
 msgstr "idatzi kritika"
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:78
+#: journal/templates/article.html:104 social/templates/_event_post.html:78
 #, fuzzy
 #| msgid "write a review"
 msgid "wrote an article"
 msgstr "idatzi kritika"
 
-#: journal/templates/article.html:136
+#: journal/templates/article.html:134
 msgid "This article may contain sensitive content. Click to reveal."
 msgstr ""
 
-#: journal/templates/article.html:155
+#: journal/templates/article.html:153
 msgid "The author has set it to be viewable only by logged-in users."
 msgstr ""
 
@@ -6171,20 +6203,20 @@ msgstr ""
 msgid "DEC"
 msgstr ""
 
-#: journal/templates/collection.html:71
+#: journal/templates/collection.html:72
 #: journal/templates/collection_share.html:12
 #: journal/templates/collection_share.html:66
 #: journal/templates/wrapped_share.html:59
 msgid "Share"
 msgstr ""
 
-#: journal/templates/collection.html:86
+#: journal/templates/collection.html:87
 #, fuzzy
 #| msgid "Collection"
 msgid "created a collection"
 msgstr "Kolekzio"
 
-#: journal/templates/collection.html:181
+#: journal/templates/collection.html:182
 msgid "Query"
 msgstr ""
 
@@ -6433,12 +6465,12 @@ msgid "Liked Collections"
 msgstr ""
 
 #: journal/templates/user_follow_list.html:23 journal/views/profile.py:507
-#: users/templates/users/account.html:443
+#: users/templates/users/account.html:455
 msgid "Following"
 msgstr ""
 
 #: journal/templates/user_follow_list.html:28 journal/views/profile.py:511
-#: users/templates/users/account.html:452
+#: users/templates/users/account.html:464
 msgid "Followers"
 msgstr ""
 
@@ -6741,8 +6773,8 @@ msgstr ""
 #: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
 #: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
 #: mastodon/views/threads.py:57 mastodon/views/threads.py:65
-#: mastodon/views/threads.py:71 users/views/account.py:256
-#: users/views/account.py:375
+#: mastodon/views/threads.py:71 users/views/account.py:257
+#: users/views/account.py:376
 msgid "Authentication failed"
 msgstr ""
 
@@ -6780,7 +6812,7 @@ msgstr ""
 msgid "Invalid user."
 msgstr ""
 
-#: mastodon/views/common.py:52 users/views/account.py:416
+#: mastodon/views/common.py:52 users/views/account.py:417
 msgid "Registration failed"
 msgstr ""
 
@@ -7659,120 +7691,133 @@ msgstr "argitaratze urtea"
 msgid "Scopes"
 msgstr ""
 
-#: users/templates/users/account.html:398
+#: users/templates/users/account.html:386
+msgid "Webhook"
+msgstr ""
+
+#: users/templates/users/account.html:400
+msgid "disabled"
+msgstr ""
+
+#: users/templates/users/account.html:402
+msgid "active"
+msgstr ""
+
+#: users/templates/users/account.html:410
 msgid "Revoke access for this application?"
 msgstr ""
 
-#: users/templates/users/account.html:401
+#: users/templates/users/account.html:413
 msgid "Revoke"
 msgstr ""
 
-#: users/templates/users/account.html:409
+#: users/templates/users/account.html:421
 msgid "No authorized applications."
 msgstr ""
 
-#: users/templates/users/account.html:412
+#: users/templates/users/account.html:424
 #: users/templates/users/authorized_app_create.html:9
 #: users/templates/users/authorized_app_create.html:19
 msgid "Create Personal Token"
 msgstr ""
 
-#: users/templates/users/account.html:418
+#: users/templates/users/account.html:430
 msgid "Import/Export Social Graph"
 msgstr ""
 
-#: users/templates/users/account.html:419
+#: users/templates/users/account.html:431
 msgid "Upload a CSV file exported from Mastodon or compatible services."
 msgstr ""
 
-#: users/templates/users/account.html:425
+#: users/templates/users/account.html:437
 msgid "Import type"
 msgstr ""
 
-#: users/templates/users/account.html:427
+#: users/templates/users/account.html:439
 msgid "Following list"
 msgstr ""
 
-#: users/templates/users/account.html:428
+#: users/templates/users/account.html:440
 msgid "Block list"
 msgstr ""
 
-#: users/templates/users/account.html:429
+#: users/templates/users/account.html:441
 msgid "Mute list"
 msgstr ""
 
-#: users/templates/users/account.html:433
+#: users/templates/users/account.html:445
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/account.html:448 users/templates/users/data.html:89
 #: users/templates/users/data.html:141 users/templates/users/data.html:198
 #: users/templates/users/data.html:249 users/templates/users/data.html:313
 #: users/templates/users/data.html:376 users/templates/users/data.html:553
+#: users/templates/users/data.html:606 users/templates/users/data.html:631
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr ""
 
-#: users/templates/users/account.html:447
-#: users/templates/users/account.html:456
-#: users/templates/users/account.html:465
-#: users/templates/users/account.html:474
+#: users/templates/users/account.html:459
+#: users/templates/users/account.html:468
+#: users/templates/users/account.html:477
+#: users/templates/users/account.html:486
 msgid "Download CSV"
 msgstr ""
 
-#: users/templates/users/account.html:461
+#: users/templates/users/account.html:473
 msgid "Blocks"
 msgstr ""
 
-#: users/templates/users/account.html:470
+#: users/templates/users/account.html:482
 msgid "Mutes"
 msgstr ""
 
-#: users/templates/users/account.html:484
+#: users/templates/users/account.html:496
 msgid "Migrate Account"
 msgstr ""
 
-#: users/templates/users/account.html:488
+#: users/templates/users/account.html:500
 msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
 msgstr ""
 
-#: users/templates/users/account.html:491
+#: users/templates/users/account.html:503
 msgid "Migrate another account here"
 msgstr ""
 
-#: users/templates/users/account.html:494
+#: users/templates/users/account.html:506
 msgid "Migrate to another account"
 msgstr ""
 
-#: users/templates/users/account.html:501
+#: users/templates/users/account.html:513
 msgid "Delete Account"
 msgstr ""
 
-#: users/templates/users/account.html:504
+#: users/templates/users/account.html:516
 msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
 msgstr ""
 
-#: users/templates/users/account.html:507
+#: users/templates/users/account.html:519
 msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
 msgstr ""
 
-#: users/templates/users/account.html:517
+#: users/templates/users/account.html:529
 msgid "Once deleted, account data cannot be recovered."
 msgstr ""
 
-#: users/templates/users/account.html:520
+#: users/templates/users/account.html:532
 msgid "Task in progress, can't delete now."
 msgstr ""
 
-#: users/templates/users/account.html:524
+#: users/templates/users/account.html:536
 msgid "Permanently Delete"
 msgstr ""
 
-#: users/templates/users/account.html:565
+#: users/templates/users/account.html:577
 msgid "Delete this passkey?"
 msgstr ""
 
-#: users/templates/users/account.html:585
+#: users/templates/users/account.html:597
 msgid "Rename passkey:"
 msgstr ""
 
@@ -7794,9 +7839,7 @@ msgstr ""
 
 #: users/templates/users/authorized_app_create.html:48
 #: users/templates/users/authorized_app_created.html:39
-#: users/templates/users/migrate_in.html:70
-#: users/templates/users/migrate_out.html:67
-msgid "Back to Preferences"
+msgid "Back to Account"
 msgstr ""
 
 #: users/templates/users/authorized_app_created.html:9
@@ -7935,7 +7978,7 @@ msgstr ""
 msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
 msgstr ""
 
-#: users/templates/users/data.html:89 users/views/data.py:1130
+#: users/templates/users/data.html:89 users/views/data.py:1194
 msgid "Import in progress, please wait"
 msgstr ""
 
@@ -8094,7 +8137,39 @@ msgstr ""
 msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
-#: users/templates/users/data.html:560
+#: users/templates/users/data.html:561
+msgid "Import Twitter / X Archive"
+msgstr ""
+
+#: users/templates/users/data.html:567
+msgid "On X, go to <b>Settings</b> - <b>Your account</b> - <b>Download an archive of your data</b>. Upload the <code>.zip</code> you receive, or only the <code>data/tweets.js</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:570
+msgid "Each tweet becomes a post with its original date, text, links and photos. Replies to your own tweets are kept as a thread. A retweet becomes a short post that links to the original tweet. Videos are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:573
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Tweets that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:615
+msgid "Import Mastodon Archive"
+msgstr ""
+
+#: users/templates/users/data.html:621
+msgid "On your Mastodon server, go to <b>Preferences</b> - <b>Import and export</b> - <b>Request your archive</b>. Upload the <code>.zip</code> you receive, or only the <code>outbox.json</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:624
+msgid "Each post is imported with its original date, text, links, photos, content warning and visibility, so a followers-only post or a direct message stays that way. Replies to your own posts are kept as a thread. A boost becomes a short post that links to the original post. Videos, favourites and bookmarks are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:627
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Posts that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:639
 msgid "View Annual Summary"
 msgstr ""
 
@@ -8217,6 +8292,11 @@ msgstr "azkeneko atalak"
 
 #: users/templates/users/migrate_in.html:64
 msgid "No aliases configured."
+msgstr ""
+
+#: users/templates/users/migrate_in.html:70
+#: users/templates/users/migrate_out.html:67
+msgid "Back to Preferences"
 msgstr ""
 
 #: users/templates/users/migrate_out.html:9
@@ -8727,192 +8807,193 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:126
+#: users/views/account.py:127
 msgid "This username is already in use."
 msgstr ""
 
-#: users/views/account.py:137
+#: users/views/account.py:138
 msgid "This email address is already in use."
 msgstr ""
 
-#: users/views/account.py:257 users/views/account.py:376
+#: users/views/account.py:258 users/views/account.py:377
 msgid "Registration is for invitation only"
 msgstr ""
 
-#: users/views/account.py:268 users/views/account.py:340
+#: users/views/account.py:269 users/views/account.py:341
 msgid "Time is up"
 msgstr ""
 
-#: users/views/account.py:269 users/views/account.py:312
-#: users/views/account.py:341
+#: users/views/account.py:270 users/views/account.py:313
+#: users/views/account.py:342
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:315
+#: users/views/account.py:316
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:327
+#: users/views/account.py:328
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:328
+#: users/views/account.py:329
 msgid "Please try again later."
 msgstr ""
 
-#: users/views/account.py:417
+#: users/views/account.py:418
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:447
+#: users/views/account.py:448
 msgid "Valid username required"
 msgstr ""
 
-#: users/views/account.py:518
+#: users/views/account.py:519
 msgid "Account is being deleted."
 msgstr ""
 
-#: users/views/account.py:521
+#: users/views/account.py:522
 msgid "Account mismatch."
 msgstr ""
 
-#: users/views/data.py:264 users/views/data.py:296
+#: users/views/data.py:276 users/views/data.py:308
 msgid "Export file not available."
 msgstr ""
 
-#: users/views/data.py:290
+#: users/views/data.py:302
 msgid "Generating exports."
 msgstr ""
 
-#: users/views/data.py:308
+#: users/views/data.py:320
 msgid "Export file expired. Please export again."
 msgstr ""
 
-#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
+#: users/views/data.py:335 users/views/data.py:356 users/views/data.py:377
 msgid "Recent export still in progress."
 msgstr ""
 
-#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
-#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
-#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
+#: users/views/data.py:393 users/views/data.py:419 users/views/data.py:447
+#: users/views/data.py:579 users/views/data.py:613 users/views/data.py:838
+#: users/views/data.py:1055 users/views/data.py:1081 users/views/data.py:1106
+#: users/views/data.py:1131 users/views/data.py:1201
 msgid "Invalid file."
 msgstr ""
 
-#: users/views/data.py:405
+#: users/views/data.py:469
 msgid "Sync in progress."
 msgstr ""
 
-#: users/views/data.py:419
+#: users/views/data.py:483
 msgid "Settings saved."
 msgstr ""
 
-#: users/views/data.py:474
+#: users/views/data.py:538
 msgid "Account no longer linked."
 msgstr ""
 
-#: users/views/data.py:477
+#: users/views/data.py:541
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:505
+#: users/views/data.py:569
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:585 users/views/data.py:810
+#: users/views/data.py:649 users/views/data.py:874
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:610 users/views/data.py:839
+#: users/views/data.py:674 users/views/data.py:903
 msgid "Cancelled."
 msgstr ""
 
-#: users/views/data.py:630
+#: users/views/data.py:694
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
-#: users/views/data.py:974
+#: users/views/data.py:702 users/views/data.py:812 users/views/data.py:933
+#: users/views/data.py:1038
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:734 users/views/data.py:960
+#: users/views/data.py:798 users/views/data.py:1024
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:744 users/views/data.py:970
+#: users/views/data.py:808 users/views/data.py:1034
 msgid "No matched file available."
 msgstr ""
 
-#: users/views/data.py:861
+#: users/views/data.py:925
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1290
 #, fuzzy
 #| msgid "required"
 msgid "Name is required."
 msgstr "derrigorrezkoa"
 
-#: users/views/data.py:1248
+#: users/views/data.py:1314
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1264
+#: users/views/data.py:1330
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1269
+#: users/views/data.py:1335
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1279 users/views/data.py:1330
+#: users/views/data.py:1345 users/views/data.py:1396
 msgid "Looking up the account. Please try again in a few seconds."
-msgstr ""
-
-#: users/views/data.py:1286
-#, python-brace-format
-msgid "Alias to {handle} removed."
-msgstr ""
-
-#: users/views/data.py:1291
-#, python-brace-format
-msgid "Alias to {handle} added."
-msgstr ""
-
-#: users/views/data.py:1317
-msgid "Migration cancelled."
-msgstr ""
-
-#: users/views/data.py:1322
-msgid "No target account specified."
-msgstr ""
-
-#: users/views/data.py:1335
-msgid "Cannot migrate to a local account."
-msgstr ""
-
-#: users/views/data.py:1346
-msgid "You must set up an alias in the target account first."
 msgstr ""
 
 #: users/views/data.py:1352
 #, python-brace-format
+msgid "Alias to {handle} removed."
+msgstr ""
+
+#: users/views/data.py:1357
+#, python-brace-format
+msgid "Alias to {handle} added."
+msgstr ""
+
+#: users/views/data.py:1383
+msgid "Migration cancelled."
+msgstr ""
+
+#: users/views/data.py:1388
+msgid "No target account specified."
+msgstr ""
+
+#: users/views/data.py:1401
+msgid "Cannot migrate to a local account."
+msgstr ""
+
+#: users/views/data.py:1412
+msgid "You must set up an alias in the target account first."
+msgstr ""
+
+#: users/views/data.py:1418
+#, python-brace-format
 msgid "Start moving to {handle}."
 msgstr ""
 
-#: users/views/data.py:1410
+#: users/views/data.py:1476
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1426
+#: users/views/data.py:1492
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1430
+#: users/views/data.py:1496
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1440
+#: users/views/data.py:1506
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""

--- a/neodb/locale/fa/LC_MESSAGES/django.po
+++ b/neodb/locale/fa/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 20:04-0400\n"
+"POT-Creation-Date: 2026-09-07 14:56-0400\n"
 "PO-Revision-Date: 2026-08-09 06:31+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/neodb/neodb/fa/>\n"
@@ -59,17 +59,17 @@ msgstr "چینی ساده‌شده"
 msgid "Traditional Chinese"
 msgstr "چینی سنتی"
 
-#: catalog/forms.py:35 catalog/models/item.py:307
+#: catalog/forms.py:35 catalog/models/item.py:412
 #, fuzzy
 msgid "Primary ID Type"
 msgstr "نوع شناسهٔ اصلی"
 
-#: catalog/forms.py:40 catalog/models/item.py:310
+#: catalog/forms.py:40 catalog/models/item.py:415
 #, fuzzy
 msgid "Primary ID Value"
 msgstr "مقدار شناسهٔ اصلی"
 
-#: catalog/forms.py:176
+#: catalog/forms.py:177
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
@@ -123,11 +123,11 @@ msgid "other title"
 msgstr "عنوان دیگر"
 
 #: catalog/models/book.py:282 catalog/models/book.py:566
-#: catalog/models/item.py:119
+#: catalog/models/item.py:224
 msgid "author"
 msgstr "نویسنده"
 
-#: catalog/models/book.py:289 catalog/models/item.py:120
+#: catalog/models/book.py:289 catalog/models/item.py:225
 msgid "translator"
 msgstr "ترجمه‌کننده"
 
@@ -137,7 +137,7 @@ msgid "book format"
 msgstr "قالب‌ کتاب"
 
 #: catalog/models/book.py:303 catalog/models/game.py:135
-#: catalog/models/item.py:134 catalog/models/music.py:142
+#: catalog/models/item.py:239 catalog/models/music.py:142
 msgid "publisher"
 msgstr "ناشر"
 
@@ -169,7 +169,7 @@ msgstr "محتویات"
 msgid "price"
 msgstr "قیمت"
 
-#: catalog/models/book.py:326 catalog/models/item.py:145
+#: catalog/models/book.py:326 catalog/models/item.py:250
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr ""
@@ -593,7 +593,7 @@ msgid "Exhibition"
 msgstr "نمایشگاه"
 
 #: catalog/models/common.py:174 catalog/models/common.py:191
-#: journal/templates/collection.html:29 journal/templates/collection.html:40
+#: journal/templates/collection.html:30 journal/templates/collection.html:41
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
@@ -719,16 +719,16 @@ msgstr ""
 msgid "Special Edition"
 msgstr ""
 
-#: catalog/models/game.py:111 catalog/models/item.py:126
+#: catalog/models/game.py:111 catalog/models/item.py:231
 msgid "designer"
 msgstr "طراح"
 
-#: catalog/models/game.py:119 catalog/models/item.py:125
+#: catalog/models/game.py:119 catalog/models/item.py:230
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr "هنرمند"
 
-#: catalog/models/game.py:127 catalog/models/item.py:135
+#: catalog/models/game.py:127 catalog/models/item.py:240
 msgid "developer"
 msgstr "توسعه‌دهنده"
 
@@ -758,144 +758,144 @@ msgstr ""
 msgid "website"
 msgstr "وبگاه"
 
-#: catalog/models/item.py:121 catalog/models/movie.py:123
+#: catalog/models/item.py:226 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
 #: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr ""
 
-#: catalog/models/item.py:122 catalog/models/movie.py:130
+#: catalog/models/item.py:227 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
 #: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr ""
 
-#: catalog/models/item.py:123 catalog/models/movie.py:137
+#: catalog/models/item.py:228 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
 #: catalog/models/tv.py:230 catalog/models/tv.py:456
 #, fuzzy
 msgid "actor"
 msgstr "بازیگر"
 
-#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/item.py:229 catalog/models/movie.py:144
 #: catalog/models/tv.py:237 catalog/models/tv.py:463
 msgid "producer"
 msgstr ""
 
-#: catalog/models/item.py:127 catalog/models/performance.py:203
+#: catalog/models/item.py:232 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr ""
 
-#: catalog/models/item.py:128 catalog/models/performance.py:210
+#: catalog/models/item.py:233 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr ""
 
-#: catalog/models/item.py:129 catalog/models/performance.py:224
+#: catalog/models/item.py:234 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr ""
 
-#: catalog/models/item.py:130 catalog/models/podcast.py:80
+#: catalog/models/item.py:235 catalog/models/podcast.py:80
 msgid "host"
 msgstr ""
 
-#: catalog/models/item.py:131 catalog/models/performance.py:196
+#: catalog/models/item.py:236 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr ""
 
-#: catalog/models/item.py:132 catalog/models/performance.py:238
+#: catalog/models/item.py:237 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr ""
 
-#: catalog/models/item.py:136
+#: catalog/models/item.py:241
 #, fuzzy
 msgid "production company"
 msgstr "تولید"
 
-#: catalog/models/item.py:137
+#: catalog/models/item.py:242
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:138
+#: catalog/models/item.py:243
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:139
+#: catalog/models/item.py:244
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:140 catalog/models/performance.py:231
+#: catalog/models/item.py:245 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr ""
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:248
 #, fuzzy
 msgid "voice actor"
 msgstr "بازیگر"
 
-#: catalog/models/item.py:144 catalog/templates/edition.html:30
+#: catalog/models/item.py:249 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr ""
 
-#: catalog/models/item.py:169 catalog/models/people.py:476
+#: catalog/models/item.py:274 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr ""
 
-#: catalog/models/item.py:170 catalog/models/people.py:155
+#: catalog/models/item.py:275 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr ""
 
-#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:277 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:304 catalog/models/item.py:336
-#: journal/models/collection.py:100
+#: catalog/models/item.py:409 catalog/models/item.py:441
+#: journal/models/collection.py:101
 msgid "title"
 msgstr "عنوان"
 
-#: catalog/models/item.py:305 catalog/models/item.py:344
-#: journal/models/collection.py:101
+#: catalog/models/item.py:410 catalog/models/item.py:449
+#: journal/models/collection.py:102
 msgid "description"
 msgstr "توضیحات"
 
-#: catalog/models/item.py:316 catalog/models/people.py:484
+#: catalog/models/item.py:421 catalog/models/people.py:484
 msgid "metadata"
 msgstr "فراداده"
 
-#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:423 catalog/templates/_item_card.html:28
 msgid "cover"
 msgstr "جلد"
 
-#: catalog/models/item.py:1526
+#: catalog/models/item.py:1612
 msgid "source site"
 msgstr "وبگاه منبع"
 
-#: catalog/models/item.py:1528
+#: catalog/models/item.py:1614
 msgid "ID on source site"
 msgstr ""
 
-#: catalog/models/item.py:1530
+#: catalog/models/item.py:1616
 msgid "source url"
 msgstr ""
 
-#: catalog/models/item.py:1546
+#: catalog/models/item.py:1632
 msgid "IdType of the source site"
 msgstr ""
 
-#: catalog/models/item.py:1552
+#: catalog/models/item.py:1638
 msgid "Primary Id on the source site"
 msgstr ""
 
-#: catalog/models/item.py:1555
+#: catalog/models/item.py:1641
 msgid "url to the resource"
 msgstr ""
 
@@ -1192,12 +1192,12 @@ msgstr ""
 #: catalog/templates/_item_card_metadata_tvseason.html:7
 #: catalog/templates/_item_card_metadata_tvshow.html:7
 #: catalog/templates/_item_card_metadata_work.html:7
-#: catalog/templates/item_base.html:201
+#: catalog/templates/item_base.html:186
 msgid "ratings"
 msgstr ""
 
-#: catalog/templates/_item_card_metadata_base.html:34
-#: catalog/templates/item_base.html:256
+#: catalog/templates/_item_card_metadata_base.html:28
+#: catalog/templates/item_base.html:241
 msgid "part of"
 msgstr ""
 
@@ -1215,14 +1215,14 @@ msgid "hide this tooltip"
 msgstr ""
 
 #: catalog/templates/_item_comments.html:58
-#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:83
+#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:81
 msgid "translate"
 msgstr ""
 
 #: catalog/templates/_item_comments.html:92
 #: catalog/templates/_item_comments_by_episode.html:80
 #: catalog/templates/_item_notes.html:88
-#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:284
+#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:269
 #: catalog/templates/podcast_episode_data.html:41
 msgid "show more"
 msgstr ""
@@ -1331,8 +1331,8 @@ msgstr ""
 #: catalog/templates/_item_user_pieces.html:101
 #: catalog/templates/catalog_edit.html:12
 #: journal/templates/action_edit_post.html:6
-#: journal/templates/action_edit_post.html:8 journal/templates/article.html:196
-#: journal/templates/collection.html:185 journal/templates/collection.html:193
+#: journal/templates/action_edit_post.html:8 journal/templates/article.html:194
+#: journal/templates/collection.html:186 journal/templates/collection.html:194
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_edit.html:26
 #: journal/templates/post_compose.html:16 journal/templates/tag_edit.html:16
@@ -1374,7 +1374,7 @@ msgstr ""
 #: catalog/templates/_sidebar_edit.html:20
 #: catalog/templates/catalog_verify.html:11
 #: catalog/templates/catalog_verify.html:17
-#: catalog/templates/item_base.html:182
+#: catalog/templates/item_base.html:167
 msgid "Creator verification"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgstr ""
 msgid "Edit Options"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
+#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:163
 #: catalog/views/edit.py:160 catalog/views/edit.py:221
 #: catalog/views/edit.py:288 catalog/views/edit.py:309
 #: catalog/views/edit.py:364 catalog/views/edit.py:471
@@ -1542,7 +1542,7 @@ msgstr ""
 #: catalog/templates/_sidebar_edit.html:265
 #: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
-#: journal/templates/article.html:199 journal/templates/collection.html:188
+#: journal/templates/article.html:197 journal/templates/collection.html:189
 #: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
@@ -1727,7 +1727,7 @@ msgstr ""
 msgid "Remove my verification"
 msgstr ""
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:311
+#: catalog/templates/_verify_status.html:31 users/views/account.py:312
 msgid "Verification failed"
 msgstr ""
 
@@ -1913,7 +1913,7 @@ msgstr ""
 
 #: catalog/templates/discover.html:229
 #: catalog/templates/discover_original_podcasts.html:25
-#: catalog/templates/item_base.html:282
+#: catalog/templates/item_base.html:267
 #: catalog/templates/item_mark_list.html:71
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
@@ -1981,67 +1981,67 @@ msgstr ""
 msgid "System busy, please try again in a minute."
 msgstr ""
 
-#: catalog/templates/item_base.html:95
+#: catalog/templates/item_base.html:80
 msgid "select one of the seasons to comment"
 msgstr ""
 
-#: catalog/templates/item_base.html:129
+#: catalog/templates/item_base.html:114
 msgid "mark, comment and collect"
 msgstr ""
 
-#: catalog/templates/item_base.html:142
+#: catalog/templates/item_base.html:127
 msgid "Login or register to review or add this item to your collection."
 msgstr ""
 
-#: catalog/templates/item_base.html:151
+#: catalog/templates/item_base.html:136
 msgid "Related Collections"
 msgstr ""
 
-#: catalog/templates/item_base.html:166
+#: catalog/templates/item_base.html:151
 msgid "Unsupported item type."
 msgstr ""
 
-#: catalog/templates/item_base.html:176
+#: catalog/templates/item_base.html:161
 msgid "Edit this item"
 msgstr ""
 
-#: catalog/templates/item_base.html:187
+#: catalog/templates/item_base.html:172
 msgid "Last edited"
 msgstr ""
 
-#: catalog/templates/item_base.html:230
+#: catalog/templates/item_base.html:215
 msgid "No enough ratings"
 msgstr ""
 
-#: catalog/templates/item_base.html:274
+#: catalog/templates/item_base.html:259
 msgid "overview"
 msgstr ""
 
-#: catalog/templates/item_base.html:305
+#: catalog/templates/item_base.html:290
 msgid "comments"
 msgstr ""
 
-#: catalog/templates/item_base.html:308
+#: catalog/templates/item_base.html:293
 #: catalog/templates/item_mark_list.html:22
 #: catalog/templates/item_mark_list.html:25
 #: catalog/templates/item_review_list.html:21
 msgid "marks"
 msgstr ""
 
-#: catalog/templates/item_base.html:309
+#: catalog/templates/item_base.html:294
 #: catalog/templates/item_mark_list.html:23
 #: catalog/templates/item_mark_list.html:26
 #: catalog/templates/item_review_list.html:22
 msgid "marks from who you follow"
 msgstr ""
 
-#: catalog/templates/item_base.html:323
+#: catalog/templates/item_base.html:308
 #: catalog/templates/item_mark_list.html:28
 #: catalog/templates/item_review_list.html:23
 msgid "reviews"
 msgstr ""
 
-#: catalog/templates/item_base.html:333
+#: catalog/templates/item_base.html:318
 msgid "notes"
 msgstr ""
 
@@ -2416,7 +2416,7 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
+#: catalog/views/verify.py:164 common/utils.py:148 common/utils.py:189
 #: journal/views/article.py:186 journal/views/review.py:182
 #: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
@@ -4094,7 +4094,7 @@ msgstr ""
 msgid "Open Registration"
 msgstr ""
 
-#: common/templates/common/about.html:40 common/views_manage.py:657
+#: common/templates/common/about.html:40 common/views_manage.py:671
 msgid "Preferred Languages"
 msgstr ""
 
@@ -4150,7 +4150,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:738
+#: common/templates/common/scan.html:60 common/views_manage.py:756
 msgid "Search"
 msgstr ""
 
@@ -4230,16 +4230,16 @@ msgstr ""
 msgid "unavailable"
 msgstr ""
 
-#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
+#: common/utils.py:152 common/utils.py:193 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr ""
 
-#: common/utils.py:135 common/utils.py:137 common/utils.py:140
-#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
+#: common/utils.py:159 common/utils.py:161 common/utils.py:164
+#: common/utils.py:200 common/utils.py:204 journal/views/profile.py:499
 msgid "Access denied"
 msgstr ""
 
-#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
+#: common/utils.py:167 common/utils.py:169 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr ""
@@ -4258,7 +4258,7 @@ msgstr ""
 msgid "Access"
 msgstr ""
 
-#: common/views_manage.py:39 common/views_manage.py:733
+#: common/views_manage.py:39 common/views_manage.py:751
 #, fuzzy
 #| msgid "description"
 msgid "Federation"
@@ -4612,446 +4612,474 @@ msgid "Sender name and address for outgoing email."
 msgstr ""
 
 #: common/views_manage.py:649
+msgid "Enable Twitter / X Archive Import"
+msgstr ""
+
+#: common/views_manage.py:651
+msgid "Show the Twitter / X archive import on the data page. Imported tweets become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:656
+msgid "Enable Mastodon Archive Import"
+msgstr ""
+
+#: common/views_manage.py:658
+msgid "Show the Mastodon archive import on the data page. Imported posts become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:663
 #, fuzzy
 #| msgid "language"
 msgid "Default Language"
 msgstr "زبان"
 
-#: common/views_manage.py:652
+#: common/views_manage.py:666
 msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:673
 msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:665
+#: common/views_manage.py:679
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:672
+#: common/views_manage.py:686
 msgid "Login Methods"
 msgstr ""
 
-#: common/views_manage.py:677 mastodon/models/common.py:30
+#: common/views_manage.py:691 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr ""
 
-#: common/views_manage.py:681
-msgid "Localization"
-msgstr ""
-
-#: common/views_manage.py:692
-msgid "Disable Default Relay"
-msgstr ""
-
-#: common/views_manage.py:694
-msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
+#: common/views_manage.py:695
+msgid "Data Import"
 msgstr ""
 
 #: common/views_manage.py:699
-msgid "Fanout Limit (days)"
+msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:700
-msgid "Posts older than this many days will not be fanned out."
-msgstr ""
-
-#: common/views_manage.py:704
-msgid "Remote Prune Horizon (days)"
-msgstr ""
-
-#: common/views_manage.py:706
-msgid "Remote profiles inactive for this many days will be pruned."
-msgstr ""
-
-#: common/views_manage.py:711
-msgid "Search Sites"
+#: common/views_manage.py:710
+msgid "Disable Default Relay"
 msgstr ""
 
 #: common/views_manage.py:712
+msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
+msgstr ""
+
+#: common/views_manage.py:717
+msgid "Fanout Limit (days)"
+msgstr ""
+
+#: common/views_manage.py:718
+msgid "Posts older than this many days will not be fanned out."
+msgstr ""
+
+#: common/views_manage.py:722
+msgid "Remote Prune Horizon (days)"
+msgstr ""
+
+#: common/views_manage.py:724
+msgid "Remote profiles inactive for this many days will be pruned."
+msgstr ""
+
+#: common/views_manage.py:729
+msgid "Search Sites"
+msgstr ""
+
+#: common/views_manage.py:730
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:715
+#: common/views_manage.py:733
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:716
+#: common/views_manage.py:734
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:719
+#: common/views_manage.py:737
 msgid "Hidden Categories"
 msgstr ""
 
-#: common/views_manage.py:720
+#: common/views_manage.py:738
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:723
+#: common/views_manage.py:741
 msgid "Guest Search Page Limit"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:743
 msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
 msgstr ""
 
-#: common/views_manage.py:751
+#: common/views_manage.py:769
 #, fuzzy
 msgid "Spotify API Key"
 msgstr "آلبوم اسپاتیفای"
 
-#: common/views_manage.py:752
+#: common/views_manage.py:770
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:773
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:756
+#: common/views_manage.py:774
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:759
+#: common/views_manage.py:777
 #, fuzzy
 #| msgid "Google Books"
 msgid "Google Books API Key"
 msgstr "کتاب‌های گوگل"
 
-#: common/views_manage.py:760
+#: common/views_manage.py:778
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:763
+#: common/views_manage.py:781
 #, fuzzy
 #| msgid "Discogs Master"
 msgid "Discogs API Key"
 msgstr "استاد دیسکاگ ها"
 
-#: common/views_manage.py:765
+#: common/views_manage.py:783
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:769
+#: common/views_manage.py:787
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:770
+#: common/views_manage.py:788
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:773
+#: common/views_manage.py:791
 msgid "IGDB Client Secret"
 msgstr ""
 
-#: common/views_manage.py:776
+#: common/views_manage.py:794
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:778
+#: common/views_manage.py:796
 msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:783
+#: common/views_manage.py:801
 msgid "MyAnimeList Client ID"
 msgstr ""
 
-#: common/views_manage.py:785
+#: common/views_manage.py:803
 msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
 msgstr ""
 
-#: common/views_manage.py:790 users/templates/users/steam_import.html:26
+#: common/views_manage.py:808 users/templates/users/steam_import.html:26
 #, fuzzy
 #| msgid "Steam Game"
 msgid "Steam API Key"
 msgstr "بازی استیم"
 
-#: common/views_manage.py:792
+#: common/views_manage.py:810
 msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:797
+#: common/views_manage.py:815
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:798
+#: common/views_manage.py:816
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:801
+#: common/views_manage.py:819
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:804
+#: common/views_manage.py:822
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:807
+#: common/views_manage.py:825
 msgid "Threads App ID"
 msgstr ""
 
-#: common/views_manage.py:808
+#: common/views_manage.py:826
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:811
+#: common/views_manage.py:829
 msgid "Threads App Secret"
 msgstr ""
 
-#: common/views_manage.py:814
+#: common/views_manage.py:832
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:834
 msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:833
+#: common/views_manage.py:851
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:844
+#: common/views_manage.py:862
 #, fuzzy
 #| msgid "translator"
 msgid "Translation"
 msgstr "ترجمه‌کننده"
 
-#: common/views_manage.py:849
+#: common/views_manage.py:867
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:853 social/templates/feed.html:27
+#: common/views_manage.py:871 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr ""
 
-#: common/views_manage.py:863
+#: common/views_manage.py:881
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:882
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:885
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:868
+#: common/views_manage.py:886
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:871
+#: common/views_manage.py:889
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:874
+#: common/views_manage.py:892
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:877
+#: common/views_manage.py:895
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:880
+#: common/views_manage.py:898
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:883
+#: common/views_manage.py:901
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:886
+#: common/views_manage.py:904
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:887
+#: common/views_manage.py:905
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:908
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:894
+#: common/views_manage.py:912
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:898
+#: common/views_manage.py:916
 #, fuzzy
 #| msgid "series"
 msgid "Retries"
 msgstr "دنباله‌ها"
 
-#: common/views_manage.py:903
+#: common/views_manage.py:921
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:908
+#: common/views_manage.py:926
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:915
+#: common/views_manage.py:933
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:927
+#: common/views_manage.py:945
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:928
+#: common/views_manage.py:946
 msgid "One domain per line."
 msgstr ""
 
-#: common/views_manage.py:931
+#: common/views_manage.py:949
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:932
+#: common/views_manage.py:950
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:935
+#: common/views_manage.py:953
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:937
+#: common/views_manage.py:955
 msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:943
+#: common/views_manage.py:961
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:944
+#: common/views_manage.py:962
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:947
+#: common/views_manage.py:965
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:948
+#: common/views_manage.py:966
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:958
+#: common/views_manage.py:976
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:960
+#: common/views_manage.py:978
 msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:966
+#: common/views_manage.py:984
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:968
+#: common/views_manage.py:986
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:974
+#: common/views_manage.py:992
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:976
+#: common/views_manage.py:994
 msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:983
+#: common/views_manage.py:1000
+msgid "Webhook Timeout (milliseconds)"
+msgstr ""
+
+#: common/views_manage.py:1001
+msgid "Timeout for delivering webhook requests to applications."
+msgstr ""
+
+#: common/views_manage.py:1006
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:986
+#: common/views_manage.py:1009
 msgid "Operational"
 msgstr ""
 
-#: common/views_manage.py:1002
+#: common/views_manage.py:1026
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:1004
+#: common/views_manage.py:1028
 msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1009
+#: common/views_manage.py:1033
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:1011
+#: common/views_manage.py:1035
 msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1016
+#: common/views_manage.py:1040
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:1018
+#: common/views_manage.py:1042
 msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1023
+#: common/views_manage.py:1047
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:1025
+#: common/views_manage.py:1049
 msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1030
+#: common/views_manage.py:1054
 #, fuzzy
 #| msgid "Podcast"
 msgid "Podcast Genres"
 msgstr "پادپخش"
 
-#: common/views_manage.py:1032
+#: common/views_manage.py:1056
 msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1037
+#: common/views_manage.py:1061
 #, fuzzy
 #| msgid "Performance"
 msgid "Performance Genres"
 msgstr "عملکرد"
 
-#: common/views_manage.py:1039
+#: common/views_manage.py:1063
 msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1045
+#: common/views_manage.py:1069
 msgid "Genres by Category"
 msgstr ""
 
-#: common/views_manage.py:1069
+#: common/views_manage.py:1093
 msgid "Site"
 msgstr ""
 
-#: common/views_manage.py:1079
+#: common/views_manage.py:1103
 msgid "Database and Services"
 msgstr ""
 
-#: common/views_manage.py:1089
+#: common/views_manage.py:1113
 msgid "Media and Files"
 msgstr ""
 
-#: common/views_manage.py:1098
+#: common/views_manage.py:1122
 msgid "Monitoring"
 msgstr ""
 
-#: common/views_manage.py:1102
+#: common/views_manage.py:1126
 msgid "Security"
 msgstr ""
 
-#: common/views_manage.py:1111
+#: common/views_manage.py:1135
 msgid "Other Environment Variables"
 msgstr ""
 
-#: common/views_manage.py:1113
+#: common/views_manage.py:1137
 msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
 msgstr ""
 
@@ -5095,7 +5123,8 @@ msgstr ""
 #: users/templates/users/data.html:60 users/templates/users/data.html:113
 #: users/templates/users/data.html:170 users/templates/users/data.html:221
 #: users/templates/users/data.html:284 users/templates/users/data.html:346
-#: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
+#: users/templates/users/data.html:525 users/templates/users/data.html:578
+#: users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
 msgid "Visibility"
@@ -5125,8 +5154,8 @@ msgstr ""
 msgid "owner and their local mutuals"
 msgstr ""
 
-#: journal/forms.py:169 journal/templates/collection.html:193
-#: journal/templates/collection.html:202
+#: journal/forms.py:169 journal/templates/collection.html:194
+#: journal/templates/collection.html:203
 msgid "Collaborative editing"
 msgstr ""
 
@@ -5177,7 +5206,7 @@ msgstr ""
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:215 journal/views/article.py:218
+#: journal/models/article.py:224 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
@@ -5189,73 +5218,74 @@ msgstr ""
 msgid "note"
 msgstr ""
 
-#: journal/models/collection.py:115
+#: journal/models/collection.py:116
 msgid "search query for dynamic collection"
 msgstr ""
 
-#: journal/models/collection.py:566 journal/templatetags/collection.py:35
+#: journal/models/collection.py:575 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:571 journal/templatetags/collection.py:43
+#: journal/models/collection.py:580 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:576 journal/templatetags/collection.py:51
+#: journal/models/collection.py:585 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:581 journal/templatetags/collection.py:59
+#: journal/models/collection.py:590 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:586 journal/templatetags/collection.py:67
+#: journal/models/collection.py:595 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:591 journal/templatetags/collection.py:75
+#: journal/models/collection.py:600 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:597 journal/templatetags/collection.py:83
+#: journal/models/collection.py:606 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:605 journal/templatetags/collection.py:91
+#: journal/models/collection.py:614 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/models/common.py:59 journal/templates/action_open_post.html:15
 #: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
 #: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
 #: users/templates/users/data.html:122 users/templates/users/data.html:179
 #: users/templates/users/data.html:230 users/templates/users/data.html:292
 #: users/templates/users/data.html:355 users/templates/users/data.html:534
+#: users/templates/users/data.html:587
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5263,13 +5293,14 @@ msgstr[1] ""
 msgid "Public"
 msgstr ""
 
-#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/models/common.py:60 journal/templates/action_open_post.html:9
 #: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
 #: users/templates/users/data.html:130 users/templates/users/data.html:187
 #: users/templates/users/data.html:238 users/templates/users/data.html:300
 #: users/templates/users/data.html:363 users/templates/users/data.html:542
+#: users/templates/users/data.html:595
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5277,12 +5308,13 @@ msgstr ""
 msgid "Followers Only"
 msgstr ""
 
-#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/models/common.py:61 journal/templates/collection_share.html:57
 #: journal/templates/mark.html:102 journal/templates/post_compose.html:72
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
 #: users/templates/users/data.html:138 users/templates/users/data.html:195
 #: users/templates/users/data.html:246 users/templates/users/data.html:308
 #: users/templates/users/data.html:371 users/templates/users/data.html:550
+#: users/templates/users/data.html:603
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5290,27 +5322,27 @@ msgstr ""
 msgid "Mentioned Only"
 msgstr ""
 
-#: journal/models/common.py:806
+#: journal/models/common.py:851
 msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr ""
 
-#: journal/models/common.py:1003
+#: journal/models/common.py:1048
 msgid "A recent post was not posted to Threads."
 msgstr ""
 
-#: journal/models/common.py:1036
+#: journal/models/common.py:1081
 msgid "A recent post was not boosted on Mastodon."
 msgstr ""
 
-#: journal/models/common.py:1046
+#: journal/models/common.py:1091
 msgid "Original post no longer exists."
 msgstr ""
 
-#: journal/models/common.py:1060
+#: journal/models/common.py:1105
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr ""
 
-#: journal/models/common.py:1069
+#: journal/models/common.py:1114
 msgid "A recent post was not posted to Mastodon."
 msgstr ""
 
@@ -5326,81 +5358,81 @@ msgstr ""
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:475
+#: journal/models/mark.py:477
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:479
+#: journal/models/mark.py:481
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:486
+#: journal/models/mark.py:488
 msgid "Invalid progress type."
 msgstr ""
 
-#: journal/models/mark.py:488
+#: journal/models/mark.py:490
 msgid "Invalid progress type for this item."
 msgstr ""
 
-#: journal/models/note.py:47 users/templates/users/rym_import.html:73
+#: journal/models/note.py:48 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr ""
 
-#: journal/models/note.py:48
+#: journal/models/note.py:49
 msgid "Chapter"
 msgstr ""
 
-#: journal/models/note.py:51
+#: journal/models/note.py:52
 msgid "Part"
 msgstr ""
 
-#: journal/models/note.py:52
+#: journal/models/note.py:53
 msgid "Episode"
 msgstr ""
 
-#: journal/models/note.py:53
+#: journal/models/note.py:54
 msgid "Track"
 msgstr ""
 
-#: journal/models/note.py:54
+#: journal/models/note.py:55
 msgid "Cycle"
 msgstr ""
 
-#: journal/models/note.py:55
+#: journal/models/note.py:56
 msgid "Timestamp"
 msgstr ""
 
-#: journal/models/note.py:56
+#: journal/models/note.py:57
 msgid "Percentage"
-msgstr ""
-
-#: journal/models/note.py:77
-#, python-brace-format
-msgid "Page {value}"
 msgstr ""
 
 #: journal/models/note.py:78
 #, python-brace-format
-msgid "Chapter {value}"
+msgid "Page {value}"
 msgstr ""
 
-#: journal/models/note.py:81
+#: journal/models/note.py:79
 #, python-brace-format
-msgid "Part {value}"
+msgid "Chapter {value}"
 msgstr ""
 
 #: journal/models/note.py:82
 #, python-brace-format
-msgid "Episode {value}"
+msgid "Part {value}"
 msgstr ""
 
 #: journal/models/note.py:83
 #, python-brace-format
-msgid "Track {value}"
+msgid "Episode {value}"
 msgstr ""
 
 #: journal/models/note.py:84
+#, python-brace-format
+msgid "Track {value}"
+msgstr ""
+
+#: journal/models/note.py:85
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr ""
@@ -5410,12 +5442,12 @@ msgstr ""
 msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr ""
 
-#: journal/models/review.py:79
+#: journal/models/review.py:80
 #, python-brace-format
 msgid "a review of {title}"
 msgstr ""
 
-#: journal/models/review.py:81
+#: journal/models/review.py:82
 msgid "(may contain spoilers)"
 msgstr ""
 
@@ -5842,7 +5874,7 @@ msgstr ""
 msgid "started following {item}"
 msgstr ""
 
-#: journal/models/shelf.py:923
+#: journal/models/shelf.py:925
 msgid "removed mark"
 msgstr ""
 
@@ -5875,7 +5907,7 @@ msgstr ""
 msgid "Update note"
 msgstr ""
 
-#: journal/templates/_list_item.html:71 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:121
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
@@ -6027,7 +6059,7 @@ msgid "View post"
 msgstr ""
 
 #: journal/templates/action_quote_post.html:3
-#: journal/templates/article.html:190 journal/templates/collection.html:174
+#: journal/templates/article.html:188 journal/templates/collection.html:175
 msgid "Quote"
 msgstr ""
 
@@ -6036,7 +6068,7 @@ msgid "reply"
 msgstr ""
 
 #: journal/templates/action_reply_post.html:3
-#: journal/templates/article.html:181 journal/templates/collection.html:165
+#: journal/templates/article.html:179 journal/templates/collection.html:166
 msgid "Reply"
 msgstr ""
 
@@ -6055,19 +6087,19 @@ msgstr ""
 msgid "Create a new collection"
 msgstr ""
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:76
+#: journal/templates/article.html:102 social/templates/_event_post.html:76
 msgid "wrote a review"
 msgstr ""
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:78
+#: journal/templates/article.html:104 social/templates/_event_post.html:78
 msgid "wrote an article"
 msgstr ""
 
-#: journal/templates/article.html:136
+#: journal/templates/article.html:134
 msgid "This article may contain sensitive content. Click to reveal."
 msgstr ""
 
-#: journal/templates/article.html:155
+#: journal/templates/article.html:153
 msgid "The author has set it to be viewable only by logged-in users."
 msgstr ""
 
@@ -6128,20 +6160,20 @@ msgstr ""
 msgid "DEC"
 msgstr ""
 
-#: journal/templates/collection.html:71
+#: journal/templates/collection.html:72
 #: journal/templates/collection_share.html:12
 #: journal/templates/collection_share.html:66
 #: journal/templates/wrapped_share.html:59
 msgid "Share"
 msgstr ""
 
-#: journal/templates/collection.html:86
+#: journal/templates/collection.html:87
 #, fuzzy
 #| msgid "Collection"
 msgid "created a collection"
 msgstr "مجموعه"
 
-#: journal/templates/collection.html:181
+#: journal/templates/collection.html:182
 msgid "Query"
 msgstr ""
 
@@ -6388,12 +6420,12 @@ msgid "Liked Collections"
 msgstr ""
 
 #: journal/templates/user_follow_list.html:23 journal/views/profile.py:507
-#: users/templates/users/account.html:443
+#: users/templates/users/account.html:455
 msgid "Following"
 msgstr ""
 
 #: journal/templates/user_follow_list.html:28 journal/views/profile.py:511
-#: users/templates/users/account.html:452
+#: users/templates/users/account.html:464
 msgid "Followers"
 msgstr ""
 
@@ -6696,8 +6728,8 @@ msgstr ""
 #: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
 #: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
 #: mastodon/views/threads.py:57 mastodon/views/threads.py:65
-#: mastodon/views/threads.py:71 users/views/account.py:256
-#: users/views/account.py:375
+#: mastodon/views/threads.py:71 users/views/account.py:257
+#: users/views/account.py:376
 msgid "Authentication failed"
 msgstr ""
 
@@ -6735,7 +6767,7 @@ msgstr ""
 msgid "Invalid user."
 msgstr ""
 
-#: mastodon/views/common.py:52 users/views/account.py:416
+#: mastodon/views/common.py:52 users/views/account.py:417
 msgid "Registration failed"
 msgstr ""
 
@@ -7616,122 +7648,135 @@ msgstr "سال انتشار"
 msgid "Scopes"
 msgstr ""
 
-#: users/templates/users/account.html:398
+#: users/templates/users/account.html:386
+msgid "Webhook"
+msgstr ""
+
+#: users/templates/users/account.html:400
+msgid "disabled"
+msgstr ""
+
+#: users/templates/users/account.html:402
+msgid "active"
+msgstr ""
+
+#: users/templates/users/account.html:410
 msgid "Revoke access for this application?"
 msgstr ""
 
-#: users/templates/users/account.html:401
+#: users/templates/users/account.html:413
 msgid "Revoke"
 msgstr ""
 
-#: users/templates/users/account.html:409
+#: users/templates/users/account.html:421
 msgid "No authorized applications."
 msgstr ""
 
-#: users/templates/users/account.html:412
+#: users/templates/users/account.html:424
 #: users/templates/users/authorized_app_create.html:9
 #: users/templates/users/authorized_app_create.html:19
 msgid "Create Personal Token"
 msgstr ""
 
-#: users/templates/users/account.html:418
+#: users/templates/users/account.html:430
 msgid "Import/Export Social Graph"
 msgstr ""
 
-#: users/templates/users/account.html:419
+#: users/templates/users/account.html:431
 msgid "Upload a CSV file exported from Mastodon or compatible services."
 msgstr ""
 
-#: users/templates/users/account.html:425
+#: users/templates/users/account.html:437
 msgid "Import type"
 msgstr ""
 
-#: users/templates/users/account.html:427
+#: users/templates/users/account.html:439
 msgid "Following list"
 msgstr ""
 
-#: users/templates/users/account.html:428
+#: users/templates/users/account.html:440
 msgid "Block list"
 msgstr ""
 
-#: users/templates/users/account.html:429
+#: users/templates/users/account.html:441
 msgid "Mute list"
 msgstr ""
 
-#: users/templates/users/account.html:433
+#: users/templates/users/account.html:445
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/account.html:448 users/templates/users/data.html:89
 #: users/templates/users/data.html:141 users/templates/users/data.html:198
 #: users/templates/users/data.html:249 users/templates/users/data.html:313
 #: users/templates/users/data.html:376 users/templates/users/data.html:553
+#: users/templates/users/data.html:606 users/templates/users/data.html:631
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr ""
 
-#: users/templates/users/account.html:447
-#: users/templates/users/account.html:456
-#: users/templates/users/account.html:465
-#: users/templates/users/account.html:474
+#: users/templates/users/account.html:459
+#: users/templates/users/account.html:468
+#: users/templates/users/account.html:477
+#: users/templates/users/account.html:486
 #, fuzzy
 #| msgid "Downloadable Content"
 msgid "Download CSV"
 msgstr "محتوای قابل بارگیری"
 
-#: users/templates/users/account.html:461
+#: users/templates/users/account.html:473
 msgid "Blocks"
 msgstr ""
 
-#: users/templates/users/account.html:470
+#: users/templates/users/account.html:482
 msgid "Mutes"
 msgstr ""
 
-#: users/templates/users/account.html:484
+#: users/templates/users/account.html:496
 msgid "Migrate Account"
 msgstr ""
 
-#: users/templates/users/account.html:488
+#: users/templates/users/account.html:500
 msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
 msgstr ""
 
-#: users/templates/users/account.html:491
+#: users/templates/users/account.html:503
 msgid "Migrate another account here"
 msgstr ""
 
-#: users/templates/users/account.html:494
+#: users/templates/users/account.html:506
 msgid "Migrate to another account"
 msgstr ""
 
-#: users/templates/users/account.html:501
+#: users/templates/users/account.html:513
 msgid "Delete Account"
 msgstr ""
 
-#: users/templates/users/account.html:504
+#: users/templates/users/account.html:516
 msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
 msgstr ""
 
-#: users/templates/users/account.html:507
+#: users/templates/users/account.html:519
 msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
 msgstr ""
 
-#: users/templates/users/account.html:517
+#: users/templates/users/account.html:529
 msgid "Once deleted, account data cannot be recovered."
 msgstr ""
 
-#: users/templates/users/account.html:520
+#: users/templates/users/account.html:532
 msgid "Task in progress, can't delete now."
 msgstr ""
 
-#: users/templates/users/account.html:524
+#: users/templates/users/account.html:536
 msgid "Permanently Delete"
 msgstr ""
 
-#: users/templates/users/account.html:565
+#: users/templates/users/account.html:577
 msgid "Delete this passkey?"
 msgstr ""
 
-#: users/templates/users/account.html:585
+#: users/templates/users/account.html:597
 msgid "Rename passkey:"
 msgstr ""
 
@@ -7753,9 +7798,7 @@ msgstr ""
 
 #: users/templates/users/authorized_app_create.html:48
 #: users/templates/users/authorized_app_created.html:39
-#: users/templates/users/migrate_in.html:70
-#: users/templates/users/migrate_out.html:67
-msgid "Back to Preferences"
+msgid "Back to Account"
 msgstr ""
 
 #: users/templates/users/authorized_app_created.html:9
@@ -7894,7 +7937,7 @@ msgstr ""
 msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
 msgstr ""
 
-#: users/templates/users/data.html:89 users/views/data.py:1130
+#: users/templates/users/data.html:89 users/views/data.py:1194
 msgid "Import in progress, please wait"
 msgstr ""
 
@@ -8053,7 +8096,39 @@ msgstr ""
 msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
-#: users/templates/users/data.html:560
+#: users/templates/users/data.html:561
+msgid "Import Twitter / X Archive"
+msgstr ""
+
+#: users/templates/users/data.html:567
+msgid "On X, go to <b>Settings</b> - <b>Your account</b> - <b>Download an archive of your data</b>. Upload the <code>.zip</code> you receive, or only the <code>data/tweets.js</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:570
+msgid "Each tweet becomes a post with its original date, text, links and photos. Replies to your own tweets are kept as a thread. A retweet becomes a short post that links to the original tweet. Videos are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:573
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Tweets that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:615
+msgid "Import Mastodon Archive"
+msgstr ""
+
+#: users/templates/users/data.html:621
+msgid "On your Mastodon server, go to <b>Preferences</b> - <b>Import and export</b> - <b>Request your archive</b>. Upload the <code>.zip</code> you receive, or only the <code>outbox.json</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:624
+msgid "Each post is imported with its original date, text, links, photos, content warning and visibility, so a followers-only post or a direct message stays that way. Replies to your own posts are kept as a thread. A boost becomes a short post that links to the original post. Videos, favourites and bookmarks are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:627
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Posts that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:639
 msgid "View Annual Summary"
 msgstr ""
 
@@ -8174,6 +8249,11 @@ msgstr ""
 
 #: users/templates/users/migrate_in.html:64
 msgid "No aliases configured."
+msgstr ""
+
+#: users/templates/users/migrate_in.html:70
+#: users/templates/users/migrate_out.html:67
+msgid "Back to Preferences"
 msgstr ""
 
 #: users/templates/users/migrate_out.html:9
@@ -8686,190 +8766,191 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:126
+#: users/views/account.py:127
 msgid "This username is already in use."
 msgstr ""
 
-#: users/views/account.py:137
+#: users/views/account.py:138
 msgid "This email address is already in use."
 msgstr ""
 
-#: users/views/account.py:257 users/views/account.py:376
+#: users/views/account.py:258 users/views/account.py:377
 msgid "Registration is for invitation only"
 msgstr ""
 
-#: users/views/account.py:268 users/views/account.py:340
+#: users/views/account.py:269 users/views/account.py:341
 msgid "Time is up"
 msgstr ""
 
-#: users/views/account.py:269 users/views/account.py:312
-#: users/views/account.py:341
+#: users/views/account.py:270 users/views/account.py:313
+#: users/views/account.py:342
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:315
+#: users/views/account.py:316
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:327
+#: users/views/account.py:328
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:328
+#: users/views/account.py:329
 msgid "Please try again later."
 msgstr ""
 
-#: users/views/account.py:417
+#: users/views/account.py:418
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:447
+#: users/views/account.py:448
 msgid "Valid username required"
 msgstr ""
 
-#: users/views/account.py:518
+#: users/views/account.py:519
 msgid "Account is being deleted."
 msgstr ""
 
-#: users/views/account.py:521
+#: users/views/account.py:522
 msgid "Account mismatch."
 msgstr ""
 
-#: users/views/data.py:264 users/views/data.py:296
+#: users/views/data.py:276 users/views/data.py:308
 msgid "Export file not available."
 msgstr ""
 
-#: users/views/data.py:290
+#: users/views/data.py:302
 msgid "Generating exports."
 msgstr ""
 
-#: users/views/data.py:308
+#: users/views/data.py:320
 msgid "Export file expired. Please export again."
 msgstr ""
 
-#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
+#: users/views/data.py:335 users/views/data.py:356 users/views/data.py:377
 msgid "Recent export still in progress."
 msgstr ""
 
-#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
-#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
-#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
+#: users/views/data.py:393 users/views/data.py:419 users/views/data.py:447
+#: users/views/data.py:579 users/views/data.py:613 users/views/data.py:838
+#: users/views/data.py:1055 users/views/data.py:1081 users/views/data.py:1106
+#: users/views/data.py:1131 users/views/data.py:1201
 msgid "Invalid file."
 msgstr ""
 
-#: users/views/data.py:405
+#: users/views/data.py:469
 msgid "Sync in progress."
 msgstr ""
 
-#: users/views/data.py:419
+#: users/views/data.py:483
 msgid "Settings saved."
 msgstr ""
 
-#: users/views/data.py:474
+#: users/views/data.py:538
 msgid "Account no longer linked."
 msgstr ""
 
-#: users/views/data.py:477
+#: users/views/data.py:541
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:505
+#: users/views/data.py:569
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:585 users/views/data.py:810
+#: users/views/data.py:649 users/views/data.py:874
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:610 users/views/data.py:839
+#: users/views/data.py:674 users/views/data.py:903
 msgid "Cancelled."
 msgstr ""
 
-#: users/views/data.py:630
+#: users/views/data.py:694
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
-#: users/views/data.py:974
+#: users/views/data.py:702 users/views/data.py:812 users/views/data.py:933
+#: users/views/data.py:1038
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:734 users/views/data.py:960
+#: users/views/data.py:798 users/views/data.py:1024
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:744 users/views/data.py:970
+#: users/views/data.py:808 users/views/data.py:1034
 msgid "No matched file available."
 msgstr ""
 
-#: users/views/data.py:861
+#: users/views/data.py:925
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1290
 msgid "Name is required."
 msgstr ""
 
-#: users/views/data.py:1248
+#: users/views/data.py:1314
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1264
+#: users/views/data.py:1330
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1269
+#: users/views/data.py:1335
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1279 users/views/data.py:1330
+#: users/views/data.py:1345 users/views/data.py:1396
 msgid "Looking up the account. Please try again in a few seconds."
-msgstr ""
-
-#: users/views/data.py:1286
-#, python-brace-format
-msgid "Alias to {handle} removed."
-msgstr ""
-
-#: users/views/data.py:1291
-#, python-brace-format
-msgid "Alias to {handle} added."
-msgstr ""
-
-#: users/views/data.py:1317
-msgid "Migration cancelled."
-msgstr ""
-
-#: users/views/data.py:1322
-msgid "No target account specified."
-msgstr ""
-
-#: users/views/data.py:1335
-msgid "Cannot migrate to a local account."
-msgstr ""
-
-#: users/views/data.py:1346
-msgid "You must set up an alias in the target account first."
 msgstr ""
 
 #: users/views/data.py:1352
 #, python-brace-format
+msgid "Alias to {handle} removed."
+msgstr ""
+
+#: users/views/data.py:1357
+#, python-brace-format
+msgid "Alias to {handle} added."
+msgstr ""
+
+#: users/views/data.py:1383
+msgid "Migration cancelled."
+msgstr ""
+
+#: users/views/data.py:1388
+msgid "No target account specified."
+msgstr ""
+
+#: users/views/data.py:1401
+msgid "Cannot migrate to a local account."
+msgstr ""
+
+#: users/views/data.py:1412
+msgid "You must set up an alias in the target account first."
+msgstr ""
+
+#: users/views/data.py:1418
+#, python-brace-format
 msgid "Start moving to {handle}."
 msgstr ""
 
-#: users/views/data.py:1410
+#: users/views/data.py:1476
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1426
+#: users/views/data.py:1492
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1430
+#: users/views/data.py:1496
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1440
+#: users/views/data.py:1506
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""

--- a/neodb/locale/fr/LC_MESSAGES/django.po
+++ b/neodb/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 20:04-0400\n"
+"POT-Creation-Date: 2026-09-07 14:56-0400\n"
 "PO-Revision-Date: 2026-08-09 06:32+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/neodb/neodb/fr/>\n"
@@ -61,15 +61,15 @@ msgstr "Chinois Simplifié"
 msgid "Traditional Chinese"
 msgstr "Chinois Traditionnel"
 
-#: catalog/forms.py:35 catalog/models/item.py:307
+#: catalog/forms.py:35 catalog/models/item.py:412
 msgid "Primary ID Type"
 msgstr "Type de l'identifiant primaire"
 
-#: catalog/forms.py:40 catalog/models/item.py:310
+#: catalog/forms.py:40 catalog/models/item.py:415
 msgid "Primary ID Value"
 msgstr "Valeur de l'identifiant primaire"
 
-#: catalog/forms.py:176
+#: catalog/forms.py:177
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
@@ -122,11 +122,11 @@ msgid "other title"
 msgstr "titre alternatif"
 
 #: catalog/models/book.py:282 catalog/models/book.py:566
-#: catalog/models/item.py:119
+#: catalog/models/item.py:224
 msgid "author"
 msgstr "écrit par"
 
-#: catalog/models/book.py:289 catalog/models/item.py:120
+#: catalog/models/book.py:289 catalog/models/item.py:225
 msgid "translator"
 msgstr "traduit par"
 
@@ -135,7 +135,7 @@ msgid "book format"
 msgstr "format"
 
 #: catalog/models/book.py:303 catalog/models/game.py:135
-#: catalog/models/item.py:134 catalog/models/music.py:142
+#: catalog/models/item.py:239 catalog/models/music.py:142
 msgid "publisher"
 msgstr "studio d'édition"
 
@@ -167,7 +167,7 @@ msgstr "contenus"
 msgid "price"
 msgstr "prix"
 
-#: catalog/models/book.py:326 catalog/models/item.py:145
+#: catalog/models/book.py:326 catalog/models/item.py:250
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr "colophon"
@@ -594,7 +594,7 @@ msgid "Exhibition"
 msgstr "Exposition"
 
 #: catalog/models/common.py:174 catalog/models/common.py:191
-#: journal/templates/collection.html:29 journal/templates/collection.html:40
+#: journal/templates/collection.html:30 journal/templates/collection.html:41
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
@@ -724,16 +724,16 @@ msgstr "Remake"
 msgid "Special Edition"
 msgstr "Édition Spéciale"
 
-#: catalog/models/game.py:111 catalog/models/item.py:126
+#: catalog/models/game.py:111 catalog/models/item.py:231
 msgid "designer"
 msgstr "conception"
 
-#: catalog/models/game.py:119 catalog/models/item.py:125
+#: catalog/models/game.py:119 catalog/models/item.py:230
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr "artiste"
 
-#: catalog/models/game.py:127 catalog/models/item.py:135
+#: catalog/models/game.py:127 catalog/models/item.py:240
 msgid "developer"
 msgstr "studio de développement"
 
@@ -763,147 +763,147 @@ msgstr "type de sortie"
 msgid "website"
 msgstr "site internet"
 
-#: catalog/models/item.py:121 catalog/models/movie.py:123
+#: catalog/models/item.py:226 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
 #: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr "réalisation"
 
-#: catalog/models/item.py:122 catalog/models/movie.py:130
+#: catalog/models/item.py:227 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
 #: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr "scénario"
 
-#: catalog/models/item.py:123 catalog/models/movie.py:137
+#: catalog/models/item.py:228 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
 #: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr "casting"
 
-#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/item.py:229 catalog/models/movie.py:144
 #: catalog/models/tv.py:237 catalog/models/tv.py:463
 #, fuzzy
 #| msgid "production"
 msgid "producer"
 msgstr "production"
 
-#: catalog/models/item.py:127 catalog/models/performance.py:203
+#: catalog/models/item.py:232 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr "composition musicale"
 
-#: catalog/models/item.py:128 catalog/models/performance.py:210
+#: catalog/models/item.py:233 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr "chorégraphe"
 
-#: catalog/models/item.py:129 catalog/models/performance.py:224
+#: catalog/models/item.py:234 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr "artiste"
 
-#: catalog/models/item.py:130 catalog/models/podcast.py:80
+#: catalog/models/item.py:235 catalog/models/podcast.py:80
 msgid "host"
 msgstr "présenté par"
 
-#: catalog/models/item.py:131 catalog/models/performance.py:196
+#: catalog/models/item.py:236 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr "une création originale de"
 
-#: catalog/models/item.py:132 catalog/models/performance.py:238
+#: catalog/models/item.py:237 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr "équipe"
 
-#: catalog/models/item.py:136
+#: catalog/models/item.py:241
 #, fuzzy
 #| msgid "production"
 msgid "production company"
 msgstr "production"
 
-#: catalog/models/item.py:137
+#: catalog/models/item.py:242
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:138
+#: catalog/models/item.py:243
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:139
+#: catalog/models/item.py:244
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:140 catalog/models/performance.py:231
+#: catalog/models/item.py:245 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr "troupe"
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:248
 #, fuzzy
 #| msgid "director"
 msgid "voice actor"
 msgstr "réalisation"
 
-#: catalog/models/item.py:144 catalog/templates/edition.html:30
+#: catalog/models/item.py:249 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr "édition"
 
-#: catalog/models/item.py:169 catalog/models/people.py:476
+#: catalog/models/item.py:274 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr "rôle"
 
-#: catalog/models/item.py:170 catalog/models/people.py:155
+#: catalog/models/item.py:275 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr "nom"
 
-#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:277 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:304 catalog/models/item.py:336
-#: journal/models/collection.py:100
+#: catalog/models/item.py:409 catalog/models/item.py:441
+#: journal/models/collection.py:101
 msgid "title"
 msgstr "titre"
 
-#: catalog/models/item.py:305 catalog/models/item.py:344
-#: journal/models/collection.py:101
+#: catalog/models/item.py:410 catalog/models/item.py:449
+#: journal/models/collection.py:102
 msgid "description"
 msgstr "description"
 
-#: catalog/models/item.py:316 catalog/models/people.py:484
+#: catalog/models/item.py:421 catalog/models/people.py:484
 msgid "metadata"
 msgstr "métadonnées"
 
-#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:423 catalog/templates/_item_card.html:28
 msgid "cover"
 msgstr "couverture"
 
-#: catalog/models/item.py:1526
+#: catalog/models/item.py:1612
 msgid "source site"
 msgstr "site d'origine"
 
-#: catalog/models/item.py:1528
+#: catalog/models/item.py:1614
 msgid "ID on source site"
 msgstr "Identifiant sur le site d'origine"
 
-#: catalog/models/item.py:1530
+#: catalog/models/item.py:1616
 msgid "source url"
 msgstr "URL de la source"
 
-#: catalog/models/item.py:1546
+#: catalog/models/item.py:1632
 msgid "IdType of the source site"
 msgstr "IdType du site d'origine"
 
-#: catalog/models/item.py:1552
+#: catalog/models/item.py:1638
 msgid "Primary Id on the source site"
 msgstr "Identifiant primaire sur le site d'origine"
 
-#: catalog/models/item.py:1555
+#: catalog/models/item.py:1641
 msgid "url to the resource"
 msgstr "URL vers la ressource"
 
@@ -1234,12 +1234,12 @@ msgstr "Récupération impossible à partir du lien, veuillez revérifier votre 
 #: catalog/templates/_item_card_metadata_tvseason.html:7
 #: catalog/templates/_item_card_metadata_tvshow.html:7
 #: catalog/templates/_item_card_metadata_work.html:7
-#: catalog/templates/item_base.html:201
+#: catalog/templates/item_base.html:186
 msgid "ratings"
 msgstr "évaluations"
 
-#: catalog/templates/_item_card_metadata_base.html:34
-#: catalog/templates/item_base.html:256
+#: catalog/templates/_item_card_metadata_base.html:28
+#: catalog/templates/item_base.html:241
 msgid "part of"
 msgstr "fait partie de"
 
@@ -1259,7 +1259,7 @@ msgid "hide this tooltip"
 msgstr "masquer l'infobulle"
 
 #: catalog/templates/_item_comments.html:58
-#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:83
+#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:81
 #, fuzzy
 #| msgid "translator"
 msgid "translate"
@@ -1268,7 +1268,7 @@ msgstr "traduit par"
 #: catalog/templates/_item_comments.html:92
 #: catalog/templates/_item_comments_by_episode.html:80
 #: catalog/templates/_item_notes.html:88
-#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:284
+#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:269
 #: catalog/templates/podcast_episode_data.html:41
 msgid "show more"
 msgstr "voir plus"
@@ -1389,8 +1389,8 @@ msgstr "Synchro en cours."
 #: catalog/templates/_item_user_pieces.html:101
 #: catalog/templates/catalog_edit.html:12
 #: journal/templates/action_edit_post.html:6
-#: journal/templates/action_edit_post.html:8 journal/templates/article.html:196
-#: journal/templates/collection.html:185 journal/templates/collection.html:193
+#: journal/templates/action_edit_post.html:8 journal/templates/article.html:194
+#: journal/templates/collection.html:186 journal/templates/collection.html:194
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_edit.html:26
 #: journal/templates/post_compose.html:16 journal/templates/tag_edit.html:16
@@ -1434,7 +1434,7 @@ msgstr "retour à l'œuvre"
 #: catalog/templates/_sidebar_edit.html:20
 #: catalog/templates/catalog_verify.html:11
 #: catalog/templates/catalog_verify.html:17
-#: catalog/templates/item_base.html:182
+#: catalog/templates/item_base.html:167
 #, fuzzy
 #| msgid "Verification"
 msgid "Creator verification"
@@ -1444,7 +1444,7 @@ msgstr "Vérification"
 msgid "Edit Options"
 msgstr "Option d'édition"
 
-#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
+#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:163
 #: catalog/views/edit.py:160 catalog/views/edit.py:221
 #: catalog/views/edit.py:288 catalog/views/edit.py:309
 #: catalog/views/edit.py:364 catalog/views/edit.py:471
@@ -1618,7 +1618,7 @@ msgstr "fusionner avec une autre œuvre"
 #: catalog/templates/_sidebar_edit.html:265
 #: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
-#: journal/templates/article.html:199 journal/templates/collection.html:188
+#: journal/templates/article.html:197 journal/templates/collection.html:189
 #: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
@@ -1815,7 +1815,7 @@ msgstr ""
 msgid "Remove my verification"
 msgstr "Retirer de la collection"
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:311
+#: catalog/templates/_verify_status.html:31 users/views/account.py:312
 #, fuzzy
 #| msgid "Verification Code"
 msgid "Verification failed"
@@ -2009,7 +2009,7 @@ msgstr "Étiquettes tendances"
 
 #: catalog/templates/discover.html:229
 #: catalog/templates/discover_original_podcasts.html:25
-#: catalog/templates/item_base.html:282
+#: catalog/templates/item_base.html:267
 #: catalog/templates/item_mark_list.html:71
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
@@ -2079,67 +2079,67 @@ msgstr "Récupération depuis %(site_label)s"
 msgid "System busy, please try again in a minute."
 msgstr "Système occupé, veuillez réessayer dans une minute."
 
-#: catalog/templates/item_base.html:95
+#: catalog/templates/item_base.html:80
 msgid "select one of the seasons to comment"
 msgstr "sélectionnez une saison pour commenter"
 
-#: catalog/templates/item_base.html:129
+#: catalog/templates/item_base.html:114
 msgid "mark, comment and collect"
 msgstr "interagir, commenter & collectionner"
 
-#: catalog/templates/item_base.html:142
+#: catalog/templates/item_base.html:127
 msgid "Login or register to review or add this item to your collection."
 msgstr "Inscrivez ou connectez-vous pour évaluer cette œuvre ou l'ajouter à votre collection."
 
-#: catalog/templates/item_base.html:151
+#: catalog/templates/item_base.html:136
 msgid "Related Collections"
 msgstr "Collections liées"
 
-#: catalog/templates/item_base.html:166
+#: catalog/templates/item_base.html:151
 msgid "Unsupported item type."
 msgstr "Type d'œuvre non supporté."
 
-#: catalog/templates/item_base.html:176
+#: catalog/templates/item_base.html:161
 msgid "Edit this item"
 msgstr "Modifier cette œuvre"
 
-#: catalog/templates/item_base.html:187
+#: catalog/templates/item_base.html:172
 msgid "Last edited"
 msgstr "Dernière édition"
 
-#: catalog/templates/item_base.html:230
+#: catalog/templates/item_base.html:215
 msgid "No enough ratings"
 msgstr "Pas assez d'évaluations"
 
-#: catalog/templates/item_base.html:274
+#: catalog/templates/item_base.html:259
 msgid "overview"
 msgstr "résumé"
 
-#: catalog/templates/item_base.html:305
+#: catalog/templates/item_base.html:290
 msgid "comments"
 msgstr "commentaires"
 
-#: catalog/templates/item_base.html:308
+#: catalog/templates/item_base.html:293
 #: catalog/templates/item_mark_list.html:22
 #: catalog/templates/item_mark_list.html:25
 #: catalog/templates/item_review_list.html:21
 msgid "marks"
 msgstr "interactions"
 
-#: catalog/templates/item_base.html:309
+#: catalog/templates/item_base.html:294
 #: catalog/templates/item_mark_list.html:23
 #: catalog/templates/item_mark_list.html:26
 #: catalog/templates/item_review_list.html:22
 msgid "marks from who you follow"
 msgstr "interactions des membres que vous suivez"
 
-#: catalog/templates/item_base.html:323
+#: catalog/templates/item_base.html:308
 #: catalog/templates/item_mark_list.html:28
 #: catalog/templates/item_review_list.html:23
 msgid "reviews"
 msgstr "avis"
 
-#: catalog/templates/item_base.html:333
+#: catalog/templates/item_base.html:318
 #, fuzzy
 #| msgid "note"
 msgid "notes"
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
+#: catalog/views/verify.py:164 common/utils.py:148 common/utils.py:189
 #: journal/views/article.py:186 journal/views/review.py:182
 #: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
@@ -4324,7 +4324,7 @@ msgstr "Mentionné⋅es seulement"
 msgid "Open Registration"
 msgstr "Échec de l'inscription"
 
-#: common/templates/common/about.html:40 common/views_manage.py:657
+#: common/templates/common/about.html:40 common/views_manage.py:671
 #, fuzzy
 #| msgid "Preferences"
 msgid "Preferred Languages"
@@ -4390,7 +4390,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:738
+#: common/templates/common/scan.html:60 common/views_manage.py:756
 #, fuzzy
 #| msgid "Search results"
 msgid "Search"
@@ -4476,16 +4476,16 @@ msgstr "vous"
 msgid "unavailable"
 msgstr "indisponible"
 
-#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
+#: common/utils.py:152 common/utils.py:193 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr "Membre disparu"
 
-#: common/utils.py:135 common/utils.py:137 common/utils.py:140
-#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
+#: common/utils.py:159 common/utils.py:161 common/utils.py:164
+#: common/utils.py:200 common/utils.py:204 journal/views/profile.py:499
 msgid "Access denied"
 msgstr "Accès refusé"
 
-#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
+#: common/utils.py:167 common/utils.py:169 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr "Connexion requise"
@@ -4508,7 +4508,7 @@ msgstr "commentaires"
 msgid "Access"
 msgstr "Accès refusé"
 
-#: common/views_manage.py:39 common/views_manage.py:733
+#: common/views_manage.py:39 common/views_manage.py:751
 #, fuzzy
 #| msgid "duration"
 msgid "Federation"
@@ -4892,465 +4892,495 @@ msgid "Sender name and address for outgoing email."
 msgstr ""
 
 #: common/views_manage.py:649
+msgid "Enable Twitter / X Archive Import"
+msgstr ""
+
+#: common/views_manage.py:651
+msgid "Show the Twitter / X archive import on the data page. Imported tweets become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:656
+msgid "Enable Mastodon Archive Import"
+msgstr ""
+
+#: common/views_manage.py:658
+msgid "Show the Mastodon archive import on the data page. Imported posts become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:663
 #, fuzzy
 #| msgid "Language"
 msgid "Default Language"
 msgstr "Langue"
 
-#: common/views_manage.py:652
+#: common/views_manage.py:666
 msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:673
 msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:665
+#: common/views_manage.py:679
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:672
+#: common/views_manage.py:686
 #, fuzzy
 #| msgid "Import Method"
 msgid "Login Methods"
 msgstr "Méthode d'import"
 
-#: common/views_manage.py:677 mastodon/models/common.py:30
+#: common/views_manage.py:691 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr "Mail"
 
-#: common/views_manage.py:681
+#: common/views_manage.py:695
+#, fuzzy
+#| msgid "Import"
+msgid "Data Import"
+msgstr "Importer"
+
+#: common/views_manage.py:699
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:692
+#: common/views_manage.py:710
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:694
+#: common/views_manage.py:712
 msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:699
+#: common/views_manage.py:717
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:700
+#: common/views_manage.py:718
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:704
+#: common/views_manage.py:722
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:706
+#: common/views_manage.py:724
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:711
+#: common/views_manage.py:729
 #, fuzzy
 #| msgid "Search results"
 msgid "Search Sites"
 msgstr "Résultats de la recherche"
 
-#: common/views_manage.py:712
+#: common/views_manage.py:730
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:715
+#: common/views_manage.py:733
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:716
+#: common/views_manage.py:734
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:719
+#: common/views_manage.py:737
 #, fuzzy
 #| msgid "Add tv series"
 msgid "Hidden Categories"
 msgstr "Ajouter des séries TV"
 
-#: common/views_manage.py:720
+#: common/views_manage.py:738
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:723
+#: common/views_manage.py:741
 msgid "Guest Search Page Limit"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:743
 msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
 msgstr ""
 
-#: common/views_manage.py:751
+#: common/views_manage.py:769
 #, fuzzy
 #| msgid "Spotify Album"
 msgid "Spotify API Key"
 msgstr "Album Spotify"
 
-#: common/views_manage.py:752
+#: common/views_manage.py:770
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:773
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:756
+#: common/views_manage.py:774
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:759
+#: common/views_manage.py:777
 #, fuzzy
 #| msgid "Google Books"
 msgid "Google Books API Key"
 msgstr "Google Livres"
 
-#: common/views_manage.py:760
+#: common/views_manage.py:778
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:763
+#: common/views_manage.py:781
 #, fuzzy
 #| msgid "Discogs"
 msgid "Discogs API Key"
 msgstr "Discogs"
 
-#: common/views_manage.py:765
+#: common/views_manage.py:783
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:769
+#: common/views_manage.py:787
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:770
+#: common/views_manage.py:788
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:773
+#: common/views_manage.py:791
 #, fuzzy
 #| msgid "client secret"
 msgid "IGDB Client Secret"
 msgstr "secret du client"
 
-#: common/views_manage.py:776
+#: common/views_manage.py:794
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:778
+#: common/views_manage.py:796
 msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:783
+#: common/views_manage.py:801
 msgid "MyAnimeList Client ID"
 msgstr ""
 
-#: common/views_manage.py:785
+#: common/views_manage.py:803
 msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
 msgstr ""
 
-#: common/views_manage.py:790 users/templates/users/steam_import.html:26
+#: common/views_manage.py:808 users/templates/users/steam_import.html:26
 #, fuzzy
 #| msgid "Steam Game"
 msgid "Steam API Key"
 msgstr "Jeu Steam"
 
-#: common/views_manage.py:792
+#: common/views_manage.py:810
 msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:797
+#: common/views_manage.py:815
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:798
+#: common/views_manage.py:816
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:801
+#: common/views_manage.py:819
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:804
+#: common/views_manage.py:822
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:807
+#: common/views_manage.py:825
 #, fuzzy
 #| msgid "Threads"
 msgid "Threads App ID"
 msgstr "Threads"
 
-#: common/views_manage.py:808
+#: common/views_manage.py:826
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:811
+#: common/views_manage.py:829
 #, fuzzy
 #| msgid "Threads.net"
 msgid "Threads App Secret"
 msgstr "Threads"
 
-#: common/views_manage.py:814
+#: common/views_manage.py:832
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:834
 msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:833
+#: common/views_manage.py:851
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:844
+#: common/views_manage.py:862
 #, fuzzy
 #| msgid "translator"
 msgid "Translation"
 msgstr "traduit par"
 
-#: common/views_manage.py:849
+#: common/views_manage.py:867
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:853 social/templates/feed.html:27
+#: common/views_manage.py:871 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr "Notifications"
 
-#: common/views_manage.py:863
+#: common/views_manage.py:881
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:882
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:885
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:868
+#: common/views_manage.py:886
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:871
+#: common/views_manage.py:889
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:874
+#: common/views_manage.py:892
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:877
+#: common/views_manage.py:895
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:880
+#: common/views_manage.py:898
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:883
+#: common/views_manage.py:901
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:886
+#: common/views_manage.py:904
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:887
+#: common/views_manage.py:905
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:908
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:894
+#: common/views_manage.py:912
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:898
+#: common/views_manage.py:916
 #, fuzzy
 #| msgid "series"
 msgid "Retries"
 msgstr "série"
 
-#: common/views_manage.py:903
+#: common/views_manage.py:921
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:908
+#: common/views_manage.py:926
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:915
+#: common/views_manage.py:933
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:927
+#: common/views_manage.py:945
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:928
+#: common/views_manage.py:946
 #, fuzzy
 #| msgid "site domain name"
 msgid "One domain per line."
 msgstr "nom de domaine du site"
 
-#: common/views_manage.py:931
+#: common/views_manage.py:949
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:932
+#: common/views_manage.py:950
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:935
+#: common/views_manage.py:953
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:937
+#: common/views_manage.py:955
 msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:943
+#: common/views_manage.py:961
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:944
+#: common/views_manage.py:962
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:947
+#: common/views_manage.py:965
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:948
+#: common/views_manage.py:966
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:958
+#: common/views_manage.py:976
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:960
+#: common/views_manage.py:978
 msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:966
+#: common/views_manage.py:984
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:968
+#: common/views_manage.py:986
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:974
+#: common/views_manage.py:992
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:976
+#: common/views_manage.py:994
 msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:983
+#: common/views_manage.py:1000
+msgid "Webhook Timeout (milliseconds)"
+msgstr ""
+
+#: common/views_manage.py:1001
+msgid "Timeout for delivering webhook requests to applications."
+msgstr ""
+
+#: common/views_manage.py:1006
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:986
+#: common/views_manage.py:1009
 #, fuzzy
 #| msgid "optional"
 msgid "Operational"
 msgstr "optionnel"
 
-#: common/views_manage.py:1002
+#: common/views_manage.py:1026
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:1004
+#: common/views_manage.py:1028
 msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1009
+#: common/views_manage.py:1033
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:1011
+#: common/views_manage.py:1035
 msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1016
+#: common/views_manage.py:1040
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:1018
+#: common/views_manage.py:1042
 msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1023
+#: common/views_manage.py:1047
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:1025
+#: common/views_manage.py:1049
 msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1030
+#: common/views_manage.py:1054
 #, fuzzy
 #| msgid "Podcast"
 msgid "Podcast Genres"
 msgstr "Podcast"
 
-#: common/views_manage.py:1032
+#: common/views_manage.py:1056
 msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1037
+#: common/views_manage.py:1061
 #, fuzzy
 #| msgid "Performance"
 msgid "Performance Genres"
 msgstr "Spectacle"
 
-#: common/views_manage.py:1039
+#: common/views_manage.py:1063
 msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1045
+#: common/views_manage.py:1069
 msgid "Genres by Category"
 msgstr ""
 
-#: common/views_manage.py:1069
+#: common/views_manage.py:1093
 msgid "Site"
 msgstr ""
 
-#: common/views_manage.py:1079
+#: common/views_manage.py:1103
 #, fuzzy
 #| msgid "Database"
 msgid "Database and Services"
 msgstr "Base de données"
 
-#: common/views_manage.py:1089
+#: common/views_manage.py:1113
 msgid "Media and Files"
 msgstr ""
 
-#: common/views_manage.py:1098
+#: common/views_manage.py:1122
 msgid "Monitoring"
 msgstr ""
 
-#: common/views_manage.py:1102
+#: common/views_manage.py:1126
 msgid "Security"
 msgstr ""
 
-#: common/views_manage.py:1111
+#: common/views_manage.py:1135
 msgid "Other Environment Variables"
 msgstr ""
 
-#: common/views_manage.py:1113
+#: common/views_manage.py:1137
 msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
 msgstr ""
 
@@ -5398,7 +5428,8 @@ msgstr "Au moment de l'enregistrement, remplacer les espaces en début de ligne 
 #: users/templates/users/data.html:60 users/templates/users/data.html:113
 #: users/templates/users/data.html:170 users/templates/users/data.html:221
 #: users/templates/users/data.html:284 users/templates/users/data.html:346
-#: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
+#: users/templates/users/data.html:525 users/templates/users/data.html:578
+#: users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
 msgid "Visibility"
@@ -5438,8 +5469,8 @@ msgstr "propriétaire seulement"
 msgid "owner and their local mutuals"
 msgstr "propriétaire & leurs suivis mutuels"
 
-#: journal/forms.py:169 journal/templates/collection.html:193
-#: journal/templates/collection.html:202
+#: journal/forms.py:169 journal/templates/collection.html:194
+#: journal/templates/collection.html:203
 msgid "Collaborative editing"
 msgstr "Édition collaborative"
 
@@ -5492,7 +5523,7 @@ msgstr ""
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:215 journal/views/article.py:218
+#: journal/models/article.py:224 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
@@ -5504,75 +5535,76 @@ msgstr ""
 msgid "note"
 msgstr "note"
 
-#: journal/models/collection.py:115
+#: journal/models/collection.py:116
 #, fuzzy
 #| msgid "shared {username}'s collection"
 msgid "search query for dynamic collection"
 msgstr "a partagé la collection de {username}"
 
-#: journal/models/collection.py:566 journal/templatetags/collection.py:35
+#: journal/models/collection.py:575 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] "%(count)d livre"
 msgstr[1] "%(count)d livres"
 
-#: journal/models/collection.py:571 journal/templatetags/collection.py:43
+#: journal/models/collection.py:580 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] "%(count)d film"
 msgstr[1] "%(count)d films"
 
-#: journal/models/collection.py:576 journal/templatetags/collection.py:51
+#: journal/models/collection.py:585 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] "%(count)d série TV"
 msgstr[1] "%(count)d séries TV"
 
-#: journal/models/collection.py:581 journal/templatetags/collection.py:59
+#: journal/models/collection.py:590 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] "%(count)d album"
 msgstr[1] "%(count)d albums"
 
-#: journal/models/collection.py:586 journal/templatetags/collection.py:67
+#: journal/models/collection.py:595 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] "%(count)d jeu"
 msgstr[1] "%(count)d jeux"
 
-#: journal/models/collection.py:591 journal/templatetags/collection.py:75
+#: journal/models/collection.py:600 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] "%(count)d podcast"
 msgstr[1] "%(count)d podcasts"
 
-#: journal/models/collection.py:597 journal/templatetags/collection.py:83
+#: journal/models/collection.py:606 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] "%(count)d spectacle"
 msgstr[1] "%(count)d spectacles"
 
-#: journal/models/collection.py:605 journal/templatetags/collection.py:91
+#: journal/models/collection.py:614 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] "%(count)d œuvre"
 msgstr[1] "%(count)d œuvres"
 
-#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/models/common.py:59 journal/templates/action_open_post.html:15
 #: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
 #: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
 #: users/templates/users/data.html:122 users/templates/users/data.html:179
 #: users/templates/users/data.html:230 users/templates/users/data.html:292
 #: users/templates/users/data.html:355 users/templates/users/data.html:534
+#: users/templates/users/data.html:587
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5580,13 +5612,14 @@ msgstr[1] "%(count)d œuvres"
 msgid "Public"
 msgstr "Public"
 
-#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/models/common.py:60 journal/templates/action_open_post.html:9
 #: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
 #: users/templates/users/data.html:130 users/templates/users/data.html:187
 #: users/templates/users/data.html:238 users/templates/users/data.html:300
 #: users/templates/users/data.html:363 users/templates/users/data.html:542
+#: users/templates/users/data.html:595
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5594,12 +5627,13 @@ msgstr "Public"
 msgid "Followers Only"
 msgstr "Abonné⋅es seulement"
 
-#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/models/common.py:61 journal/templates/collection_share.html:57
 #: journal/templates/mark.html:102 journal/templates/post_compose.html:72
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
 #: users/templates/users/data.html:138 users/templates/users/data.html:195
 #: users/templates/users/data.html:246 users/templates/users/data.html:308
 #: users/templates/users/data.html:371 users/templates/users/data.html:550
+#: users/templates/users/data.html:603
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5607,33 +5641,33 @@ msgstr "Abonné⋅es seulement"
 msgid "Mentioned Only"
 msgstr "Mentionné⋅es seulement"
 
-#: journal/models/common.py:806
+#: journal/models/common.py:851
 #, fuzzy
 #| msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr "Échec de publication sur Mastodon. Veuillez réautoriser."
 
-#: journal/models/common.py:1003
+#: journal/models/common.py:1048
 msgid "A recent post was not posted to Threads."
 msgstr "Échec de publication sur Threads."
 
-#: journal/models/common.py:1036
+#: journal/models/common.py:1081
 #, fuzzy
 #| msgid "A recent post was not posted to Mastodon."
 msgid "A recent post was not boosted on Mastodon."
 msgstr "Échec de publication sur Mastodon."
 
-#: journal/models/common.py:1046
+#: journal/models/common.py:1091
 #, fuzzy
 #| msgid "Item no longer exists"
 msgid "Original post no longer exists."
 msgstr "Élément disparu"
 
-#: journal/models/common.py:1060
+#: journal/models/common.py:1105
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr "Échec de publication sur Mastodon. Veuillez réautoriser."
 
-#: journal/models/common.py:1069
+#: journal/models/common.py:1114
 msgid "A recent post was not posted to Mastodon."
 msgstr "Échec de publication sur Mastodon."
 
@@ -5651,85 +5685,85 @@ msgstr "Échec"
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:475
+#: journal/models/mark.py:477
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:479
+#: journal/models/mark.py:481
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:486
+#: journal/models/mark.py:488
 #, fuzzy
 #| msgid "Invalid parameter"
 msgid "Invalid progress type."
 msgstr "Paramètre invalide"
 
-#: journal/models/mark.py:488
+#: journal/models/mark.py:490
 #, fuzzy
 #| msgid "Invalid response from Fediverse instance."
 msgid "Invalid progress type for this item."
 msgstr "Réponse incorrecte depuis l'instance du Fédivers."
 
-#: journal/models/note.py:47 users/templates/users/rym_import.html:73
+#: journal/models/note.py:48 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr "Page"
 
-#: journal/models/note.py:48
+#: journal/models/note.py:49
 msgid "Chapter"
 msgstr "Chapitre"
 
-#: journal/models/note.py:51
+#: journal/models/note.py:52
 msgid "Part"
 msgstr "Partie"
 
-#: journal/models/note.py:52
+#: journal/models/note.py:53
 msgid "Episode"
 msgstr "Épisode"
 
-#: journal/models/note.py:53
+#: journal/models/note.py:54
 msgid "Track"
 msgstr "Piste"
 
-#: journal/models/note.py:54
+#: journal/models/note.py:55
 msgid "Cycle"
 msgstr "Répétition"
 
-#: journal/models/note.py:55
+#: journal/models/note.py:56
 msgid "Timestamp"
 msgstr "Horodatage"
 
-#: journal/models/note.py:56
+#: journal/models/note.py:57
 msgid "Percentage"
 msgstr "Pourcentage"
 
-#: journal/models/note.py:77
+#: journal/models/note.py:78
 #, python-brace-format
 msgid "Page {value}"
 msgstr "Page {value}"
 
-#: journal/models/note.py:78
+#: journal/models/note.py:79
 #, python-brace-format
 msgid "Chapter {value}"
 msgstr "Chapitre {value}"
 
-#: journal/models/note.py:81
+#: journal/models/note.py:82
 #, python-brace-format
 msgid "Part {value}"
 msgstr "Partie {value}"
 
-#: journal/models/note.py:82
+#: journal/models/note.py:83
 #, python-brace-format
 msgid "Episode {value}"
 msgstr "Épisode {value}"
 
-#: journal/models/note.py:83
+#: journal/models/note.py:84
 #, python-brace-format
 msgid "Track {value}"
 msgstr "Piste {value}"
 
-#: journal/models/note.py:84
+#: journal/models/note.py:85
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr "Répétition {value}"
@@ -5739,13 +5773,13 @@ msgstr "Répétition {value}"
 msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr "à propos de {item_title}, peut contenir des spoilers ou du contenu potentiellement choquant"
 
-#: journal/models/review.py:79
+#: journal/models/review.py:80
 #, fuzzy, python-brace-format
 #| msgid "a review of {item_title}"
 msgid "a review of {title}"
 msgstr "un avis sur {item_title}"
 
-#: journal/models/review.py:81
+#: journal/models/review.py:82
 #, fuzzy
 #| msgid "Item contains sub-items."
 msgid "(may contain spoilers)"
@@ -6177,7 +6211,7 @@ msgstr "Membres que vous suivez"
 msgid "started following {item}"
 msgstr "a commencé à jouer à {item}"
 
-#: journal/models/shelf.py:923
+#: journal/models/shelf.py:925
 msgid "removed mark"
 msgstr "interaction effacée"
 
@@ -6212,7 +6246,7 @@ msgstr "Retirer de la collection"
 msgid "Update note"
 msgstr "Mettre à jour la note"
 
-#: journal/templates/_list_item.html:71 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:121
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
@@ -6381,7 +6415,7 @@ msgid "View post"
 msgstr ""
 
 #: journal/templates/action_quote_post.html:3
-#: journal/templates/article.html:190 journal/templates/collection.html:174
+#: journal/templates/article.html:188 journal/templates/collection.html:175
 msgid "Quote"
 msgstr ""
 
@@ -6390,7 +6424,7 @@ msgid "reply"
 msgstr "répondre"
 
 #: journal/templates/action_reply_post.html:3
-#: journal/templates/article.html:181 journal/templates/collection.html:165
+#: journal/templates/article.html:179 journal/templates/collection.html:166
 msgid "Reply"
 msgstr "Répondre"
 
@@ -6409,23 +6443,23 @@ msgstr "Ajouter à la collection"
 msgid "Create a new collection"
 msgstr "Créer une nouvelle collection"
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:76
+#: journal/templates/article.html:102 social/templates/_event_post.html:76
 #, fuzzy
 #| msgid "wrote a review of {item}"
 msgid "wrote a review"
 msgstr "a laissé un avis sur {item}"
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:78
+#: journal/templates/article.html:104 social/templates/_event_post.html:78
 #, fuzzy
 #| msgid "wrote a note"
 msgid "wrote an article"
 msgstr "a écrit une note"
 
-#: journal/templates/article.html:136
+#: journal/templates/article.html:134
 msgid "This article may contain sensitive content. Click to reveal."
 msgstr ""
 
-#: journal/templates/article.html:155
+#: journal/templates/article.html:153
 msgid "The author has set it to be viewable only by logged-in users."
 msgstr "Læ propriétaire a défini ce contenu comme réservé aux membres connectés."
 
@@ -6490,20 +6524,20 @@ msgstr "NOV"
 msgid "DEC"
 msgstr "DÉC"
 
-#: journal/templates/collection.html:71
+#: journal/templates/collection.html:72
 #: journal/templates/collection_share.html:12
 #: journal/templates/collection_share.html:66
 #: journal/templates/wrapped_share.html:59
 msgid "Share"
 msgstr "Partager"
 
-#: journal/templates/collection.html:86
+#: journal/templates/collection.html:87
 #, fuzzy
 #| msgid "created collection"
 msgid "created a collection"
 msgstr "collection créée"
 
-#: journal/templates/collection.html:181
+#: journal/templates/collection.html:182
 msgid "Query"
 msgstr ""
 
@@ -6856,14 +6890,14 @@ msgid "Liked Collections"
 msgstr "Collections aimées"
 
 #: journal/templates/user_follow_list.html:23 journal/views/profile.py:507
-#: users/templates/users/account.html:443
+#: users/templates/users/account.html:455
 #, fuzzy
 #| msgid "following you"
 msgid "Following"
 msgstr "vous suit"
 
 #: journal/templates/user_follow_list.html:28 journal/views/profile.py:511
-#: users/templates/users/account.html:452
+#: users/templates/users/account.html:464
 #, fuzzy
 #| msgid "Followers Only"
 msgid "Followers"
@@ -7205,8 +7239,8 @@ msgstr "Identifiant de connexion Bluesky"
 #: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
 #: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
 #: mastodon/views/threads.py:57 mastodon/views/threads.py:65
-#: mastodon/views/threads.py:71 users/views/account.py:256
-#: users/views/account.py:375
+#: mastodon/views/threads.py:71 users/views/account.py:257
+#: users/views/account.py:376
 msgid "Authentication failed"
 msgstr "Échec d'authentification"
 
@@ -7254,7 +7288,7 @@ msgstr "Informations du compte BlueSky invalides."
 msgid "Invalid user."
 msgstr "Membre non-reconnu."
 
-#: mastodon/views/common.py:52 users/views/account.py:416
+#: mastodon/views/common.py:52 users/views/account.py:417
 msgid "Registration failed"
 msgstr "Échec de l'inscription"
 
@@ -8242,146 +8276,161 @@ msgstr "année de publication"
 msgid "Scopes"
 msgstr ""
 
-#: users/templates/users/account.html:398
+#: users/templates/users/account.html:386
+msgid "Webhook"
+msgstr ""
+
+#: users/templates/users/account.html:400
+msgid "disabled"
+msgstr ""
+
+#: users/templates/users/account.html:402
+#, fuzzy
+#| msgid "Activities"
+msgid "active"
+msgstr "Activités"
+
+#: users/templates/users/account.html:410
 msgid "Revoke access for this application?"
 msgstr ""
 
-#: users/templates/users/account.html:401
+#: users/templates/users/account.html:413
 msgid "Revoke"
 msgstr ""
 
-#: users/templates/users/account.html:409
+#: users/templates/users/account.html:421
 #, fuzzy
 #| msgid "View authorized applications"
 msgid "No authorized applications."
 msgstr "Voir les applications autorisées"
 
-#: users/templates/users/account.html:412
+#: users/templates/users/account.html:424
 #: users/templates/users/authorized_app_create.html:9
 #: users/templates/users/authorized_app_create.html:19
 msgid "Create Personal Token"
 msgstr ""
 
-#: users/templates/users/account.html:418
+#: users/templates/users/account.html:430
 msgid "Import/Export Social Graph"
 msgstr ""
 
-#: users/templates/users/account.html:419
+#: users/templates/users/account.html:431
 msgid "Upload a CSV file exported from Mastodon or compatible services."
 msgstr ""
 
-#: users/templates/users/account.html:425
+#: users/templates/users/account.html:437
 #, fuzzy
 #| msgid "Import"
 msgid "Import type"
 msgstr "Importer"
 
-#: users/templates/users/account.html:427
+#: users/templates/users/account.html:439
 #, fuzzy
 #| msgid "following you"
 msgid "Following list"
 msgstr "vous suit"
 
-#: users/templates/users/account.html:428
+#: users/templates/users/account.html:440
 #, fuzzy
 #| msgid "to listen"
 msgid "Block list"
 msgstr "à écouter"
 
-#: users/templates/users/account.html:429
+#: users/templates/users/account.html:441
 #, fuzzy
 #| msgid "to listen"
 msgid "Mute list"
 msgstr "à écouter"
 
-#: users/templates/users/account.html:433
+#: users/templates/users/account.html:445
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/account.html:448 users/templates/users/data.html:89
 #: users/templates/users/data.html:141 users/templates/users/data.html:198
 #: users/templates/users/data.html:249 users/templates/users/data.html:313
 #: users/templates/users/data.html:376 users/templates/users/data.html:553
+#: users/templates/users/data.html:606 users/templates/users/data.html:631
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr "Importer"
 
-#: users/templates/users/account.html:447
-#: users/templates/users/account.html:456
-#: users/templates/users/account.html:465
-#: users/templates/users/account.html:474
+#: users/templates/users/account.html:459
+#: users/templates/users/account.html:468
+#: users/templates/users/account.html:477
+#: users/templates/users/account.html:486
 #, fuzzy
 #| msgid "Download"
 msgid "Download CSV"
 msgstr "Télécharger"
 
-#: users/templates/users/account.html:461
+#: users/templates/users/account.html:473
 #, fuzzy
 #| msgid "blocked"
 msgid "Blocks"
 msgstr "bloqué⋅e"
 
-#: users/templates/users/account.html:470
+#: users/templates/users/account.html:482
 msgid "Mutes"
 msgstr ""
 
-#: users/templates/users/account.html:484
+#: users/templates/users/account.html:496
 #, fuzzy
 #| msgid "Migrate account"
 msgid "Migrate Account"
 msgstr "Migrer mon compte"
 
-#: users/templates/users/account.html:488
+#: users/templates/users/account.html:500
 #, fuzzy
 #| msgid "Link an email so that you can migrate followers from other Fediverse instances."
 msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
 msgstr "Associez une adresse mail afin de pouvoir migrer vos abonné⋅es depuis une autre instance du Fédivers."
 
-#: users/templates/users/account.html:491
+#: users/templates/users/account.html:503
 #, fuzzy
 #| msgid "Migrate account"
 msgid "Migrate another account here"
 msgstr "Migrer mon compte"
 
-#: users/templates/users/account.html:494
+#: users/templates/users/account.html:506
 #, fuzzy
 #| msgid "Migrate account"
 msgid "Migrate to another account"
 msgstr "Migrer mon compte"
 
-#: users/templates/users/account.html:501
+#: users/templates/users/account.html:513
 msgid "Delete Account"
 msgstr "Supprimer mon compte"
 
-#: users/templates/users/account.html:504
+#: users/templates/users/account.html:516
 msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
 msgstr "Une fois supprimées, les données d'un compte ne peuvent être récupérées. Voulez-vous continuer ?"
 
-#: users/templates/users/account.html:507
+#: users/templates/users/account.html:519
 msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
 msgstr "Veuillez saisir l'identifiant complet <code>pseudo@instance.social</code> ou <code>email@domain.com</code> pour confirmer la suppression."
 
-#: users/templates/users/account.html:517
+#: users/templates/users/account.html:529
 msgid "Once deleted, account data cannot be recovered."
 msgstr "Une fois votre compte supprimé, ses données ne peuvent être restaurées."
 
-#: users/templates/users/account.html:520
+#: users/templates/users/account.html:532
 #, fuzzy
 #| msgid "Importing in progress, can't delete now."
 msgid "Task in progress, can't delete now."
 msgstr "Import en cours, suppression impossible pour le moment."
 
-#: users/templates/users/account.html:524
+#: users/templates/users/account.html:536
 msgid "Permanently Delete"
 msgstr "Supprimer définitivement"
 
-#: users/templates/users/account.html:565
+#: users/templates/users/account.html:577
 #, fuzzy
 #| msgid "Delete this tag"
 msgid "Delete this passkey?"
 msgstr "Supprimer cette étiquette"
 
-#: users/templates/users/account.html:585
+#: users/templates/users/account.html:597
 msgid "Rename passkey:"
 msgstr ""
 
@@ -8405,12 +8454,10 @@ msgstr ""
 
 #: users/templates/users/authorized_app_create.html:48
 #: users/templates/users/authorized_app_created.html:39
-#: users/templates/users/migrate_in.html:70
-#: users/templates/users/migrate_out.html:67
 #, fuzzy
-#| msgid "Preferences"
-msgid "Back to Preferences"
-msgstr "Préférences"
+#| msgid "Migrate account"
+msgid "Back to Account"
+msgstr "Migrer mon compte"
 
 #: users/templates/users/authorized_app_created.html:9
 #: users/templates/users/authorized_app_created.html:19
@@ -8554,7 +8601,7 @@ msgstr "Écraser : mettre à jour tous les statuts importés."
 msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
 msgstr "Un autre import est en cours. Démarrer un nouvel import peut créer des erreurs. Voulez-vous continuer ?"
 
-#: users/templates/users/data.html:89 users/views/data.py:1130
+#: users/templates/users/data.html:89 users/views/data.py:1194
 msgid "Import in progress, please wait"
 msgstr "Import en cours, veuillez patienter"
 
@@ -8729,7 +8776,41 @@ msgstr ""
 msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
-#: users/templates/users/data.html:560
+#: users/templates/users/data.html:561
+msgid "Import Twitter / X Archive"
+msgstr ""
+
+#: users/templates/users/data.html:567
+msgid "On X, go to <b>Settings</b> - <b>Your account</b> - <b>Download an archive of your data</b>. Upload the <code>.zip</code> you receive, or only the <code>data/tweets.js</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:570
+msgid "Each tweet becomes a post with its original date, text, links and photos. Replies to your own tweets are kept as a thread. A retweet becomes a short post that links to the original tweet. Videos are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:573
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Tweets that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:615
+#, fuzzy
+#| msgid "Import Method"
+msgid "Import Mastodon Archive"
+msgstr "Méthode d'import"
+
+#: users/templates/users/data.html:621
+msgid "On your Mastodon server, go to <b>Preferences</b> - <b>Import and export</b> - <b>Request your archive</b>. Upload the <code>.zip</code> you receive, or only the <code>outbox.json</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:624
+msgid "Each post is imported with its original date, text, links, photos, content warning and visibility, so a followers-only post or a direct message stays that way. Replies to your own posts are kept as a thread. A boost becomes a short post that links to the original post. Videos, favourites and bookmarks are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:627
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Posts that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:639
 msgid "View Annual Summary"
 msgstr "Voir le Récap' annuel"
 
@@ -8859,6 +8940,13 @@ msgstr "Objectifs actuels"
 #: users/templates/users/migrate_in.html:64
 msgid "No aliases configured."
 msgstr ""
+
+#: users/templates/users/migrate_in.html:70
+#: users/templates/users/migrate_out.html:67
+#, fuzzy
+#| msgid "Preferences"
+msgid "Back to Preferences"
+msgstr "Préférences"
 
 #: users/templates/users/migrate_out.html:9
 #: users/templates/users/migrate_out.html:43
@@ -9415,207 +9503,208 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:126
+#: users/views/account.py:127
 msgid "This username is already in use."
 msgstr "Cet identifiant est déjà utilisé."
 
-#: users/views/account.py:137
+#: users/views/account.py:138
 msgid "This email address is already in use."
 msgstr "Cette adresse mail est déjà utilisée."
 
-#: users/views/account.py:257 users/views/account.py:376
+#: users/views/account.py:258 users/views/account.py:377
 msgid "Registration is for invitation only"
 msgstr "Inscription sur invitation seulement"
 
-#: users/views/account.py:268 users/views/account.py:340
+#: users/views/account.py:269 users/views/account.py:341
 #, fuzzy
 #| msgid "Timestamp"
 msgid "Time is up"
 msgstr "Horodatage"
 
-#: users/views/account.py:269 users/views/account.py:312
-#: users/views/account.py:341
+#: users/views/account.py:270 users/views/account.py:313
+#: users/views/account.py:342
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:315
+#: users/views/account.py:316
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:327
+#: users/views/account.py:328
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:328
+#: users/views/account.py:329
 #, fuzzy
 #| msgid "System busy, please try again in a minute."
 msgid "Please try again later."
 msgstr "Système occupé, veuillez réessayer dans une minute."
 
-#: users/views/account.py:417
+#: users/views/account.py:418
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:447
+#: users/views/account.py:448
 msgid "Valid username required"
 msgstr "Un identifiant valide est requis"
 
-#: users/views/account.py:518
+#: users/views/account.py:519
 msgid "Account is being deleted."
 msgstr "Votre compte est en cours de suppression."
 
-#: users/views/account.py:521
+#: users/views/account.py:522
 msgid "Account mismatch."
 msgstr "Les infos du compte ne correspondent pas."
 
-#: users/views/data.py:264 users/views/data.py:296
+#: users/views/data.py:276 users/views/data.py:308
 msgid "Export file not available."
 msgstr "FIchier d'export non disponible."
 
-#: users/views/data.py:290
+#: users/views/data.py:302
 msgid "Generating exports."
 msgstr "Ficher d'export en cours de génération."
 
-#: users/views/data.py:308
+#: users/views/data.py:320
 msgid "Export file expired. Please export again."
 msgstr "Fichier d'export expiré. Veuillez ré-exporter."
 
-#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
+#: users/views/data.py:335 users/views/data.py:356 users/views/data.py:377
 #, fuzzy
 #| msgid "Import in progress."
 msgid "Recent export still in progress."
 msgstr "Import en cours."
 
-#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
-#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
-#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
+#: users/views/data.py:393 users/views/data.py:419 users/views/data.py:447
+#: users/views/data.py:579 users/views/data.py:613 users/views/data.py:838
+#: users/views/data.py:1055 users/views/data.py:1081 users/views/data.py:1106
+#: users/views/data.py:1131 users/views/data.py:1201
 msgid "Invalid file."
 msgstr "Fichier incorrect."
 
-#: users/views/data.py:405
+#: users/views/data.py:469
 msgid "Sync in progress."
 msgstr "Synchro en cours."
 
-#: users/views/data.py:419
+#: users/views/data.py:483
 msgid "Settings saved."
 msgstr "Réglages sauvegardés."
 
-#: users/views/data.py:474
+#: users/views/data.py:538
 #, fuzzy
 #| msgid "Account is being deleted."
 msgid "Account no longer linked."
 msgstr "Votre compte est en cours de suppression."
 
-#: users/views/data.py:477
+#: users/views/data.py:541
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:505
+#: users/views/data.py:569
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:585 users/views/data.py:810
+#: users/views/data.py:649 users/views/data.py:874
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:610 users/views/data.py:839
+#: users/views/data.py:674 users/views/data.py:903
 #, fuzzy
 #| msgid "Cancel"
 msgid "Cancelled."
 msgstr "Annuler"
 
-#: users/views/data.py:630
+#: users/views/data.py:694
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
-#: users/views/data.py:974
+#: users/views/data.py:702 users/views/data.py:812 users/views/data.py:933
+#: users/views/data.py:1038
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:734 users/views/data.py:960
+#: users/views/data.py:798 users/views/data.py:1024
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:744 users/views/data.py:970
+#: users/views/data.py:808 users/views/data.py:1034
 #, fuzzy
 #| msgid "Export file not available."
 msgid "No matched file available."
 msgstr "FIchier d'export non disponible."
 
-#: users/views/data.py:861
+#: users/views/data.py:925
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1290
 #, fuzzy
 #| msgid "Login required"
 msgid "Name is required."
 msgstr "Connexion requise"
 
-#: users/views/data.py:1248
+#: users/views/data.py:1314
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1264
+#: users/views/data.py:1330
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1269
+#: users/views/data.py:1335
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1279 users/views/data.py:1330
+#: users/views/data.py:1345 users/views/data.py:1396
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:1286
+#: users/views/data.py:1352
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:1291
+#: users/views/data.py:1357
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:1317
+#: users/views/data.py:1383
 #, fuzzy
 #| msgid "Registration failed"
 msgid "Migration cancelled."
 msgstr "Échec de l'inscription"
 
-#: users/views/data.py:1322
+#: users/views/data.py:1388
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:1335
+#: users/views/data.py:1401
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:1346
+#: users/views/data.py:1412
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:1352
+#: users/views/data.py:1418
 #, fuzzy, python-brace-format
 #| msgid "Continue login as {handle}."
 msgid "Start moving to {handle}."
 msgstr "Poursuivre la connexion en tant que {handle}."
 
-#: users/views/data.py:1410
+#: users/views/data.py:1476
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1426
+#: users/views/data.py:1492
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1430
+#: users/views/data.py:1496
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1440
+#: users/views/data.py:1506
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""

--- a/neodb/locale/it/LC_MESSAGES/django.po
+++ b/neodb/locale/it/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 20:04-0400\n"
+"POT-Creation-Date: 2026-09-07 14:56-0400\n"
 "PO-Revision-Date: 2026-08-09 06:32+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/neodb/neodb/it/>\n"
@@ -61,15 +61,15 @@ msgstr "Cinese Semplificato"
 msgid "Traditional Chinese"
 msgstr "Cinese Tradizionale"
 
-#: catalog/forms.py:35 catalog/models/item.py:307
+#: catalog/forms.py:35 catalog/models/item.py:412
 msgid "Primary ID Type"
 msgstr "Tipo d'identificativo primario"
 
-#: catalog/forms.py:40 catalog/models/item.py:310
+#: catalog/forms.py:40 catalog/models/item.py:415
 msgid "Primary ID Value"
 msgstr "Valore dell'ID primario"
 
-#: catalog/forms.py:176
+#: catalog/forms.py:177
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
@@ -122,11 +122,11 @@ msgid "other title"
 msgstr "titolo alternativo"
 
 #: catalog/models/book.py:282 catalog/models/book.py:566
-#: catalog/models/item.py:119
+#: catalog/models/item.py:224
 msgid "author"
 msgstr "Autore"
 
-#: catalog/models/book.py:289 catalog/models/item.py:120
+#: catalog/models/book.py:289 catalog/models/item.py:225
 msgid "translator"
 msgstr "Tradotto da"
 
@@ -135,7 +135,7 @@ msgid "book format"
 msgstr "formato del libro"
 
 #: catalog/models/book.py:303 catalog/models/game.py:135
-#: catalog/models/item.py:134 catalog/models/music.py:142
+#: catalog/models/item.py:239 catalog/models/music.py:142
 msgid "publisher"
 msgstr "Editore"
 
@@ -167,7 +167,7 @@ msgstr "contenuti"
 msgid "price"
 msgstr "Prezzo"
 
-#: catalog/models/book.py:326 catalog/models/item.py:145
+#: catalog/models/book.py:326 catalog/models/item.py:250
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr "Stampa"
@@ -594,7 +594,7 @@ msgid "Exhibition"
 msgstr "Mostra"
 
 #: catalog/models/common.py:174 catalog/models/common.py:191
-#: journal/templates/collection.html:29 journal/templates/collection.html:40
+#: journal/templates/collection.html:30 journal/templates/collection.html:41
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
@@ -724,16 +724,16 @@ msgstr "Remake"
 msgid "Special Edition"
 msgstr "Edizione Speciale"
 
-#: catalog/models/game.py:111 catalog/models/item.py:126
+#: catalog/models/game.py:111 catalog/models/item.py:231
 msgid "designer"
 msgstr "designer"
 
-#: catalog/models/game.py:119 catalog/models/item.py:125
+#: catalog/models/game.py:119 catalog/models/item.py:230
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr "artista"
 
-#: catalog/models/game.py:127 catalog/models/item.py:135
+#: catalog/models/game.py:127 catalog/models/item.py:240
 msgid "developer"
 msgstr "Sviluppatore"
 
@@ -763,147 +763,147 @@ msgstr "tipo di rilascio"
 msgid "website"
 msgstr "Sito internet"
 
-#: catalog/models/item.py:121 catalog/models/movie.py:123
+#: catalog/models/item.py:226 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
 #: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr "Diretto da"
 
-#: catalog/models/item.py:122 catalog/models/movie.py:130
+#: catalog/models/item.py:227 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
 #: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr "Scritto da"
 
-#: catalog/models/item.py:123 catalog/models/movie.py:137
+#: catalog/models/item.py:228 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
 #: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr "Cast"
 
-#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/item.py:229 catalog/models/movie.py:144
 #: catalog/models/tv.py:237 catalog/models/tv.py:463
 #, fuzzy
 #| msgid "production"
 msgid "producer"
 msgstr "produzione"
 
-#: catalog/models/item.py:127 catalog/models/performance.py:203
+#: catalog/models/item.py:232 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr "compositore"
 
-#: catalog/models/item.py:128 catalog/models/performance.py:210
+#: catalog/models/item.py:233 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr "coreografo"
 
-#: catalog/models/item.py:129 catalog/models/performance.py:224
+#: catalog/models/item.py:234 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr "performer"
 
-#: catalog/models/item.py:130 catalog/models/podcast.py:80
+#: catalog/models/item.py:235 catalog/models/podcast.py:80
 msgid "host"
 msgstr "presentatore"
 
-#: catalog/models/item.py:131 catalog/models/performance.py:196
+#: catalog/models/item.py:236 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr "creatore originale"
 
-#: catalog/models/item.py:132 catalog/models/performance.py:238
+#: catalog/models/item.py:237 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr "squadra"
 
-#: catalog/models/item.py:136
+#: catalog/models/item.py:241
 #, fuzzy
 #| msgid "production"
 msgid "production company"
 msgstr "produzione"
 
-#: catalog/models/item.py:137
+#: catalog/models/item.py:242
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:138
+#: catalog/models/item.py:243
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:139
+#: catalog/models/item.py:244
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:140 catalog/models/performance.py:231
+#: catalog/models/item.py:245 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr "troupe"
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:248
 #, fuzzy
 #| msgid "director"
 msgid "voice actor"
 msgstr "Diretto da"
 
-#: catalog/models/item.py:144 catalog/templates/edition.html:30
+#: catalog/models/item.py:249 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr "Casa editrice"
 
-#: catalog/models/item.py:169 catalog/models/people.py:476
+#: catalog/models/item.py:274 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr "ruolo"
 
-#: catalog/models/item.py:170 catalog/models/people.py:155
+#: catalog/models/item.py:275 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr "nome"
 
-#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:277 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:304 catalog/models/item.py:336
-#: journal/models/collection.py:100
+#: catalog/models/item.py:409 catalog/models/item.py:441
+#: journal/models/collection.py:101
 msgid "title"
 msgstr "titolo"
 
-#: catalog/models/item.py:305 catalog/models/item.py:344
-#: journal/models/collection.py:101
+#: catalog/models/item.py:410 catalog/models/item.py:449
+#: journal/models/collection.py:102
 msgid "description"
 msgstr "descrizione"
 
-#: catalog/models/item.py:316 catalog/models/people.py:484
+#: catalog/models/item.py:421 catalog/models/people.py:484
 msgid "metadata"
 msgstr "metadati"
 
-#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:423 catalog/templates/_item_card.html:28
 msgid "cover"
 msgstr "copertina"
 
-#: catalog/models/item.py:1526
+#: catalog/models/item.py:1612
 msgid "source site"
 msgstr "sito d'origine"
 
-#: catalog/models/item.py:1528
+#: catalog/models/item.py:1614
 msgid "ID on source site"
 msgstr "ID sul sito sorgente"
 
-#: catalog/models/item.py:1530
+#: catalog/models/item.py:1616
 msgid "source url"
 msgstr "URL della sorgente"
 
-#: catalog/models/item.py:1546
+#: catalog/models/item.py:1632
 msgid "IdType of the source site"
 msgstr "IdType del sito sorgente"
 
-#: catalog/models/item.py:1552
+#: catalog/models/item.py:1638
 msgid "Primary Id on the source site"
 msgstr "Id Primario sul sito sorgente"
 
-#: catalog/models/item.py:1555
+#: catalog/models/item.py:1641
 msgid "url to the resource"
 msgstr "URL alla risorsa"
 
@@ -1234,12 +1234,12 @@ msgstr "Impossibile recuperare dal link, si prega di controllare ancora. Alcuni 
 #: catalog/templates/_item_card_metadata_tvseason.html:7
 #: catalog/templates/_item_card_metadata_tvshow.html:7
 #: catalog/templates/_item_card_metadata_work.html:7
-#: catalog/templates/item_base.html:201
+#: catalog/templates/item_base.html:186
 msgid "ratings"
 msgstr "valutazioni"
 
-#: catalog/templates/_item_card_metadata_base.html:34
-#: catalog/templates/item_base.html:256
+#: catalog/templates/_item_card_metadata_base.html:28
+#: catalog/templates/item_base.html:241
 msgid "part of"
 msgstr "Parte della"
 
@@ -1259,7 +1259,7 @@ msgid "hide this tooltip"
 msgstr "nascondi questo suggerimento"
 
 #: catalog/templates/_item_comments.html:58
-#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:83
+#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:81
 #, fuzzy
 #| msgid "translator"
 msgid "translate"
@@ -1268,7 +1268,7 @@ msgstr "Tradotto da"
 #: catalog/templates/_item_comments.html:92
 #: catalog/templates/_item_comments_by_episode.html:80
 #: catalog/templates/_item_notes.html:88
-#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:284
+#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:269
 #: catalog/templates/podcast_episode_data.html:41
 msgid "show more"
 msgstr "mostra di più"
@@ -1389,8 +1389,8 @@ msgstr "Sincronizzazione in corso."
 #: catalog/templates/_item_user_pieces.html:101
 #: catalog/templates/catalog_edit.html:12
 #: journal/templates/action_edit_post.html:6
-#: journal/templates/action_edit_post.html:8 journal/templates/article.html:196
-#: journal/templates/collection.html:185 journal/templates/collection.html:193
+#: journal/templates/action_edit_post.html:8 journal/templates/article.html:194
+#: journal/templates/collection.html:186 journal/templates/collection.html:194
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_edit.html:26
 #: journal/templates/post_compose.html:16 journal/templates/tag_edit.html:16
@@ -1434,7 +1434,7 @@ msgstr "ritorna all'elemento"
 #: catalog/templates/_sidebar_edit.html:20
 #: catalog/templates/catalog_verify.html:11
 #: catalog/templates/catalog_verify.html:17
-#: catalog/templates/item_base.html:182
+#: catalog/templates/item_base.html:167
 #, fuzzy
 #| msgid "Verification"
 msgid "Creator verification"
@@ -1444,7 +1444,7 @@ msgstr "Verifica"
 msgid "Edit Options"
 msgstr "Modifica Opzioni"
 
-#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
+#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:163
 #: catalog/views/edit.py:160 catalog/views/edit.py:221
 #: catalog/views/edit.py:288 catalog/views/edit.py:309
 #: catalog/views/edit.py:364 catalog/views/edit.py:471
@@ -1618,7 +1618,7 @@ msgstr "unisci ad un altro elemento"
 #: catalog/templates/_sidebar_edit.html:265
 #: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
-#: journal/templates/article.html:199 journal/templates/collection.html:188
+#: journal/templates/article.html:197 journal/templates/collection.html:189
 #: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
@@ -1815,7 +1815,7 @@ msgstr ""
 msgid "Remove my verification"
 msgstr "Rimuovi dalla collezione"
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:311
+#: catalog/templates/_verify_status.html:31 users/views/account.py:312
 #, fuzzy
 #| msgid "Verification Code"
 msgid "Verification failed"
@@ -2009,7 +2009,7 @@ msgstr "Tag popolari"
 
 #: catalog/templates/discover.html:229
 #: catalog/templates/discover_original_podcasts.html:25
-#: catalog/templates/item_base.html:282
+#: catalog/templates/item_base.html:267
 #: catalog/templates/item_mark_list.html:71
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
@@ -2079,67 +2079,67 @@ msgstr "Recuperando da %(site_label)s"
 msgid "System busy, please try again in a minute."
 msgstr "Sistema occupato, si prega di riprovare fra un minuto."
 
-#: catalog/templates/item_base.html:95
+#: catalog/templates/item_base.html:80
 msgid "select one of the seasons to comment"
 msgstr "seleziona una delle stagioni per commentare"
 
-#: catalog/templates/item_base.html:129
+#: catalog/templates/item_base.html:114
 msgid "mark, comment and collect"
 msgstr "Segna, commenta e colleziona"
 
-#: catalog/templates/item_base.html:142
+#: catalog/templates/item_base.html:127
 msgid "Login or register to review or add this item to your collection."
 msgstr "Accedi o registrati per recensire o aggiungere questo elemento alla tua collezione."
 
-#: catalog/templates/item_base.html:151
+#: catalog/templates/item_base.html:136
 msgid "Related Collections"
 msgstr "Collezioni Correlate"
 
-#: catalog/templates/item_base.html:166
+#: catalog/templates/item_base.html:151
 msgid "Unsupported item type."
 msgstr "Tipo d'elemento non supportato."
 
-#: catalog/templates/item_base.html:176
+#: catalog/templates/item_base.html:161
 msgid "Edit this item"
 msgstr "Modifica questo elemento"
 
-#: catalog/templates/item_base.html:187
+#: catalog/templates/item_base.html:172
 msgid "Last edited"
 msgstr "Modificato l'ultima volta"
 
-#: catalog/templates/item_base.html:230
+#: catalog/templates/item_base.html:215
 msgid "No enough ratings"
 msgstr "Non ci sono abbastanza valutazioni"
 
-#: catalog/templates/item_base.html:274
+#: catalog/templates/item_base.html:259
 msgid "overview"
 msgstr "Sinossi"
 
-#: catalog/templates/item_base.html:305
+#: catalog/templates/item_base.html:290
 msgid "comments"
 msgstr "Commenti"
 
-#: catalog/templates/item_base.html:308
+#: catalog/templates/item_base.html:293
 #: catalog/templates/item_mark_list.html:22
 #: catalog/templates/item_mark_list.html:25
 #: catalog/templates/item_review_list.html:21
 msgid "marks"
 msgstr "Interazioni"
 
-#: catalog/templates/item_base.html:309
+#: catalog/templates/item_base.html:294
 #: catalog/templates/item_mark_list.html:23
 #: catalog/templates/item_mark_list.html:26
 #: catalog/templates/item_review_list.html:22
 msgid "marks from who you follow"
 msgstr "Interazioni degli utenti che segui tu"
 
-#: catalog/templates/item_base.html:323
+#: catalog/templates/item_base.html:308
 #: catalog/templates/item_mark_list.html:28
 #: catalog/templates/item_review_list.html:23
 msgid "reviews"
 msgstr "Recensioni"
 
-#: catalog/templates/item_base.html:333
+#: catalog/templates/item_base.html:318
 #, fuzzy
 #| msgid "note"
 msgid "notes"
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
+#: catalog/views/verify.py:164 common/utils.py:148 common/utils.py:189
 #: journal/views/article.py:186 journal/views/review.py:182
 #: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
@@ -4324,7 +4324,7 @@ msgstr "Solo Menzionati"
 msgid "Open Registration"
 msgstr "Registrazione fallita"
 
-#: common/templates/common/about.html:40 common/views_manage.py:657
+#: common/templates/common/about.html:40 common/views_manage.py:671
 #, fuzzy
 #| msgid "Preferences"
 msgid "Preferred Languages"
@@ -4390,7 +4390,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:738
+#: common/templates/common/scan.html:60 common/views_manage.py:756
 #, fuzzy
 #| msgid "Search results"
 msgid "Search"
@@ -4476,16 +4476,16 @@ msgstr "tu"
 msgid "unavailable"
 msgstr "non disponibile"
 
-#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
+#: common/utils.py:152 common/utils.py:193 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr "L'utente non esiste più"
 
-#: common/utils.py:135 common/utils.py:137 common/utils.py:140
-#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
+#: common/utils.py:159 common/utils.py:161 common/utils.py:164
+#: common/utils.py:200 common/utils.py:204 journal/views/profile.py:499
 msgid "Access denied"
 msgstr "Accesso negato"
 
-#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
+#: common/utils.py:167 common/utils.py:169 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr "Richiesto l'accesso"
@@ -4508,7 +4508,7 @@ msgstr "Commenti"
 msgid "Access"
 msgstr "Accesso negato"
 
-#: common/views_manage.py:39 common/views_manage.py:733
+#: common/views_manage.py:39 common/views_manage.py:751
 #, fuzzy
 #| msgid "duration"
 msgid "Federation"
@@ -4892,465 +4892,495 @@ msgid "Sender name and address for outgoing email."
 msgstr ""
 
 #: common/views_manage.py:649
+msgid "Enable Twitter / X Archive Import"
+msgstr ""
+
+#: common/views_manage.py:651
+msgid "Show the Twitter / X archive import on the data page. Imported tweets become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:656
+msgid "Enable Mastodon Archive Import"
+msgstr ""
+
+#: common/views_manage.py:658
+msgid "Show the Mastodon archive import on the data page. Imported posts become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:663
 #, fuzzy
 #| msgid "Language"
 msgid "Default Language"
 msgstr "Lingua"
 
-#: common/views_manage.py:652
+#: common/views_manage.py:666
 msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:673
 msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:665
+#: common/views_manage.py:679
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:672
+#: common/views_manage.py:686
 #, fuzzy
 #| msgid "Import Method"
 msgid "Login Methods"
 msgstr "Metodo d'importazione"
 
-#: common/views_manage.py:677 mastodon/models/common.py:30
+#: common/views_manage.py:691 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr "Email"
 
-#: common/views_manage.py:681
+#: common/views_manage.py:695
+#, fuzzy
+#| msgid "Import"
+msgid "Data Import"
+msgstr "Importa"
+
+#: common/views_manage.py:699
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:692
+#: common/views_manage.py:710
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:694
+#: common/views_manage.py:712
 msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:699
+#: common/views_manage.py:717
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:700
+#: common/views_manage.py:718
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:704
+#: common/views_manage.py:722
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:706
+#: common/views_manage.py:724
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:711
+#: common/views_manage.py:729
 #, fuzzy
 #| msgid "Search results"
 msgid "Search Sites"
 msgstr "Risultati della ricerca"
 
-#: common/views_manage.py:712
+#: common/views_manage.py:730
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:715
+#: common/views_manage.py:733
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:716
+#: common/views_manage.py:734
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:719
+#: common/views_manage.py:737
 #, fuzzy
 #| msgid "Add tv series"
 msgid "Hidden Categories"
 msgstr "Aggiungi serie tv"
 
-#: common/views_manage.py:720
+#: common/views_manage.py:738
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:723
+#: common/views_manage.py:741
 msgid "Guest Search Page Limit"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:743
 msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
 msgstr ""
 
-#: common/views_manage.py:751
+#: common/views_manage.py:769
 #, fuzzy
 #| msgid "Spotify Album"
 msgid "Spotify API Key"
 msgstr "Album Spotify"
 
-#: common/views_manage.py:752
+#: common/views_manage.py:770
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:773
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:756
+#: common/views_manage.py:774
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:759
+#: common/views_manage.py:777
 #, fuzzy
 #| msgid "Google Books"
 msgid "Google Books API Key"
 msgstr "Google Books"
 
-#: common/views_manage.py:760
+#: common/views_manage.py:778
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:763
+#: common/views_manage.py:781
 #, fuzzy
 #| msgid "Discogs"
 msgid "Discogs API Key"
 msgstr "Discogs"
 
-#: common/views_manage.py:765
+#: common/views_manage.py:783
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:769
+#: common/views_manage.py:787
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:770
+#: common/views_manage.py:788
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:773
+#: common/views_manage.py:791
 #, fuzzy
 #| msgid "client secret"
 msgid "IGDB Client Secret"
 msgstr "segreto del client"
 
-#: common/views_manage.py:776
+#: common/views_manage.py:794
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:778
+#: common/views_manage.py:796
 msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:783
+#: common/views_manage.py:801
 msgid "MyAnimeList Client ID"
 msgstr ""
 
-#: common/views_manage.py:785
+#: common/views_manage.py:803
 msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
 msgstr ""
 
-#: common/views_manage.py:790 users/templates/users/steam_import.html:26
+#: common/views_manage.py:808 users/templates/users/steam_import.html:26
 #, fuzzy
 #| msgid "Steam Game"
 msgid "Steam API Key"
 msgstr "Gioco Steam"
 
-#: common/views_manage.py:792
+#: common/views_manage.py:810
 msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:797
+#: common/views_manage.py:815
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:798
+#: common/views_manage.py:816
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:801
+#: common/views_manage.py:819
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:804
+#: common/views_manage.py:822
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:807
+#: common/views_manage.py:825
 #, fuzzy
 #| msgid "Threads"
 msgid "Threads App ID"
 msgstr "Threads"
 
-#: common/views_manage.py:808
+#: common/views_manage.py:826
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:811
+#: common/views_manage.py:829
 #, fuzzy
 #| msgid "Threads.net"
 msgid "Threads App Secret"
 msgstr "Threads.net"
 
-#: common/views_manage.py:814
+#: common/views_manage.py:832
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:834
 msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:833
+#: common/views_manage.py:851
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:844
+#: common/views_manage.py:862
 #, fuzzy
 #| msgid "translator"
 msgid "Translation"
 msgstr "Tradotto da"
 
-#: common/views_manage.py:849
+#: common/views_manage.py:867
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:853 social/templates/feed.html:27
+#: common/views_manage.py:871 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr "Notifiche"
 
-#: common/views_manage.py:863
+#: common/views_manage.py:881
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:882
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:885
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:868
+#: common/views_manage.py:886
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:871
+#: common/views_manage.py:889
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:874
+#: common/views_manage.py:892
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:877
+#: common/views_manage.py:895
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:880
+#: common/views_manage.py:898
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:883
+#: common/views_manage.py:901
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:886
+#: common/views_manage.py:904
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:887
+#: common/views_manage.py:905
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:908
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:894
+#: common/views_manage.py:912
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:898
+#: common/views_manage.py:916
 #, fuzzy
 #| msgid "series"
 msgid "Retries"
 msgstr "Serie"
 
-#: common/views_manage.py:903
+#: common/views_manage.py:921
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:908
+#: common/views_manage.py:926
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:915
+#: common/views_manage.py:933
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:927
+#: common/views_manage.py:945
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:928
+#: common/views_manage.py:946
 #, fuzzy
 #| msgid "site domain name"
 msgid "One domain per line."
 msgstr "nome del dominio del sito"
 
-#: common/views_manage.py:931
+#: common/views_manage.py:949
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:932
+#: common/views_manage.py:950
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:935
+#: common/views_manage.py:953
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:937
+#: common/views_manage.py:955
 msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:943
+#: common/views_manage.py:961
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:944
+#: common/views_manage.py:962
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:947
+#: common/views_manage.py:965
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:948
+#: common/views_manage.py:966
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:958
+#: common/views_manage.py:976
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:960
+#: common/views_manage.py:978
 msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:966
+#: common/views_manage.py:984
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:968
+#: common/views_manage.py:986
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:974
+#: common/views_manage.py:992
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:976
+#: common/views_manage.py:994
 msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:983
+#: common/views_manage.py:1000
+msgid "Webhook Timeout (milliseconds)"
+msgstr ""
+
+#: common/views_manage.py:1001
+msgid "Timeout for delivering webhook requests to applications."
+msgstr ""
+
+#: common/views_manage.py:1006
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:986
+#: common/views_manage.py:1009
 #, fuzzy
 #| msgid "optional"
 msgid "Operational"
 msgstr "opzionale"
 
-#: common/views_manage.py:1002
+#: common/views_manage.py:1026
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:1004
+#: common/views_manage.py:1028
 msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1009
+#: common/views_manage.py:1033
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:1011
+#: common/views_manage.py:1035
 msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1016
+#: common/views_manage.py:1040
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:1018
+#: common/views_manage.py:1042
 msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1023
+#: common/views_manage.py:1047
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:1025
+#: common/views_manage.py:1049
 msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1030
+#: common/views_manage.py:1054
 #, fuzzy
 #| msgid "Podcast"
 msgid "Podcast Genres"
 msgstr "Podcast"
 
-#: common/views_manage.py:1032
+#: common/views_manage.py:1056
 msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1037
+#: common/views_manage.py:1061
 #, fuzzy
 #| msgid "Performance"
 msgid "Performance Genres"
 msgstr "Esibizione"
 
-#: common/views_manage.py:1039
+#: common/views_manage.py:1063
 msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1045
+#: common/views_manage.py:1069
 msgid "Genres by Category"
 msgstr ""
 
-#: common/views_manage.py:1069
+#: common/views_manage.py:1093
 msgid "Site"
 msgstr ""
 
-#: common/views_manage.py:1079
+#: common/views_manage.py:1103
 #, fuzzy
 #| msgid "Database"
 msgid "Database and Services"
 msgstr "Database"
 
-#: common/views_manage.py:1089
+#: common/views_manage.py:1113
 msgid "Media and Files"
 msgstr ""
 
-#: common/views_manage.py:1098
+#: common/views_manage.py:1122
 msgid "Monitoring"
 msgstr ""
 
-#: common/views_manage.py:1102
+#: common/views_manage.py:1126
 msgid "Security"
 msgstr ""
 
-#: common/views_manage.py:1111
+#: common/views_manage.py:1135
 msgid "Other Environment Variables"
 msgstr ""
 
-#: common/views_manage.py:1113
+#: common/views_manage.py:1137
 msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
 msgstr ""
 
@@ -5398,7 +5428,8 @@ msgstr "Mentre si salva, sostituire spazi iniziali con spazi a tutta larghezza"
 #: users/templates/users/data.html:60 users/templates/users/data.html:113
 #: users/templates/users/data.html:170 users/templates/users/data.html:221
 #: users/templates/users/data.html:284 users/templates/users/data.html:346
-#: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
+#: users/templates/users/data.html:525 users/templates/users/data.html:578
+#: users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
 msgid "Visibility"
@@ -5438,8 +5469,8 @@ msgstr "solo creatore"
 msgid "owner and their local mutuals"
 msgstr "creatore e i suoi reciproci"
 
-#: journal/forms.py:169 journal/templates/collection.html:193
-#: journal/templates/collection.html:202
+#: journal/forms.py:169 journal/templates/collection.html:194
+#: journal/templates/collection.html:203
 msgid "Collaborative editing"
 msgstr "Modifica collaborativa"
 
@@ -5492,7 +5523,7 @@ msgstr ""
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:215 journal/views/article.py:218
+#: journal/models/article.py:224 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
@@ -5504,75 +5535,76 @@ msgstr ""
 msgid "note"
 msgstr "nota"
 
-#: journal/models/collection.py:115
+#: journal/models/collection.py:116
 #, fuzzy
 #| msgid "shared {username}'s collection"
 msgid "search query for dynamic collection"
 msgstr "condivisa la collezione di {username}"
 
-#: journal/models/collection.py:566 journal/templatetags/collection.py:35
+#: journal/models/collection.py:575 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] "%(count)d libro"
 msgstr[1] "%(count)d libri"
 
-#: journal/models/collection.py:571 journal/templatetags/collection.py:43
+#: journal/models/collection.py:580 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] "%(count)d film"
 msgstr[1] "%(count)d film"
 
-#: journal/models/collection.py:576 journal/templatetags/collection.py:51
+#: journal/models/collection.py:585 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] "%(count)d serie tv"
 msgstr[1] "%(count)d serie tv"
 
-#: journal/models/collection.py:581 journal/templatetags/collection.py:59
+#: journal/models/collection.py:590 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] "%(count)d album"
 msgstr[1] "%(count)d album"
 
-#: journal/models/collection.py:586 journal/templatetags/collection.py:67
+#: journal/models/collection.py:595 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] "%(count)d gioco"
 msgstr[1] "%(count)d giochi"
 
-#: journal/models/collection.py:591 journal/templatetags/collection.py:75
+#: journal/models/collection.py:600 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] "%(count)d podcast"
 msgstr[1] "%(count)d podcast"
 
-#: journal/models/collection.py:597 journal/templatetags/collection.py:83
+#: journal/models/collection.py:606 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] "%(count)d esibizione"
 msgstr[1] "%(count)d esibizioni"
 
-#: journal/models/collection.py:605 journal/templatetags/collection.py:91
+#: journal/models/collection.py:614 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] "%(count)d elemento"
 msgstr[1] "%(count)d elementi"
 
-#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/models/common.py:59 journal/templates/action_open_post.html:15
 #: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
 #: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
 #: users/templates/users/data.html:122 users/templates/users/data.html:179
 #: users/templates/users/data.html:230 users/templates/users/data.html:292
 #: users/templates/users/data.html:355 users/templates/users/data.html:534
+#: users/templates/users/data.html:587
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5580,13 +5612,14 @@ msgstr[1] "%(count)d elementi"
 msgid "Public"
 msgstr "Pubblico"
 
-#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/models/common.py:60 journal/templates/action_open_post.html:9
 #: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
 #: users/templates/users/data.html:130 users/templates/users/data.html:187
 #: users/templates/users/data.html:238 users/templates/users/data.html:300
 #: users/templates/users/data.html:363 users/templates/users/data.html:542
+#: users/templates/users/data.html:595
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5594,12 +5627,13 @@ msgstr "Pubblico"
 msgid "Followers Only"
 msgstr "Solo Follower"
 
-#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/models/common.py:61 journal/templates/collection_share.html:57
 #: journal/templates/mark.html:102 journal/templates/post_compose.html:72
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
 #: users/templates/users/data.html:138 users/templates/users/data.html:195
 #: users/templates/users/data.html:246 users/templates/users/data.html:308
 #: users/templates/users/data.html:371 users/templates/users/data.html:550
+#: users/templates/users/data.html:603
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5607,33 +5641,33 @@ msgstr "Solo Follower"
 msgid "Mentioned Only"
 msgstr "Solo Menzionati"
 
-#: journal/models/common.py:806
+#: journal/models/common.py:851
 #, fuzzy
 #| msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr "Un post recente non è stato pubblicato su Mastodon, si prega di re-autorizzare."
 
-#: journal/models/common.py:1003
+#: journal/models/common.py:1048
 msgid "A recent post was not posted to Threads."
 msgstr "Un post recente non è stato pubblicato su Threads."
 
-#: journal/models/common.py:1036
+#: journal/models/common.py:1081
 #, fuzzy
 #| msgid "A recent post was not posted to Mastodon."
 msgid "A recent post was not boosted on Mastodon."
 msgstr "Un post recente non è stato pubblicato su Mastodon."
 
-#: journal/models/common.py:1046
+#: journal/models/common.py:1091
 #, fuzzy
 #| msgid "Item no longer exists"
 msgid "Original post no longer exists."
 msgstr "L'elemento non esiste più"
 
-#: journal/models/common.py:1060
+#: journal/models/common.py:1105
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr "Un post recente non è stato pubblicato su Mastodon, si prega di re-autorizzare."
 
-#: journal/models/common.py:1069
+#: journal/models/common.py:1114
 msgid "A recent post was not posted to Mastodon."
 msgstr "Un post recente non è stato pubblicato su Mastodon."
 
@@ -5651,85 +5685,85 @@ msgstr "Fallito"
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:475
+#: journal/models/mark.py:477
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:479
+#: journal/models/mark.py:481
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:486
+#: journal/models/mark.py:488
 #, fuzzy
 #| msgid "Invalid parameter"
 msgid "Invalid progress type."
 msgstr "Parametro non valido"
 
-#: journal/models/mark.py:488
+#: journal/models/mark.py:490
 #, fuzzy
 #| msgid "Invalid response from Fediverse instance."
 msgid "Invalid progress type for this item."
 msgstr "Risposta non valida dall'istanza del fediverso."
 
-#: journal/models/note.py:47 users/templates/users/rym_import.html:73
+#: journal/models/note.py:48 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr "Pagina"
 
-#: journal/models/note.py:48
+#: journal/models/note.py:49
 msgid "Chapter"
 msgstr "Capitolo"
 
-#: journal/models/note.py:51
+#: journal/models/note.py:52
 msgid "Part"
 msgstr "Parte"
 
-#: journal/models/note.py:52
+#: journal/models/note.py:53
 msgid "Episode"
 msgstr "Episodio"
 
-#: journal/models/note.py:53
+#: journal/models/note.py:54
 msgid "Track"
 msgstr "Traccia"
 
-#: journal/models/note.py:54
+#: journal/models/note.py:55
 msgid "Cycle"
 msgstr "Ciclo"
 
-#: journal/models/note.py:55
+#: journal/models/note.py:56
 msgid "Timestamp"
 msgstr "Timbro temporale"
 
-#: journal/models/note.py:56
+#: journal/models/note.py:57
 msgid "Percentage"
 msgstr "Percentuale"
 
-#: journal/models/note.py:77
+#: journal/models/note.py:78
 #, python-brace-format
 msgid "Page {value}"
 msgstr "Pagina {value}"
 
-#: journal/models/note.py:78
+#: journal/models/note.py:79
 #, python-brace-format
 msgid "Chapter {value}"
 msgstr "Capitolo {value}"
 
-#: journal/models/note.py:81
+#: journal/models/note.py:82
 #, python-brace-format
 msgid "Part {value}"
 msgstr "Parte {value}"
 
-#: journal/models/note.py:82
+#: journal/models/note.py:83
 #, python-brace-format
 msgid "Episode {value}"
 msgstr "Episodio {value}"
 
-#: journal/models/note.py:83
+#: journal/models/note.py:84
 #, python-brace-format
 msgid "Track {value}"
 msgstr "Traccia {value}"
 
-#: journal/models/note.py:84
+#: journal/models/note.py:85
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr "Ciclo {value}"
@@ -5739,13 +5773,13 @@ msgstr "Ciclo {value}"
 msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr "riguardo {item_title}, potrebbe contenere spoiler o contenuto sensibile"
 
-#: journal/models/review.py:79
+#: journal/models/review.py:80
 #, fuzzy, python-brace-format
 #| msgid "a review of {item_title}"
 msgid "a review of {title}"
 msgstr "una recensione di {item_title}"
 
-#: journal/models/review.py:81
+#: journal/models/review.py:82
 #, fuzzy
 #| msgid "Item contains sub-items."
 msgid "(may contain spoilers)"
@@ -6177,7 +6211,7 @@ msgstr "Utenti che stai seguendo"
 msgid "started following {item}"
 msgstr "iniziato a giocare {item}"
 
-#: journal/models/shelf.py:923
+#: journal/models/shelf.py:925
 msgid "removed mark"
 msgstr "rimosso segno"
 
@@ -6212,7 +6246,7 @@ msgstr "Rimuovi dalla collezione"
 msgid "Update note"
 msgstr "Aggiorna nota"
 
-#: journal/templates/_list_item.html:71 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:121
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
@@ -6381,7 +6415,7 @@ msgid "View post"
 msgstr ""
 
 #: journal/templates/action_quote_post.html:3
-#: journal/templates/article.html:190 journal/templates/collection.html:174
+#: journal/templates/article.html:188 journal/templates/collection.html:175
 msgid "Quote"
 msgstr ""
 
@@ -6390,7 +6424,7 @@ msgid "reply"
 msgstr "risposta"
 
 #: journal/templates/action_reply_post.html:3
-#: journal/templates/article.html:181 journal/templates/collection.html:165
+#: journal/templates/article.html:179 journal/templates/collection.html:166
 msgid "Reply"
 msgstr "Rispondi"
 
@@ -6409,23 +6443,23 @@ msgstr "Aggiungi alla collezione"
 msgid "Create a new collection"
 msgstr "Crea una nuova collezione"
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:76
+#: journal/templates/article.html:102 social/templates/_event_post.html:76
 #, fuzzy
 #| msgid "wrote a review of {item}"
 msgid "wrote a review"
 msgstr "ho scritto una recensione di {item}"
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:78
+#: journal/templates/article.html:104 social/templates/_event_post.html:78
 #, fuzzy
 #| msgid "wrote a note"
 msgid "wrote an article"
 msgstr "ha scritto una nota"
 
-#: journal/templates/article.html:136
+#: journal/templates/article.html:134
 msgid "This article may contain sensitive content. Click to reveal."
 msgstr ""
 
-#: journal/templates/article.html:155
+#: journal/templates/article.html:153
 msgid "The author has set it to be viewable only by logged-in users."
 msgstr "L'autore ha impostato la visibilità solo per gli utenti che hanno fatto l'accesso."
 
@@ -6490,20 +6524,20 @@ msgstr "NOV"
 msgid "DEC"
 msgstr "DIC"
 
-#: journal/templates/collection.html:71
+#: journal/templates/collection.html:72
 #: journal/templates/collection_share.html:12
 #: journal/templates/collection_share.html:66
 #: journal/templates/wrapped_share.html:59
 msgid "Share"
 msgstr "Condividi"
 
-#: journal/templates/collection.html:86
+#: journal/templates/collection.html:87
 #, fuzzy
 #| msgid "created collection"
 msgid "created a collection"
 msgstr "Collezione creata"
 
-#: journal/templates/collection.html:181
+#: journal/templates/collection.html:182
 msgid "Query"
 msgstr ""
 
@@ -6856,14 +6890,14 @@ msgid "Liked Collections"
 msgstr "Collezioni piaciute"
 
 #: journal/templates/user_follow_list.html:23 journal/views/profile.py:507
-#: users/templates/users/account.html:443
+#: users/templates/users/account.html:455
 #, fuzzy
 #| msgid "following you"
 msgid "Following"
 msgstr "ti seguono"
 
 #: journal/templates/user_follow_list.html:28 journal/views/profile.py:511
-#: users/templates/users/account.html:452
+#: users/templates/users/account.html:464
 #, fuzzy
 #| msgid "Followers Only"
 msgid "Followers"
@@ -7205,8 +7239,8 @@ msgstr "Login ID Bluesky"
 #: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
 #: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
 #: mastodon/views/threads.py:57 mastodon/views/threads.py:65
-#: mastodon/views/threads.py:71 users/views/account.py:256
-#: users/views/account.py:375
+#: mastodon/views/threads.py:71 users/views/account.py:257
+#: users/views/account.py:376
 msgid "Authentication failed"
 msgstr "Autenticazione fallita"
 
@@ -7254,7 +7288,7 @@ msgstr "Informazioni dell'account Bluesky non valide."
 msgid "Invalid user."
 msgstr "Utente non valido."
 
-#: mastodon/views/common.py:52 users/views/account.py:416
+#: mastodon/views/common.py:52 users/views/account.py:417
 msgid "Registration failed"
 msgstr "Registrazione fallita"
 
@@ -8242,146 +8276,161 @@ msgstr "anno di pubblicazione"
 msgid "Scopes"
 msgstr ""
 
-#: users/templates/users/account.html:398
+#: users/templates/users/account.html:386
+msgid "Webhook"
+msgstr ""
+
+#: users/templates/users/account.html:400
+msgid "disabled"
+msgstr ""
+
+#: users/templates/users/account.html:402
+#, fuzzy
+#| msgid "Activities"
+msgid "active"
+msgstr "Attività"
+
+#: users/templates/users/account.html:410
 msgid "Revoke access for this application?"
 msgstr ""
 
-#: users/templates/users/account.html:401
+#: users/templates/users/account.html:413
 msgid "Revoke"
 msgstr ""
 
-#: users/templates/users/account.html:409
+#: users/templates/users/account.html:421
 #, fuzzy
 #| msgid "View authorized applications"
 msgid "No authorized applications."
 msgstr "Visualizza applicazioni autorizzate"
 
-#: users/templates/users/account.html:412
+#: users/templates/users/account.html:424
 #: users/templates/users/authorized_app_create.html:9
 #: users/templates/users/authorized_app_create.html:19
 msgid "Create Personal Token"
 msgstr ""
 
-#: users/templates/users/account.html:418
+#: users/templates/users/account.html:430
 msgid "Import/Export Social Graph"
 msgstr ""
 
-#: users/templates/users/account.html:419
+#: users/templates/users/account.html:431
 msgid "Upload a CSV file exported from Mastodon or compatible services."
 msgstr ""
 
-#: users/templates/users/account.html:425
+#: users/templates/users/account.html:437
 #, fuzzy
 #| msgid "Import"
 msgid "Import type"
 msgstr "Importa"
 
-#: users/templates/users/account.html:427
+#: users/templates/users/account.html:439
 #, fuzzy
 #| msgid "following you"
 msgid "Following list"
 msgstr "ti seguono"
 
-#: users/templates/users/account.html:428
+#: users/templates/users/account.html:440
 #, fuzzy
 #| msgid "to listen"
 msgid "Block list"
 msgstr "da ascoltare"
 
-#: users/templates/users/account.html:429
+#: users/templates/users/account.html:441
 #, fuzzy
 #| msgid "to listen"
 msgid "Mute list"
 msgstr "da ascoltare"
 
-#: users/templates/users/account.html:433
+#: users/templates/users/account.html:445
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/account.html:448 users/templates/users/data.html:89
 #: users/templates/users/data.html:141 users/templates/users/data.html:198
 #: users/templates/users/data.html:249 users/templates/users/data.html:313
 #: users/templates/users/data.html:376 users/templates/users/data.html:553
+#: users/templates/users/data.html:606 users/templates/users/data.html:631
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr "Importa"
 
-#: users/templates/users/account.html:447
-#: users/templates/users/account.html:456
-#: users/templates/users/account.html:465
-#: users/templates/users/account.html:474
+#: users/templates/users/account.html:459
+#: users/templates/users/account.html:468
+#: users/templates/users/account.html:477
+#: users/templates/users/account.html:486
 #, fuzzy
 #| msgid "Download"
 msgid "Download CSV"
 msgstr "Scarica"
 
-#: users/templates/users/account.html:461
+#: users/templates/users/account.html:473
 #, fuzzy
 #| msgid "blocked"
 msgid "Blocks"
 msgstr "bloccato"
 
-#: users/templates/users/account.html:470
+#: users/templates/users/account.html:482
 msgid "Mutes"
 msgstr ""
 
-#: users/templates/users/account.html:484
+#: users/templates/users/account.html:496
 #, fuzzy
 #| msgid "Migrate account"
 msgid "Migrate Account"
 msgstr "Migra account"
 
-#: users/templates/users/account.html:488
+#: users/templates/users/account.html:500
 #, fuzzy
 #| msgid "Link an email so that you can migrate followers from other Fediverse instances."
 msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
 msgstr "Associa un'email in modo da poter trasferire i seguaci da altre istanze del Fediverso."
 
-#: users/templates/users/account.html:491
+#: users/templates/users/account.html:503
 #, fuzzy
 #| msgid "Migrate account"
 msgid "Migrate another account here"
 msgstr "Migra account"
 
-#: users/templates/users/account.html:494
+#: users/templates/users/account.html:506
 #, fuzzy
 #| msgid "Migrate account"
 msgid "Migrate to another account"
 msgstr "Migra account"
 
-#: users/templates/users/account.html:501
+#: users/templates/users/account.html:513
 msgid "Delete Account"
 msgstr "Elimina Profilo"
 
-#: users/templates/users/account.html:504
+#: users/templates/users/account.html:516
 msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
 msgstr "Una volta eliminato, i dati dell'account non potranno essere recuperati. Vuoi continuare?"
 
-#: users/templates/users/account.html:507
+#: users/templates/users/account.html:519
 msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
 msgstr "Per confermare l'eliminazione inserire per intero <code>username@instance.social</code> o <code>email@domain.com</code>."
 
-#: users/templates/users/account.html:517
+#: users/templates/users/account.html:529
 msgid "Once deleted, account data cannot be recovered."
 msgstr "Una volta eliminati, i dati dell'account non potranno essere recuperati."
 
-#: users/templates/users/account.html:520
+#: users/templates/users/account.html:532
 #, fuzzy
 #| msgid "Importing in progress, can't delete now."
 msgid "Task in progress, can't delete now."
 msgstr "Importazione in corso, impossibile eliminare adesso."
 
-#: users/templates/users/account.html:524
+#: users/templates/users/account.html:536
 msgid "Permanently Delete"
 msgstr "Eliminato Definitivamente"
 
-#: users/templates/users/account.html:565
+#: users/templates/users/account.html:577
 #, fuzzy
 #| msgid "Delete this tag"
 msgid "Delete this passkey?"
 msgstr "Elimina questo tag"
 
-#: users/templates/users/account.html:585
+#: users/templates/users/account.html:597
 msgid "Rename passkey:"
 msgstr ""
 
@@ -8405,12 +8454,10 @@ msgstr ""
 
 #: users/templates/users/authorized_app_create.html:48
 #: users/templates/users/authorized_app_created.html:39
-#: users/templates/users/migrate_in.html:70
-#: users/templates/users/migrate_out.html:67
 #, fuzzy
-#| msgid "Preferences"
-msgid "Back to Preferences"
-msgstr "Preferenze"
+#| msgid "Migrate account"
+msgid "Back to Account"
+msgstr "Migra account"
 
 #: users/templates/users/authorized_app_created.html:9
 #: users/templates/users/authorized_app_created.html:19
@@ -8554,7 +8601,7 @@ msgstr "Sovrascrivi: aggiorna tutti gli status importati."
 msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
 msgstr "Un'altra importazione è in corso, avviare una nuova importazione potrebbe causare problemi, sicuro di voler importare?"
 
-#: users/templates/users/data.html:89 users/views/data.py:1130
+#: users/templates/users/data.html:89 users/views/data.py:1194
 msgid "Import in progress, please wait"
 msgstr "Importazione in corso, attendere prego"
 
@@ -8729,7 +8776,41 @@ msgstr ""
 msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
-#: users/templates/users/data.html:560
+#: users/templates/users/data.html:561
+msgid "Import Twitter / X Archive"
+msgstr ""
+
+#: users/templates/users/data.html:567
+msgid "On X, go to <b>Settings</b> - <b>Your account</b> - <b>Download an archive of your data</b>. Upload the <code>.zip</code> you receive, or only the <code>data/tweets.js</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:570
+msgid "Each tweet becomes a post with its original date, text, links and photos. Replies to your own tweets are kept as a thread. A retweet becomes a short post that links to the original tweet. Videos are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:573
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Tweets that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:615
+#, fuzzy
+#| msgid "Import Method"
+msgid "Import Mastodon Archive"
+msgstr "Metodo d'importazione"
+
+#: users/templates/users/data.html:621
+msgid "On your Mastodon server, go to <b>Preferences</b> - <b>Import and export</b> - <b>Request your archive</b>. Upload the <code>.zip</code> you receive, or only the <code>outbox.json</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:624
+msgid "Each post is imported with its original date, text, links, photos, content warning and visibility, so a followers-only post or a direct message stays that way. Replies to your own posts are kept as a thread. A boost becomes a short post that links to the original post. Videos, favourites and bookmarks are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:627
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Posts that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:639
 msgid "View Annual Summary"
 msgstr "Visualizza Sintesi Annuale"
 
@@ -8859,6 +8940,13 @@ msgstr "Obbiettivi in corso"
 #: users/templates/users/migrate_in.html:64
 msgid "No aliases configured."
 msgstr ""
+
+#: users/templates/users/migrate_in.html:70
+#: users/templates/users/migrate_out.html:67
+#, fuzzy
+#| msgid "Preferences"
+msgid "Back to Preferences"
+msgstr "Preferenze"
 
 #: users/templates/users/migrate_out.html:9
 #: users/templates/users/migrate_out.html:43
@@ -9415,207 +9503,208 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:126
+#: users/views/account.py:127
 msgid "This username is already in use."
 msgstr "Questo nome utente è già in uso."
 
-#: users/views/account.py:137
+#: users/views/account.py:138
 msgid "This email address is already in use."
 msgstr "Questo indirizzo email è già in uso."
 
-#: users/views/account.py:257 users/views/account.py:376
+#: users/views/account.py:258 users/views/account.py:377
 msgid "Registration is for invitation only"
 msgstr "La registrazione è soltanto per invito"
 
-#: users/views/account.py:268 users/views/account.py:340
+#: users/views/account.py:269 users/views/account.py:341
 #, fuzzy
 #| msgid "Timestamp"
 msgid "Time is up"
 msgstr "Timbro temporale"
 
-#: users/views/account.py:269 users/views/account.py:312
-#: users/views/account.py:341
+#: users/views/account.py:270 users/views/account.py:313
+#: users/views/account.py:342
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:315
+#: users/views/account.py:316
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:327
+#: users/views/account.py:328
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:328
+#: users/views/account.py:329
 #, fuzzy
 #| msgid "System busy, please try again in a minute."
 msgid "Please try again later."
 msgstr "Sistema occupato, si prega di riprovare fra un minuto."
 
-#: users/views/account.py:417
+#: users/views/account.py:418
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:447
+#: users/views/account.py:448
 msgid "Valid username required"
 msgstr "Nome utente valido richiesto"
 
-#: users/views/account.py:518
+#: users/views/account.py:519
 msgid "Account is being deleted."
 msgstr "L'account è in fase di eliminazione."
 
-#: users/views/account.py:521
+#: users/views/account.py:522
 msgid "Account mismatch."
 msgstr "Le informazzioni del profilo non corrispondono."
 
-#: users/views/data.py:264 users/views/data.py:296
+#: users/views/data.py:276 users/views/data.py:308
 msgid "Export file not available."
 msgstr "File d'esportazione non disponibile."
 
-#: users/views/data.py:290
+#: users/views/data.py:302
 msgid "Generating exports."
 msgstr "Generando esportazioni."
 
-#: users/views/data.py:308
+#: users/views/data.py:320
 msgid "Export file expired. Please export again."
 msgstr "File d'esportazione scaduto. Si prega di esportare nuovamente."
 
-#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
+#: users/views/data.py:335 users/views/data.py:356 users/views/data.py:377
 #, fuzzy
 #| msgid "Import in progress."
 msgid "Recent export still in progress."
 msgstr "Importazione in corso."
 
-#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
-#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
-#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
+#: users/views/data.py:393 users/views/data.py:419 users/views/data.py:447
+#: users/views/data.py:579 users/views/data.py:613 users/views/data.py:838
+#: users/views/data.py:1055 users/views/data.py:1081 users/views/data.py:1106
+#: users/views/data.py:1131 users/views/data.py:1201
 msgid "Invalid file."
 msgstr "File non valido."
 
-#: users/views/data.py:405
+#: users/views/data.py:469
 msgid "Sync in progress."
 msgstr "Sincronizzazione in corso."
 
-#: users/views/data.py:419
+#: users/views/data.py:483
 msgid "Settings saved."
 msgstr "Impostazioni salvate."
 
-#: users/views/data.py:474
+#: users/views/data.py:538
 #, fuzzy
 #| msgid "Account is being deleted."
 msgid "Account no longer linked."
 msgstr "L'account è in fase di eliminazione."
 
-#: users/views/data.py:477
+#: users/views/data.py:541
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:505
+#: users/views/data.py:569
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:585 users/views/data.py:810
+#: users/views/data.py:649 users/views/data.py:874
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:610 users/views/data.py:839
+#: users/views/data.py:674 users/views/data.py:903
 #, fuzzy
 #| msgid "Cancel"
 msgid "Cancelled."
 msgstr "Cancella"
 
-#: users/views/data.py:630
+#: users/views/data.py:694
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
-#: users/views/data.py:974
+#: users/views/data.py:702 users/views/data.py:812 users/views/data.py:933
+#: users/views/data.py:1038
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:734 users/views/data.py:960
+#: users/views/data.py:798 users/views/data.py:1024
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:744 users/views/data.py:970
+#: users/views/data.py:808 users/views/data.py:1034
 #, fuzzy
 #| msgid "Export file not available."
 msgid "No matched file available."
 msgstr "File d'esportazione non disponibile."
 
-#: users/views/data.py:861
+#: users/views/data.py:925
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1290
 #, fuzzy
 #| msgid "Login required"
 msgid "Name is required."
 msgstr "Richiesto l'accesso"
 
-#: users/views/data.py:1248
+#: users/views/data.py:1314
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1264
+#: users/views/data.py:1330
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1269
+#: users/views/data.py:1335
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1279 users/views/data.py:1330
+#: users/views/data.py:1345 users/views/data.py:1396
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:1286
+#: users/views/data.py:1352
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:1291
+#: users/views/data.py:1357
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:1317
+#: users/views/data.py:1383
 #, fuzzy
 #| msgid "Registration failed"
 msgid "Migration cancelled."
 msgstr "Registrazione fallita"
 
-#: users/views/data.py:1322
+#: users/views/data.py:1388
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:1335
+#: users/views/data.py:1401
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:1346
+#: users/views/data.py:1412
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:1352
+#: users/views/data.py:1418
 #, fuzzy, python-brace-format
 #| msgid "Continue login as {handle}."
 msgid "Start moving to {handle}."
 msgstr "Continua l'accesso come {handle}."
 
-#: users/views/data.py:1410
+#: users/views/data.py:1476
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1426
+#: users/views/data.py:1492
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1430
+#: users/views/data.py:1496
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1440
+#: users/views/data.py:1506
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""

--- a/neodb/locale/ja/LC_MESSAGES/django.po
+++ b/neodb/locale/ja/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 20:04-0400\n"
+"POT-Creation-Date: 2026-09-07 14:56-0400\n"
 "PO-Revision-Date: 2026-08-09 06:32+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/neodb/neodb/ja/>\n"
@@ -59,15 +59,15 @@ msgstr ""
 msgid "Traditional Chinese"
 msgstr ""
 
-#: catalog/forms.py:35 catalog/models/item.py:307
+#: catalog/forms.py:35 catalog/models/item.py:412
 msgid "Primary ID Type"
 msgstr ""
 
-#: catalog/forms.py:40 catalog/models/item.py:310
+#: catalog/forms.py:40 catalog/models/item.py:415
 msgid "Primary ID Value"
 msgstr ""
 
-#: catalog/forms.py:176
+#: catalog/forms.py:177
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
@@ -120,11 +120,11 @@ msgid "other title"
 msgstr ""
 
 #: catalog/models/book.py:282 catalog/models/book.py:566
-#: catalog/models/item.py:119
+#: catalog/models/item.py:224
 msgid "author"
 msgstr ""
 
-#: catalog/models/book.py:289 catalog/models/item.py:120
+#: catalog/models/book.py:289 catalog/models/item.py:225
 msgid "translator"
 msgstr ""
 
@@ -133,7 +133,7 @@ msgid "book format"
 msgstr ""
 
 #: catalog/models/book.py:303 catalog/models/game.py:135
-#: catalog/models/item.py:134 catalog/models/music.py:142
+#: catalog/models/item.py:239 catalog/models/music.py:142
 msgid "publisher"
 msgstr ""
 
@@ -165,7 +165,7 @@ msgstr ""
 msgid "price"
 msgstr ""
 
-#: catalog/models/book.py:326 catalog/models/item.py:145
+#: catalog/models/book.py:326 catalog/models/item.py:250
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr ""
@@ -564,7 +564,7 @@ msgid "Exhibition"
 msgstr ""
 
 #: catalog/models/common.py:174 catalog/models/common.py:191
-#: journal/templates/collection.html:29 journal/templates/collection.html:40
+#: journal/templates/collection.html:30 journal/templates/collection.html:41
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
@@ -686,16 +686,16 @@ msgstr ""
 msgid "Special Edition"
 msgstr ""
 
-#: catalog/models/game.py:111 catalog/models/item.py:126
+#: catalog/models/game.py:111 catalog/models/item.py:231
 msgid "designer"
 msgstr ""
 
-#: catalog/models/game.py:119 catalog/models/item.py:125
+#: catalog/models/game.py:119 catalog/models/item.py:230
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr ""
 
-#: catalog/models/game.py:127 catalog/models/item.py:135
+#: catalog/models/game.py:127 catalog/models/item.py:240
 msgid "developer"
 msgstr ""
 
@@ -725,141 +725,141 @@ msgstr ""
 msgid "website"
 msgstr ""
 
-#: catalog/models/item.py:121 catalog/models/movie.py:123
+#: catalog/models/item.py:226 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
 #: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr ""
 
-#: catalog/models/item.py:122 catalog/models/movie.py:130
+#: catalog/models/item.py:227 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
 #: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr ""
 
-#: catalog/models/item.py:123 catalog/models/movie.py:137
+#: catalog/models/item.py:228 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
 #: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr ""
 
-#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/item.py:229 catalog/models/movie.py:144
 #: catalog/models/tv.py:237 catalog/models/tv.py:463
 msgid "producer"
 msgstr ""
 
-#: catalog/models/item.py:127 catalog/models/performance.py:203
+#: catalog/models/item.py:232 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr ""
 
-#: catalog/models/item.py:128 catalog/models/performance.py:210
+#: catalog/models/item.py:233 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr ""
 
-#: catalog/models/item.py:129 catalog/models/performance.py:224
+#: catalog/models/item.py:234 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr ""
 
-#: catalog/models/item.py:130 catalog/models/podcast.py:80
+#: catalog/models/item.py:235 catalog/models/podcast.py:80
 msgid "host"
 msgstr ""
 
-#: catalog/models/item.py:131 catalog/models/performance.py:196
+#: catalog/models/item.py:236 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr ""
 
-#: catalog/models/item.py:132 catalog/models/performance.py:238
+#: catalog/models/item.py:237 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr ""
 
-#: catalog/models/item.py:136
+#: catalog/models/item.py:241
 msgid "production company"
 msgstr ""
 
-#: catalog/models/item.py:137
+#: catalog/models/item.py:242
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:138
+#: catalog/models/item.py:243
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:139
+#: catalog/models/item.py:244
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:140 catalog/models/performance.py:231
+#: catalog/models/item.py:245 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr ""
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:248
 msgid "voice actor"
 msgstr ""
 
-#: catalog/models/item.py:144 catalog/templates/edition.html:30
+#: catalog/models/item.py:249 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr ""
 
-#: catalog/models/item.py:169 catalog/models/people.py:476
+#: catalog/models/item.py:274 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr ""
 
-#: catalog/models/item.py:170 catalog/models/people.py:155
+#: catalog/models/item.py:275 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr ""
 
-#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:277 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:304 catalog/models/item.py:336
-#: journal/models/collection.py:100
+#: catalog/models/item.py:409 catalog/models/item.py:441
+#: journal/models/collection.py:101
 msgid "title"
 msgstr ""
 
-#: catalog/models/item.py:305 catalog/models/item.py:344
-#: journal/models/collection.py:101
+#: catalog/models/item.py:410 catalog/models/item.py:449
+#: journal/models/collection.py:102
 msgid "description"
 msgstr ""
 
-#: catalog/models/item.py:316 catalog/models/people.py:484
+#: catalog/models/item.py:421 catalog/models/people.py:484
 msgid "metadata"
 msgstr ""
 
-#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:423 catalog/templates/_item_card.html:28
 msgid "cover"
 msgstr ""
 
-#: catalog/models/item.py:1526
+#: catalog/models/item.py:1612
 msgid "source site"
 msgstr ""
 
-#: catalog/models/item.py:1528
+#: catalog/models/item.py:1614
 msgid "ID on source site"
 msgstr ""
 
-#: catalog/models/item.py:1530
+#: catalog/models/item.py:1616
 msgid "source url"
 msgstr ""
 
-#: catalog/models/item.py:1546
+#: catalog/models/item.py:1632
 msgid "IdType of the source site"
 msgstr ""
 
-#: catalog/models/item.py:1552
+#: catalog/models/item.py:1638
 msgid "Primary Id on the source site"
 msgstr ""
 
-#: catalog/models/item.py:1555
+#: catalog/models/item.py:1641
 msgid "url to the resource"
 msgstr ""
 
@@ -1144,12 +1144,12 @@ msgstr ""
 #: catalog/templates/_item_card_metadata_tvseason.html:7
 #: catalog/templates/_item_card_metadata_tvshow.html:7
 #: catalog/templates/_item_card_metadata_work.html:7
-#: catalog/templates/item_base.html:201
+#: catalog/templates/item_base.html:186
 msgid "ratings"
 msgstr ""
 
-#: catalog/templates/_item_card_metadata_base.html:34
-#: catalog/templates/item_base.html:256
+#: catalog/templates/_item_card_metadata_base.html:28
+#: catalog/templates/item_base.html:241
 msgid "part of"
 msgstr ""
 
@@ -1167,14 +1167,14 @@ msgid "hide this tooltip"
 msgstr ""
 
 #: catalog/templates/_item_comments.html:58
-#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:83
+#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:81
 msgid "translate"
 msgstr ""
 
 #: catalog/templates/_item_comments.html:92
 #: catalog/templates/_item_comments_by_episode.html:80
 #: catalog/templates/_item_notes.html:88
-#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:284
+#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:269
 #: catalog/templates/podcast_episode_data.html:41
 msgid "show more"
 msgstr ""
@@ -1285,8 +1285,8 @@ msgstr "同期中です。"
 #: catalog/templates/_item_user_pieces.html:101
 #: catalog/templates/catalog_edit.html:12
 #: journal/templates/action_edit_post.html:6
-#: journal/templates/action_edit_post.html:8 journal/templates/article.html:196
-#: journal/templates/collection.html:185 journal/templates/collection.html:193
+#: journal/templates/action_edit_post.html:8 journal/templates/article.html:194
+#: journal/templates/collection.html:186 journal/templates/collection.html:194
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_edit.html:26
 #: journal/templates/post_compose.html:16 journal/templates/tag_edit.html:16
@@ -1328,7 +1328,7 @@ msgstr ""
 #: catalog/templates/_sidebar_edit.html:20
 #: catalog/templates/catalog_verify.html:11
 #: catalog/templates/catalog_verify.html:17
-#: catalog/templates/item_base.html:182
+#: catalog/templates/item_base.html:167
 #, fuzzy
 #| msgid "Send verification code"
 msgid "Creator verification"
@@ -1338,7 +1338,7 @@ msgstr "確認コードを送信"
 msgid "Edit Options"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
+#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:163
 #: catalog/views/edit.py:160 catalog/views/edit.py:221
 #: catalog/views/edit.py:288 catalog/views/edit.py:309
 #: catalog/views/edit.py:364 catalog/views/edit.py:471
@@ -1502,7 +1502,7 @@ msgstr ""
 #: catalog/templates/_sidebar_edit.html:265
 #: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
-#: journal/templates/article.html:199 journal/templates/collection.html:188
+#: journal/templates/article.html:197 journal/templates/collection.html:189
 #: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
@@ -1691,7 +1691,7 @@ msgstr ""
 msgid "Remove my verification"
 msgstr "確認コードを送信"
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:311
+#: catalog/templates/_verify_status.html:31 users/views/account.py:312
 #, fuzzy
 #| msgid "Send verification code"
 msgid "Verification failed"
@@ -1885,7 +1885,7 @@ msgstr ""
 
 #: catalog/templates/discover.html:229
 #: catalog/templates/discover_original_podcasts.html:25
-#: catalog/templates/item_base.html:282
+#: catalog/templates/item_base.html:267
 #: catalog/templates/item_mark_list.html:71
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
@@ -1951,67 +1951,67 @@ msgstr ""
 msgid "System busy, please try again in a minute."
 msgstr ""
 
-#: catalog/templates/item_base.html:95
+#: catalog/templates/item_base.html:80
 msgid "select one of the seasons to comment"
 msgstr ""
 
-#: catalog/templates/item_base.html:129
+#: catalog/templates/item_base.html:114
 msgid "mark, comment and collect"
 msgstr ""
 
-#: catalog/templates/item_base.html:142
+#: catalog/templates/item_base.html:127
 msgid "Login or register to review or add this item to your collection."
 msgstr ""
 
-#: catalog/templates/item_base.html:151
+#: catalog/templates/item_base.html:136
 msgid "Related Collections"
 msgstr ""
 
-#: catalog/templates/item_base.html:166
+#: catalog/templates/item_base.html:151
 msgid "Unsupported item type."
 msgstr ""
 
-#: catalog/templates/item_base.html:176
+#: catalog/templates/item_base.html:161
 msgid "Edit this item"
 msgstr ""
 
-#: catalog/templates/item_base.html:187
+#: catalog/templates/item_base.html:172
 msgid "Last edited"
 msgstr ""
 
-#: catalog/templates/item_base.html:230
+#: catalog/templates/item_base.html:215
 msgid "No enough ratings"
 msgstr ""
 
-#: catalog/templates/item_base.html:274
+#: catalog/templates/item_base.html:259
 msgid "overview"
 msgstr ""
 
-#: catalog/templates/item_base.html:305
+#: catalog/templates/item_base.html:290
 msgid "comments"
 msgstr ""
 
-#: catalog/templates/item_base.html:308
+#: catalog/templates/item_base.html:293
 #: catalog/templates/item_mark_list.html:22
 #: catalog/templates/item_mark_list.html:25
 #: catalog/templates/item_review_list.html:21
 msgid "marks"
 msgstr ""
 
-#: catalog/templates/item_base.html:309
+#: catalog/templates/item_base.html:294
 #: catalog/templates/item_mark_list.html:23
 #: catalog/templates/item_mark_list.html:26
 #: catalog/templates/item_review_list.html:22
 msgid "marks from who you follow"
 msgstr ""
 
-#: catalog/templates/item_base.html:323
+#: catalog/templates/item_base.html:308
 #: catalog/templates/item_mark_list.html:28
 #: catalog/templates/item_review_list.html:23
 msgid "reviews"
 msgstr ""
 
-#: catalog/templates/item_base.html:333
+#: catalog/templates/item_base.html:318
 msgid "notes"
 msgstr ""
 
@@ -2400,7 +2400,7 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
+#: catalog/views/verify.py:164 common/utils.py:148 common/utils.py:189
 #: journal/views/article.py:186 journal/views/review.py:182
 #: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
@@ -4053,7 +4053,7 @@ msgstr ""
 msgid "Open Registration"
 msgstr ""
 
-#: common/templates/common/about.html:40 common/views_manage.py:657
+#: common/templates/common/about.html:40 common/views_manage.py:671
 msgid "Preferred Languages"
 msgstr ""
 
@@ -4115,7 +4115,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:738
+#: common/templates/common/scan.html:60 common/views_manage.py:756
 msgid "Search"
 msgstr ""
 
@@ -4197,16 +4197,16 @@ msgstr ""
 msgid "unavailable"
 msgstr ""
 
-#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
+#: common/utils.py:152 common/utils.py:193 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr ""
 
-#: common/utils.py:135 common/utils.py:137 common/utils.py:140
-#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
+#: common/utils.py:159 common/utils.py:161 common/utils.py:164
+#: common/utils.py:200 common/utils.py:204 journal/views/profile.py:499
 msgid "Access denied"
 msgstr ""
 
-#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
+#: common/utils.py:167 common/utils.py:169 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr ""
@@ -4225,7 +4225,7 @@ msgstr ""
 msgid "Access"
 msgstr "承認"
 
-#: common/views_manage.py:39 common/views_manage.py:733
+#: common/views_manage.py:39 common/views_manage.py:751
 msgid "Federation"
 msgstr ""
 
@@ -4581,433 +4581,463 @@ msgid "Sender name and address for outgoing email."
 msgstr ""
 
 #: common/views_manage.py:649
+msgid "Enable Twitter / X Archive Import"
+msgstr ""
+
+#: common/views_manage.py:651
+msgid "Show the Twitter / X archive import on the data page. Imported tweets become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:656
+msgid "Enable Mastodon Archive Import"
+msgstr ""
+
+#: common/views_manage.py:658
+msgid "Show the Mastodon archive import on the data page. Imported posts become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:663
 #, fuzzy
 #| msgid "Language"
 msgid "Default Language"
 msgstr "言語"
 
-#: common/views_manage.py:652
+#: common/views_manage.py:666
 msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:673
 msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:665
+#: common/views_manage.py:679
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:672
+#: common/views_manage.py:686
 #, fuzzy
 #| msgid "Import Method"
 msgid "Login Methods"
 msgstr "インポート方法"
 
-#: common/views_manage.py:677 mastodon/models/common.py:30
+#: common/views_manage.py:691 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr ""
 
-#: common/views_manage.py:681
+#: common/views_manage.py:695
+#, fuzzy
+#| msgid "Import"
+msgid "Data Import"
+msgstr "インポート"
+
+#: common/views_manage.py:699
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:692
+#: common/views_manage.py:710
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:694
+#: common/views_manage.py:712
 msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:699
+#: common/views_manage.py:717
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:700
+#: common/views_manage.py:718
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:704
+#: common/views_manage.py:722
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:706
+#: common/views_manage.py:724
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:711
+#: common/views_manage.py:729
 msgid "Search Sites"
 msgstr ""
 
-#: common/views_manage.py:712
+#: common/views_manage.py:730
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:715
+#: common/views_manage.py:733
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:716
+#: common/views_manage.py:734
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:719
+#: common/views_manage.py:737
 msgid "Hidden Categories"
 msgstr ""
 
-#: common/views_manage.py:720
+#: common/views_manage.py:738
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:723
+#: common/views_manage.py:741
 msgid "Guest Search Page Limit"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:743
 msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
 msgstr ""
 
-#: common/views_manage.py:751
+#: common/views_manage.py:769
 msgid "Spotify API Key"
 msgstr ""
 
-#: common/views_manage.py:752
+#: common/views_manage.py:770
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:773
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:756
+#: common/views_manage.py:774
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:759
+#: common/views_manage.py:777
 msgid "Google Books API Key"
 msgstr ""
 
-#: common/views_manage.py:760
+#: common/views_manage.py:778
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:763
+#: common/views_manage.py:781
 msgid "Discogs API Key"
 msgstr ""
 
-#: common/views_manage.py:765
+#: common/views_manage.py:783
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:769
+#: common/views_manage.py:787
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:770
+#: common/views_manage.py:788
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:773
+#: common/views_manage.py:791
 msgid "IGDB Client Secret"
 msgstr ""
 
-#: common/views_manage.py:776
+#: common/views_manage.py:794
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:778
+#: common/views_manage.py:796
 msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:783
+#: common/views_manage.py:801
 msgid "MyAnimeList Client ID"
 msgstr ""
 
-#: common/views_manage.py:785
+#: common/views_manage.py:803
 msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
 msgstr ""
 
-#: common/views_manage.py:790 users/templates/users/steam_import.html:26
+#: common/views_manage.py:808 users/templates/users/steam_import.html:26
 msgid "Steam API Key"
 msgstr ""
 
-#: common/views_manage.py:792
+#: common/views_manage.py:810
 msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:797
+#: common/views_manage.py:815
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:798
+#: common/views_manage.py:816
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:801
+#: common/views_manage.py:819
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:804
+#: common/views_manage.py:822
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:807
+#: common/views_manage.py:825
 msgid "Threads App ID"
 msgstr ""
 
-#: common/views_manage.py:808
+#: common/views_manage.py:826
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:811
+#: common/views_manage.py:829
 msgid "Threads App Secret"
 msgstr ""
 
-#: common/views_manage.py:814
+#: common/views_manage.py:832
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:834
 msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:833
+#: common/views_manage.py:851
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:844
+#: common/views_manage.py:862
 msgid "Translation"
 msgstr ""
 
-#: common/views_manage.py:849
+#: common/views_manage.py:867
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:853 social/templates/feed.html:27
+#: common/views_manage.py:871 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr ""
 
-#: common/views_manage.py:863
+#: common/views_manage.py:881
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:882
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:885
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:868
+#: common/views_manage.py:886
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:871
+#: common/views_manage.py:889
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:874
+#: common/views_manage.py:892
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:877
+#: common/views_manage.py:895
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:880
+#: common/views_manage.py:898
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:883
+#: common/views_manage.py:901
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:886
+#: common/views_manage.py:904
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:887
+#: common/views_manage.py:905
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:908
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:894
+#: common/views_manage.py:912
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:898
+#: common/views_manage.py:916
 msgid "Retries"
 msgstr ""
 
-#: common/views_manage.py:903
+#: common/views_manage.py:921
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:908
+#: common/views_manage.py:926
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:915
+#: common/views_manage.py:933
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:927
+#: common/views_manage.py:945
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:928
+#: common/views_manage.py:946
 msgid "One domain per line."
 msgstr ""
 
-#: common/views_manage.py:931
+#: common/views_manage.py:949
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:932
+#: common/views_manage.py:950
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:935
+#: common/views_manage.py:953
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:937
+#: common/views_manage.py:955
 msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:943
+#: common/views_manage.py:961
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:944
+#: common/views_manage.py:962
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:947
+#: common/views_manage.py:965
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:948
+#: common/views_manage.py:966
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:958
+#: common/views_manage.py:976
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:960
+#: common/views_manage.py:978
 msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:966
+#: common/views_manage.py:984
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:968
+#: common/views_manage.py:986
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:974
+#: common/views_manage.py:992
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:976
+#: common/views_manage.py:994
 msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:983
+#: common/views_manage.py:1000
+msgid "Webhook Timeout (milliseconds)"
+msgstr ""
+
+#: common/views_manage.py:1001
+msgid "Timeout for delivering webhook requests to applications."
+msgstr ""
+
+#: common/views_manage.py:1006
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:986
+#: common/views_manage.py:1009
 msgid "Operational"
 msgstr ""
 
-#: common/views_manage.py:1002
+#: common/views_manage.py:1026
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:1004
+#: common/views_manage.py:1028
 msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1009
+#: common/views_manage.py:1033
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:1011
+#: common/views_manage.py:1035
 msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1016
+#: common/views_manage.py:1040
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:1018
+#: common/views_manage.py:1042
 msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1023
+#: common/views_manage.py:1047
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:1025
+#: common/views_manage.py:1049
 msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1030
+#: common/views_manage.py:1054
 msgid "Podcast Genres"
 msgstr ""
 
-#: common/views_manage.py:1032
+#: common/views_manage.py:1056
 msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1037
+#: common/views_manage.py:1061
 msgid "Performance Genres"
 msgstr ""
 
-#: common/views_manage.py:1039
+#: common/views_manage.py:1063
 msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1045
+#: common/views_manage.py:1069
 msgid "Genres by Category"
 msgstr ""
 
-#: common/views_manage.py:1069
+#: common/views_manage.py:1093
 msgid "Site"
 msgstr ""
 
-#: common/views_manage.py:1079
+#: common/views_manage.py:1103
 msgid "Database and Services"
 msgstr ""
 
-#: common/views_manage.py:1089
+#: common/views_manage.py:1113
 msgid "Media and Files"
 msgstr ""
 
-#: common/views_manage.py:1098
+#: common/views_manage.py:1122
 msgid "Monitoring"
 msgstr ""
 
-#: common/views_manage.py:1102
+#: common/views_manage.py:1126
 msgid "Security"
 msgstr ""
 
-#: common/views_manage.py:1111
+#: common/views_manage.py:1135
 msgid "Other Environment Variables"
 msgstr ""
 
-#: common/views_manage.py:1113
+#: common/views_manage.py:1137
 msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
 msgstr ""
 
@@ -5051,7 +5081,8 @@ msgstr ""
 #: users/templates/users/data.html:60 users/templates/users/data.html:113
 #: users/templates/users/data.html:170 users/templates/users/data.html:221
 #: users/templates/users/data.html:284 users/templates/users/data.html:346
-#: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
+#: users/templates/users/data.html:525 users/templates/users/data.html:578
+#: users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
 msgid "Visibility"
@@ -5083,8 +5114,8 @@ msgstr ""
 msgid "owner and their local mutuals"
 msgstr ""
 
-#: journal/forms.py:169 journal/templates/collection.html:193
-#: journal/templates/collection.html:202
+#: journal/forms.py:169 journal/templates/collection.html:194
+#: journal/templates/collection.html:203
 msgid "Collaborative editing"
 msgstr ""
 
@@ -5135,7 +5166,7 @@ msgstr ""
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:215 journal/views/article.py:218
+#: journal/models/article.py:224 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
@@ -5147,65 +5178,66 @@ msgstr ""
 msgid "note"
 msgstr ""
 
-#: journal/models/collection.py:115
+#: journal/models/collection.py:116
 msgid "search query for dynamic collection"
 msgstr ""
 
-#: journal/models/collection.py:566 journal/templatetags/collection.py:35
+#: journal/models/collection.py:575 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] ""
 
-#: journal/models/collection.py:571 journal/templatetags/collection.py:43
+#: journal/models/collection.py:580 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] ""
 
-#: journal/models/collection.py:576 journal/templatetags/collection.py:51
+#: journal/models/collection.py:585 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] ""
 
-#: journal/models/collection.py:581 journal/templatetags/collection.py:59
+#: journal/models/collection.py:590 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] ""
 
-#: journal/models/collection.py:586 journal/templatetags/collection.py:67
+#: journal/models/collection.py:595 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] ""
 
-#: journal/models/collection.py:591 journal/templatetags/collection.py:75
+#: journal/models/collection.py:600 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] ""
 
-#: journal/models/collection.py:597 journal/templatetags/collection.py:83
+#: journal/models/collection.py:606 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] ""
 
-#: journal/models/collection.py:605 journal/templatetags/collection.py:91
+#: journal/models/collection.py:614 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] ""
 
-#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/models/common.py:59 journal/templates/action_open_post.html:15
 #: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
 #: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
 #: users/templates/users/data.html:122 users/templates/users/data.html:179
 #: users/templates/users/data.html:230 users/templates/users/data.html:292
 #: users/templates/users/data.html:355 users/templates/users/data.html:534
+#: users/templates/users/data.html:587
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5213,13 +5245,14 @@ msgstr[0] ""
 msgid "Public"
 msgstr ""
 
-#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/models/common.py:60 journal/templates/action_open_post.html:9
 #: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
 #: users/templates/users/data.html:130 users/templates/users/data.html:187
 #: users/templates/users/data.html:238 users/templates/users/data.html:300
 #: users/templates/users/data.html:363 users/templates/users/data.html:542
+#: users/templates/users/data.html:595
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5227,12 +5260,13 @@ msgstr ""
 msgid "Followers Only"
 msgstr ""
 
-#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/models/common.py:61 journal/templates/collection_share.html:57
 #: journal/templates/mark.html:102 journal/templates/post_compose.html:72
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
 #: users/templates/users/data.html:138 users/templates/users/data.html:195
 #: users/templates/users/data.html:246 users/templates/users/data.html:308
 #: users/templates/users/data.html:371 users/templates/users/data.html:550
+#: users/templates/users/data.html:603
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5240,27 +5274,27 @@ msgstr ""
 msgid "Mentioned Only"
 msgstr ""
 
-#: journal/models/common.py:806
+#: journal/models/common.py:851
 msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr ""
 
-#: journal/models/common.py:1003
+#: journal/models/common.py:1048
 msgid "A recent post was not posted to Threads."
 msgstr ""
 
-#: journal/models/common.py:1036
+#: journal/models/common.py:1081
 msgid "A recent post was not boosted on Mastodon."
 msgstr ""
 
-#: journal/models/common.py:1046
+#: journal/models/common.py:1091
 msgid "Original post no longer exists."
 msgstr ""
 
-#: journal/models/common.py:1060
+#: journal/models/common.py:1105
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr ""
 
-#: journal/models/common.py:1069
+#: journal/models/common.py:1114
 msgid "A recent post was not posted to Mastodon."
 msgstr ""
 
@@ -5278,83 +5312,83 @@ msgstr ""
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:475
+#: journal/models/mark.py:477
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:479
+#: journal/models/mark.py:481
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:486
+#: journal/models/mark.py:488
 #, fuzzy
 #| msgid "Sync in progress."
 msgid "Invalid progress type."
 msgstr "同期中です。"
 
-#: journal/models/mark.py:488
+#: journal/models/mark.py:490
 msgid "Invalid progress type for this item."
 msgstr ""
 
-#: journal/models/note.py:47 users/templates/users/rym_import.html:73
+#: journal/models/note.py:48 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr ""
 
-#: journal/models/note.py:48
+#: journal/models/note.py:49
 msgid "Chapter"
 msgstr ""
 
-#: journal/models/note.py:51
+#: journal/models/note.py:52
 msgid "Part"
 msgstr ""
 
-#: journal/models/note.py:52
+#: journal/models/note.py:53
 msgid "Episode"
 msgstr ""
 
-#: journal/models/note.py:53
+#: journal/models/note.py:54
 msgid "Track"
 msgstr ""
 
-#: journal/models/note.py:54
+#: journal/models/note.py:55
 msgid "Cycle"
 msgstr ""
 
-#: journal/models/note.py:55
+#: journal/models/note.py:56
 msgid "Timestamp"
 msgstr ""
 
-#: journal/models/note.py:56
+#: journal/models/note.py:57
 msgid "Percentage"
-msgstr ""
-
-#: journal/models/note.py:77
-#, python-brace-format
-msgid "Page {value}"
 msgstr ""
 
 #: journal/models/note.py:78
 #, python-brace-format
-msgid "Chapter {value}"
+msgid "Page {value}"
 msgstr ""
 
-#: journal/models/note.py:81
+#: journal/models/note.py:79
 #, python-brace-format
-msgid "Part {value}"
+msgid "Chapter {value}"
 msgstr ""
 
 #: journal/models/note.py:82
 #, python-brace-format
-msgid "Episode {value}"
+msgid "Part {value}"
 msgstr ""
 
 #: journal/models/note.py:83
 #, python-brace-format
-msgid "Track {value}"
+msgid "Episode {value}"
 msgstr ""
 
 #: journal/models/note.py:84
+#, python-brace-format
+msgid "Track {value}"
+msgstr ""
+
+#: journal/models/note.py:85
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr ""
@@ -5364,12 +5398,12 @@ msgstr ""
 msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr ""
 
-#: journal/models/review.py:79
+#: journal/models/review.py:80
 #, python-brace-format
 msgid "a review of {title}"
 msgstr ""
 
-#: journal/models/review.py:81
+#: journal/models/review.py:82
 msgid "(may contain spoilers)"
 msgstr ""
 
@@ -5798,7 +5832,7 @@ msgstr "フォロー中のユーザー"
 msgid "started following {item}"
 msgstr ""
 
-#: journal/models/shelf.py:923
+#: journal/models/shelf.py:925
 msgid "removed mark"
 msgstr ""
 
@@ -5831,7 +5865,7 @@ msgstr ""
 msgid "Update note"
 msgstr ""
 
-#: journal/templates/_list_item.html:71 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:121
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
@@ -5983,7 +6017,7 @@ msgid "View post"
 msgstr ""
 
 #: journal/templates/action_quote_post.html:3
-#: journal/templates/article.html:190 journal/templates/collection.html:174
+#: journal/templates/article.html:188 journal/templates/collection.html:175
 msgid "Quote"
 msgstr ""
 
@@ -5992,7 +6026,7 @@ msgid "reply"
 msgstr ""
 
 #: journal/templates/action_reply_post.html:3
-#: journal/templates/article.html:181 journal/templates/collection.html:165
+#: journal/templates/article.html:179 journal/templates/collection.html:166
 msgid "Reply"
 msgstr ""
 
@@ -6009,19 +6043,19 @@ msgstr ""
 msgid "Create a new collection"
 msgstr ""
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:76
+#: journal/templates/article.html:102 social/templates/_event_post.html:76
 msgid "wrote a review"
 msgstr ""
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:78
+#: journal/templates/article.html:104 social/templates/_event_post.html:78
 msgid "wrote an article"
 msgstr ""
 
-#: journal/templates/article.html:136
+#: journal/templates/article.html:134
 msgid "This article may contain sensitive content. Click to reveal."
 msgstr ""
 
-#: journal/templates/article.html:155
+#: journal/templates/article.html:153
 msgid "The author has set it to be viewable only by logged-in users."
 msgstr ""
 
@@ -6082,20 +6116,20 @@ msgstr ""
 msgid "DEC"
 msgstr ""
 
-#: journal/templates/collection.html:71
+#: journal/templates/collection.html:72
 #: journal/templates/collection_share.html:12
 #: journal/templates/collection_share.html:66
 #: journal/templates/wrapped_share.html:59
 msgid "Share"
 msgstr ""
 
-#: journal/templates/collection.html:86
+#: journal/templates/collection.html:87
 #, fuzzy
 #| msgid "Import as a new collection"
 msgid "created a collection"
 msgstr "新しいコレクションとしてインポート"
 
-#: journal/templates/collection.html:181
+#: journal/templates/collection.html:182
 msgid "Query"
 msgstr ""
 
@@ -6352,12 +6386,12 @@ msgid "Liked Collections"
 msgstr ""
 
 #: journal/templates/user_follow_list.html:23 journal/views/profile.py:507
-#: users/templates/users/account.html:443
+#: users/templates/users/account.html:455
 msgid "Following"
 msgstr ""
 
 #: journal/templates/user_follow_list.html:28 journal/views/profile.py:511
-#: users/templates/users/account.html:452
+#: users/templates/users/account.html:464
 msgid "Followers"
 msgstr ""
 
@@ -6668,8 +6702,8 @@ msgstr ""
 #: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
 #: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
 #: mastodon/views/threads.py:57 mastodon/views/threads.py:65
-#: mastodon/views/threads.py:71 users/views/account.py:256
-#: users/views/account.py:375
+#: mastodon/views/threads.py:71 users/views/account.py:257
+#: users/views/account.py:376
 msgid "Authentication failed"
 msgstr ""
 
@@ -6711,7 +6745,7 @@ msgstr ""
 msgid "Invalid user."
 msgstr ""
 
-#: mastodon/views/common.py:52 users/views/account.py:416
+#: mastodon/views/common.py:52 users/views/account.py:417
 msgid "Registration failed"
 msgstr ""
 
@@ -7604,134 +7638,147 @@ msgstr ""
 msgid "Scopes"
 msgstr ""
 
-#: users/templates/users/account.html:398
+#: users/templates/users/account.html:386
+msgid "Webhook"
+msgstr ""
+
+#: users/templates/users/account.html:400
+msgid "disabled"
+msgstr ""
+
+#: users/templates/users/account.html:402
+msgid "active"
+msgstr ""
+
+#: users/templates/users/account.html:410
 msgid "Revoke access for this application?"
 msgstr ""
 
-#: users/templates/users/account.html:401
+#: users/templates/users/account.html:413
 msgid "Revoke"
 msgstr ""
 
-#: users/templates/users/account.html:409
+#: users/templates/users/account.html:421
 #, fuzzy
 #| msgid "View authorized applications"
 msgid "No authorized applications."
 msgstr "認可されたアプリを表示"
 
-#: users/templates/users/account.html:412
+#: users/templates/users/account.html:424
 #: users/templates/users/authorized_app_create.html:9
 #: users/templates/users/authorized_app_create.html:19
 msgid "Create Personal Token"
 msgstr ""
 
-#: users/templates/users/account.html:418
+#: users/templates/users/account.html:430
 msgid "Import/Export Social Graph"
 msgstr ""
 
-#: users/templates/users/account.html:419
+#: users/templates/users/account.html:431
 msgid "Upload a CSV file exported from Mastodon or compatible services."
 msgstr ""
 
-#: users/templates/users/account.html:425
+#: users/templates/users/account.html:437
 #, fuzzy
 #| msgid "Import"
 msgid "Import type"
 msgstr "インポート"
 
-#: users/templates/users/account.html:427
+#: users/templates/users/account.html:439
 msgid "Following list"
 msgstr ""
 
-#: users/templates/users/account.html:428
+#: users/templates/users/account.html:440
 msgid "Block list"
 msgstr ""
 
-#: users/templates/users/account.html:429
+#: users/templates/users/account.html:441
 msgid "Mute list"
 msgstr ""
 
-#: users/templates/users/account.html:433
+#: users/templates/users/account.html:445
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/account.html:448 users/templates/users/data.html:89
 #: users/templates/users/data.html:141 users/templates/users/data.html:198
 #: users/templates/users/data.html:249 users/templates/users/data.html:313
 #: users/templates/users/data.html:376 users/templates/users/data.html:553
+#: users/templates/users/data.html:606 users/templates/users/data.html:631
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr "インポート"
 
-#: users/templates/users/account.html:447
-#: users/templates/users/account.html:456
-#: users/templates/users/account.html:465
-#: users/templates/users/account.html:474
+#: users/templates/users/account.html:459
+#: users/templates/users/account.html:468
+#: users/templates/users/account.html:477
+#: users/templates/users/account.html:486
 #, fuzzy
 #| msgid "Download"
 msgid "Download CSV"
 msgstr "ダウンロード"
 
-#: users/templates/users/account.html:461
+#: users/templates/users/account.html:473
 #, fuzzy
 #| msgid "blocked"
 msgid "Blocks"
 msgstr "ブロック済み"
 
-#: users/templates/users/account.html:470
+#: users/templates/users/account.html:482
 msgid "Mutes"
 msgstr ""
 
-#: users/templates/users/account.html:484
+#: users/templates/users/account.html:496
 msgid "Migrate Account"
 msgstr "アカウント移行"
 
-#: users/templates/users/account.html:488
+#: users/templates/users/account.html:500
 msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
 msgstr "他のインスタンスから移行する前に、メールアドレスを関連付けることをお勧めします。"
 
-#: users/templates/users/account.html:491
+#: users/templates/users/account.html:503
 #, fuzzy
 #| msgid "Migrate from anther instance to here"
 msgid "Migrate another account here"
 msgstr "他のインスタンスから本サイトへ移行"
 
-#: users/templates/users/account.html:494
+#: users/templates/users/account.html:506
 #, fuzzy
 #| msgid "Migrate to another instance"
 msgid "Migrate to another account"
 msgstr "本サイトから他のインスタンスへ移行"
 
-#: users/templates/users/account.html:501
+#: users/templates/users/account.html:513
 msgid "Delete Account"
 msgstr "アカウント削除"
 
-#: users/templates/users/account.html:504
+#: users/templates/users/account.html:516
 msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
 msgstr "一度削除すると、アカウントデータは復元できません。続行しますか？"
 
-#: users/templates/users/account.html:507
+#: users/templates/users/account.html:519
 msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
 msgstr "削除を確認するために、完全な<code>ユーザー名@インスタンス名</code>または<code>メール@アドレス</code>を入力してください"
 
-#: users/templates/users/account.html:517
+#: users/templates/users/account.html:529
 msgid "Once deleted, account data cannot be recovered."
 msgstr "一度削除すると、アカウントデータは復元できません"
 
-#: users/templates/users/account.html:520
+#: users/templates/users/account.html:532
 #, fuzzy
 #| msgid "Importing in progress, can't delete now."
 msgid "Task in progress, can't delete now."
 msgstr "インポート中のため、現在削除できません"
 
-#: users/templates/users/account.html:524
+#: users/templates/users/account.html:536
 msgid "Permanently Delete"
 msgstr "完全に削除"
 
-#: users/templates/users/account.html:565
+#: users/templates/users/account.html:577
 msgid "Delete this passkey?"
 msgstr ""
 
-#: users/templates/users/account.html:585
+#: users/templates/users/account.html:597
 msgid "Rename passkey:"
 msgstr ""
 
@@ -7753,10 +7800,10 @@ msgstr ""
 
 #: users/templates/users/authorized_app_create.html:48
 #: users/templates/users/authorized_app_created.html:39
-#: users/templates/users/migrate_in.html:70
-#: users/templates/users/migrate_out.html:67
-msgid "Back to Preferences"
-msgstr ""
+#, fuzzy
+#| msgid "Migrate Account"
+msgid "Back to Account"
+msgstr "アカウント移行"
 
 #: users/templates/users/authorized_app_created.html:9
 #: users/templates/users/authorized_app_created.html:19
@@ -7891,7 +7938,7 @@ msgstr "強制上書き：既存のマークとレビューを上書きします
 msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
 msgstr "短期間に繰り返しアップロードすると予期しない結果が生じる可能性があります。今すぐインポートしますか？"
 
-#: users/templates/users/data.html:89 users/views/data.py:1130
+#: users/templates/users/data.html:89 users/views/data.py:1194
 msgid "Import in progress, please wait"
 msgstr "バックアップファイルがアップロードされました。インポートが完了するまでお待ちいただくか、ページを更新して最新の進捗状況を確認してください"
 
@@ -8060,7 +8107,41 @@ msgstr ""
 msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
-#: users/templates/users/data.html:560
+#: users/templates/users/data.html:561
+msgid "Import Twitter / X Archive"
+msgstr ""
+
+#: users/templates/users/data.html:567
+msgid "On X, go to <b>Settings</b> - <b>Your account</b> - <b>Download an archive of your data</b>. Upload the <code>.zip</code> you receive, or only the <code>data/tweets.js</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:570
+msgid "Each tweet becomes a post with its original date, text, links and photos. Replies to your own tweets are kept as a thread. A retweet becomes a short post that links to the original tweet. Videos are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:573
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Tweets that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:615
+#, fuzzy
+#| msgid "Import Method"
+msgid "Import Mastodon Archive"
+msgstr "インポート方法"
+
+#: users/templates/users/data.html:621
+msgid "On your Mastodon server, go to <b>Preferences</b> - <b>Import and export</b> - <b>Request your archive</b>. Upload the <code>.zip</code> you receive, or only the <code>outbox.json</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:624
+msgid "Each post is imported with its original date, text, links, photos, content warning and visibility, so a followers-only post or a direct message stays that way. Replies to your own posts are kept as a thread. A boost becomes a short post that links to the original post. Videos, favourites and bookmarks are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:627
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Posts that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:639
 msgid "View Annual Summary"
 msgstr "年間サマリーを表示"
 
@@ -8185,6 +8266,11 @@ msgstr ""
 
 #: users/templates/users/migrate_in.html:64
 msgid "No aliases configured."
+msgstr ""
+
+#: users/templates/users/migrate_in.html:70
+#: users/templates/users/migrate_out.html:67
+msgid "Back to Preferences"
 msgstr ""
 
 #: users/templates/users/migrate_out.html:9
@@ -8709,196 +8795,197 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:126
+#: users/views/account.py:127
 msgid "This username is already in use."
 msgstr "このユーザー名は既に使用されています。"
 
-#: users/views/account.py:137
+#: users/views/account.py:138
 msgid "This email address is already in use."
 msgstr "このメールアドレスは既に使用されています。"
 
-#: users/views/account.py:257 users/views/account.py:376
+#: users/views/account.py:258 users/views/account.py:377
 msgid "Registration is for invitation only"
 msgstr "登録は招待制のみです。"
 
-#: users/views/account.py:268 users/views/account.py:340
+#: users/views/account.py:269 users/views/account.py:341
 msgid "Time is up"
 msgstr ""
 
-#: users/views/account.py:269 users/views/account.py:312
-#: users/views/account.py:341
+#: users/views/account.py:270 users/views/account.py:313
+#: users/views/account.py:342
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:315
+#: users/views/account.py:316
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:327
+#: users/views/account.py:328
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:328
+#: users/views/account.py:329
 msgid "Please try again later."
 msgstr ""
 
-#: users/views/account.py:417
+#: users/views/account.py:418
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:447
+#: users/views/account.py:448
 msgid "Valid username required"
 msgstr "有効なユーザー名を入力してください。"
 
-#: users/views/account.py:518
+#: users/views/account.py:519
 msgid "Account is being deleted."
 msgstr "アカウントの削除が進行中です。"
 
-#: users/views/account.py:521
+#: users/views/account.py:522
 msgid "Account mismatch."
 msgstr "アカウントが一致しません。"
 
-#: users/views/data.py:264 users/views/data.py:296
+#: users/views/data.py:276 users/views/data.py:308
 msgid "Export file not available."
 msgstr "エクスポートファイルが利用できません。"
 
-#: users/views/data.py:290
+#: users/views/data.py:302
 msgid "Generating exports."
 msgstr "エクスポートを生成しています。"
 
-#: users/views/data.py:308
+#: users/views/data.py:320
 msgid "Export file expired. Please export again."
 msgstr "エクスポートファイルの有効期限が切れました。再度エクスポートしてください。"
 
-#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
+#: users/views/data.py:335 users/views/data.py:356 users/views/data.py:377
 msgid "Recent export still in progress."
 msgstr "最新のエクスポートが進行中です。"
 
-#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
-#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
-#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
+#: users/views/data.py:393 users/views/data.py:419 users/views/data.py:447
+#: users/views/data.py:579 users/views/data.py:613 users/views/data.py:838
+#: users/views/data.py:1055 users/views/data.py:1081 users/views/data.py:1106
+#: users/views/data.py:1131 users/views/data.py:1201
 msgid "Invalid file."
 msgstr "無効なファイルです。"
 
-#: users/views/data.py:405
+#: users/views/data.py:469
 msgid "Sync in progress."
 msgstr "同期中です。"
 
-#: users/views/data.py:419
+#: users/views/data.py:483
 msgid "Settings saved."
 msgstr "設定が保存されました。"
 
-#: users/views/data.py:474
+#: users/views/data.py:538
 #, fuzzy
 #| msgid "Account is being deleted."
 msgid "Account no longer linked."
 msgstr "アカウントの削除が進行中です。"
 
-#: users/views/data.py:477
+#: users/views/data.py:541
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:505
+#: users/views/data.py:569
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:585 users/views/data.py:810
+#: users/views/data.py:649 users/views/data.py:874
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:610 users/views/data.py:839
+#: users/views/data.py:674 users/views/data.py:903
 msgid "Cancelled."
 msgstr ""
 
-#: users/views/data.py:630
+#: users/views/data.py:694
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
-#: users/views/data.py:974
+#: users/views/data.py:702 users/views/data.py:812 users/views/data.py:933
+#: users/views/data.py:1038
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:734 users/views/data.py:960
+#: users/views/data.py:798 users/views/data.py:1024
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:744 users/views/data.py:970
+#: users/views/data.py:808 users/views/data.py:1034
 #, fuzzy
 #| msgid "Export file not available."
 msgid "No matched file available."
 msgstr "エクスポートファイルが利用できません。"
 
-#: users/views/data.py:861
+#: users/views/data.py:925
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1290
 #, fuzzy
 #| msgid "Valid username required"
 msgid "Name is required."
 msgstr "有効なユーザー名を入力してください。"
 
-#: users/views/data.py:1248
+#: users/views/data.py:1314
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1264
+#: users/views/data.py:1330
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1269
+#: users/views/data.py:1335
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1279 users/views/data.py:1330
+#: users/views/data.py:1345 users/views/data.py:1396
 msgid "Looking up the account. Please try again in a few seconds."
-msgstr ""
-
-#: users/views/data.py:1286
-#, python-brace-format
-msgid "Alias to {handle} removed."
-msgstr ""
-
-#: users/views/data.py:1291
-#, python-brace-format
-msgid "Alias to {handle} added."
-msgstr ""
-
-#: users/views/data.py:1317
-msgid "Migration cancelled."
-msgstr ""
-
-#: users/views/data.py:1322
-msgid "No target account specified."
-msgstr ""
-
-#: users/views/data.py:1335
-msgid "Cannot migrate to a local account."
-msgstr ""
-
-#: users/views/data.py:1346
-msgid "You must set up an alias in the target account first."
 msgstr ""
 
 #: users/views/data.py:1352
 #, python-brace-format
+msgid "Alias to {handle} removed."
+msgstr ""
+
+#: users/views/data.py:1357
+#, python-brace-format
+msgid "Alias to {handle} added."
+msgstr ""
+
+#: users/views/data.py:1383
+msgid "Migration cancelled."
+msgstr ""
+
+#: users/views/data.py:1388
+msgid "No target account specified."
+msgstr ""
+
+#: users/views/data.py:1401
+msgid "Cannot migrate to a local account."
+msgstr ""
+
+#: users/views/data.py:1412
+msgid "You must set up an alias in the target account first."
+msgstr ""
+
+#: users/views/data.py:1418
+#, python-brace-format
 msgid "Start moving to {handle}."
 msgstr ""
 
-#: users/views/data.py:1410
+#: users/views/data.py:1476
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1426
+#: users/views/data.py:1492
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1430
+#: users/views/data.py:1496
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1440
+#: users/views/data.py:1506
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""

--- a/neodb/locale/lmo/LC_MESSAGES/django.po
+++ b/neodb/locale/lmo/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 20:04-0400\n"
+"POT-Creation-Date: 2026-09-07 14:56-0400\n"
 "PO-Revision-Date: 2026-08-09 06:32+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Lombard <https://hosted.weblate.org/projects/neodb/neodb/lmo/>\n"
@@ -59,15 +59,15 @@ msgstr ""
 msgid "Traditional Chinese"
 msgstr ""
 
-#: catalog/forms.py:35 catalog/models/item.py:307
+#: catalog/forms.py:35 catalog/models/item.py:412
 msgid "Primary ID Type"
 msgstr ""
 
-#: catalog/forms.py:40 catalog/models/item.py:310
+#: catalog/forms.py:40 catalog/models/item.py:415
 msgid "Primary ID Value"
 msgstr ""
 
-#: catalog/forms.py:176
+#: catalog/forms.py:177
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
@@ -120,11 +120,11 @@ msgid "other title"
 msgstr ""
 
 #: catalog/models/book.py:282 catalog/models/book.py:566
-#: catalog/models/item.py:119
+#: catalog/models/item.py:224
 msgid "author"
 msgstr ""
 
-#: catalog/models/book.py:289 catalog/models/item.py:120
+#: catalog/models/book.py:289 catalog/models/item.py:225
 msgid "translator"
 msgstr ""
 
@@ -133,7 +133,7 @@ msgid "book format"
 msgstr ""
 
 #: catalog/models/book.py:303 catalog/models/game.py:135
-#: catalog/models/item.py:134 catalog/models/music.py:142
+#: catalog/models/item.py:239 catalog/models/music.py:142
 msgid "publisher"
 msgstr ""
 
@@ -165,7 +165,7 @@ msgstr ""
 msgid "price"
 msgstr ""
 
-#: catalog/models/book.py:326 catalog/models/item.py:145
+#: catalog/models/book.py:326 catalog/models/item.py:250
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr ""
@@ -567,7 +567,7 @@ msgid "Exhibition"
 msgstr ""
 
 #: catalog/models/common.py:174 catalog/models/common.py:191
-#: journal/templates/collection.html:29 journal/templates/collection.html:40
+#: journal/templates/collection.html:30 journal/templates/collection.html:41
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
@@ -689,16 +689,16 @@ msgstr ""
 msgid "Special Edition"
 msgstr ""
 
-#: catalog/models/game.py:111 catalog/models/item.py:126
+#: catalog/models/game.py:111 catalog/models/item.py:231
 msgid "designer"
 msgstr ""
 
-#: catalog/models/game.py:119 catalog/models/item.py:125
+#: catalog/models/game.py:119 catalog/models/item.py:230
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr ""
 
-#: catalog/models/game.py:127 catalog/models/item.py:135
+#: catalog/models/game.py:127 catalog/models/item.py:240
 msgid "developer"
 msgstr ""
 
@@ -728,141 +728,141 @@ msgstr ""
 msgid "website"
 msgstr ""
 
-#: catalog/models/item.py:121 catalog/models/movie.py:123
+#: catalog/models/item.py:226 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
 #: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr ""
 
-#: catalog/models/item.py:122 catalog/models/movie.py:130
+#: catalog/models/item.py:227 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
 #: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr ""
 
-#: catalog/models/item.py:123 catalog/models/movie.py:137
+#: catalog/models/item.py:228 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
 #: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr ""
 
-#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/item.py:229 catalog/models/movie.py:144
 #: catalog/models/tv.py:237 catalog/models/tv.py:463
 msgid "producer"
 msgstr ""
 
-#: catalog/models/item.py:127 catalog/models/performance.py:203
+#: catalog/models/item.py:232 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr ""
 
-#: catalog/models/item.py:128 catalog/models/performance.py:210
+#: catalog/models/item.py:233 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr ""
 
-#: catalog/models/item.py:129 catalog/models/performance.py:224
+#: catalog/models/item.py:234 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr ""
 
-#: catalog/models/item.py:130 catalog/models/podcast.py:80
+#: catalog/models/item.py:235 catalog/models/podcast.py:80
 msgid "host"
 msgstr ""
 
-#: catalog/models/item.py:131 catalog/models/performance.py:196
+#: catalog/models/item.py:236 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr ""
 
-#: catalog/models/item.py:132 catalog/models/performance.py:238
+#: catalog/models/item.py:237 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr ""
 
-#: catalog/models/item.py:136
+#: catalog/models/item.py:241
 msgid "production company"
 msgstr ""
 
-#: catalog/models/item.py:137
+#: catalog/models/item.py:242
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:138
+#: catalog/models/item.py:243
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:139
+#: catalog/models/item.py:244
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:140 catalog/models/performance.py:231
+#: catalog/models/item.py:245 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr ""
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:248
 msgid "voice actor"
 msgstr ""
 
-#: catalog/models/item.py:144 catalog/templates/edition.html:30
+#: catalog/models/item.py:249 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr ""
 
-#: catalog/models/item.py:169 catalog/models/people.py:476
+#: catalog/models/item.py:274 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr ""
 
-#: catalog/models/item.py:170 catalog/models/people.py:155
+#: catalog/models/item.py:275 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr ""
 
-#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:277 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:304 catalog/models/item.py:336
-#: journal/models/collection.py:100
+#: catalog/models/item.py:409 catalog/models/item.py:441
+#: journal/models/collection.py:101
 msgid "title"
 msgstr ""
 
-#: catalog/models/item.py:305 catalog/models/item.py:344
-#: journal/models/collection.py:101
+#: catalog/models/item.py:410 catalog/models/item.py:449
+#: journal/models/collection.py:102
 msgid "description"
 msgstr ""
 
-#: catalog/models/item.py:316 catalog/models/people.py:484
+#: catalog/models/item.py:421 catalog/models/people.py:484
 msgid "metadata"
 msgstr ""
 
-#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:423 catalog/templates/_item_card.html:28
 msgid "cover"
 msgstr ""
 
-#: catalog/models/item.py:1526
+#: catalog/models/item.py:1612
 msgid "source site"
 msgstr ""
 
-#: catalog/models/item.py:1528
+#: catalog/models/item.py:1614
 msgid "ID on source site"
 msgstr ""
 
-#: catalog/models/item.py:1530
+#: catalog/models/item.py:1616
 msgid "source url"
 msgstr ""
 
-#: catalog/models/item.py:1546
+#: catalog/models/item.py:1632
 msgid "IdType of the source site"
 msgstr ""
 
-#: catalog/models/item.py:1552
+#: catalog/models/item.py:1638
 msgid "Primary Id on the source site"
 msgstr ""
 
-#: catalog/models/item.py:1555
+#: catalog/models/item.py:1641
 msgid "url to the resource"
 msgstr ""
 
@@ -1141,12 +1141,12 @@ msgstr ""
 #: catalog/templates/_item_card_metadata_tvseason.html:7
 #: catalog/templates/_item_card_metadata_tvshow.html:7
 #: catalog/templates/_item_card_metadata_work.html:7
-#: catalog/templates/item_base.html:201
+#: catalog/templates/item_base.html:186
 msgid "ratings"
 msgstr ""
 
-#: catalog/templates/_item_card_metadata_base.html:34
-#: catalog/templates/item_base.html:256
+#: catalog/templates/_item_card_metadata_base.html:28
+#: catalog/templates/item_base.html:241
 msgid "part of"
 msgstr ""
 
@@ -1164,14 +1164,14 @@ msgid "hide this tooltip"
 msgstr ""
 
 #: catalog/templates/_item_comments.html:58
-#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:83
+#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:81
 msgid "translate"
 msgstr ""
 
 #: catalog/templates/_item_comments.html:92
 #: catalog/templates/_item_comments_by_episode.html:80
 #: catalog/templates/_item_notes.html:88
-#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:284
+#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:269
 #: catalog/templates/podcast_episode_data.html:41
 msgid "show more"
 msgstr ""
@@ -1278,8 +1278,8 @@ msgstr ""
 #: catalog/templates/_item_user_pieces.html:101
 #: catalog/templates/catalog_edit.html:12
 #: journal/templates/action_edit_post.html:6
-#: journal/templates/action_edit_post.html:8 journal/templates/article.html:196
-#: journal/templates/collection.html:185 journal/templates/collection.html:193
+#: journal/templates/action_edit_post.html:8 journal/templates/article.html:194
+#: journal/templates/collection.html:186 journal/templates/collection.html:194
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_edit.html:26
 #: journal/templates/post_compose.html:16 journal/templates/tag_edit.html:16
@@ -1321,7 +1321,7 @@ msgstr ""
 #: catalog/templates/_sidebar_edit.html:20
 #: catalog/templates/catalog_verify.html:11
 #: catalog/templates/catalog_verify.html:17
-#: catalog/templates/item_base.html:182
+#: catalog/templates/item_base.html:167
 msgid "Creator verification"
 msgstr ""
 
@@ -1329,7 +1329,7 @@ msgstr ""
 msgid "Edit Options"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
+#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:163
 #: catalog/views/edit.py:160 catalog/views/edit.py:221
 #: catalog/views/edit.py:288 catalog/views/edit.py:309
 #: catalog/views/edit.py:364 catalog/views/edit.py:471
@@ -1489,7 +1489,7 @@ msgstr ""
 #: catalog/templates/_sidebar_edit.html:265
 #: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
-#: journal/templates/article.html:199 journal/templates/collection.html:188
+#: journal/templates/article.html:197 journal/templates/collection.html:189
 #: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Remove my verification"
 msgstr ""
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:311
+#: catalog/templates/_verify_status.html:31 users/views/account.py:312
 msgid "Verification failed"
 msgstr ""
 
@@ -1860,7 +1860,7 @@ msgstr ""
 
 #: catalog/templates/discover.html:229
 #: catalog/templates/discover_original_podcasts.html:25
-#: catalog/templates/item_base.html:282
+#: catalog/templates/item_base.html:267
 #: catalog/templates/item_mark_list.html:71
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
@@ -1926,67 +1926,67 @@ msgstr ""
 msgid "System busy, please try again in a minute."
 msgstr ""
 
-#: catalog/templates/item_base.html:95
+#: catalog/templates/item_base.html:80
 msgid "select one of the seasons to comment"
 msgstr ""
 
-#: catalog/templates/item_base.html:129
+#: catalog/templates/item_base.html:114
 msgid "mark, comment and collect"
 msgstr ""
 
-#: catalog/templates/item_base.html:142
+#: catalog/templates/item_base.html:127
 msgid "Login or register to review or add this item to your collection."
 msgstr ""
 
-#: catalog/templates/item_base.html:151
+#: catalog/templates/item_base.html:136
 msgid "Related Collections"
 msgstr ""
 
-#: catalog/templates/item_base.html:166
+#: catalog/templates/item_base.html:151
 msgid "Unsupported item type."
 msgstr ""
 
-#: catalog/templates/item_base.html:176
+#: catalog/templates/item_base.html:161
 msgid "Edit this item"
 msgstr ""
 
-#: catalog/templates/item_base.html:187
+#: catalog/templates/item_base.html:172
 msgid "Last edited"
 msgstr ""
 
-#: catalog/templates/item_base.html:230
+#: catalog/templates/item_base.html:215
 msgid "No enough ratings"
 msgstr ""
 
-#: catalog/templates/item_base.html:274
+#: catalog/templates/item_base.html:259
 msgid "overview"
 msgstr ""
 
-#: catalog/templates/item_base.html:305
+#: catalog/templates/item_base.html:290
 msgid "comments"
 msgstr ""
 
-#: catalog/templates/item_base.html:308
+#: catalog/templates/item_base.html:293
 #: catalog/templates/item_mark_list.html:22
 #: catalog/templates/item_mark_list.html:25
 #: catalog/templates/item_review_list.html:21
 msgid "marks"
 msgstr ""
 
-#: catalog/templates/item_base.html:309
+#: catalog/templates/item_base.html:294
 #: catalog/templates/item_mark_list.html:23
 #: catalog/templates/item_mark_list.html:26
 #: catalog/templates/item_review_list.html:22
 msgid "marks from who you follow"
 msgstr ""
 
-#: catalog/templates/item_base.html:323
+#: catalog/templates/item_base.html:308
 #: catalog/templates/item_mark_list.html:28
 #: catalog/templates/item_review_list.html:23
 msgid "reviews"
 msgstr ""
 
-#: catalog/templates/item_base.html:333
+#: catalog/templates/item_base.html:318
 msgid "notes"
 msgstr ""
 
@@ -2361,7 +2361,7 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
+#: catalog/views/verify.py:164 common/utils.py:148 common/utils.py:189
 #: journal/views/article.py:186 journal/views/review.py:182
 #: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
@@ -4000,7 +4000,7 @@ msgstr ""
 msgid "Open Registration"
 msgstr ""
 
-#: common/templates/common/about.html:40 common/views_manage.py:657
+#: common/templates/common/about.html:40 common/views_manage.py:671
 msgid "Preferred Languages"
 msgstr ""
 
@@ -4056,7 +4056,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:738
+#: common/templates/common/scan.html:60 common/views_manage.py:756
 msgid "Search"
 msgstr ""
 
@@ -4136,16 +4136,16 @@ msgstr ""
 msgid "unavailable"
 msgstr ""
 
-#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
+#: common/utils.py:152 common/utils.py:193 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr ""
 
-#: common/utils.py:135 common/utils.py:137 common/utils.py:140
-#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
+#: common/utils.py:159 common/utils.py:161 common/utils.py:164
+#: common/utils.py:200 common/utils.py:204 journal/views/profile.py:499
 msgid "Access denied"
 msgstr ""
 
-#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
+#: common/utils.py:167 common/utils.py:169 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr ""
@@ -4162,7 +4162,7 @@ msgstr ""
 msgid "Access"
 msgstr ""
 
-#: common/views_manage.py:39 common/views_manage.py:733
+#: common/views_manage.py:39 common/views_manage.py:751
 msgid "Federation"
 msgstr ""
 
@@ -4508,429 +4508,457 @@ msgid "Sender name and address for outgoing email."
 msgstr ""
 
 #: common/views_manage.py:649
+msgid "Enable Twitter / X Archive Import"
+msgstr ""
+
+#: common/views_manage.py:651
+msgid "Show the Twitter / X archive import on the data page. Imported tweets become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:656
+msgid "Enable Mastodon Archive Import"
+msgstr ""
+
+#: common/views_manage.py:658
+msgid "Show the Mastodon archive import on the data page. Imported posts become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:663
 msgid "Default Language"
 msgstr ""
 
-#: common/views_manage.py:652
+#: common/views_manage.py:666
 msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:673
 msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:665
+#: common/views_manage.py:679
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:672
+#: common/views_manage.py:686
 msgid "Login Methods"
 msgstr ""
 
-#: common/views_manage.py:677 mastodon/models/common.py:30
+#: common/views_manage.py:691 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr ""
 
-#: common/views_manage.py:681
-msgid "Localization"
-msgstr ""
-
-#: common/views_manage.py:692
-msgid "Disable Default Relay"
-msgstr ""
-
-#: common/views_manage.py:694
-msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
+#: common/views_manage.py:695
+msgid "Data Import"
 msgstr ""
 
 #: common/views_manage.py:699
-msgid "Fanout Limit (days)"
+msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:700
-msgid "Posts older than this many days will not be fanned out."
-msgstr ""
-
-#: common/views_manage.py:704
-msgid "Remote Prune Horizon (days)"
-msgstr ""
-
-#: common/views_manage.py:706
-msgid "Remote profiles inactive for this many days will be pruned."
-msgstr ""
-
-#: common/views_manage.py:711
-msgid "Search Sites"
+#: common/views_manage.py:710
+msgid "Disable Default Relay"
 msgstr ""
 
 #: common/views_manage.py:712
+msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
+msgstr ""
+
+#: common/views_manage.py:717
+msgid "Fanout Limit (days)"
+msgstr ""
+
+#: common/views_manage.py:718
+msgid "Posts older than this many days will not be fanned out."
+msgstr ""
+
+#: common/views_manage.py:722
+msgid "Remote Prune Horizon (days)"
+msgstr ""
+
+#: common/views_manage.py:724
+msgid "Remote profiles inactive for this many days will be pruned."
+msgstr ""
+
+#: common/views_manage.py:729
+msgid "Search Sites"
+msgstr ""
+
+#: common/views_manage.py:730
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:715
+#: common/views_manage.py:733
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:716
+#: common/views_manage.py:734
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:719
+#: common/views_manage.py:737
 msgid "Hidden Categories"
 msgstr ""
 
-#: common/views_manage.py:720
+#: common/views_manage.py:738
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:723
+#: common/views_manage.py:741
 msgid "Guest Search Page Limit"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:743
 msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
 msgstr ""
 
-#: common/views_manage.py:751
+#: common/views_manage.py:769
 msgid "Spotify API Key"
 msgstr ""
 
-#: common/views_manage.py:752
+#: common/views_manage.py:770
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:773
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:756
+#: common/views_manage.py:774
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:759
+#: common/views_manage.py:777
 msgid "Google Books API Key"
 msgstr ""
 
-#: common/views_manage.py:760
+#: common/views_manage.py:778
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:763
+#: common/views_manage.py:781
 msgid "Discogs API Key"
 msgstr ""
 
-#: common/views_manage.py:765
+#: common/views_manage.py:783
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:769
+#: common/views_manage.py:787
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:770
+#: common/views_manage.py:788
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:773
+#: common/views_manage.py:791
 msgid "IGDB Client Secret"
 msgstr ""
 
-#: common/views_manage.py:776
+#: common/views_manage.py:794
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:778
+#: common/views_manage.py:796
 msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:783
+#: common/views_manage.py:801
 msgid "MyAnimeList Client ID"
 msgstr ""
 
-#: common/views_manage.py:785
+#: common/views_manage.py:803
 msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
 msgstr ""
 
-#: common/views_manage.py:790 users/templates/users/steam_import.html:26
+#: common/views_manage.py:808 users/templates/users/steam_import.html:26
 msgid "Steam API Key"
 msgstr ""
 
-#: common/views_manage.py:792
+#: common/views_manage.py:810
 msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:797
+#: common/views_manage.py:815
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:798
+#: common/views_manage.py:816
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:801
+#: common/views_manage.py:819
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:804
+#: common/views_manage.py:822
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:807
+#: common/views_manage.py:825
 msgid "Threads App ID"
 msgstr ""
 
-#: common/views_manage.py:808
+#: common/views_manage.py:826
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:811
+#: common/views_manage.py:829
 msgid "Threads App Secret"
 msgstr ""
 
-#: common/views_manage.py:814
+#: common/views_manage.py:832
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:834
 msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:833
+#: common/views_manage.py:851
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:844
+#: common/views_manage.py:862
 msgid "Translation"
 msgstr ""
 
-#: common/views_manage.py:849
+#: common/views_manage.py:867
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:853 social/templates/feed.html:27
+#: common/views_manage.py:871 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr ""
 
-#: common/views_manage.py:863
+#: common/views_manage.py:881
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:882
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:885
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:868
+#: common/views_manage.py:886
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:871
+#: common/views_manage.py:889
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:874
+#: common/views_manage.py:892
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:877
+#: common/views_manage.py:895
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:880
+#: common/views_manage.py:898
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:883
+#: common/views_manage.py:901
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:886
+#: common/views_manage.py:904
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:887
+#: common/views_manage.py:905
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:908
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:894
+#: common/views_manage.py:912
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:898
+#: common/views_manage.py:916
 msgid "Retries"
 msgstr ""
 
-#: common/views_manage.py:903
+#: common/views_manage.py:921
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:908
+#: common/views_manage.py:926
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:915
+#: common/views_manage.py:933
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:927
+#: common/views_manage.py:945
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:928
+#: common/views_manage.py:946
 msgid "One domain per line."
 msgstr ""
 
-#: common/views_manage.py:931
+#: common/views_manage.py:949
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:932
+#: common/views_manage.py:950
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:935
+#: common/views_manage.py:953
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:937
+#: common/views_manage.py:955
 msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:943
+#: common/views_manage.py:961
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:944
+#: common/views_manage.py:962
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:947
+#: common/views_manage.py:965
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:948
+#: common/views_manage.py:966
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:958
+#: common/views_manage.py:976
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:960
+#: common/views_manage.py:978
 msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:966
+#: common/views_manage.py:984
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:968
+#: common/views_manage.py:986
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:974
+#: common/views_manage.py:992
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:976
+#: common/views_manage.py:994
 msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:983
+#: common/views_manage.py:1000
+msgid "Webhook Timeout (milliseconds)"
+msgstr ""
+
+#: common/views_manage.py:1001
+msgid "Timeout for delivering webhook requests to applications."
+msgstr ""
+
+#: common/views_manage.py:1006
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:986
+#: common/views_manage.py:1009
 msgid "Operational"
 msgstr ""
 
-#: common/views_manage.py:1002
+#: common/views_manage.py:1026
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:1004
+#: common/views_manage.py:1028
 msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1009
+#: common/views_manage.py:1033
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:1011
+#: common/views_manage.py:1035
 msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1016
+#: common/views_manage.py:1040
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:1018
+#: common/views_manage.py:1042
 msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1023
+#: common/views_manage.py:1047
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:1025
+#: common/views_manage.py:1049
 msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1030
+#: common/views_manage.py:1054
 msgid "Podcast Genres"
 msgstr ""
 
-#: common/views_manage.py:1032
+#: common/views_manage.py:1056
 msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1037
+#: common/views_manage.py:1061
 msgid "Performance Genres"
 msgstr ""
 
-#: common/views_manage.py:1039
+#: common/views_manage.py:1063
 msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1045
+#: common/views_manage.py:1069
 msgid "Genres by Category"
 msgstr ""
 
-#: common/views_manage.py:1069
+#: common/views_manage.py:1093
 msgid "Site"
 msgstr ""
 
-#: common/views_manage.py:1079
+#: common/views_manage.py:1103
 msgid "Database and Services"
 msgstr ""
 
-#: common/views_manage.py:1089
+#: common/views_manage.py:1113
 msgid "Media and Files"
 msgstr ""
 
-#: common/views_manage.py:1098
+#: common/views_manage.py:1122
 msgid "Monitoring"
 msgstr ""
 
-#: common/views_manage.py:1102
+#: common/views_manage.py:1126
 msgid "Security"
 msgstr ""
 
-#: common/views_manage.py:1111
+#: common/views_manage.py:1135
 msgid "Other Environment Variables"
 msgstr ""
 
-#: common/views_manage.py:1113
+#: common/views_manage.py:1137
 msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
 msgstr ""
 
@@ -4974,7 +5002,8 @@ msgstr ""
 #: users/templates/users/data.html:60 users/templates/users/data.html:113
 #: users/templates/users/data.html:170 users/templates/users/data.html:221
 #: users/templates/users/data.html:284 users/templates/users/data.html:346
-#: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
+#: users/templates/users/data.html:525 users/templates/users/data.html:578
+#: users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
 msgid "Visibility"
@@ -5004,8 +5033,8 @@ msgstr ""
 msgid "owner and their local mutuals"
 msgstr ""
 
-#: journal/forms.py:169 journal/templates/collection.html:193
-#: journal/templates/collection.html:202
+#: journal/forms.py:169 journal/templates/collection.html:194
+#: journal/templates/collection.html:203
 msgid "Collaborative editing"
 msgstr ""
 
@@ -5056,7 +5085,7 @@ msgstr ""
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:215 journal/views/article.py:218
+#: journal/models/article.py:224 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
@@ -5068,73 +5097,74 @@ msgstr ""
 msgid "note"
 msgstr ""
 
-#: journal/models/collection.py:115
+#: journal/models/collection.py:116
 msgid "search query for dynamic collection"
 msgstr ""
 
-#: journal/models/collection.py:566 journal/templatetags/collection.py:35
+#: journal/models/collection.py:575 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:571 journal/templatetags/collection.py:43
+#: journal/models/collection.py:580 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:576 journal/templatetags/collection.py:51
+#: journal/models/collection.py:585 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:581 journal/templatetags/collection.py:59
+#: journal/models/collection.py:590 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:586 journal/templatetags/collection.py:67
+#: journal/models/collection.py:595 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:591 journal/templatetags/collection.py:75
+#: journal/models/collection.py:600 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:597 journal/templatetags/collection.py:83
+#: journal/models/collection.py:606 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:605 journal/templatetags/collection.py:91
+#: journal/models/collection.py:614 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/models/common.py:59 journal/templates/action_open_post.html:15
 #: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
 #: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
 #: users/templates/users/data.html:122 users/templates/users/data.html:179
 #: users/templates/users/data.html:230 users/templates/users/data.html:292
 #: users/templates/users/data.html:355 users/templates/users/data.html:534
+#: users/templates/users/data.html:587
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5142,13 +5172,14 @@ msgstr[1] ""
 msgid "Public"
 msgstr ""
 
-#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/models/common.py:60 journal/templates/action_open_post.html:9
 #: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
 #: users/templates/users/data.html:130 users/templates/users/data.html:187
 #: users/templates/users/data.html:238 users/templates/users/data.html:300
 #: users/templates/users/data.html:363 users/templates/users/data.html:542
+#: users/templates/users/data.html:595
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5156,12 +5187,13 @@ msgstr ""
 msgid "Followers Only"
 msgstr ""
 
-#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/models/common.py:61 journal/templates/collection_share.html:57
 #: journal/templates/mark.html:102 journal/templates/post_compose.html:72
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
 #: users/templates/users/data.html:138 users/templates/users/data.html:195
 #: users/templates/users/data.html:246 users/templates/users/data.html:308
 #: users/templates/users/data.html:371 users/templates/users/data.html:550
+#: users/templates/users/data.html:603
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5169,27 +5201,27 @@ msgstr ""
 msgid "Mentioned Only"
 msgstr ""
 
-#: journal/models/common.py:806
+#: journal/models/common.py:851
 msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr ""
 
-#: journal/models/common.py:1003
+#: journal/models/common.py:1048
 msgid "A recent post was not posted to Threads."
 msgstr ""
 
-#: journal/models/common.py:1036
+#: journal/models/common.py:1081
 msgid "A recent post was not boosted on Mastodon."
 msgstr ""
 
-#: journal/models/common.py:1046
+#: journal/models/common.py:1091
 msgid "Original post no longer exists."
 msgstr ""
 
-#: journal/models/common.py:1060
+#: journal/models/common.py:1105
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr ""
 
-#: journal/models/common.py:1069
+#: journal/models/common.py:1114
 msgid "A recent post was not posted to Mastodon."
 msgstr ""
 
@@ -5205,81 +5237,81 @@ msgstr ""
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:475
+#: journal/models/mark.py:477
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:479
+#: journal/models/mark.py:481
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:486
+#: journal/models/mark.py:488
 msgid "Invalid progress type."
 msgstr ""
 
-#: journal/models/mark.py:488
+#: journal/models/mark.py:490
 msgid "Invalid progress type for this item."
 msgstr ""
 
-#: journal/models/note.py:47 users/templates/users/rym_import.html:73
+#: journal/models/note.py:48 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr ""
 
-#: journal/models/note.py:48
+#: journal/models/note.py:49
 msgid "Chapter"
 msgstr ""
 
-#: journal/models/note.py:51
+#: journal/models/note.py:52
 msgid "Part"
 msgstr ""
 
-#: journal/models/note.py:52
+#: journal/models/note.py:53
 msgid "Episode"
 msgstr ""
 
-#: journal/models/note.py:53
+#: journal/models/note.py:54
 msgid "Track"
 msgstr ""
 
-#: journal/models/note.py:54
+#: journal/models/note.py:55
 msgid "Cycle"
 msgstr ""
 
-#: journal/models/note.py:55
+#: journal/models/note.py:56
 msgid "Timestamp"
 msgstr ""
 
-#: journal/models/note.py:56
+#: journal/models/note.py:57
 msgid "Percentage"
-msgstr ""
-
-#: journal/models/note.py:77
-#, python-brace-format
-msgid "Page {value}"
 msgstr ""
 
 #: journal/models/note.py:78
 #, python-brace-format
-msgid "Chapter {value}"
+msgid "Page {value}"
 msgstr ""
 
-#: journal/models/note.py:81
+#: journal/models/note.py:79
 #, python-brace-format
-msgid "Part {value}"
+msgid "Chapter {value}"
 msgstr ""
 
 #: journal/models/note.py:82
 #, python-brace-format
-msgid "Episode {value}"
+msgid "Part {value}"
 msgstr ""
 
 #: journal/models/note.py:83
 #, python-brace-format
-msgid "Track {value}"
+msgid "Episode {value}"
 msgstr ""
 
 #: journal/models/note.py:84
+#, python-brace-format
+msgid "Track {value}"
+msgstr ""
+
+#: journal/models/note.py:85
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr ""
@@ -5289,12 +5321,12 @@ msgstr ""
 msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr ""
 
-#: journal/models/review.py:79
+#: journal/models/review.py:80
 #, python-brace-format
 msgid "a review of {title}"
 msgstr ""
 
-#: journal/models/review.py:81
+#: journal/models/review.py:82
 msgid "(may contain spoilers)"
 msgstr ""
 
@@ -5721,7 +5753,7 @@ msgstr ""
 msgid "started following {item}"
 msgstr ""
 
-#: journal/models/shelf.py:923
+#: journal/models/shelf.py:925
 msgid "removed mark"
 msgstr ""
 
@@ -5754,7 +5786,7 @@ msgstr ""
 msgid "Update note"
 msgstr ""
 
-#: journal/templates/_list_item.html:71 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:121
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
@@ -5904,7 +5936,7 @@ msgid "View post"
 msgstr ""
 
 #: journal/templates/action_quote_post.html:3
-#: journal/templates/article.html:190 journal/templates/collection.html:174
+#: journal/templates/article.html:188 journal/templates/collection.html:175
 msgid "Quote"
 msgstr ""
 
@@ -5913,7 +5945,7 @@ msgid "reply"
 msgstr ""
 
 #: journal/templates/action_reply_post.html:3
-#: journal/templates/article.html:181 journal/templates/collection.html:165
+#: journal/templates/article.html:179 journal/templates/collection.html:166
 msgid "Reply"
 msgstr ""
 
@@ -5930,19 +5962,19 @@ msgstr ""
 msgid "Create a new collection"
 msgstr ""
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:76
+#: journal/templates/article.html:102 social/templates/_event_post.html:76
 msgid "wrote a review"
 msgstr ""
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:78
+#: journal/templates/article.html:104 social/templates/_event_post.html:78
 msgid "wrote an article"
 msgstr ""
 
-#: journal/templates/article.html:136
+#: journal/templates/article.html:134
 msgid "This article may contain sensitive content. Click to reveal."
 msgstr ""
 
-#: journal/templates/article.html:155
+#: journal/templates/article.html:153
 msgid "The author has set it to be viewable only by logged-in users."
 msgstr ""
 
@@ -6003,18 +6035,18 @@ msgstr ""
 msgid "DEC"
 msgstr ""
 
-#: journal/templates/collection.html:71
+#: journal/templates/collection.html:72
 #: journal/templates/collection_share.html:12
 #: journal/templates/collection_share.html:66
 #: journal/templates/wrapped_share.html:59
 msgid "Share"
 msgstr ""
 
-#: journal/templates/collection.html:86
+#: journal/templates/collection.html:87
 msgid "created a collection"
 msgstr ""
 
-#: journal/templates/collection.html:181
+#: journal/templates/collection.html:182
 msgid "Query"
 msgstr ""
 
@@ -6261,12 +6293,12 @@ msgid "Liked Collections"
 msgstr ""
 
 #: journal/templates/user_follow_list.html:23 journal/views/profile.py:507
-#: users/templates/users/account.html:443
+#: users/templates/users/account.html:455
 msgid "Following"
 msgstr ""
 
 #: journal/templates/user_follow_list.html:28 journal/views/profile.py:511
-#: users/templates/users/account.html:452
+#: users/templates/users/account.html:464
 msgid "Followers"
 msgstr ""
 
@@ -6569,8 +6601,8 @@ msgstr ""
 #: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
 #: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
 #: mastodon/views/threads.py:57 mastodon/views/threads.py:65
-#: mastodon/views/threads.py:71 users/views/account.py:256
-#: users/views/account.py:375
+#: mastodon/views/threads.py:71 users/views/account.py:257
+#: users/views/account.py:376
 msgid "Authentication failed"
 msgstr ""
 
@@ -6608,7 +6640,7 @@ msgstr ""
 msgid "Invalid user."
 msgstr ""
 
-#: mastodon/views/common.py:52 users/views/account.py:416
+#: mastodon/views/common.py:52 users/views/account.py:417
 msgid "Registration failed"
 msgstr ""
 
@@ -7475,120 +7507,133 @@ msgstr ""
 msgid "Scopes"
 msgstr ""
 
-#: users/templates/users/account.html:398
+#: users/templates/users/account.html:386
+msgid "Webhook"
+msgstr ""
+
+#: users/templates/users/account.html:400
+msgid "disabled"
+msgstr ""
+
+#: users/templates/users/account.html:402
+msgid "active"
+msgstr ""
+
+#: users/templates/users/account.html:410
 msgid "Revoke access for this application?"
 msgstr ""
 
-#: users/templates/users/account.html:401
+#: users/templates/users/account.html:413
 msgid "Revoke"
 msgstr ""
 
-#: users/templates/users/account.html:409
+#: users/templates/users/account.html:421
 msgid "No authorized applications."
 msgstr ""
 
-#: users/templates/users/account.html:412
+#: users/templates/users/account.html:424
 #: users/templates/users/authorized_app_create.html:9
 #: users/templates/users/authorized_app_create.html:19
 msgid "Create Personal Token"
 msgstr ""
 
-#: users/templates/users/account.html:418
+#: users/templates/users/account.html:430
 msgid "Import/Export Social Graph"
 msgstr ""
 
-#: users/templates/users/account.html:419
+#: users/templates/users/account.html:431
 msgid "Upload a CSV file exported from Mastodon or compatible services."
 msgstr ""
 
-#: users/templates/users/account.html:425
+#: users/templates/users/account.html:437
 msgid "Import type"
 msgstr ""
 
-#: users/templates/users/account.html:427
+#: users/templates/users/account.html:439
 msgid "Following list"
 msgstr ""
 
-#: users/templates/users/account.html:428
+#: users/templates/users/account.html:440
 msgid "Block list"
 msgstr ""
 
-#: users/templates/users/account.html:429
+#: users/templates/users/account.html:441
 msgid "Mute list"
 msgstr ""
 
-#: users/templates/users/account.html:433
+#: users/templates/users/account.html:445
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/account.html:448 users/templates/users/data.html:89
 #: users/templates/users/data.html:141 users/templates/users/data.html:198
 #: users/templates/users/data.html:249 users/templates/users/data.html:313
 #: users/templates/users/data.html:376 users/templates/users/data.html:553
+#: users/templates/users/data.html:606 users/templates/users/data.html:631
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr ""
 
-#: users/templates/users/account.html:447
-#: users/templates/users/account.html:456
-#: users/templates/users/account.html:465
-#: users/templates/users/account.html:474
+#: users/templates/users/account.html:459
+#: users/templates/users/account.html:468
+#: users/templates/users/account.html:477
+#: users/templates/users/account.html:486
 msgid "Download CSV"
 msgstr ""
 
-#: users/templates/users/account.html:461
+#: users/templates/users/account.html:473
 msgid "Blocks"
 msgstr ""
 
-#: users/templates/users/account.html:470
+#: users/templates/users/account.html:482
 msgid "Mutes"
 msgstr ""
 
-#: users/templates/users/account.html:484
+#: users/templates/users/account.html:496
 msgid "Migrate Account"
 msgstr ""
 
-#: users/templates/users/account.html:488
+#: users/templates/users/account.html:500
 msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
 msgstr ""
 
-#: users/templates/users/account.html:491
+#: users/templates/users/account.html:503
 msgid "Migrate another account here"
 msgstr ""
 
-#: users/templates/users/account.html:494
+#: users/templates/users/account.html:506
 msgid "Migrate to another account"
 msgstr ""
 
-#: users/templates/users/account.html:501
+#: users/templates/users/account.html:513
 msgid "Delete Account"
 msgstr ""
 
-#: users/templates/users/account.html:504
+#: users/templates/users/account.html:516
 msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
 msgstr ""
 
-#: users/templates/users/account.html:507
+#: users/templates/users/account.html:519
 msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
 msgstr ""
 
-#: users/templates/users/account.html:517
+#: users/templates/users/account.html:529
 msgid "Once deleted, account data cannot be recovered."
 msgstr ""
 
-#: users/templates/users/account.html:520
+#: users/templates/users/account.html:532
 msgid "Task in progress, can't delete now."
 msgstr ""
 
-#: users/templates/users/account.html:524
+#: users/templates/users/account.html:536
 msgid "Permanently Delete"
 msgstr ""
 
-#: users/templates/users/account.html:565
+#: users/templates/users/account.html:577
 msgid "Delete this passkey?"
 msgstr ""
 
-#: users/templates/users/account.html:585
+#: users/templates/users/account.html:597
 msgid "Rename passkey:"
 msgstr ""
 
@@ -7610,9 +7655,7 @@ msgstr ""
 
 #: users/templates/users/authorized_app_create.html:48
 #: users/templates/users/authorized_app_created.html:39
-#: users/templates/users/migrate_in.html:70
-#: users/templates/users/migrate_out.html:67
-msgid "Back to Preferences"
+msgid "Back to Account"
 msgstr ""
 
 #: users/templates/users/authorized_app_created.html:9
@@ -7747,7 +7790,7 @@ msgstr ""
 msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
 msgstr ""
 
-#: users/templates/users/data.html:89 users/views/data.py:1130
+#: users/templates/users/data.html:89 users/views/data.py:1194
 msgid "Import in progress, please wait"
 msgstr ""
 
@@ -7905,7 +7948,39 @@ msgstr ""
 msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
-#: users/templates/users/data.html:560
+#: users/templates/users/data.html:561
+msgid "Import Twitter / X Archive"
+msgstr ""
+
+#: users/templates/users/data.html:567
+msgid "On X, go to <b>Settings</b> - <b>Your account</b> - <b>Download an archive of your data</b>. Upload the <code>.zip</code> you receive, or only the <code>data/tweets.js</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:570
+msgid "Each tweet becomes a post with its original date, text, links and photos. Replies to your own tweets are kept as a thread. A retweet becomes a short post that links to the original tweet. Videos are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:573
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Tweets that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:615
+msgid "Import Mastodon Archive"
+msgstr ""
+
+#: users/templates/users/data.html:621
+msgid "On your Mastodon server, go to <b>Preferences</b> - <b>Import and export</b> - <b>Request your archive</b>. Upload the <code>.zip</code> you receive, or only the <code>outbox.json</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:624
+msgid "Each post is imported with its original date, text, links, photos, content warning and visibility, so a followers-only post or a direct message stays that way. Replies to your own posts are kept as a thread. A boost becomes a short post that links to the original post. Videos, favourites and bookmarks are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:627
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Posts that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:639
 msgid "View Annual Summary"
 msgstr ""
 
@@ -8026,6 +8101,11 @@ msgstr ""
 
 #: users/templates/users/migrate_in.html:64
 msgid "No aliases configured."
+msgstr ""
+
+#: users/templates/users/migrate_in.html:70
+#: users/templates/users/migrate_out.html:67
+msgid "Back to Preferences"
 msgstr ""
 
 #: users/templates/users/migrate_out.html:9
@@ -8534,190 +8614,191 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:126
+#: users/views/account.py:127
 msgid "This username is already in use."
 msgstr ""
 
-#: users/views/account.py:137
+#: users/views/account.py:138
 msgid "This email address is already in use."
 msgstr ""
 
-#: users/views/account.py:257 users/views/account.py:376
+#: users/views/account.py:258 users/views/account.py:377
 msgid "Registration is for invitation only"
 msgstr ""
 
-#: users/views/account.py:268 users/views/account.py:340
+#: users/views/account.py:269 users/views/account.py:341
 msgid "Time is up"
 msgstr ""
 
-#: users/views/account.py:269 users/views/account.py:312
-#: users/views/account.py:341
+#: users/views/account.py:270 users/views/account.py:313
+#: users/views/account.py:342
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:315
+#: users/views/account.py:316
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:327
+#: users/views/account.py:328
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:328
+#: users/views/account.py:329
 msgid "Please try again later."
 msgstr ""
 
-#: users/views/account.py:417
+#: users/views/account.py:418
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:447
+#: users/views/account.py:448
 msgid "Valid username required"
 msgstr ""
 
-#: users/views/account.py:518
+#: users/views/account.py:519
 msgid "Account is being deleted."
 msgstr ""
 
-#: users/views/account.py:521
+#: users/views/account.py:522
 msgid "Account mismatch."
 msgstr ""
 
-#: users/views/data.py:264 users/views/data.py:296
+#: users/views/data.py:276 users/views/data.py:308
 msgid "Export file not available."
 msgstr ""
 
-#: users/views/data.py:290
+#: users/views/data.py:302
 msgid "Generating exports."
 msgstr ""
 
-#: users/views/data.py:308
+#: users/views/data.py:320
 msgid "Export file expired. Please export again."
 msgstr ""
 
-#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
+#: users/views/data.py:335 users/views/data.py:356 users/views/data.py:377
 msgid "Recent export still in progress."
 msgstr ""
 
-#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
-#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
-#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
+#: users/views/data.py:393 users/views/data.py:419 users/views/data.py:447
+#: users/views/data.py:579 users/views/data.py:613 users/views/data.py:838
+#: users/views/data.py:1055 users/views/data.py:1081 users/views/data.py:1106
+#: users/views/data.py:1131 users/views/data.py:1201
 msgid "Invalid file."
 msgstr ""
 
-#: users/views/data.py:405
+#: users/views/data.py:469
 msgid "Sync in progress."
 msgstr ""
 
-#: users/views/data.py:419
+#: users/views/data.py:483
 msgid "Settings saved."
 msgstr ""
 
-#: users/views/data.py:474
+#: users/views/data.py:538
 msgid "Account no longer linked."
 msgstr ""
 
-#: users/views/data.py:477
+#: users/views/data.py:541
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:505
+#: users/views/data.py:569
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:585 users/views/data.py:810
+#: users/views/data.py:649 users/views/data.py:874
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:610 users/views/data.py:839
+#: users/views/data.py:674 users/views/data.py:903
 msgid "Cancelled."
 msgstr ""
 
-#: users/views/data.py:630
+#: users/views/data.py:694
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
-#: users/views/data.py:974
+#: users/views/data.py:702 users/views/data.py:812 users/views/data.py:933
+#: users/views/data.py:1038
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:734 users/views/data.py:960
+#: users/views/data.py:798 users/views/data.py:1024
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:744 users/views/data.py:970
+#: users/views/data.py:808 users/views/data.py:1034
 msgid "No matched file available."
 msgstr ""
 
-#: users/views/data.py:861
+#: users/views/data.py:925
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1290
 msgid "Name is required."
 msgstr ""
 
-#: users/views/data.py:1248
+#: users/views/data.py:1314
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1264
+#: users/views/data.py:1330
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1269
+#: users/views/data.py:1335
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1279 users/views/data.py:1330
+#: users/views/data.py:1345 users/views/data.py:1396
 msgid "Looking up the account. Please try again in a few seconds."
-msgstr ""
-
-#: users/views/data.py:1286
-#, python-brace-format
-msgid "Alias to {handle} removed."
-msgstr ""
-
-#: users/views/data.py:1291
-#, python-brace-format
-msgid "Alias to {handle} added."
-msgstr ""
-
-#: users/views/data.py:1317
-msgid "Migration cancelled."
-msgstr ""
-
-#: users/views/data.py:1322
-msgid "No target account specified."
-msgstr ""
-
-#: users/views/data.py:1335
-msgid "Cannot migrate to a local account."
-msgstr ""
-
-#: users/views/data.py:1346
-msgid "You must set up an alias in the target account first."
 msgstr ""
 
 #: users/views/data.py:1352
 #, python-brace-format
+msgid "Alias to {handle} removed."
+msgstr ""
+
+#: users/views/data.py:1357
+#, python-brace-format
+msgid "Alias to {handle} added."
+msgstr ""
+
+#: users/views/data.py:1383
+msgid "Migration cancelled."
+msgstr ""
+
+#: users/views/data.py:1388
+msgid "No target account specified."
+msgstr ""
+
+#: users/views/data.py:1401
+msgid "Cannot migrate to a local account."
+msgstr ""
+
+#: users/views/data.py:1412
+msgid "You must set up an alias in the target account first."
+msgstr ""
+
+#: users/views/data.py:1418
+#, python-brace-format
 msgid "Start moving to {handle}."
 msgstr ""
 
-#: users/views/data.py:1410
+#: users/views/data.py:1476
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1426
+#: users/views/data.py:1492
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1430
+#: users/views/data.py:1496
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1440
+#: users/views/data.py:1506
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""

--- a/neodb/locale/lzh/LC_MESSAGES/django.po
+++ b/neodb/locale/lzh/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 20:04-0400\n"
+"POT-Creation-Date: 2026-09-07 14:56-0400\n"
 "PO-Revision-Date: 2026-08-08 21:18+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Literary Chinese <https://hosted.weblate.org/projects/neodb/neodb/lzh/>\n"
@@ -59,15 +59,15 @@ msgstr ""
 msgid "Traditional Chinese"
 msgstr ""
 
-#: catalog/forms.py:35 catalog/models/item.py:307
+#: catalog/forms.py:35 catalog/models/item.py:412
 msgid "Primary ID Type"
 msgstr ""
 
-#: catalog/forms.py:40 catalog/models/item.py:310
+#: catalog/forms.py:40 catalog/models/item.py:415
 msgid "Primary ID Value"
 msgstr ""
 
-#: catalog/forms.py:176
+#: catalog/forms.py:177
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
@@ -120,11 +120,11 @@ msgid "other title"
 msgstr ""
 
 #: catalog/models/book.py:282 catalog/models/book.py:566
-#: catalog/models/item.py:119
+#: catalog/models/item.py:224
 msgid "author"
 msgstr ""
 
-#: catalog/models/book.py:289 catalog/models/item.py:120
+#: catalog/models/book.py:289 catalog/models/item.py:225
 msgid "translator"
 msgstr ""
 
@@ -133,7 +133,7 @@ msgid "book format"
 msgstr ""
 
 #: catalog/models/book.py:303 catalog/models/game.py:135
-#: catalog/models/item.py:134 catalog/models/music.py:142
+#: catalog/models/item.py:239 catalog/models/music.py:142
 msgid "publisher"
 msgstr ""
 
@@ -165,7 +165,7 @@ msgstr ""
 msgid "price"
 msgstr ""
 
-#: catalog/models/book.py:326 catalog/models/item.py:145
+#: catalog/models/book.py:326 catalog/models/item.py:250
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr ""
@@ -564,7 +564,7 @@ msgid "Exhibition"
 msgstr ""
 
 #: catalog/models/common.py:174 catalog/models/common.py:191
-#: journal/templates/collection.html:29 journal/templates/collection.html:40
+#: journal/templates/collection.html:30 journal/templates/collection.html:41
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
@@ -686,16 +686,16 @@ msgstr ""
 msgid "Special Edition"
 msgstr ""
 
-#: catalog/models/game.py:111 catalog/models/item.py:126
+#: catalog/models/game.py:111 catalog/models/item.py:231
 msgid "designer"
 msgstr ""
 
-#: catalog/models/game.py:119 catalog/models/item.py:125
+#: catalog/models/game.py:119 catalog/models/item.py:230
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr ""
 
-#: catalog/models/game.py:127 catalog/models/item.py:135
+#: catalog/models/game.py:127 catalog/models/item.py:240
 msgid "developer"
 msgstr ""
 
@@ -725,141 +725,141 @@ msgstr ""
 msgid "website"
 msgstr ""
 
-#: catalog/models/item.py:121 catalog/models/movie.py:123
+#: catalog/models/item.py:226 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
 #: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr ""
 
-#: catalog/models/item.py:122 catalog/models/movie.py:130
+#: catalog/models/item.py:227 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
 #: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr ""
 
-#: catalog/models/item.py:123 catalog/models/movie.py:137
+#: catalog/models/item.py:228 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
 #: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr ""
 
-#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/item.py:229 catalog/models/movie.py:144
 #: catalog/models/tv.py:237 catalog/models/tv.py:463
 msgid "producer"
 msgstr ""
 
-#: catalog/models/item.py:127 catalog/models/performance.py:203
+#: catalog/models/item.py:232 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr ""
 
-#: catalog/models/item.py:128 catalog/models/performance.py:210
+#: catalog/models/item.py:233 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr ""
 
-#: catalog/models/item.py:129 catalog/models/performance.py:224
+#: catalog/models/item.py:234 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr ""
 
-#: catalog/models/item.py:130 catalog/models/podcast.py:80
+#: catalog/models/item.py:235 catalog/models/podcast.py:80
 msgid "host"
 msgstr ""
 
-#: catalog/models/item.py:131 catalog/models/performance.py:196
+#: catalog/models/item.py:236 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr ""
 
-#: catalog/models/item.py:132 catalog/models/performance.py:238
+#: catalog/models/item.py:237 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr ""
 
-#: catalog/models/item.py:136
+#: catalog/models/item.py:241
 msgid "production company"
 msgstr ""
 
-#: catalog/models/item.py:137
+#: catalog/models/item.py:242
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:138
+#: catalog/models/item.py:243
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:139
+#: catalog/models/item.py:244
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:140 catalog/models/performance.py:231
+#: catalog/models/item.py:245 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr ""
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:248
 msgid "voice actor"
 msgstr ""
 
-#: catalog/models/item.py:144 catalog/templates/edition.html:30
+#: catalog/models/item.py:249 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr ""
 
-#: catalog/models/item.py:169 catalog/models/people.py:476
+#: catalog/models/item.py:274 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr ""
 
-#: catalog/models/item.py:170 catalog/models/people.py:155
+#: catalog/models/item.py:275 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr ""
 
-#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:277 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:304 catalog/models/item.py:336
-#: journal/models/collection.py:100
+#: catalog/models/item.py:409 catalog/models/item.py:441
+#: journal/models/collection.py:101
 msgid "title"
 msgstr ""
 
-#: catalog/models/item.py:305 catalog/models/item.py:344
-#: journal/models/collection.py:101
+#: catalog/models/item.py:410 catalog/models/item.py:449
+#: journal/models/collection.py:102
 msgid "description"
 msgstr ""
 
-#: catalog/models/item.py:316 catalog/models/people.py:484
+#: catalog/models/item.py:421 catalog/models/people.py:484
 msgid "metadata"
 msgstr ""
 
-#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:423 catalog/templates/_item_card.html:28
 msgid "cover"
 msgstr ""
 
-#: catalog/models/item.py:1526
+#: catalog/models/item.py:1612
 msgid "source site"
 msgstr ""
 
-#: catalog/models/item.py:1528
+#: catalog/models/item.py:1614
 msgid "ID on source site"
 msgstr ""
 
-#: catalog/models/item.py:1530
+#: catalog/models/item.py:1616
 msgid "source url"
 msgstr ""
 
-#: catalog/models/item.py:1546
+#: catalog/models/item.py:1632
 msgid "IdType of the source site"
 msgstr ""
 
-#: catalog/models/item.py:1552
+#: catalog/models/item.py:1638
 msgid "Primary Id on the source site"
 msgstr ""
 
-#: catalog/models/item.py:1555
+#: catalog/models/item.py:1641
 msgid "url to the resource"
 msgstr ""
 
@@ -1138,12 +1138,12 @@ msgstr ""
 #: catalog/templates/_item_card_metadata_tvseason.html:7
 #: catalog/templates/_item_card_metadata_tvshow.html:7
 #: catalog/templates/_item_card_metadata_work.html:7
-#: catalog/templates/item_base.html:201
+#: catalog/templates/item_base.html:186
 msgid "ratings"
 msgstr ""
 
-#: catalog/templates/_item_card_metadata_base.html:34
-#: catalog/templates/item_base.html:256
+#: catalog/templates/_item_card_metadata_base.html:28
+#: catalog/templates/item_base.html:241
 msgid "part of"
 msgstr ""
 
@@ -1161,14 +1161,14 @@ msgid "hide this tooltip"
 msgstr ""
 
 #: catalog/templates/_item_comments.html:58
-#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:83
+#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:81
 msgid "translate"
 msgstr ""
 
 #: catalog/templates/_item_comments.html:92
 #: catalog/templates/_item_comments_by_episode.html:80
 #: catalog/templates/_item_notes.html:88
-#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:284
+#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:269
 #: catalog/templates/podcast_episode_data.html:41
 msgid "show more"
 msgstr ""
@@ -1275,8 +1275,8 @@ msgstr ""
 #: catalog/templates/_item_user_pieces.html:101
 #: catalog/templates/catalog_edit.html:12
 #: journal/templates/action_edit_post.html:6
-#: journal/templates/action_edit_post.html:8 journal/templates/article.html:196
-#: journal/templates/collection.html:185 journal/templates/collection.html:193
+#: journal/templates/action_edit_post.html:8 journal/templates/article.html:194
+#: journal/templates/collection.html:186 journal/templates/collection.html:194
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_edit.html:26
 #: journal/templates/post_compose.html:16 journal/templates/tag_edit.html:16
@@ -1318,7 +1318,7 @@ msgstr ""
 #: catalog/templates/_sidebar_edit.html:20
 #: catalog/templates/catalog_verify.html:11
 #: catalog/templates/catalog_verify.html:17
-#: catalog/templates/item_base.html:182
+#: catalog/templates/item_base.html:167
 msgid "Creator verification"
 msgstr ""
 
@@ -1326,7 +1326,7 @@ msgstr ""
 msgid "Edit Options"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
+#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:163
 #: catalog/views/edit.py:160 catalog/views/edit.py:221
 #: catalog/views/edit.py:288 catalog/views/edit.py:309
 #: catalog/views/edit.py:364 catalog/views/edit.py:471
@@ -1486,7 +1486,7 @@ msgstr ""
 #: catalog/templates/_sidebar_edit.html:265
 #: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
-#: journal/templates/article.html:199 journal/templates/collection.html:188
+#: journal/templates/article.html:197 journal/templates/collection.html:189
 #: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
@@ -1671,7 +1671,7 @@ msgstr ""
 msgid "Remove my verification"
 msgstr ""
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:311
+#: catalog/templates/_verify_status.html:31 users/views/account.py:312
 msgid "Verification failed"
 msgstr ""
 
@@ -1857,7 +1857,7 @@ msgstr ""
 
 #: catalog/templates/discover.html:229
 #: catalog/templates/discover_original_podcasts.html:25
-#: catalog/templates/item_base.html:282
+#: catalog/templates/item_base.html:267
 #: catalog/templates/item_mark_list.html:71
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
@@ -1923,67 +1923,67 @@ msgstr ""
 msgid "System busy, please try again in a minute."
 msgstr ""
 
-#: catalog/templates/item_base.html:95
+#: catalog/templates/item_base.html:80
 msgid "select one of the seasons to comment"
 msgstr ""
 
-#: catalog/templates/item_base.html:129
+#: catalog/templates/item_base.html:114
 msgid "mark, comment and collect"
 msgstr ""
 
-#: catalog/templates/item_base.html:142
+#: catalog/templates/item_base.html:127
 msgid "Login or register to review or add this item to your collection."
 msgstr ""
 
-#: catalog/templates/item_base.html:151
+#: catalog/templates/item_base.html:136
 msgid "Related Collections"
 msgstr ""
 
-#: catalog/templates/item_base.html:166
+#: catalog/templates/item_base.html:151
 msgid "Unsupported item type."
 msgstr ""
 
-#: catalog/templates/item_base.html:176
+#: catalog/templates/item_base.html:161
 msgid "Edit this item"
 msgstr ""
 
-#: catalog/templates/item_base.html:187
+#: catalog/templates/item_base.html:172
 msgid "Last edited"
 msgstr ""
 
-#: catalog/templates/item_base.html:230
+#: catalog/templates/item_base.html:215
 msgid "No enough ratings"
 msgstr ""
 
-#: catalog/templates/item_base.html:274
+#: catalog/templates/item_base.html:259
 msgid "overview"
 msgstr ""
 
-#: catalog/templates/item_base.html:305
+#: catalog/templates/item_base.html:290
 msgid "comments"
 msgstr ""
 
-#: catalog/templates/item_base.html:308
+#: catalog/templates/item_base.html:293
 #: catalog/templates/item_mark_list.html:22
 #: catalog/templates/item_mark_list.html:25
 #: catalog/templates/item_review_list.html:21
 msgid "marks"
 msgstr ""
 
-#: catalog/templates/item_base.html:309
+#: catalog/templates/item_base.html:294
 #: catalog/templates/item_mark_list.html:23
 #: catalog/templates/item_mark_list.html:26
 #: catalog/templates/item_review_list.html:22
 msgid "marks from who you follow"
 msgstr ""
 
-#: catalog/templates/item_base.html:323
+#: catalog/templates/item_base.html:308
 #: catalog/templates/item_mark_list.html:28
 #: catalog/templates/item_review_list.html:23
 msgid "reviews"
 msgstr ""
 
-#: catalog/templates/item_base.html:333
+#: catalog/templates/item_base.html:318
 msgid "notes"
 msgstr ""
 
@@ -2358,7 +2358,7 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
+#: catalog/views/verify.py:164 common/utils.py:148 common/utils.py:189
 #: journal/views/article.py:186 journal/views/review.py:182
 #: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
@@ -3997,7 +3997,7 @@ msgstr ""
 msgid "Open Registration"
 msgstr ""
 
-#: common/templates/common/about.html:40 common/views_manage.py:657
+#: common/templates/common/about.html:40 common/views_manage.py:671
 msgid "Preferred Languages"
 msgstr ""
 
@@ -4053,7 +4053,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:738
+#: common/templates/common/scan.html:60 common/views_manage.py:756
 msgid "Search"
 msgstr ""
 
@@ -4133,16 +4133,16 @@ msgstr ""
 msgid "unavailable"
 msgstr ""
 
-#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
+#: common/utils.py:152 common/utils.py:193 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr ""
 
-#: common/utils.py:135 common/utils.py:137 common/utils.py:140
-#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
+#: common/utils.py:159 common/utils.py:161 common/utils.py:164
+#: common/utils.py:200 common/utils.py:204 journal/views/profile.py:499
 msgid "Access denied"
 msgstr ""
 
-#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
+#: common/utils.py:167 common/utils.py:169 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr ""
@@ -4159,7 +4159,7 @@ msgstr ""
 msgid "Access"
 msgstr ""
 
-#: common/views_manage.py:39 common/views_manage.py:733
+#: common/views_manage.py:39 common/views_manage.py:751
 msgid "Federation"
 msgstr ""
 
@@ -4505,431 +4505,459 @@ msgid "Sender name and address for outgoing email."
 msgstr ""
 
 #: common/views_manage.py:649
+msgid "Enable Twitter / X Archive Import"
+msgstr ""
+
+#: common/views_manage.py:651
+msgid "Show the Twitter / X archive import on the data page. Imported tweets become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:656
+msgid "Enable Mastodon Archive Import"
+msgstr ""
+
+#: common/views_manage.py:658
+msgid "Show the Mastodon archive import on the data page. Imported posts become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:663
 #, fuzzy
 #| msgid "Language"
 msgid "Default Language"
 msgstr "語言"
 
-#: common/views_manage.py:652
+#: common/views_manage.py:666
 msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:673
 msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:665
+#: common/views_manage.py:679
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:672
+#: common/views_manage.py:686
 msgid "Login Methods"
 msgstr ""
 
-#: common/views_manage.py:677 mastodon/models/common.py:30
+#: common/views_manage.py:691 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr ""
 
-#: common/views_manage.py:681
-msgid "Localization"
-msgstr ""
-
-#: common/views_manage.py:692
-msgid "Disable Default Relay"
-msgstr ""
-
-#: common/views_manage.py:694
-msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
+#: common/views_manage.py:695
+msgid "Data Import"
 msgstr ""
 
 #: common/views_manage.py:699
-msgid "Fanout Limit (days)"
+msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:700
-msgid "Posts older than this many days will not be fanned out."
-msgstr ""
-
-#: common/views_manage.py:704
-msgid "Remote Prune Horizon (days)"
-msgstr ""
-
-#: common/views_manage.py:706
-msgid "Remote profiles inactive for this many days will be pruned."
-msgstr ""
-
-#: common/views_manage.py:711
-msgid "Search Sites"
+#: common/views_manage.py:710
+msgid "Disable Default Relay"
 msgstr ""
 
 #: common/views_manage.py:712
+msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
+msgstr ""
+
+#: common/views_manage.py:717
+msgid "Fanout Limit (days)"
+msgstr ""
+
+#: common/views_manage.py:718
+msgid "Posts older than this many days will not be fanned out."
+msgstr ""
+
+#: common/views_manage.py:722
+msgid "Remote Prune Horizon (days)"
+msgstr ""
+
+#: common/views_manage.py:724
+msgid "Remote profiles inactive for this many days will be pruned."
+msgstr ""
+
+#: common/views_manage.py:729
+msgid "Search Sites"
+msgstr ""
+
+#: common/views_manage.py:730
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:715
+#: common/views_manage.py:733
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:716
+#: common/views_manage.py:734
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:719
+#: common/views_manage.py:737
 msgid "Hidden Categories"
 msgstr ""
 
-#: common/views_manage.py:720
+#: common/views_manage.py:738
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:723
+#: common/views_manage.py:741
 msgid "Guest Search Page Limit"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:743
 msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
 msgstr ""
 
-#: common/views_manage.py:751
+#: common/views_manage.py:769
 msgid "Spotify API Key"
 msgstr ""
 
-#: common/views_manage.py:752
+#: common/views_manage.py:770
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:773
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:756
+#: common/views_manage.py:774
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:759
+#: common/views_manage.py:777
 msgid "Google Books API Key"
 msgstr ""
 
-#: common/views_manage.py:760
+#: common/views_manage.py:778
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:763
+#: common/views_manage.py:781
 msgid "Discogs API Key"
 msgstr ""
 
-#: common/views_manage.py:765
+#: common/views_manage.py:783
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:769
+#: common/views_manage.py:787
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:770
+#: common/views_manage.py:788
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:773
+#: common/views_manage.py:791
 msgid "IGDB Client Secret"
 msgstr ""
 
-#: common/views_manage.py:776
+#: common/views_manage.py:794
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:778
+#: common/views_manage.py:796
 msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:783
+#: common/views_manage.py:801
 msgid "MyAnimeList Client ID"
 msgstr ""
 
-#: common/views_manage.py:785
+#: common/views_manage.py:803
 msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
 msgstr ""
 
-#: common/views_manage.py:790 users/templates/users/steam_import.html:26
+#: common/views_manage.py:808 users/templates/users/steam_import.html:26
 msgid "Steam API Key"
 msgstr ""
 
-#: common/views_manage.py:792
+#: common/views_manage.py:810
 msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:797
+#: common/views_manage.py:815
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:798
+#: common/views_manage.py:816
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:801
+#: common/views_manage.py:819
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:804
+#: common/views_manage.py:822
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:807
+#: common/views_manage.py:825
 msgid "Threads App ID"
 msgstr ""
 
-#: common/views_manage.py:808
+#: common/views_manage.py:826
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:811
+#: common/views_manage.py:829
 msgid "Threads App Secret"
 msgstr ""
 
-#: common/views_manage.py:814
+#: common/views_manage.py:832
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:834
 msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:833
+#: common/views_manage.py:851
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:844
+#: common/views_manage.py:862
 msgid "Translation"
 msgstr ""
 
-#: common/views_manage.py:849
+#: common/views_manage.py:867
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:853 social/templates/feed.html:27
+#: common/views_manage.py:871 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr ""
 
-#: common/views_manage.py:863
+#: common/views_manage.py:881
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:882
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:885
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:868
+#: common/views_manage.py:886
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:871
+#: common/views_manage.py:889
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:874
+#: common/views_manage.py:892
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:877
+#: common/views_manage.py:895
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:880
+#: common/views_manage.py:898
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:883
+#: common/views_manage.py:901
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:886
+#: common/views_manage.py:904
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:887
+#: common/views_manage.py:905
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:908
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:894
+#: common/views_manage.py:912
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:898
+#: common/views_manage.py:916
 msgid "Retries"
 msgstr ""
 
-#: common/views_manage.py:903
+#: common/views_manage.py:921
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:908
+#: common/views_manage.py:926
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:915
+#: common/views_manage.py:933
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:927
+#: common/views_manage.py:945
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:928
+#: common/views_manage.py:946
 msgid "One domain per line."
 msgstr ""
 
-#: common/views_manage.py:931
+#: common/views_manage.py:949
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:932
+#: common/views_manage.py:950
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:935
+#: common/views_manage.py:953
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:937
+#: common/views_manage.py:955
 msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:943
+#: common/views_manage.py:961
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:944
+#: common/views_manage.py:962
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:947
+#: common/views_manage.py:965
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:948
+#: common/views_manage.py:966
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:958
+#: common/views_manage.py:976
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:960
+#: common/views_manage.py:978
 msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:966
+#: common/views_manage.py:984
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:968
+#: common/views_manage.py:986
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:974
+#: common/views_manage.py:992
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:976
+#: common/views_manage.py:994
 msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:983
+#: common/views_manage.py:1000
+msgid "Webhook Timeout (milliseconds)"
+msgstr ""
+
+#: common/views_manage.py:1001
+msgid "Timeout for delivering webhook requests to applications."
+msgstr ""
+
+#: common/views_manage.py:1006
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:986
+#: common/views_manage.py:1009
 msgid "Operational"
 msgstr ""
 
-#: common/views_manage.py:1002
+#: common/views_manage.py:1026
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:1004
+#: common/views_manage.py:1028
 msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1009
+#: common/views_manage.py:1033
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:1011
+#: common/views_manage.py:1035
 msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1016
+#: common/views_manage.py:1040
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:1018
+#: common/views_manage.py:1042
 msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1023
+#: common/views_manage.py:1047
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:1025
+#: common/views_manage.py:1049
 msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1030
+#: common/views_manage.py:1054
 msgid "Podcast Genres"
 msgstr ""
 
-#: common/views_manage.py:1032
+#: common/views_manage.py:1056
 msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1037
+#: common/views_manage.py:1061
 msgid "Performance Genres"
 msgstr ""
 
-#: common/views_manage.py:1039
+#: common/views_manage.py:1063
 msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1045
+#: common/views_manage.py:1069
 msgid "Genres by Category"
 msgstr ""
 
-#: common/views_manage.py:1069
+#: common/views_manage.py:1093
 msgid "Site"
 msgstr ""
 
-#: common/views_manage.py:1079
+#: common/views_manage.py:1103
 msgid "Database and Services"
 msgstr ""
 
-#: common/views_manage.py:1089
+#: common/views_manage.py:1113
 msgid "Media and Files"
 msgstr ""
 
-#: common/views_manage.py:1098
+#: common/views_manage.py:1122
 msgid "Monitoring"
 msgstr ""
 
-#: common/views_manage.py:1102
+#: common/views_manage.py:1126
 msgid "Security"
 msgstr ""
 
-#: common/views_manage.py:1111
+#: common/views_manage.py:1135
 msgid "Other Environment Variables"
 msgstr ""
 
-#: common/views_manage.py:1113
+#: common/views_manage.py:1137
 msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
 msgstr ""
 
@@ -4973,7 +5001,8 @@ msgstr ""
 #: users/templates/users/data.html:60 users/templates/users/data.html:113
 #: users/templates/users/data.html:170 users/templates/users/data.html:221
 #: users/templates/users/data.html:284 users/templates/users/data.html:346
-#: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
+#: users/templates/users/data.html:525 users/templates/users/data.html:578
+#: users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
 msgid "Visibility"
@@ -5003,8 +5032,8 @@ msgstr ""
 msgid "owner and their local mutuals"
 msgstr ""
 
-#: journal/forms.py:169 journal/templates/collection.html:193
-#: journal/templates/collection.html:202
+#: journal/forms.py:169 journal/templates/collection.html:194
+#: journal/templates/collection.html:203
 msgid "Collaborative editing"
 msgstr ""
 
@@ -5055,7 +5084,7 @@ msgstr ""
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:215 journal/views/article.py:218
+#: journal/models/article.py:224 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
@@ -5067,65 +5096,66 @@ msgstr ""
 msgid "note"
 msgstr ""
 
-#: journal/models/collection.py:115
+#: journal/models/collection.py:116
 msgid "search query for dynamic collection"
 msgstr ""
 
-#: journal/models/collection.py:566 journal/templatetags/collection.py:35
+#: journal/models/collection.py:575 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] ""
 
-#: journal/models/collection.py:571 journal/templatetags/collection.py:43
+#: journal/models/collection.py:580 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] ""
 
-#: journal/models/collection.py:576 journal/templatetags/collection.py:51
+#: journal/models/collection.py:585 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] ""
 
-#: journal/models/collection.py:581 journal/templatetags/collection.py:59
+#: journal/models/collection.py:590 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] ""
 
-#: journal/models/collection.py:586 journal/templatetags/collection.py:67
+#: journal/models/collection.py:595 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] ""
 
-#: journal/models/collection.py:591 journal/templatetags/collection.py:75
+#: journal/models/collection.py:600 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] ""
 
-#: journal/models/collection.py:597 journal/templatetags/collection.py:83
+#: journal/models/collection.py:606 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] ""
 
-#: journal/models/collection.py:605 journal/templatetags/collection.py:91
+#: journal/models/collection.py:614 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] ""
 
-#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/models/common.py:59 journal/templates/action_open_post.html:15
 #: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
 #: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
 #: users/templates/users/data.html:122 users/templates/users/data.html:179
 #: users/templates/users/data.html:230 users/templates/users/data.html:292
 #: users/templates/users/data.html:355 users/templates/users/data.html:534
+#: users/templates/users/data.html:587
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5133,13 +5163,14 @@ msgstr[0] ""
 msgid "Public"
 msgstr ""
 
-#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/models/common.py:60 journal/templates/action_open_post.html:9
 #: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
 #: users/templates/users/data.html:130 users/templates/users/data.html:187
 #: users/templates/users/data.html:238 users/templates/users/data.html:300
 #: users/templates/users/data.html:363 users/templates/users/data.html:542
+#: users/templates/users/data.html:595
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5147,12 +5178,13 @@ msgstr ""
 msgid "Followers Only"
 msgstr ""
 
-#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/models/common.py:61 journal/templates/collection_share.html:57
 #: journal/templates/mark.html:102 journal/templates/post_compose.html:72
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
 #: users/templates/users/data.html:138 users/templates/users/data.html:195
 #: users/templates/users/data.html:246 users/templates/users/data.html:308
 #: users/templates/users/data.html:371 users/templates/users/data.html:550
+#: users/templates/users/data.html:603
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5160,27 +5192,27 @@ msgstr ""
 msgid "Mentioned Only"
 msgstr ""
 
-#: journal/models/common.py:806
+#: journal/models/common.py:851
 msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr ""
 
-#: journal/models/common.py:1003
+#: journal/models/common.py:1048
 msgid "A recent post was not posted to Threads."
 msgstr ""
 
-#: journal/models/common.py:1036
+#: journal/models/common.py:1081
 msgid "A recent post was not boosted on Mastodon."
 msgstr ""
 
-#: journal/models/common.py:1046
+#: journal/models/common.py:1091
 msgid "Original post no longer exists."
 msgstr ""
 
-#: journal/models/common.py:1060
+#: journal/models/common.py:1105
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr ""
 
-#: journal/models/common.py:1069
+#: journal/models/common.py:1114
 msgid "A recent post was not posted to Mastodon."
 msgstr ""
 
@@ -5196,81 +5228,81 @@ msgstr ""
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:475
+#: journal/models/mark.py:477
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:479
+#: journal/models/mark.py:481
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:486
+#: journal/models/mark.py:488
 msgid "Invalid progress type."
 msgstr ""
 
-#: journal/models/mark.py:488
+#: journal/models/mark.py:490
 msgid "Invalid progress type for this item."
 msgstr ""
 
-#: journal/models/note.py:47 users/templates/users/rym_import.html:73
+#: journal/models/note.py:48 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr ""
 
-#: journal/models/note.py:48
+#: journal/models/note.py:49
 msgid "Chapter"
 msgstr ""
 
-#: journal/models/note.py:51
+#: journal/models/note.py:52
 msgid "Part"
 msgstr ""
 
-#: journal/models/note.py:52
+#: journal/models/note.py:53
 msgid "Episode"
 msgstr ""
 
-#: journal/models/note.py:53
+#: journal/models/note.py:54
 msgid "Track"
 msgstr ""
 
-#: journal/models/note.py:54
+#: journal/models/note.py:55
 msgid "Cycle"
 msgstr ""
 
-#: journal/models/note.py:55
+#: journal/models/note.py:56
 msgid "Timestamp"
 msgstr ""
 
-#: journal/models/note.py:56
+#: journal/models/note.py:57
 msgid "Percentage"
-msgstr ""
-
-#: journal/models/note.py:77
-#, python-brace-format
-msgid "Page {value}"
 msgstr ""
 
 #: journal/models/note.py:78
 #, python-brace-format
-msgid "Chapter {value}"
+msgid "Page {value}"
 msgstr ""
 
-#: journal/models/note.py:81
+#: journal/models/note.py:79
 #, python-brace-format
-msgid "Part {value}"
+msgid "Chapter {value}"
 msgstr ""
 
 #: journal/models/note.py:82
 #, python-brace-format
-msgid "Episode {value}"
+msgid "Part {value}"
 msgstr ""
 
 #: journal/models/note.py:83
 #, python-brace-format
-msgid "Track {value}"
+msgid "Episode {value}"
 msgstr ""
 
 #: journal/models/note.py:84
+#, python-brace-format
+msgid "Track {value}"
+msgstr ""
+
+#: journal/models/note.py:85
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr ""
@@ -5280,12 +5312,12 @@ msgstr ""
 msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr ""
 
-#: journal/models/review.py:79
+#: journal/models/review.py:80
 #, python-brace-format
 msgid "a review of {title}"
 msgstr ""
 
-#: journal/models/review.py:81
+#: journal/models/review.py:82
 msgid "(may contain spoilers)"
 msgstr ""
 
@@ -5712,7 +5744,7 @@ msgstr ""
 msgid "started following {item}"
 msgstr ""
 
-#: journal/models/shelf.py:923
+#: journal/models/shelf.py:925
 msgid "removed mark"
 msgstr ""
 
@@ -5745,7 +5777,7 @@ msgstr ""
 msgid "Update note"
 msgstr ""
 
-#: journal/templates/_list_item.html:71 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:121
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
@@ -5895,7 +5927,7 @@ msgid "View post"
 msgstr ""
 
 #: journal/templates/action_quote_post.html:3
-#: journal/templates/article.html:190 journal/templates/collection.html:174
+#: journal/templates/article.html:188 journal/templates/collection.html:175
 msgid "Quote"
 msgstr ""
 
@@ -5904,7 +5936,7 @@ msgid "reply"
 msgstr ""
 
 #: journal/templates/action_reply_post.html:3
-#: journal/templates/article.html:181 journal/templates/collection.html:165
+#: journal/templates/article.html:179 journal/templates/collection.html:166
 msgid "Reply"
 msgstr ""
 
@@ -5921,19 +5953,19 @@ msgstr ""
 msgid "Create a new collection"
 msgstr ""
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:76
+#: journal/templates/article.html:102 social/templates/_event_post.html:76
 msgid "wrote a review"
 msgstr ""
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:78
+#: journal/templates/article.html:104 social/templates/_event_post.html:78
 msgid "wrote an article"
 msgstr ""
 
-#: journal/templates/article.html:136
+#: journal/templates/article.html:134
 msgid "This article may contain sensitive content. Click to reveal."
 msgstr ""
 
-#: journal/templates/article.html:155
+#: journal/templates/article.html:153
 msgid "The author has set it to be viewable only by logged-in users."
 msgstr ""
 
@@ -5994,18 +6026,18 @@ msgstr ""
 msgid "DEC"
 msgstr ""
 
-#: journal/templates/collection.html:71
+#: journal/templates/collection.html:72
 #: journal/templates/collection_share.html:12
 #: journal/templates/collection_share.html:66
 #: journal/templates/wrapped_share.html:59
 msgid "Share"
 msgstr ""
 
-#: journal/templates/collection.html:86
+#: journal/templates/collection.html:87
 msgid "created a collection"
 msgstr ""
 
-#: journal/templates/collection.html:181
+#: journal/templates/collection.html:182
 msgid "Query"
 msgstr ""
 
@@ -6252,12 +6284,12 @@ msgid "Liked Collections"
 msgstr ""
 
 #: journal/templates/user_follow_list.html:23 journal/views/profile.py:507
-#: users/templates/users/account.html:443
+#: users/templates/users/account.html:455
 msgid "Following"
 msgstr ""
 
 #: journal/templates/user_follow_list.html:28 journal/views/profile.py:511
-#: users/templates/users/account.html:452
+#: users/templates/users/account.html:464
 msgid "Followers"
 msgstr ""
 
@@ -6560,8 +6592,8 @@ msgstr ""
 #: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
 #: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
 #: mastodon/views/threads.py:57 mastodon/views/threads.py:65
-#: mastodon/views/threads.py:71 users/views/account.py:256
-#: users/views/account.py:375
+#: mastodon/views/threads.py:71 users/views/account.py:257
+#: users/views/account.py:376
 msgid "Authentication failed"
 msgstr ""
 
@@ -6599,7 +6631,7 @@ msgstr ""
 msgid "Invalid user."
 msgstr ""
 
-#: mastodon/views/common.py:52 users/views/account.py:416
+#: mastodon/views/common.py:52 users/views/account.py:417
 msgid "Registration failed"
 msgstr ""
 
@@ -7466,120 +7498,134 @@ msgstr ""
 msgid "Scopes"
 msgstr ""
 
-#: users/templates/users/account.html:398
+#: users/templates/users/account.html:386
+msgid "Webhook"
+msgstr ""
+
+#: users/templates/users/account.html:400
+msgid "disabled"
+msgstr ""
+
+#: users/templates/users/account.html:402
+#, fuzzy
+msgid "active"
+msgstr "世事"
+
+#: users/templates/users/account.html:410
 msgid "Revoke access for this application?"
 msgstr ""
 
-#: users/templates/users/account.html:401
+#: users/templates/users/account.html:413
 msgid "Revoke"
 msgstr ""
 
-#: users/templates/users/account.html:409
+#: users/templates/users/account.html:421
 msgid "No authorized applications."
 msgstr ""
 
-#: users/templates/users/account.html:412
+#: users/templates/users/account.html:424
 #: users/templates/users/authorized_app_create.html:9
 #: users/templates/users/authorized_app_create.html:19
 msgid "Create Personal Token"
 msgstr ""
 
-#: users/templates/users/account.html:418
+#: users/templates/users/account.html:430
 msgid "Import/Export Social Graph"
 msgstr ""
 
-#: users/templates/users/account.html:419
+#: users/templates/users/account.html:431
 msgid "Upload a CSV file exported from Mastodon or compatible services."
 msgstr ""
 
-#: users/templates/users/account.html:425
+#: users/templates/users/account.html:437
 msgid "Import type"
 msgstr ""
 
-#: users/templates/users/account.html:427
+#: users/templates/users/account.html:439
 msgid "Following list"
 msgstr ""
 
-#: users/templates/users/account.html:428
+#: users/templates/users/account.html:440
 msgid "Block list"
 msgstr ""
 
-#: users/templates/users/account.html:429
+#: users/templates/users/account.html:441
 msgid "Mute list"
 msgstr ""
 
-#: users/templates/users/account.html:433
+#: users/templates/users/account.html:445
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/account.html:448 users/templates/users/data.html:89
 #: users/templates/users/data.html:141 users/templates/users/data.html:198
 #: users/templates/users/data.html:249 users/templates/users/data.html:313
 #: users/templates/users/data.html:376 users/templates/users/data.html:553
+#: users/templates/users/data.html:606 users/templates/users/data.html:631
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr ""
 
-#: users/templates/users/account.html:447
-#: users/templates/users/account.html:456
-#: users/templates/users/account.html:465
-#: users/templates/users/account.html:474
+#: users/templates/users/account.html:459
+#: users/templates/users/account.html:468
+#: users/templates/users/account.html:477
+#: users/templates/users/account.html:486
 msgid "Download CSV"
 msgstr ""
 
-#: users/templates/users/account.html:461
+#: users/templates/users/account.html:473
 msgid "Blocks"
 msgstr ""
 
-#: users/templates/users/account.html:470
+#: users/templates/users/account.html:482
 msgid "Mutes"
 msgstr ""
 
-#: users/templates/users/account.html:484
+#: users/templates/users/account.html:496
 msgid "Migrate Account"
 msgstr ""
 
-#: users/templates/users/account.html:488
+#: users/templates/users/account.html:500
 msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
 msgstr ""
 
-#: users/templates/users/account.html:491
+#: users/templates/users/account.html:503
 msgid "Migrate another account here"
 msgstr ""
 
-#: users/templates/users/account.html:494
+#: users/templates/users/account.html:506
 msgid "Migrate to another account"
 msgstr ""
 
-#: users/templates/users/account.html:501
+#: users/templates/users/account.html:513
 msgid "Delete Account"
 msgstr ""
 
-#: users/templates/users/account.html:504
+#: users/templates/users/account.html:516
 msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
 msgstr ""
 
-#: users/templates/users/account.html:507
+#: users/templates/users/account.html:519
 msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
 msgstr ""
 
-#: users/templates/users/account.html:517
+#: users/templates/users/account.html:529
 msgid "Once deleted, account data cannot be recovered."
 msgstr ""
 
-#: users/templates/users/account.html:520
+#: users/templates/users/account.html:532
 msgid "Task in progress, can't delete now."
 msgstr ""
 
-#: users/templates/users/account.html:524
+#: users/templates/users/account.html:536
 msgid "Permanently Delete"
 msgstr ""
 
-#: users/templates/users/account.html:565
+#: users/templates/users/account.html:577
 msgid "Delete this passkey?"
 msgstr ""
 
-#: users/templates/users/account.html:585
+#: users/templates/users/account.html:597
 msgid "Rename passkey:"
 msgstr ""
 
@@ -7601,9 +7647,7 @@ msgstr ""
 
 #: users/templates/users/authorized_app_create.html:48
 #: users/templates/users/authorized_app_created.html:39
-#: users/templates/users/migrate_in.html:70
-#: users/templates/users/migrate_out.html:67
-msgid "Back to Preferences"
+msgid "Back to Account"
 msgstr ""
 
 #: users/templates/users/authorized_app_created.html:9
@@ -7737,7 +7781,7 @@ msgstr ""
 msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
 msgstr ""
 
-#: users/templates/users/data.html:89 users/views/data.py:1130
+#: users/templates/users/data.html:89 users/views/data.py:1194
 msgid "Import in progress, please wait"
 msgstr ""
 
@@ -7894,7 +7938,39 @@ msgstr ""
 msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
-#: users/templates/users/data.html:560
+#: users/templates/users/data.html:561
+msgid "Import Twitter / X Archive"
+msgstr ""
+
+#: users/templates/users/data.html:567
+msgid "On X, go to <b>Settings</b> - <b>Your account</b> - <b>Download an archive of your data</b>. Upload the <code>.zip</code> you receive, or only the <code>data/tweets.js</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:570
+msgid "Each tweet becomes a post with its original date, text, links and photos. Replies to your own tweets are kept as a thread. A retweet becomes a short post that links to the original tweet. Videos are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:573
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Tweets that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:615
+msgid "Import Mastodon Archive"
+msgstr ""
+
+#: users/templates/users/data.html:621
+msgid "On your Mastodon server, go to <b>Preferences</b> - <b>Import and export</b> - <b>Request your archive</b>. Upload the <code>.zip</code> you receive, or only the <code>outbox.json</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:624
+msgid "Each post is imported with its original date, text, links, photos, content warning and visibility, so a followers-only post or a direct message stays that way. Replies to your own posts are kept as a thread. A boost becomes a short post that links to the original post. Videos, favourites and bookmarks are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:627
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Posts that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:639
 msgid "View Annual Summary"
 msgstr ""
 
@@ -8015,6 +8091,11 @@ msgstr ""
 
 #: users/templates/users/migrate_in.html:64
 msgid "No aliases configured."
+msgstr ""
+
+#: users/templates/users/migrate_in.html:70
+#: users/templates/users/migrate_out.html:67
+msgid "Back to Preferences"
 msgstr ""
 
 #: users/templates/users/migrate_out.html:9
@@ -8523,190 +8604,191 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:126
+#: users/views/account.py:127
 msgid "This username is already in use."
 msgstr ""
 
-#: users/views/account.py:137
+#: users/views/account.py:138
 msgid "This email address is already in use."
 msgstr ""
 
-#: users/views/account.py:257 users/views/account.py:376
+#: users/views/account.py:258 users/views/account.py:377
 msgid "Registration is for invitation only"
 msgstr ""
 
-#: users/views/account.py:268 users/views/account.py:340
+#: users/views/account.py:269 users/views/account.py:341
 msgid "Time is up"
 msgstr ""
 
-#: users/views/account.py:269 users/views/account.py:312
-#: users/views/account.py:341
+#: users/views/account.py:270 users/views/account.py:313
+#: users/views/account.py:342
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:315
+#: users/views/account.py:316
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:327
+#: users/views/account.py:328
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:328
+#: users/views/account.py:329
 msgid "Please try again later."
 msgstr ""
 
-#: users/views/account.py:417
+#: users/views/account.py:418
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:447
+#: users/views/account.py:448
 msgid "Valid username required"
 msgstr ""
 
-#: users/views/account.py:518
+#: users/views/account.py:519
 msgid "Account is being deleted."
 msgstr ""
 
-#: users/views/account.py:521
+#: users/views/account.py:522
 msgid "Account mismatch."
 msgstr ""
 
-#: users/views/data.py:264 users/views/data.py:296
+#: users/views/data.py:276 users/views/data.py:308
 msgid "Export file not available."
 msgstr ""
 
-#: users/views/data.py:290
+#: users/views/data.py:302
 msgid "Generating exports."
 msgstr ""
 
-#: users/views/data.py:308
+#: users/views/data.py:320
 msgid "Export file expired. Please export again."
 msgstr ""
 
-#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
+#: users/views/data.py:335 users/views/data.py:356 users/views/data.py:377
 msgid "Recent export still in progress."
 msgstr ""
 
-#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
-#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
-#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
+#: users/views/data.py:393 users/views/data.py:419 users/views/data.py:447
+#: users/views/data.py:579 users/views/data.py:613 users/views/data.py:838
+#: users/views/data.py:1055 users/views/data.py:1081 users/views/data.py:1106
+#: users/views/data.py:1131 users/views/data.py:1201
 msgid "Invalid file."
 msgstr ""
 
-#: users/views/data.py:405
+#: users/views/data.py:469
 msgid "Sync in progress."
 msgstr ""
 
-#: users/views/data.py:419
+#: users/views/data.py:483
 msgid "Settings saved."
 msgstr ""
 
-#: users/views/data.py:474
+#: users/views/data.py:538
 msgid "Account no longer linked."
 msgstr ""
 
-#: users/views/data.py:477
+#: users/views/data.py:541
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:505
+#: users/views/data.py:569
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:585 users/views/data.py:810
+#: users/views/data.py:649 users/views/data.py:874
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:610 users/views/data.py:839
+#: users/views/data.py:674 users/views/data.py:903
 msgid "Cancelled."
 msgstr ""
 
-#: users/views/data.py:630
+#: users/views/data.py:694
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
-#: users/views/data.py:974
+#: users/views/data.py:702 users/views/data.py:812 users/views/data.py:933
+#: users/views/data.py:1038
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:734 users/views/data.py:960
+#: users/views/data.py:798 users/views/data.py:1024
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:744 users/views/data.py:970
+#: users/views/data.py:808 users/views/data.py:1034
 msgid "No matched file available."
 msgstr ""
 
-#: users/views/data.py:861
+#: users/views/data.py:925
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1290
 msgid "Name is required."
 msgstr ""
 
-#: users/views/data.py:1248
+#: users/views/data.py:1314
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1264
+#: users/views/data.py:1330
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1269
+#: users/views/data.py:1335
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1279 users/views/data.py:1330
+#: users/views/data.py:1345 users/views/data.py:1396
 msgid "Looking up the account. Please try again in a few seconds."
-msgstr ""
-
-#: users/views/data.py:1286
-#, python-brace-format
-msgid "Alias to {handle} removed."
-msgstr ""
-
-#: users/views/data.py:1291
-#, python-brace-format
-msgid "Alias to {handle} added."
-msgstr ""
-
-#: users/views/data.py:1317
-msgid "Migration cancelled."
-msgstr ""
-
-#: users/views/data.py:1322
-msgid "No target account specified."
-msgstr ""
-
-#: users/views/data.py:1335
-msgid "Cannot migrate to a local account."
-msgstr ""
-
-#: users/views/data.py:1346
-msgid "You must set up an alias in the target account first."
 msgstr ""
 
 #: users/views/data.py:1352
 #, python-brace-format
+msgid "Alias to {handle} removed."
+msgstr ""
+
+#: users/views/data.py:1357
+#, python-brace-format
+msgid "Alias to {handle} added."
+msgstr ""
+
+#: users/views/data.py:1383
+msgid "Migration cancelled."
+msgstr ""
+
+#: users/views/data.py:1388
+msgid "No target account specified."
+msgstr ""
+
+#: users/views/data.py:1401
+msgid "Cannot migrate to a local account."
+msgstr ""
+
+#: users/views/data.py:1412
+msgid "You must set up an alias in the target account first."
+msgstr ""
+
+#: users/views/data.py:1418
+#, python-brace-format
 msgid "Start moving to {handle}."
 msgstr ""
 
-#: users/views/data.py:1410
+#: users/views/data.py:1476
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1426
+#: users/views/data.py:1492
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1430
+#: users/views/data.py:1496
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1440
+#: users/views/data.py:1506
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""

--- a/neodb/locale/pt/LC_MESSAGES/django.po
+++ b/neodb/locale/pt/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 20:04-0400\n"
+"POT-Creation-Date: 2026-09-07 14:56-0400\n"
 "PO-Revision-Date: 2026-08-09 06:32+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/neodb/neodb/pt/>\n"
@@ -61,15 +61,15 @@ msgstr "Chinês Simplificado"
 msgid "Traditional Chinese"
 msgstr "Chinês tradicional"
 
-#: catalog/forms.py:35 catalog/models/item.py:307
+#: catalog/forms.py:35 catalog/models/item.py:412
 msgid "Primary ID Type"
 msgstr "Tipo de Identificação primário"
 
-#: catalog/forms.py:40 catalog/models/item.py:310
+#: catalog/forms.py:40 catalog/models/item.py:415
 msgid "Primary ID Value"
 msgstr "Valor de Identificação primário"
 
-#: catalog/forms.py:176
+#: catalog/forms.py:177
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
@@ -122,11 +122,11 @@ msgid "other title"
 msgstr "outro título"
 
 #: catalog/models/book.py:282 catalog/models/book.py:566
-#: catalog/models/item.py:119
+#: catalog/models/item.py:224
 msgid "author"
 msgstr "autor"
 
-#: catalog/models/book.py:289 catalog/models/item.py:120
+#: catalog/models/book.py:289 catalog/models/item.py:225
 msgid "translator"
 msgstr "tradutor"
 
@@ -135,7 +135,7 @@ msgid "book format"
 msgstr "formato do livro"
 
 #: catalog/models/book.py:303 catalog/models/game.py:135
-#: catalog/models/item.py:134 catalog/models/music.py:142
+#: catalog/models/item.py:239 catalog/models/music.py:142
 msgid "publisher"
 msgstr "publicadora"
 
@@ -167,7 +167,7 @@ msgstr "conteúdos"
 msgid "price"
 msgstr "preço"
 
-#: catalog/models/book.py:326 catalog/models/item.py:145
+#: catalog/models/book.py:326 catalog/models/item.py:250
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr "selo editorial"
@@ -594,7 +594,7 @@ msgid "Exhibition"
 msgstr "Exposição"
 
 #: catalog/models/common.py:174 catalog/models/common.py:191
-#: journal/templates/collection.html:29 journal/templates/collection.html:40
+#: journal/templates/collection.html:30 journal/templates/collection.html:41
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
@@ -725,16 +725,16 @@ msgstr "Remake"
 msgid "Special Edition"
 msgstr "Edição especial"
 
-#: catalog/models/game.py:111 catalog/models/item.py:126
+#: catalog/models/game.py:111 catalog/models/item.py:231
 msgid "designer"
 msgstr "Criador"
 
-#: catalog/models/game.py:119 catalog/models/item.py:125
+#: catalog/models/game.py:119 catalog/models/item.py:230
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr "artista"
 
-#: catalog/models/game.py:127 catalog/models/item.py:135
+#: catalog/models/game.py:127 catalog/models/item.py:240
 msgid "developer"
 msgstr "desenvolvedora"
 
@@ -764,147 +764,147 @@ msgstr "tipo de edição"
 msgid "website"
 msgstr "website"
 
-#: catalog/models/item.py:121 catalog/models/movie.py:123
+#: catalog/models/item.py:226 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
 #: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr "diretor"
 
-#: catalog/models/item.py:122 catalog/models/movie.py:130
+#: catalog/models/item.py:227 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
 #: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr "guionista"
 
-#: catalog/models/item.py:123 catalog/models/movie.py:137
+#: catalog/models/item.py:228 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
 #: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr "ator"
 
-#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/item.py:229 catalog/models/movie.py:144
 #: catalog/models/tv.py:237 catalog/models/tv.py:463
 #, fuzzy
 #| msgid "production"
 msgid "producer"
 msgstr "produção"
 
-#: catalog/models/item.py:127 catalog/models/performance.py:203
+#: catalog/models/item.py:232 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr "compositor"
 
-#: catalog/models/item.py:128 catalog/models/performance.py:210
+#: catalog/models/item.py:233 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr "coreógrafo"
 
-#: catalog/models/item.py:129 catalog/models/performance.py:224
+#: catalog/models/item.py:234 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr "performista"
 
-#: catalog/models/item.py:130 catalog/models/podcast.py:80
+#: catalog/models/item.py:235 catalog/models/podcast.py:80
 msgid "host"
 msgstr "apresentador(es)"
 
-#: catalog/models/item.py:131 catalog/models/performance.py:196
+#: catalog/models/item.py:236 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr "criador original"
 
-#: catalog/models/item.py:132 catalog/models/performance.py:238
+#: catalog/models/item.py:237 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr "grupo"
 
-#: catalog/models/item.py:136
+#: catalog/models/item.py:241
 #, fuzzy
 #| msgid "production"
 msgid "production company"
 msgstr "produção"
 
-#: catalog/models/item.py:137
+#: catalog/models/item.py:242
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:138
+#: catalog/models/item.py:243
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:139
+#: catalog/models/item.py:244
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:140 catalog/models/performance.py:231
+#: catalog/models/item.py:245 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr "companhia"
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:248
 #, fuzzy
 #| msgid "director"
 msgid "voice actor"
 msgstr "diretor"
 
-#: catalog/models/item.py:144 catalog/templates/edition.html:30
+#: catalog/models/item.py:249 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr "editora"
 
-#: catalog/models/item.py:169 catalog/models/people.py:476
+#: catalog/models/item.py:274 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr "papel"
 
-#: catalog/models/item.py:170 catalog/models/people.py:155
+#: catalog/models/item.py:275 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr "nome"
 
-#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:277 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:304 catalog/models/item.py:336
-#: journal/models/collection.py:100
+#: catalog/models/item.py:409 catalog/models/item.py:441
+#: journal/models/collection.py:101
 msgid "title"
 msgstr "título"
 
-#: catalog/models/item.py:305 catalog/models/item.py:344
-#: journal/models/collection.py:101
+#: catalog/models/item.py:410 catalog/models/item.py:449
+#: journal/models/collection.py:102
 msgid "description"
 msgstr "descrição"
 
-#: catalog/models/item.py:316 catalog/models/people.py:484
+#: catalog/models/item.py:421 catalog/models/people.py:484
 msgid "metadata"
 msgstr "metadados"
 
-#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:423 catalog/templates/_item_card.html:28
 msgid "cover"
 msgstr "capa"
 
-#: catalog/models/item.py:1526
+#: catalog/models/item.py:1612
 msgid "source site"
 msgstr "fonte"
 
-#: catalog/models/item.py:1528
+#: catalog/models/item.py:1614
 msgid "ID on source site"
 msgstr "Identificação na fonte"
 
-#: catalog/models/item.py:1530
+#: catalog/models/item.py:1616
 msgid "source url"
 msgstr "url da fonte"
 
-#: catalog/models/item.py:1546
+#: catalog/models/item.py:1632
 msgid "IdType of the source site"
 msgstr "IdType do site de origem"
 
-#: catalog/models/item.py:1552
+#: catalog/models/item.py:1638
 msgid "Primary Id on the source site"
 msgstr "Identificação primária na fonte"
 
-#: catalog/models/item.py:1555
+#: catalog/models/item.py:1641
 msgid "url to the resource"
 msgstr "url para o recurso"
 
@@ -1235,12 +1235,12 @@ msgstr "Não foi possível obter informação pelo link, verifique novamente. Al
 #: catalog/templates/_item_card_metadata_tvseason.html:7
 #: catalog/templates/_item_card_metadata_tvshow.html:7
 #: catalog/templates/_item_card_metadata_work.html:7
-#: catalog/templates/item_base.html:201
+#: catalog/templates/item_base.html:186
 msgid "ratings"
 msgstr "avaliações"
 
-#: catalog/templates/_item_card_metadata_base.html:34
-#: catalog/templates/item_base.html:256
+#: catalog/templates/_item_card_metadata_base.html:28
+#: catalog/templates/item_base.html:241
 msgid "part of"
 msgstr "parte de"
 
@@ -1258,7 +1258,7 @@ msgid "hide this tooltip"
 msgstr "Ocultar esta dica"
 
 #: catalog/templates/_item_comments.html:58
-#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:83
+#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:81
 #, fuzzy
 #| msgid "translator"
 msgid "translate"
@@ -1267,7 +1267,7 @@ msgstr "tradutor"
 #: catalog/templates/_item_comments.html:92
 #: catalog/templates/_item_comments_by_episode.html:80
 #: catalog/templates/_item_notes.html:88
-#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:284
+#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:269
 #: catalog/templates/podcast_episode_data.html:41
 msgid "show more"
 msgstr "mostrar mais"
@@ -1388,8 +1388,8 @@ msgstr "Sincronização em progresso."
 #: catalog/templates/_item_user_pieces.html:101
 #: catalog/templates/catalog_edit.html:12
 #: journal/templates/action_edit_post.html:6
-#: journal/templates/action_edit_post.html:8 journal/templates/article.html:196
-#: journal/templates/collection.html:185 journal/templates/collection.html:193
+#: journal/templates/action_edit_post.html:8 journal/templates/article.html:194
+#: journal/templates/collection.html:186 journal/templates/collection.html:194
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_edit.html:26
 #: journal/templates/post_compose.html:16 journal/templates/tag_edit.html:16
@@ -1433,7 +1433,7 @@ msgstr "voltar para o artigo"
 #: catalog/templates/_sidebar_edit.html:20
 #: catalog/templates/catalog_verify.html:11
 #: catalog/templates/catalog_verify.html:17
-#: catalog/templates/item_base.html:182
+#: catalog/templates/item_base.html:167
 #, fuzzy
 #| msgid "Verification"
 msgid "Creator verification"
@@ -1443,7 +1443,7 @@ msgstr "Verificação"
 msgid "Edit Options"
 msgstr "Editar Opções"
 
-#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
+#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:163
 #: catalog/views/edit.py:160 catalog/views/edit.py:221
 #: catalog/views/edit.py:288 catalog/views/edit.py:309
 #: catalog/views/edit.py:364 catalog/views/edit.py:471
@@ -1617,7 +1617,7 @@ msgstr "mesclar a outro elemento"
 #: catalog/templates/_sidebar_edit.html:265
 #: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
-#: journal/templates/article.html:199 journal/templates/collection.html:188
+#: journal/templates/article.html:197 journal/templates/collection.html:189
 #: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
@@ -1814,7 +1814,7 @@ msgstr ""
 msgid "Remove my verification"
 msgstr "Remover da coleção"
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:311
+#: catalog/templates/_verify_status.html:31 users/views/account.py:312
 #, fuzzy
 #| msgid "Verification Code"
 msgid "Verification failed"
@@ -2008,7 +2008,7 @@ msgstr "Etiquetas populares"
 
 #: catalog/templates/discover.html:229
 #: catalog/templates/discover_original_podcasts.html:25
-#: catalog/templates/item_base.html:282
+#: catalog/templates/item_base.html:267
 #: catalog/templates/item_mark_list.html:71
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
@@ -2078,67 +2078,67 @@ msgstr "Obtendo de %(site_label)s"
 msgid "System busy, please try again in a minute."
 msgstr "Sistema sobrecarregado. Por favor, tente novamente dentro de um minuto."
 
-#: catalog/templates/item_base.html:95
+#: catalog/templates/item_base.html:80
 msgid "select one of the seasons to comment"
 msgstr "Selecione uma das temporadas para comentar"
 
-#: catalog/templates/item_base.html:129
+#: catalog/templates/item_base.html:114
 msgid "mark, comment and collect"
 msgstr "marcar, comentar e coleccionar"
 
-#: catalog/templates/item_base.html:142
+#: catalog/templates/item_base.html:127
 msgid "Login or register to review or add this item to your collection."
 msgstr "Registe-se ou faça Login para escrever uma crítica ou adicionar este item à sua coleção."
 
-#: catalog/templates/item_base.html:151
+#: catalog/templates/item_base.html:136
 msgid "Related Collections"
 msgstr "Coleções relacionadas"
 
-#: catalog/templates/item_base.html:166
+#: catalog/templates/item_base.html:151
 msgid "Unsupported item type."
 msgstr "Tipo de item não suportado."
 
-#: catalog/templates/item_base.html:176
+#: catalog/templates/item_base.html:161
 msgid "Edit this item"
 msgstr "Editar este item"
 
-#: catalog/templates/item_base.html:187
+#: catalog/templates/item_base.html:172
 msgid "Last edited"
 msgstr "Última edição"
 
-#: catalog/templates/item_base.html:230
+#: catalog/templates/item_base.html:215
 msgid "No enough ratings"
 msgstr "Sem críticas suficientes"
 
-#: catalog/templates/item_base.html:274
+#: catalog/templates/item_base.html:259
 msgid "overview"
 msgstr "visão geral"
 
-#: catalog/templates/item_base.html:305
+#: catalog/templates/item_base.html:290
 msgid "comments"
 msgstr "comentários"
 
-#: catalog/templates/item_base.html:308
+#: catalog/templates/item_base.html:293
 #: catalog/templates/item_mark_list.html:22
 #: catalog/templates/item_mark_list.html:25
 #: catalog/templates/item_review_list.html:21
 msgid "marks"
 msgstr "marcações"
 
-#: catalog/templates/item_base.html:309
+#: catalog/templates/item_base.html:294
 #: catalog/templates/item_mark_list.html:23
 #: catalog/templates/item_mark_list.html:26
 #: catalog/templates/item_review_list.html:22
 msgid "marks from who you follow"
 msgstr "marcações de quem você segue"
 
-#: catalog/templates/item_base.html:323
+#: catalog/templates/item_base.html:308
 #: catalog/templates/item_mark_list.html:28
 #: catalog/templates/item_review_list.html:23
 msgid "reviews"
 msgstr "críticas"
 
-#: catalog/templates/item_base.html:333
+#: catalog/templates/item_base.html:318
 #, fuzzy
 #| msgid "note"
 msgid "notes"
@@ -2551,7 +2551,7 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
+#: catalog/views/verify.py:164 common/utils.py:148 common/utils.py:189
 #: journal/views/article.py:186 journal/views/review.py:182
 #: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
@@ -4324,7 +4324,7 @@ msgstr "Apenas mencionado"
 msgid "Open Registration"
 msgstr "Falha ao registar-se"
 
-#: common/templates/common/about.html:40 common/views_manage.py:657
+#: common/templates/common/about.html:40 common/views_manage.py:671
 #, fuzzy
 #| msgid "Preferences"
 msgid "Preferred Languages"
@@ -4390,7 +4390,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:738
+#: common/templates/common/scan.html:60 common/views_manage.py:756
 #, fuzzy
 #| msgid "Search results"
 msgid "Search"
@@ -4476,16 +4476,16 @@ msgstr "Você"
 msgid "unavailable"
 msgstr "indisponível"
 
-#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
+#: common/utils.py:152 common/utils.py:193 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr "Este utilizador já não existe"
 
-#: common/utils.py:135 common/utils.py:137 common/utils.py:140
-#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
+#: common/utils.py:159 common/utils.py:161 common/utils.py:164
+#: common/utils.py:200 common/utils.py:204 journal/views/profile.py:499
 msgid "Access denied"
 msgstr "Acesso negado"
 
-#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
+#: common/utils.py:167 common/utils.py:169 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr "Requer iniciar sessão"
@@ -4508,7 +4508,7 @@ msgstr "comentários"
 msgid "Access"
 msgstr "Acesso negado"
 
-#: common/views_manage.py:39 common/views_manage.py:733
+#: common/views_manage.py:39 common/views_manage.py:751
 #, fuzzy
 #| msgid "duration"
 msgid "Federation"
@@ -4892,465 +4892,495 @@ msgid "Sender name and address for outgoing email."
 msgstr ""
 
 #: common/views_manage.py:649
+msgid "Enable Twitter / X Archive Import"
+msgstr ""
+
+#: common/views_manage.py:651
+msgid "Show the Twitter / X archive import on the data page. Imported tweets become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:656
+msgid "Enable Mastodon Archive Import"
+msgstr ""
+
+#: common/views_manage.py:658
+msgid "Show the Mastodon archive import on the data page. Imported posts become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:663
 #, fuzzy
 #| msgid "Language"
 msgid "Default Language"
 msgstr "Idioma"
 
-#: common/views_manage.py:652
+#: common/views_manage.py:666
 msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:673
 msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:665
+#: common/views_manage.py:679
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:672
+#: common/views_manage.py:686
 #, fuzzy
 #| msgid "Import Method"
 msgid "Login Methods"
 msgstr "Método de importação"
 
-#: common/views_manage.py:677 mastodon/models/common.py:30
+#: common/views_manage.py:691 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr "Email"
 
-#: common/views_manage.py:681
+#: common/views_manage.py:695
+#, fuzzy
+#| msgid "Import"
+msgid "Data Import"
+msgstr "Importar"
+
+#: common/views_manage.py:699
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:692
+#: common/views_manage.py:710
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:694
+#: common/views_manage.py:712
 msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:699
+#: common/views_manage.py:717
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:700
+#: common/views_manage.py:718
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:704
+#: common/views_manage.py:722
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:706
+#: common/views_manage.py:724
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:711
+#: common/views_manage.py:729
 #, fuzzy
 #| msgid "Search results"
 msgid "Search Sites"
 msgstr "Procurar resultados"
 
-#: common/views_manage.py:712
+#: common/views_manage.py:730
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:715
+#: common/views_manage.py:733
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:716
+#: common/views_manage.py:734
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:719
+#: common/views_manage.py:737
 #, fuzzy
 #| msgid "Add tv series"
 msgid "Hidden Categories"
 msgstr "Adicionar séries de tv"
 
-#: common/views_manage.py:720
+#: common/views_manage.py:738
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:723
+#: common/views_manage.py:741
 msgid "Guest Search Page Limit"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:743
 msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
 msgstr ""
 
-#: common/views_manage.py:751
+#: common/views_manage.py:769
 #, fuzzy
 #| msgid "Spotify Album"
 msgid "Spotify API Key"
 msgstr "Álbum Spotify"
 
-#: common/views_manage.py:752
+#: common/views_manage.py:770
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:773
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:756
+#: common/views_manage.py:774
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:759
+#: common/views_manage.py:777
 #, fuzzy
 #| msgid "Google Books"
 msgid "Google Books API Key"
 msgstr "Google Livros"
 
-#: common/views_manage.py:760
+#: common/views_manage.py:778
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:763
+#: common/views_manage.py:781
 #, fuzzy
 #| msgid "Discogs"
 msgid "Discogs API Key"
 msgstr "Discogs"
 
-#: common/views_manage.py:765
+#: common/views_manage.py:783
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:769
+#: common/views_manage.py:787
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:770
+#: common/views_manage.py:788
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:773
+#: common/views_manage.py:791
 #, fuzzy
 #| msgid "client secret"
 msgid "IGDB Client Secret"
 msgstr "segredo do cliente"
 
-#: common/views_manage.py:776
+#: common/views_manage.py:794
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:778
+#: common/views_manage.py:796
 msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:783
+#: common/views_manage.py:801
 msgid "MyAnimeList Client ID"
 msgstr ""
 
-#: common/views_manage.py:785
+#: common/views_manage.py:803
 msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
 msgstr ""
 
-#: common/views_manage.py:790 users/templates/users/steam_import.html:26
+#: common/views_manage.py:808 users/templates/users/steam_import.html:26
 #, fuzzy
 #| msgid "Steam Game"
 msgid "Steam API Key"
 msgstr "Jogo Steam"
 
-#: common/views_manage.py:792
+#: common/views_manage.py:810
 msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:797
+#: common/views_manage.py:815
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:798
+#: common/views_manage.py:816
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:801
+#: common/views_manage.py:819
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:804
+#: common/views_manage.py:822
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:807
+#: common/views_manage.py:825
 #, fuzzy
 #| msgid "Threads"
 msgid "Threads App ID"
 msgstr "Threads"
 
-#: common/views_manage.py:808
+#: common/views_manage.py:826
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:811
+#: common/views_manage.py:829
 #, fuzzy
 #| msgid "Threads.net"
 msgid "Threads App Secret"
 msgstr "Threads.net"
 
-#: common/views_manage.py:814
+#: common/views_manage.py:832
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:834
 msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:833
+#: common/views_manage.py:851
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:844
+#: common/views_manage.py:862
 #, fuzzy
 #| msgid "translator"
 msgid "Translation"
 msgstr "tradutor"
 
-#: common/views_manage.py:849
+#: common/views_manage.py:867
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:853 social/templates/feed.html:27
+#: common/views_manage.py:871 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr "Notificações"
 
-#: common/views_manage.py:863
+#: common/views_manage.py:881
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:882
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:885
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:868
+#: common/views_manage.py:886
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:871
+#: common/views_manage.py:889
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:874
+#: common/views_manage.py:892
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:877
+#: common/views_manage.py:895
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:880
+#: common/views_manage.py:898
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:883
+#: common/views_manage.py:901
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:886
+#: common/views_manage.py:904
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:887
+#: common/views_manage.py:905
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:908
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:894
+#: common/views_manage.py:912
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:898
+#: common/views_manage.py:916
 #, fuzzy
 #| msgid "series"
 msgid "Retries"
 msgstr "séries"
 
-#: common/views_manage.py:903
+#: common/views_manage.py:921
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:908
+#: common/views_manage.py:926
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:915
+#: common/views_manage.py:933
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:927
+#: common/views_manage.py:945
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:928
+#: common/views_manage.py:946
 #, fuzzy
 #| msgid "site domain name"
 msgid "One domain per line."
 msgstr "nome do domínio do site"
 
-#: common/views_manage.py:931
+#: common/views_manage.py:949
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:932
+#: common/views_manage.py:950
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:935
+#: common/views_manage.py:953
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:937
+#: common/views_manage.py:955
 msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:943
+#: common/views_manage.py:961
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:944
+#: common/views_manage.py:962
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:947
+#: common/views_manage.py:965
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:948
+#: common/views_manage.py:966
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:958
+#: common/views_manage.py:976
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:960
+#: common/views_manage.py:978
 msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:966
+#: common/views_manage.py:984
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:968
+#: common/views_manage.py:986
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:974
+#: common/views_manage.py:992
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:976
+#: common/views_manage.py:994
 msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:983
+#: common/views_manage.py:1000
+msgid "Webhook Timeout (milliseconds)"
+msgstr ""
+
+#: common/views_manage.py:1001
+msgid "Timeout for delivering webhook requests to applications."
+msgstr ""
+
+#: common/views_manage.py:1006
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:986
+#: common/views_manage.py:1009
 #, fuzzy
 #| msgid "optional"
 msgid "Operational"
 msgstr "opcional"
 
-#: common/views_manage.py:1002
+#: common/views_manage.py:1026
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:1004
+#: common/views_manage.py:1028
 msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1009
+#: common/views_manage.py:1033
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:1011
+#: common/views_manage.py:1035
 msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1016
+#: common/views_manage.py:1040
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:1018
+#: common/views_manage.py:1042
 msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1023
+#: common/views_manage.py:1047
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:1025
+#: common/views_manage.py:1049
 msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1030
+#: common/views_manage.py:1054
 #, fuzzy
 #| msgid "Podcast"
 msgid "Podcast Genres"
 msgstr "Podcast"
 
-#: common/views_manage.py:1032
+#: common/views_manage.py:1056
 msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1037
+#: common/views_manage.py:1061
 #, fuzzy
 #| msgid "Performance"
 msgid "Performance Genres"
 msgstr "Espetáculo"
 
-#: common/views_manage.py:1039
+#: common/views_manage.py:1063
 msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1045
+#: common/views_manage.py:1069
 msgid "Genres by Category"
 msgstr ""
 
-#: common/views_manage.py:1069
+#: common/views_manage.py:1093
 msgid "Site"
 msgstr ""
 
-#: common/views_manage.py:1079
+#: common/views_manage.py:1103
 #, fuzzy
 #| msgid "Database"
 msgid "Database and Services"
 msgstr "Base de dados"
 
-#: common/views_manage.py:1089
+#: common/views_manage.py:1113
 msgid "Media and Files"
 msgstr ""
 
-#: common/views_manage.py:1098
+#: common/views_manage.py:1122
 msgid "Monitoring"
 msgstr ""
 
-#: common/views_manage.py:1102
+#: common/views_manage.py:1126
 msgid "Security"
 msgstr ""
 
-#: common/views_manage.py:1111
+#: common/views_manage.py:1135
 msgid "Other Environment Variables"
 msgstr ""
 
-#: common/views_manage.py:1113
+#: common/views_manage.py:1137
 msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
 msgstr ""
 
@@ -5398,7 +5428,8 @@ msgstr "Ao gravar, substituir espaços iniciais por espaços de largura total"
 #: users/templates/users/data.html:60 users/templates/users/data.html:113
 #: users/templates/users/data.html:170 users/templates/users/data.html:221
 #: users/templates/users/data.html:284 users/templates/users/data.html:346
-#: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
+#: users/templates/users/data.html:525 users/templates/users/data.html:578
+#: users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
 msgid "Visibility"
@@ -5436,8 +5467,8 @@ msgstr "só o criador"
 msgid "owner and their local mutuals"
 msgstr ""
 
-#: journal/forms.py:169 journal/templates/collection.html:193
-#: journal/templates/collection.html:202
+#: journal/forms.py:169 journal/templates/collection.html:194
+#: journal/templates/collection.html:203
 msgid "Collaborative editing"
 msgstr "Editar em grupo/colaboração"
 
@@ -5490,7 +5521,7 @@ msgstr ""
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:215 journal/views/article.py:218
+#: journal/models/article.py:224 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
@@ -5502,75 +5533,76 @@ msgstr ""
 msgid "note"
 msgstr "nota"
 
-#: journal/models/collection.py:115
+#: journal/models/collection.py:116
 #, fuzzy
 #| msgid "shared {username}'s collection"
 msgid "search query for dynamic collection"
 msgstr "partilhou a coleção de {username}"
 
-#: journal/models/collection.py:566 journal/templatetags/collection.py:35
+#: journal/models/collection.py:575 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] "%(count)d livro"
 msgstr[1] "%(count)d livros"
 
-#: journal/models/collection.py:571 journal/templatetags/collection.py:43
+#: journal/models/collection.py:580 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] "%(count)d filme"
 msgstr[1] "%(count)d filmes"
 
-#: journal/models/collection.py:576 journal/templatetags/collection.py:51
+#: journal/models/collection.py:585 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] "%(count)d programa de tv"
 msgstr[1] "%(count)d programas de tv"
 
-#: journal/models/collection.py:581 journal/templatetags/collection.py:59
+#: journal/models/collection.py:590 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] "%(count)d álbum"
 msgstr[1] "%(count)d álbuns"
 
-#: journal/models/collection.py:586 journal/templatetags/collection.py:67
+#: journal/models/collection.py:595 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] "%(count)d jogo"
 msgstr[1] "%(count)d jogos"
 
-#: journal/models/collection.py:591 journal/templatetags/collection.py:75
+#: journal/models/collection.py:600 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] "%(count)d podcast"
 msgstr[1] "%(count)d podcasts"
 
-#: journal/models/collection.py:597 journal/templatetags/collection.py:83
+#: journal/models/collection.py:606 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] "%(count)d espetáculo"
 msgstr[1] "%(count)d espetáculos"
 
-#: journal/models/collection.py:605 journal/templatetags/collection.py:91
+#: journal/models/collection.py:614 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] "%(count)d artigo"
 msgstr[1] "%(count)d artigos"
 
-#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/models/common.py:59 journal/templates/action_open_post.html:15
 #: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
 #: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
 #: users/templates/users/data.html:122 users/templates/users/data.html:179
 #: users/templates/users/data.html:230 users/templates/users/data.html:292
 #: users/templates/users/data.html:355 users/templates/users/data.html:534
+#: users/templates/users/data.html:587
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5578,13 +5610,14 @@ msgstr[1] "%(count)d artigos"
 msgid "Public"
 msgstr "Público"
 
-#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/models/common.py:60 journal/templates/action_open_post.html:9
 #: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
 #: users/templates/users/data.html:130 users/templates/users/data.html:187
 #: users/templates/users/data.html:238 users/templates/users/data.html:300
 #: users/templates/users/data.html:363 users/templates/users/data.html:542
+#: users/templates/users/data.html:595
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5592,12 +5625,13 @@ msgstr "Público"
 msgid "Followers Only"
 msgstr "Apenas seguidores"
 
-#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/models/common.py:61 journal/templates/collection_share.html:57
 #: journal/templates/mark.html:102 journal/templates/post_compose.html:72
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
 #: users/templates/users/data.html:138 users/templates/users/data.html:195
 #: users/templates/users/data.html:246 users/templates/users/data.html:308
 #: users/templates/users/data.html:371 users/templates/users/data.html:550
+#: users/templates/users/data.html:603
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5605,33 +5639,33 @@ msgstr "Apenas seguidores"
 msgid "Mentioned Only"
 msgstr "Apenas mencionado"
 
-#: journal/models/common.py:806
+#: journal/models/common.py:851
 #, fuzzy
 #| msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr "Um post recente não foi publicado no Mastodon. Por favor, volte a autorizar."
 
-#: journal/models/common.py:1003
+#: journal/models/common.py:1048
 msgid "A recent post was not posted to Threads."
 msgstr "Um post recente não foi publicado no Threads."
 
-#: journal/models/common.py:1036
+#: journal/models/common.py:1081
 #, fuzzy
 #| msgid "A recent post was not posted to Mastodon."
 msgid "A recent post was not boosted on Mastodon."
 msgstr "Um post recente não foi publicado no Mastodon."
 
-#: journal/models/common.py:1046
+#: journal/models/common.py:1091
 #, fuzzy
 #| msgid "Item no longer exists"
 msgid "Original post no longer exists."
 msgstr "Este item já não existe"
 
-#: journal/models/common.py:1060
+#: journal/models/common.py:1105
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr "Um post recente não foi publicado no Mastodon. Por favor, volte a autorizar."
 
-#: journal/models/common.py:1069
+#: journal/models/common.py:1114
 msgid "A recent post was not posted to Mastodon."
 msgstr "Um post recente não foi publicado no Mastodon."
 
@@ -5649,85 +5683,85 @@ msgstr "Falhou"
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:475
+#: journal/models/mark.py:477
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:479
+#: journal/models/mark.py:481
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:486
+#: journal/models/mark.py:488
 #, fuzzy
 #| msgid "Invalid parameter"
 msgid "Invalid progress type."
 msgstr "Parâmetro inválido"
 
-#: journal/models/mark.py:488
+#: journal/models/mark.py:490
 #, fuzzy
 #| msgid "Invalid response from Fediverse instance."
 msgid "Invalid progress type for this item."
 msgstr "Resposta inválida da instância do Fediverso."
 
-#: journal/models/note.py:47 users/templates/users/rym_import.html:73
+#: journal/models/note.py:48 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr "Página"
 
-#: journal/models/note.py:48
+#: journal/models/note.py:49
 msgid "Chapter"
 msgstr "Capítulo"
 
-#: journal/models/note.py:51
+#: journal/models/note.py:52
 msgid "Part"
 msgstr "Parte"
 
-#: journal/models/note.py:52
+#: journal/models/note.py:53
 msgid "Episode"
 msgstr "Episódio"
 
-#: journal/models/note.py:53
+#: journal/models/note.py:54
 msgid "Track"
 msgstr "Faixa"
 
-#: journal/models/note.py:54
+#: journal/models/note.py:55
 msgid "Cycle"
 msgstr "Ciclo"
 
-#: journal/models/note.py:55
+#: journal/models/note.py:56
 msgid "Timestamp"
 msgstr "Marca temporal"
 
-#: journal/models/note.py:56
+#: journal/models/note.py:57
 msgid "Percentage"
 msgstr "Percentagem"
 
-#: journal/models/note.py:77
+#: journal/models/note.py:78
 #, python-brace-format
 msgid "Page {value}"
 msgstr "Página {value}"
 
-#: journal/models/note.py:78
+#: journal/models/note.py:79
 #, python-brace-format
 msgid "Chapter {value}"
 msgstr "Capítulo {value}"
 
-#: journal/models/note.py:81
+#: journal/models/note.py:82
 #, python-brace-format
 msgid "Part {value}"
 msgstr "Parte {value}"
 
-#: journal/models/note.py:82
+#: journal/models/note.py:83
 #, python-brace-format
 msgid "Episode {value}"
 msgstr "Episódio {value}"
 
-#: journal/models/note.py:83
+#: journal/models/note.py:84
 #, python-brace-format
 msgid "Track {value}"
 msgstr "Faixa {value}"
 
-#: journal/models/note.py:84
+#: journal/models/note.py:85
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr "Ciclo {value}"
@@ -5737,13 +5771,13 @@ msgstr "Ciclo {value}"
 msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr "Relativamente a {item_title}, pode conter spoilers e conteúdo inapropriado"
 
-#: journal/models/review.py:79
+#: journal/models/review.py:80
 #, fuzzy, python-brace-format
 #| msgid "a review of {item_title}"
 msgid "a review of {title}"
 msgstr "uma crítica de {item_title}"
 
-#: journal/models/review.py:81
+#: journal/models/review.py:82
 #, fuzzy
 #| msgid "Item contains sub-items."
 msgid "(may contain spoilers)"
@@ -6175,7 +6209,7 @@ msgstr "Utilizadores que está a seguir"
 msgid "started following {item}"
 msgstr "começou a jogar {item}"
 
-#: journal/models/shelf.py:923
+#: journal/models/shelf.py:925
 msgid "removed mark"
 msgstr "marcação removida"
 
@@ -6210,7 +6244,7 @@ msgstr "Remover da coleção"
 msgid "Update note"
 msgstr "Atualizar nota"
 
-#: journal/templates/_list_item.html:71 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:121
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
@@ -6379,7 +6413,7 @@ msgid "View post"
 msgstr ""
 
 #: journal/templates/action_quote_post.html:3
-#: journal/templates/article.html:190 journal/templates/collection.html:174
+#: journal/templates/article.html:188 journal/templates/collection.html:175
 msgid "Quote"
 msgstr ""
 
@@ -6388,7 +6422,7 @@ msgid "reply"
 msgstr "responder"
 
 #: journal/templates/action_reply_post.html:3
-#: journal/templates/article.html:181 journal/templates/collection.html:165
+#: journal/templates/article.html:179 journal/templates/collection.html:166
 msgid "Reply"
 msgstr "Responder"
 
@@ -6407,23 +6441,23 @@ msgstr "Adicionar à coleção"
 msgid "Create a new collection"
 msgstr "Criar nova coleção"
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:76
+#: journal/templates/article.html:102 social/templates/_event_post.html:76
 #, fuzzy
 #| msgid "wrote a review of {item}"
 msgid "wrote a review"
 msgstr "escreveu uma resenha sobre {item}"
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:78
+#: journal/templates/article.html:104 social/templates/_event_post.html:78
 #, fuzzy
 #| msgid "wrote a note"
 msgid "wrote an article"
 msgstr "escreveu uma nota"
 
-#: journal/templates/article.html:136
+#: journal/templates/article.html:134
 msgid "This article may contain sensitive content. Click to reveal."
 msgstr ""
 
-#: journal/templates/article.html:155
+#: journal/templates/article.html:153
 msgid "The author has set it to be viewable only by logged-in users."
 msgstr "O autor definiu o conteúdo a visualizar apenas para utilizadores com sessão iniciada."
 
@@ -6488,20 +6522,20 @@ msgstr "NOV"
 msgid "DEC"
 msgstr "DEZ"
 
-#: journal/templates/collection.html:71
+#: journal/templates/collection.html:72
 #: journal/templates/collection_share.html:12
 #: journal/templates/collection_share.html:66
 #: journal/templates/wrapped_share.html:59
 msgid "Share"
 msgstr "Partilhar"
 
-#: journal/templates/collection.html:86
+#: journal/templates/collection.html:87
 #, fuzzy
 #| msgid "created collection"
 msgid "created a collection"
 msgstr "coleção criada"
 
-#: journal/templates/collection.html:181
+#: journal/templates/collection.html:182
 msgid "Query"
 msgstr ""
 
@@ -6770,14 +6804,14 @@ msgid "Liked Collections"
 msgstr "Coleções gostadas"
 
 #: journal/templates/user_follow_list.html:23 journal/views/profile.py:507
-#: users/templates/users/account.html:443
+#: users/templates/users/account.html:455
 #, fuzzy
 #| msgid "following you"
 msgid "Following"
 msgstr "segue-o"
 
 #: journal/templates/user_follow_list.html:28 journal/views/profile.py:511
-#: users/templates/users/account.html:452
+#: users/templates/users/account.html:464
 #, fuzzy
 #| msgid "Followers Only"
 msgid "Followers"
@@ -7119,8 +7153,8 @@ msgstr "Iniciar sessão com ID de Bluesky"
 #: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
 #: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
 #: mastodon/views/threads.py:57 mastodon/views/threads.py:65
-#: mastodon/views/threads.py:71 users/views/account.py:256
-#: users/views/account.py:375
+#: mastodon/views/threads.py:71 users/views/account.py:257
+#: users/views/account.py:376
 msgid "Authentication failed"
 msgstr "A autenticação falhou"
 
@@ -7168,7 +7202,7 @@ msgstr "Dados de conta Bluesky inválidos."
 msgid "Invalid user."
 msgstr "Utilizador inválido."
 
-#: mastodon/views/common.py:52 users/views/account.py:416
+#: mastodon/views/common.py:52 users/views/account.py:417
 msgid "Registration failed"
 msgstr "Falha ao registar-se"
 
@@ -8154,146 +8188,161 @@ msgstr "ano de publicação"
 msgid "Scopes"
 msgstr ""
 
-#: users/templates/users/account.html:398
+#: users/templates/users/account.html:386
+msgid "Webhook"
+msgstr ""
+
+#: users/templates/users/account.html:400
+msgid "disabled"
+msgstr ""
+
+#: users/templates/users/account.html:402
+#, fuzzy
+#| msgid "Activities"
+msgid "active"
+msgstr "Atividades"
+
+#: users/templates/users/account.html:410
 msgid "Revoke access for this application?"
 msgstr ""
 
-#: users/templates/users/account.html:401
+#: users/templates/users/account.html:413
 msgid "Revoke"
 msgstr ""
 
-#: users/templates/users/account.html:409
+#: users/templates/users/account.html:421
 #, fuzzy
 #| msgid "View authorized applications"
 msgid "No authorized applications."
 msgstr "Ver aplicações autorizadas"
 
-#: users/templates/users/account.html:412
+#: users/templates/users/account.html:424
 #: users/templates/users/authorized_app_create.html:9
 #: users/templates/users/authorized_app_create.html:19
 msgid "Create Personal Token"
 msgstr ""
 
-#: users/templates/users/account.html:418
+#: users/templates/users/account.html:430
 msgid "Import/Export Social Graph"
 msgstr ""
 
-#: users/templates/users/account.html:419
+#: users/templates/users/account.html:431
 msgid "Upload a CSV file exported from Mastodon or compatible services."
 msgstr ""
 
-#: users/templates/users/account.html:425
+#: users/templates/users/account.html:437
 #, fuzzy
 #| msgid "Import"
 msgid "Import type"
 msgstr "Importar"
 
-#: users/templates/users/account.html:427
+#: users/templates/users/account.html:439
 #, fuzzy
 #| msgid "following you"
 msgid "Following list"
 msgstr "segue-o"
 
-#: users/templates/users/account.html:428
+#: users/templates/users/account.html:440
 #, fuzzy
 #| msgid "to listen"
 msgid "Block list"
 msgstr "para ouvir"
 
-#: users/templates/users/account.html:429
+#: users/templates/users/account.html:441
 #, fuzzy
 #| msgid "to listen"
 msgid "Mute list"
 msgstr "para ouvir"
 
-#: users/templates/users/account.html:433
+#: users/templates/users/account.html:445
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/account.html:448 users/templates/users/data.html:89
 #: users/templates/users/data.html:141 users/templates/users/data.html:198
 #: users/templates/users/data.html:249 users/templates/users/data.html:313
 #: users/templates/users/data.html:376 users/templates/users/data.html:553
+#: users/templates/users/data.html:606 users/templates/users/data.html:631
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr "Importar"
 
-#: users/templates/users/account.html:447
-#: users/templates/users/account.html:456
-#: users/templates/users/account.html:465
-#: users/templates/users/account.html:474
+#: users/templates/users/account.html:459
+#: users/templates/users/account.html:468
+#: users/templates/users/account.html:477
+#: users/templates/users/account.html:486
 #, fuzzy
 #| msgid "Download"
 msgid "Download CSV"
 msgstr "Download"
 
-#: users/templates/users/account.html:461
+#: users/templates/users/account.html:473
 #, fuzzy
 #| msgid "blocked"
 msgid "Blocks"
 msgstr "bloqueado"
 
-#: users/templates/users/account.html:470
+#: users/templates/users/account.html:482
 msgid "Mutes"
 msgstr ""
 
-#: users/templates/users/account.html:484
+#: users/templates/users/account.html:496
 #, fuzzy
 #| msgid "Migrate account"
 msgid "Migrate Account"
 msgstr "Migrar conta"
 
-#: users/templates/users/account.html:488
+#: users/templates/users/account.html:500
 #, fuzzy
 #| msgid "Link an email so that you can migrate followers from other Fediverse instances."
 msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
 msgstr "Vincular um email para que possa migrar seguidores de outras instâncias do Fediverso."
 
-#: users/templates/users/account.html:491
+#: users/templates/users/account.html:503
 #, fuzzy
 #| msgid "Migrate account"
 msgid "Migrate another account here"
 msgstr "Migrar conta"
 
-#: users/templates/users/account.html:494
+#: users/templates/users/account.html:506
 #, fuzzy
 #| msgid "Migrate account"
 msgid "Migrate to another account"
 msgstr "Migrar conta"
 
-#: users/templates/users/account.html:501
+#: users/templates/users/account.html:513
 msgid "Delete Account"
 msgstr "Eliminar conta"
 
-#: users/templates/users/account.html:504
+#: users/templates/users/account.html:516
 msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
 msgstr "Após eliminada, a sua conta não pode ser recuperada. Deseja prosseguir?"
 
-#: users/templates/users/account.html:507
+#: users/templates/users/account.html:519
 msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
 msgstr "Insira o nome de utilizador completo <code>username@instance.social</code> ou <code>email@domain.com</code> para confirmar a sua eliminação."
 
-#: users/templates/users/account.html:517
+#: users/templates/users/account.html:529
 msgid "Once deleted, account data cannot be recovered."
 msgstr "Após eliminada, a conta não pode ser recuperada."
 
-#: users/templates/users/account.html:520
+#: users/templates/users/account.html:532
 #, fuzzy
 #| msgid "Importing in progress, can't delete now."
 msgid "Task in progress, can't delete now."
 msgstr "Importação em progresso. Neste momento não pode ser apagada."
 
-#: users/templates/users/account.html:524
+#: users/templates/users/account.html:536
 msgid "Permanently Delete"
 msgstr "Eliminar de forma permanente"
 
-#: users/templates/users/account.html:565
+#: users/templates/users/account.html:577
 #, fuzzy
 #| msgid "Delete this tag"
 msgid "Delete this passkey?"
 msgstr "Eliminar esta etiqueta"
 
-#: users/templates/users/account.html:585
+#: users/templates/users/account.html:597
 msgid "Rename passkey:"
 msgstr ""
 
@@ -8317,12 +8366,10 @@ msgstr ""
 
 #: users/templates/users/authorized_app_create.html:48
 #: users/templates/users/authorized_app_created.html:39
-#: users/templates/users/migrate_in.html:70
-#: users/templates/users/migrate_out.html:67
 #, fuzzy
-#| msgid "Preferences"
-msgid "Back to Preferences"
-msgstr "Preferências"
+#| msgid "Migrate account"
+msgid "Back to Account"
+msgstr "Migrar conta"
 
 #: users/templates/users/authorized_app_created.html:9
 #: users/templates/users/authorized_app_created.html:19
@@ -8466,7 +8513,7 @@ msgstr "Substituir: atualiza todos os estado importados."
 msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
 msgstr "Tem uma importação em progresso. Realizar uma nova importação poderá causar erros. Tem a certeza que deseja continuar?"
 
-#: users/templates/users/data.html:89 users/views/data.py:1130
+#: users/templates/users/data.html:89 users/views/data.py:1194
 msgid "Import in progress, please wait"
 msgstr "Importação em progresso, por favor espere"
 
@@ -8639,7 +8686,41 @@ msgstr ""
 msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
-#: users/templates/users/data.html:560
+#: users/templates/users/data.html:561
+msgid "Import Twitter / X Archive"
+msgstr ""
+
+#: users/templates/users/data.html:567
+msgid "On X, go to <b>Settings</b> - <b>Your account</b> - <b>Download an archive of your data</b>. Upload the <code>.zip</code> you receive, or only the <code>data/tweets.js</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:570
+msgid "Each tweet becomes a post with its original date, text, links and photos. Replies to your own tweets are kept as a thread. A retweet becomes a short post that links to the original tweet. Videos are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:573
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Tweets that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:615
+#, fuzzy
+#| msgid "Import Method"
+msgid "Import Mastodon Archive"
+msgstr "Método de importação"
+
+#: users/templates/users/data.html:621
+msgid "On your Mastodon server, go to <b>Preferences</b> - <b>Import and export</b> - <b>Request your archive</b>. Upload the <code>.zip</code> you receive, or only the <code>outbox.json</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:624
+msgid "Each post is imported with its original date, text, links, photos, content warning and visibility, so a followers-only post or a direct message stays that way. Replies to your own posts are kept as a thread. A boost becomes a short post that links to the original post. Videos, favourites and bookmarks are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:627
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Posts that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:639
 msgid "View Annual Summary"
 msgstr "Ver Relatório Anual"
 
@@ -8769,6 +8850,13 @@ msgstr "Objetivos atuais"
 #: users/templates/users/migrate_in.html:64
 msgid "No aliases configured."
 msgstr ""
+
+#: users/templates/users/migrate_in.html:70
+#: users/templates/users/migrate_out.html:67
+#, fuzzy
+#| msgid "Preferences"
+msgid "Back to Preferences"
+msgstr "Preferências"
 
 #: users/templates/users/migrate_out.html:9
 #: users/templates/users/migrate_out.html:43
@@ -9325,207 +9413,208 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:126
+#: users/views/account.py:127
 msgid "This username is already in use."
 msgstr "Este nome de utilizador já está a ser usado."
 
-#: users/views/account.py:137
+#: users/views/account.py:138
 msgid "This email address is already in use."
 msgstr "Este email já se encontra a ser usado."
 
-#: users/views/account.py:257 users/views/account.py:376
+#: users/views/account.py:258 users/views/account.py:377
 msgid "Registration is for invitation only"
 msgstr "O registo está apenas disponível através de convite"
 
-#: users/views/account.py:268 users/views/account.py:340
+#: users/views/account.py:269 users/views/account.py:341
 #, fuzzy
 #| msgid "Timestamp"
 msgid "Time is up"
 msgstr "Marca temporal"
 
-#: users/views/account.py:269 users/views/account.py:312
-#: users/views/account.py:341
+#: users/views/account.py:270 users/views/account.py:313
+#: users/views/account.py:342
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:315
+#: users/views/account.py:316
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:327
+#: users/views/account.py:328
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:328
+#: users/views/account.py:329
 #, fuzzy
 #| msgid "System busy, please try again in a minute."
 msgid "Please try again later."
 msgstr "Sistema sobrecarregado. Por favor, tente novamente dentro de um minuto."
 
-#: users/views/account.py:417
+#: users/views/account.py:418
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:447
+#: users/views/account.py:448
 msgid "Valid username required"
 msgstr "Requer um nome de utilizador válido"
 
-#: users/views/account.py:518
+#: users/views/account.py:519
 msgid "Account is being deleted."
 msgstr "A conta está a ser apagada."
 
-#: users/views/account.py:521
+#: users/views/account.py:522
 msgid "Account mismatch."
 msgstr "Conta incompatível."
 
-#: users/views/data.py:264 users/views/data.py:296
+#: users/views/data.py:276 users/views/data.py:308
 msgid "Export file not available."
 msgstr "O ficheiro de exportação não se encontra disponível."
 
-#: users/views/data.py:290
+#: users/views/data.py:302
 msgid "Generating exports."
 msgstr "A gerar exportações."
 
-#: users/views/data.py:308
+#: users/views/data.py:320
 msgid "Export file expired. Please export again."
 msgstr "O ficheiro de exportação expirou. Por favor, tente novamente."
 
-#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
+#: users/views/data.py:335 users/views/data.py:356 users/views/data.py:377
 #, fuzzy
 #| msgid "Import in progress."
 msgid "Recent export still in progress."
 msgstr "Importação em progresso."
 
-#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
-#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
-#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
+#: users/views/data.py:393 users/views/data.py:419 users/views/data.py:447
+#: users/views/data.py:579 users/views/data.py:613 users/views/data.py:838
+#: users/views/data.py:1055 users/views/data.py:1081 users/views/data.py:1106
+#: users/views/data.py:1131 users/views/data.py:1201
 msgid "Invalid file."
 msgstr "Ficheiro inválido."
 
-#: users/views/data.py:405
+#: users/views/data.py:469
 msgid "Sync in progress."
 msgstr "Sincronização em progresso."
 
-#: users/views/data.py:419
+#: users/views/data.py:483
 msgid "Settings saved."
 msgstr "Definições guardadas."
 
-#: users/views/data.py:474
+#: users/views/data.py:538
 #, fuzzy
 #| msgid "Account is being deleted."
 msgid "Account no longer linked."
 msgstr "A conta está a ser apagada."
 
-#: users/views/data.py:477
+#: users/views/data.py:541
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:505
+#: users/views/data.py:569
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:585 users/views/data.py:810
+#: users/views/data.py:649 users/views/data.py:874
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:610 users/views/data.py:839
+#: users/views/data.py:674 users/views/data.py:903
 #, fuzzy
 #| msgid "Cancel"
 msgid "Cancelled."
 msgstr "Cancelar"
 
-#: users/views/data.py:630
+#: users/views/data.py:694
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
-#: users/views/data.py:974
+#: users/views/data.py:702 users/views/data.py:812 users/views/data.py:933
+#: users/views/data.py:1038
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:734 users/views/data.py:960
+#: users/views/data.py:798 users/views/data.py:1024
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:744 users/views/data.py:970
+#: users/views/data.py:808 users/views/data.py:1034
 #, fuzzy
 #| msgid "Export file not available."
 msgid "No matched file available."
 msgstr "O ficheiro de exportação não se encontra disponível."
 
-#: users/views/data.py:861
+#: users/views/data.py:925
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1290
 #, fuzzy
 #| msgid "Login required"
 msgid "Name is required."
 msgstr "Requer iniciar sessão"
 
-#: users/views/data.py:1248
+#: users/views/data.py:1314
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1264
+#: users/views/data.py:1330
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1269
+#: users/views/data.py:1335
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1279 users/views/data.py:1330
+#: users/views/data.py:1345 users/views/data.py:1396
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:1286
+#: users/views/data.py:1352
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:1291
+#: users/views/data.py:1357
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:1317
+#: users/views/data.py:1383
 #, fuzzy
 #| msgid "Registration failed"
 msgid "Migration cancelled."
 msgstr "Falha ao registar-se"
 
-#: users/views/data.py:1322
+#: users/views/data.py:1388
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:1335
+#: users/views/data.py:1401
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:1346
+#: users/views/data.py:1412
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:1352
+#: users/views/data.py:1418
 #, fuzzy, python-brace-format
 #| msgid "Continue login as {handle}."
 msgid "Start moving to {handle}."
 msgstr "Continuar início de sessão como {handle}."
 
-#: users/views/data.py:1410
+#: users/views/data.py:1476
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1426
+#: users/views/data.py:1492
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1430
+#: users/views/data.py:1496
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1440
+#: users/views/data.py:1506
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""

--- a/neodb/locale/pt_BR/LC_MESSAGES/django.po
+++ b/neodb/locale/pt_BR/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 20:04-0400\n"
+"POT-Creation-Date: 2026-09-07 14:56-0400\n"
 "PO-Revision-Date: 2026-09-02 01:51+0000\n"
 "Last-Translator: Havokdan <havokdan@yahoo.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/neodb/neodb/pt_BR/>\n"
@@ -59,15 +59,15 @@ msgstr "Chinês Simplificado"
 msgid "Traditional Chinese"
 msgstr "Chinês Tradicional"
 
-#: catalog/forms.py:35 catalog/models/item.py:307
+#: catalog/forms.py:35 catalog/models/item.py:412
 msgid "Primary ID Type"
 msgstr "Tipo de ID Primário"
 
-#: catalog/forms.py:40 catalog/models/item.py:310
+#: catalog/forms.py:40 catalog/models/item.py:415
 msgid "Primary ID Value"
 msgstr "Valor do ID Primário"
 
-#: catalog/forms.py:176
+#: catalog/forms.py:177
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr "Data inválida, o formato esperado é AAAA, AAAA-MM ou AAAA-MM-DD."
 
@@ -120,11 +120,11 @@ msgid "other title"
 msgstr "outro título"
 
 #: catalog/models/book.py:282 catalog/models/book.py:566
-#: catalog/models/item.py:119
+#: catalog/models/item.py:224
 msgid "author"
 msgstr "autor"
 
-#: catalog/models/book.py:289 catalog/models/item.py:120
+#: catalog/models/book.py:289 catalog/models/item.py:225
 msgid "translator"
 msgstr "tradutor"
 
@@ -133,7 +133,7 @@ msgid "book format"
 msgstr "formato do livro"
 
 #: catalog/models/book.py:303 catalog/models/game.py:135
-#: catalog/models/item.py:134 catalog/models/music.py:142
+#: catalog/models/item.py:239 catalog/models/music.py:142
 msgid "publisher"
 msgstr "editora"
 
@@ -165,7 +165,7 @@ msgstr "conteúdo"
 msgid "price"
 msgstr "preço"
 
-#: catalog/models/book.py:326 catalog/models/item.py:145
+#: catalog/models/book.py:326 catalog/models/item.py:250
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr "selo editorial"
@@ -568,7 +568,7 @@ msgid "Exhibition"
 msgstr "Exibição"
 
 #: catalog/models/common.py:174 catalog/models/common.py:191
-#: journal/templates/collection.html:29 journal/templates/collection.html:40
+#: journal/templates/collection.html:30 journal/templates/collection.html:41
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
@@ -690,16 +690,16 @@ msgstr "Remake"
 msgid "Special Edition"
 msgstr "Edição Especial"
 
-#: catalog/models/game.py:111 catalog/models/item.py:126
+#: catalog/models/game.py:111 catalog/models/item.py:231
 msgid "designer"
 msgstr "designer"
 
-#: catalog/models/game.py:119 catalog/models/item.py:125
+#: catalog/models/game.py:119 catalog/models/item.py:230
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr "artista"
 
-#: catalog/models/game.py:127 catalog/models/item.py:135
+#: catalog/models/game.py:127 catalog/models/item.py:240
 msgid "developer"
 msgstr "desenvolvedor"
 
@@ -729,141 +729,141 @@ msgstr "tipo de lançamento"
 msgid "website"
 msgstr "site"
 
-#: catalog/models/item.py:121 catalog/models/movie.py:123
+#: catalog/models/item.py:226 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
 #: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr "diretor"
 
-#: catalog/models/item.py:122 catalog/models/movie.py:130
+#: catalog/models/item.py:227 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
 #: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr "dramaturgo"
 
-#: catalog/models/item.py:123 catalog/models/movie.py:137
+#: catalog/models/item.py:228 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
 #: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr "ator"
 
-#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/item.py:229 catalog/models/movie.py:144
 #: catalog/models/tv.py:237 catalog/models/tv.py:463
 msgid "producer"
 msgstr "produtor"
 
-#: catalog/models/item.py:127 catalog/models/performance.py:203
+#: catalog/models/item.py:232 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr "compositor"
 
-#: catalog/models/item.py:128 catalog/models/performance.py:210
+#: catalog/models/item.py:233 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr "coreógrafo"
 
-#: catalog/models/item.py:129 catalog/models/performance.py:224
+#: catalog/models/item.py:234 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr "artista"
 
-#: catalog/models/item.py:130 catalog/models/podcast.py:80
+#: catalog/models/item.py:235 catalog/models/podcast.py:80
 msgid "host"
 msgstr "host"
 
-#: catalog/models/item.py:131 catalog/models/performance.py:196
+#: catalog/models/item.py:236 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr "criador original"
 
-#: catalog/models/item.py:132 catalog/models/performance.py:238
+#: catalog/models/item.py:237 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr "equipe"
 
-#: catalog/models/item.py:136
+#: catalog/models/item.py:241
 msgid "production company"
 msgstr "produtora"
 
-#: catalog/models/item.py:137
+#: catalog/models/item.py:242
 msgid "record label"
 msgstr "gravadora"
 
-#: catalog/models/item.py:138
+#: catalog/models/item.py:243
 msgid "distributor"
 msgstr "distribuidora"
 
-#: catalog/models/item.py:139
+#: catalog/models/item.py:244
 msgid "studio"
 msgstr "estúdio"
 
-#: catalog/models/item.py:140 catalog/models/performance.py:231
+#: catalog/models/item.py:245 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr "trupe"
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:248
 msgid "voice actor"
 msgstr "dublador"
 
-#: catalog/models/item.py:144 catalog/templates/edition.html:30
+#: catalog/models/item.py:249 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr "casa editorial"
 
-#: catalog/models/item.py:169 catalog/models/people.py:476
+#: catalog/models/item.py:274 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr "papel"
 
-#: catalog/models/item.py:170 catalog/models/people.py:155
+#: catalog/models/item.py:275 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr "nome"
 
-#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:277 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr "nome do personagem"
 
-#: catalog/models/item.py:304 catalog/models/item.py:336
-#: journal/models/collection.py:100
+#: catalog/models/item.py:409 catalog/models/item.py:441
+#: journal/models/collection.py:101
 msgid "title"
 msgstr "título"
 
-#: catalog/models/item.py:305 catalog/models/item.py:344
-#: journal/models/collection.py:101
+#: catalog/models/item.py:410 catalog/models/item.py:449
+#: journal/models/collection.py:102
 msgid "description"
 msgstr "descrição"
 
-#: catalog/models/item.py:316 catalog/models/people.py:484
+#: catalog/models/item.py:421 catalog/models/people.py:484
 msgid "metadata"
 msgstr "metadados"
 
-#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:423 catalog/templates/_item_card.html:28
 msgid "cover"
 msgstr "capa"
 
-#: catalog/models/item.py:1526
+#: catalog/models/item.py:1612
 msgid "source site"
 msgstr "site de origem"
 
-#: catalog/models/item.py:1528
+#: catalog/models/item.py:1614
 msgid "ID on source site"
 msgstr "ID no site de origem"
 
-#: catalog/models/item.py:1530
+#: catalog/models/item.py:1616
 msgid "source url"
 msgstr "URL de origem"
 
-#: catalog/models/item.py:1546
+#: catalog/models/item.py:1632
 msgid "IdType of the source site"
 msgstr "Tipo de ID do site de origem"
 
-#: catalog/models/item.py:1552
+#: catalog/models/item.py:1638
 msgid "Primary Id on the source site"
 msgstr "ID primário no site de origem"
 
-#: catalog/models/item.py:1555
+#: catalog/models/item.py:1641
 msgid "url to the resource"
 msgstr "URL do recurso"
 
@@ -1148,12 +1148,12 @@ msgstr "Não foi possível buscar a partir do link. Por favor, verifique novamen
 #: catalog/templates/_item_card_metadata_tvseason.html:7
 #: catalog/templates/_item_card_metadata_tvshow.html:7
 #: catalog/templates/_item_card_metadata_work.html:7
-#: catalog/templates/item_base.html:201
+#: catalog/templates/item_base.html:186
 msgid "ratings"
 msgstr "avaliações"
 
-#: catalog/templates/_item_card_metadata_base.html:34
-#: catalog/templates/item_base.html:256
+#: catalog/templates/_item_card_metadata_base.html:28
+#: catalog/templates/item_base.html:241
 msgid "part of"
 msgstr "parte de"
 
@@ -1171,14 +1171,14 @@ msgid "hide this tooltip"
 msgstr "ocultar esta dica"
 
 #: catalog/templates/_item_comments.html:58
-#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:83
+#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:81
 msgid "translate"
 msgstr "traduzir"
 
 #: catalog/templates/_item_comments.html:92
 #: catalog/templates/_item_comments_by_episode.html:80
 #: catalog/templates/_item_notes.html:88
-#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:284
+#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:269
 #: catalog/templates/podcast_episode_data.html:41
 msgid "show more"
 msgstr "mostrar mais"
@@ -1285,8 +1285,8 @@ msgstr "Definir progresso"
 #: catalog/templates/_item_user_pieces.html:101
 #: catalog/templates/catalog_edit.html:12
 #: journal/templates/action_edit_post.html:6
-#: journal/templates/action_edit_post.html:8 journal/templates/article.html:196
-#: journal/templates/collection.html:185 journal/templates/collection.html:193
+#: journal/templates/action_edit_post.html:8 journal/templates/article.html:194
+#: journal/templates/collection.html:186 journal/templates/collection.html:194
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_edit.html:26
 #: journal/templates/post_compose.html:16 journal/templates/tag_edit.html:16
@@ -1330,7 +1330,7 @@ msgstr "voltar ao item"
 #: catalog/templates/_sidebar_edit.html:20
 #: catalog/templates/catalog_verify.html:11
 #: catalog/templates/catalog_verify.html:17
-#: catalog/templates/item_base.html:182
+#: catalog/templates/item_base.html:167
 msgid "Creator verification"
 msgstr "Verificação de criador"
 
@@ -1338,7 +1338,7 @@ msgstr "Verificação de criador"
 msgid "Edit Options"
 msgstr "Editar Opções"
 
-#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
+#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:163
 #: catalog/views/edit.py:160 catalog/views/edit.py:221
 #: catalog/views/edit.py:288 catalog/views/edit.py:309
 #: catalog/views/edit.py:364 catalog/views/edit.py:471
@@ -1498,7 +1498,7 @@ msgstr "mesclar com outro item"
 #: catalog/templates/_sidebar_edit.html:265
 #: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
-#: journal/templates/article.html:199 journal/templates/collection.html:188
+#: journal/templates/article.html:197 journal/templates/collection.html:189
 #: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
@@ -1685,7 +1685,7 @@ msgstr "Tem certeza de que deseja remover sua verificação de criador? Qualquer
 msgid "Remove my verification"
 msgstr "Remover minha verificação"
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:311
+#: catalog/templates/_verify_status.html:31 users/views/account.py:312
 msgid "Verification failed"
 msgstr "Falha na verificação"
 
@@ -1871,7 +1871,7 @@ msgstr "Etiquetas Populares"
 
 #: catalog/templates/discover.html:229
 #: catalog/templates/discover_original_podcasts.html:25
-#: catalog/templates/item_base.html:282
+#: catalog/templates/item_base.html:267
 #: catalog/templates/item_mark_list.html:71
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
@@ -1937,67 +1937,67 @@ msgstr "Buscando de %(site_label)s"
 msgid "System busy, please try again in a minute."
 msgstr "Sistema ocupado. Por favor, tente novamente em um minuto."
 
-#: catalog/templates/item_base.html:95
+#: catalog/templates/item_base.html:80
 msgid "select one of the seasons to comment"
 msgstr "selecione uma das temporadas para comentar"
 
-#: catalog/templates/item_base.html:129
+#: catalog/templates/item_base.html:114
 msgid "mark, comment and collect"
 msgstr "marcar, comentar e colecionar"
 
-#: catalog/templates/item_base.html:142
+#: catalog/templates/item_base.html:127
 msgid "Login or register to review or add this item to your collection."
 msgstr "Entre ou cadastre-se para escrever uma análise ou adicionar este item à sua coleção."
 
-#: catalog/templates/item_base.html:151
+#: catalog/templates/item_base.html:136
 msgid "Related Collections"
 msgstr "Coleções Relacionadas"
 
-#: catalog/templates/item_base.html:166
+#: catalog/templates/item_base.html:151
 msgid "Unsupported item type."
 msgstr "Tipo de item não suportado."
 
-#: catalog/templates/item_base.html:176
+#: catalog/templates/item_base.html:161
 msgid "Edit this item"
 msgstr "Editar este item"
 
-#: catalog/templates/item_base.html:187
+#: catalog/templates/item_base.html:172
 msgid "Last edited"
 msgstr "Última edição"
 
-#: catalog/templates/item_base.html:230
+#: catalog/templates/item_base.html:215
 msgid "No enough ratings"
 msgstr "Avaliações insuficientes"
 
-#: catalog/templates/item_base.html:274
+#: catalog/templates/item_base.html:259
 msgid "overview"
 msgstr "visão geral"
 
-#: catalog/templates/item_base.html:305
+#: catalog/templates/item_base.html:290
 msgid "comments"
 msgstr "comentários"
 
-#: catalog/templates/item_base.html:308
+#: catalog/templates/item_base.html:293
 #: catalog/templates/item_mark_list.html:22
 #: catalog/templates/item_mark_list.html:25
 #: catalog/templates/item_review_list.html:21
 msgid "marks"
 msgstr "marcações"
 
-#: catalog/templates/item_base.html:309
+#: catalog/templates/item_base.html:294
 #: catalog/templates/item_mark_list.html:23
 #: catalog/templates/item_mark_list.html:26
 #: catalog/templates/item_review_list.html:22
 msgid "marks from who you follow"
 msgstr "marcações de quem você segue"
 
-#: catalog/templates/item_base.html:323
+#: catalog/templates/item_base.html:308
 #: catalog/templates/item_mark_list.html:28
 #: catalog/templates/item_review_list.html:23
 msgid "reviews"
 msgstr "análises"
 
-#: catalog/templates/item_base.html:333
+#: catalog/templates/item_base.html:318
 msgid "notes"
 msgstr "notas"
 
@@ -2394,7 +2394,7 @@ msgstr "A verificação já está em andamento."
 msgid "Please wait a moment before trying again."
 msgstr "Aguarde um instante antes de tentar novamente."
 
-#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
+#: catalog/views/verify.py:164 common/utils.py:148 common/utils.py:189
 #: journal/views/article.py:186 journal/views/review.py:182
 #: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
@@ -4054,7 +4054,7 @@ msgstr "Somente por Convite"
 msgid "Open Registration"
 msgstr "Registro Aberto"
 
-#: common/templates/common/about.html:40 common/views_manage.py:657
+#: common/templates/common/about.html:40 common/views_manage.py:671
 msgid "Preferred Languages"
 msgstr "Idiomas Preferidos"
 
@@ -4110,7 +4110,7 @@ msgstr "Solicitando acesso à câmera..."
 msgid "Or type barcode / ISBN manually"
 msgstr "Ou digite o código de barras / ISBN manualmente"
 
-#: common/templates/common/scan.html:60 common/views_manage.py:738
+#: common/templates/common/scan.html:60 common/views_manage.py:756
 msgid "Search"
 msgstr "Buscar"
 
@@ -4190,16 +4190,16 @@ msgstr "você"
 msgid "unavailable"
 msgstr "indisponível"
 
-#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
+#: common/utils.py:152 common/utils.py:193 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr "Usuário não existe mais"
 
-#: common/utils.py:135 common/utils.py:137 common/utils.py:140
-#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
+#: common/utils.py:159 common/utils.py:161 common/utils.py:164
+#: common/utils.py:200 common/utils.py:204 journal/views/profile.py:499
 msgid "Access denied"
 msgstr "Acesso negado"
 
-#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
+#: common/utils.py:167 common/utils.py:169 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr "Login obrigatório"
@@ -4216,7 +4216,7 @@ msgstr "Recomendações"
 msgid "Access"
 msgstr "Acesso"
 
-#: common/views_manage.py:39 common/views_manage.py:733
+#: common/views_manage.py:39 common/views_manage.py:751
 msgid "Federation"
 msgstr "Federação"
 
@@ -4568,435 +4568,469 @@ msgid "Sender name and address for outgoing email."
 msgstr "Nome e endereço do remetente para e-mails enviados."
 
 #: common/views_manage.py:649
+msgid "Enable Twitter / X Archive Import"
+msgstr ""
+
+#: common/views_manage.py:651
+msgid "Show the Twitter / X archive import on the data page. Imported tweets become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:656
+#, fuzzy
+#| msgid "Enable Mastodon Login"
+msgid "Enable Mastodon Archive Import"
+msgstr "Ativar Login via Mastodon"
+
+#: common/views_manage.py:658
+msgid "Show the Mastodon archive import on the data page. Imported posts become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:663
 msgid "Default Language"
 msgstr "Idioma Padrão"
 
-#: common/views_manage.py:652
+#: common/views_manage.py:666
 msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr "Idioma da interface para visitantes e para usuários que ainda não escolheram um idioma próprio."
 
-#: common/views_manage.py:659
+#: common/views_manage.py:673
 msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr "Códigos de idioma, um por linha (por exemplo, en, zh, ja). O primeiro idioma é o padrão."
 
-#: common/views_manage.py:665
+#: common/views_manage.py:679
 msgid "Access Control"
 msgstr "Controle de Acesso"
 
-#: common/views_manage.py:672
+#: common/views_manage.py:686
 msgid "Login Methods"
 msgstr "Métodos de Login"
 
-#: common/views_manage.py:677 mastodon/models/common.py:30
+#: common/views_manage.py:691 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr "Email"
 
-#: common/views_manage.py:681
+#: common/views_manage.py:695
+#, fuzzy
+#| msgid "Import"
+msgid "Data Import"
+msgstr "Importar"
+
+#: common/views_manage.py:699
 msgid "Localization"
 msgstr "Localização"
 
-#: common/views_manage.py:692
+#: common/views_manage.py:710
 msgid "Disable Default Relay"
 msgstr "Desativar Relay Padrão"
 
-#: common/views_manage.py:694
+#: common/views_manage.py:712
 msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr "Desativar a federação relay.neodb.net usada para compartilhar avaliações públicas entre instâncias."
 
-#: common/views_manage.py:699
+#: common/views_manage.py:717
 msgid "Fanout Limit (days)"
 msgstr "Limite de Distribuição (dias)"
 
-#: common/views_manage.py:700
+#: common/views_manage.py:718
 msgid "Posts older than this many days will not be fanned out."
 msgstr "Publicações mais antigas que este número de dias não serão distribuídas."
 
-#: common/views_manage.py:704
+#: common/views_manage.py:722
 msgid "Remote Prune Horizon (days)"
 msgstr "Horizonte de Remoção Remota (dias)"
 
-#: common/views_manage.py:706
+#: common/views_manage.py:724
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr "Perfis remotos inativos por esse número de dias serão removidos."
 
-#: common/views_manage.py:711
+#: common/views_manage.py:729
 msgid "Search Sites"
 msgstr "Sites de Busca"
 
-#: common/views_manage.py:712
+#: common/views_manage.py:730
 msgid "External search sites to include, one per line."
 msgstr "Sites de busca externos a incluir, um por linha."
 
-#: common/views_manage.py:715
+#: common/views_manage.py:733
 msgid "Federated Search Peers"
 msgstr "Pares de Busca Federada"
 
-#: common/views_manage.py:716
+#: common/views_manage.py:734
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr "Instâncias parceiras do NeoDB para busca federada, uma por linha."
 
-#: common/views_manage.py:719
+#: common/views_manage.py:737
 msgid "Hidden Categories"
 msgstr "Categorias Ocultas"
 
-#: common/views_manage.py:720
+#: common/views_manage.py:738
 msgid "Category values to hide from the catalog, one per line."
 msgstr "Valores de categoria a ocultar do catálogo, um por linha."
 
-#: common/views_manage.py:723
+#: common/views_manage.py:741
 msgid "Guest Search Page Limit"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:743
 msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
 msgstr ""
 
-#: common/views_manage.py:751
+#: common/views_manage.py:769
 msgid "Spotify API Key"
 msgstr "Chave de API do Spotify"
 
-#: common/views_manage.py:752
+#: common/views_manage.py:770
 msgid "https://developer.spotify.com/"
 msgstr "https://developer.spotify.com/"
 
-#: common/views_manage.py:755
+#: common/views_manage.py:773
 msgid "TMDB API Key"
 msgstr "Chave de API do TMDB"
 
-#: common/views_manage.py:756
+#: common/views_manage.py:774
 msgid "https://developer.themoviedb.org/"
 msgstr "https://developer.themoviedb.org/"
 
-#: common/views_manage.py:759
+#: common/views_manage.py:777
 msgid "Google Books API Key"
 msgstr "Chave de API do Google Books"
 
-#: common/views_manage.py:760
+#: common/views_manage.py:778
 msgid "https://developers.google.com/books/"
 msgstr "https://developers.google.com/books/"
 
-#: common/views_manage.py:763
+#: common/views_manage.py:781
 msgid "Discogs API Key"
 msgstr "Chave de API do Discogs"
 
-#: common/views_manage.py:765
+#: common/views_manage.py:783
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr "Token de acesso pessoal em https://www.discogs.com/settings/developers"
 
-#: common/views_manage.py:769
+#: common/views_manage.py:787
 msgid "IGDB Client ID"
 msgstr "ID do Cliente IGDB"
 
-#: common/views_manage.py:770
+#: common/views_manage.py:788
 msgid "https://api-docs.igdb.com/"
 msgstr "https://api-docs.igdb.com/"
 
-#: common/views_manage.py:773
+#: common/views_manage.py:791
 msgid "IGDB Client Secret"
 msgstr "Segredo do Cliente IGDB"
 
-#: common/views_manage.py:776
+#: common/views_manage.py:794
 msgid "BoardGameGeek API Token"
 msgstr "Token de API do BoardGameGeek"
 
-#: common/views_manage.py:778
+#: common/views_manage.py:796
 msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr "Token de portador (bearer token) obtido em https://boardgamegeek.com/applications (consulte https://boardgamegeek.com/using_the_xml_api#toc9)."
 
-#: common/views_manage.py:783
+#: common/views_manage.py:801
 #, fuzzy
 #| msgid "MyAnimeList Anime"
 msgid "MyAnimeList Client ID"
 msgstr "MyAnimeList Anime"
 
-#: common/views_manage.py:785
+#: common/views_manage.py:803
 msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
 msgstr ""
 
-#: common/views_manage.py:790 users/templates/users/steam_import.html:26
+#: common/views_manage.py:808 users/templates/users/steam_import.html:26
 msgid "Steam API Key"
 msgstr "Chave de API da Steam"
 
-#: common/views_manage.py:792
+#: common/views_manage.py:810
 msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr "https://steamcommunity.com/dev - chave alternativa (fallback) para o importador da Steam. Os usuários podem fornecer sua própria chave ao importar."
 
-#: common/views_manage.py:797
+#: common/views_manage.py:815
 msgid "DeepL API Key"
 msgstr "Chave de API do DeepL"
 
-#: common/views_manage.py:798
+#: common/views_manage.py:816
 msgid "For translation features."
 msgstr "Para os recursos de tradução."
 
-#: common/views_manage.py:801
+#: common/views_manage.py:819
 msgid "LibreTranslate API URL"
 msgstr "URL da API do LibreTranslate"
 
-#: common/views_manage.py:804
+#: common/views_manage.py:822
 msgid "LibreTranslate API Key"
 msgstr "Chave de API do LibreTranslate"
 
-#: common/views_manage.py:807
+#: common/views_manage.py:825
 msgid "Threads App ID"
 msgstr "ID do Aplicativo Threads"
 
-#: common/views_manage.py:808
+#: common/views_manage.py:826
 msgid "OAuth app ID for Threads login."
 msgstr "ID do aplicativo OAuth para login via Threads."
 
-#: common/views_manage.py:811
+#: common/views_manage.py:829
 msgid "Threads App Secret"
 msgstr "Segredo do Aplicativo Threads"
 
-#: common/views_manage.py:814
+#: common/views_manage.py:832
 msgid "Discord Webhooks"
 msgstr "Webhooks do Discord"
 
-#: common/views_manage.py:816
+#: common/views_manage.py:834
 msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr "URLs de webhook definidas por canal (default, report, audit, suggest, system). Todos os canais devem ser fóruns do Discord ou canais de mídia (modo de tópicos), pois as notificações são publicadas como tópicos."
 
-#: common/views_manage.py:833
+#: common/views_manage.py:851
 msgid "Catalog APIs"
 msgstr "APIs de Catálogo"
 
-#: common/views_manage.py:844
+#: common/views_manage.py:862
 msgid "Translation"
 msgstr "Tradução"
 
-#: common/views_manage.py:849
+#: common/views_manage.py:867
 msgid "Third-Party Login"
 msgstr "Login com Terceiros"
 
-#: common/views_manage.py:853 social/templates/feed.html:27
+#: common/views_manage.py:871 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr "Notificações"
 
-#: common/views_manage.py:863
+#: common/views_manage.py:881
 msgid "Scraping Providers"
 msgstr "Provedores de Coleta de Dados"
 
-#: common/views_manage.py:864
+#: common/views_manage.py:882
 msgid "Comma-separated list of providers to try in order."
 msgstr "Lista de provedores separados por vírgula, a serem tentados na ordem indicada."
 
-#: common/views_manage.py:867
+#: common/views_manage.py:885
 msgid "Proxy List"
 msgstr "Lista de Proxies"
 
-#: common/views_manage.py:868
+#: common/views_manage.py:886
 msgid "One per line, format: http://server?url=__URL__"
 msgstr "Um por linha, no formato: http://server?url=__URL__"
 
-#: common/views_manage.py:871
+#: common/views_manage.py:889
 msgid "Backup Proxy"
 msgstr "Proxy de Backup"
 
-#: common/views_manage.py:874
+#: common/views_manage.py:892
 msgid "Scrapfly API Key"
 msgstr "Chave de API do Scrapfly"
 
-#: common/views_manage.py:877
+#: common/views_manage.py:895
 msgid "Decodo Base64 Auth Token"
 msgstr "Token de Autenticação Base64 do Decodo"
 
-#: common/views_manage.py:880
+#: common/views_manage.py:898
 msgid "ScraperAPI Key"
 msgstr "Chave de API do ScraperAPI"
 
-#: common/views_manage.py:883
+#: common/views_manage.py:901
 msgid "ScrapingBee API Key"
 msgstr "Chave de API do ScrapingBee"
 
-#: common/views_manage.py:886
+#: common/views_manage.py:904
 msgid "Custom Scraper URL"
 msgstr "URL de Coletor Personalizado"
 
-#: common/views_manage.py:887
+#: common/views_manage.py:905
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr "URL com os marcadores __URL__ e __SELECTOR__."
 
-#: common/views_manage.py:890
+#: common/views_manage.py:908
 msgid "Request Timeout (seconds)"
 msgstr "Tempo Limite de Requisição (segundos)"
 
-#: common/views_manage.py:894
+#: common/views_manage.py:912
 msgid "Cache Timeout (seconds)"
 msgstr "Tempo Limite de Cache (segundos)"
 
-#: common/views_manage.py:898
+#: common/views_manage.py:916
 msgid "Retries"
 msgstr "Tentativas"
 
-#: common/views_manage.py:903
+#: common/views_manage.py:921
 msgid "Providers"
 msgstr "Provedores"
 
-#: common/views_manage.py:908
+#: common/views_manage.py:926
 msgid "Provider Keys"
 msgstr "Chaves de Provedor"
 
-#: common/views_manage.py:915
+#: common/views_manage.py:933
 msgid "Timeouts"
 msgstr "Tempos Limite"
 
-#: common/views_manage.py:927
+#: common/views_manage.py:945
 msgid "Alternative Domains"
 msgstr "Domínios Alternativos"
 
-#: common/views_manage.py:928
+#: common/views_manage.py:946
 msgid "One domain per line."
 msgstr "Um domínio por linha."
 
-#: common/views_manage.py:931
+#: common/views_manage.py:949
 msgid "Mastodon Client Scope"
 msgstr "Escopo do Cliente Mastodon"
 
-#: common/views_manage.py:932
+#: common/views_manage.py:950
 msgid "OAuth scope when creating Mastodon apps."
 msgstr "Escopo OAuth ao criar aplicativos Mastodon."
 
-#: common/views_manage.py:935
+#: common/views_manage.py:953
 msgid "Mastodon API Timeout (seconds)"
 msgstr "Tempo Limite da API do Mastodon (segundos)"
 
-#: common/views_manage.py:937
+#: common/views_manage.py:955
 msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr "Tempo limite para requisições a instâncias do Mastodon e servidores remotos do fediverse."
 
-#: common/views_manage.py:943
+#: common/views_manage.py:961
 msgid "Disable Cron Jobs"
 msgstr "Desativar Tarefas Agendadas (Cron Jobs)"
 
-#: common/views_manage.py:944
+#: common/views_manage.py:962
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr "Nomes das tarefas a desativar, um por linha. Use * para desativar todas."
 
-#: common/views_manage.py:947
+#: common/views_manage.py:965
 msgid "Index Aliases"
 msgstr "Aliases de Índice"
 
-#: common/views_manage.py:948
+#: common/views_manage.py:966
 msgid "Map index names to their aliases."
 msgstr "Mapear nomes de índices para seus aliases."
 
-#: common/views_manage.py:958
+#: common/views_manage.py:976
 msgid "Task Cleanup (days)"
 msgstr "Limpeza de Tarefas (dias)"
 
-#: common/views_manage.py:960
+#: common/views_manage.py:978
 msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr "Excluir tarefas de importação/exportação e seus arquivos após este número de dias. Defina como 0 para desativar a limpeza."
 
-#: common/views_manage.py:966
+#: common/views_manage.py:984
 msgid "Skip Migration Jobs"
 msgstr "Ignorar Tarefas de Migração"
 
-#: common/views_manage.py:968
+#: common/views_manage.py:986
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr "Chaves de tarefas pós-migração a ignorar, uma por linha (por exemplo, normalize_genre). Verificado pelo worker no momento da retirada da fila; tarefas ignoradas registram um aviso e notificam o canal system do Discord."
 
-#: common/views_manage.py:974
+#: common/views_manage.py:992
 msgid "ATProto OAuth Client Key"
 msgstr "Chave do Cliente OAuth ATProto"
 
-#: common/views_manage.py:976
+#: common/views_manage.py:994
 msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr "Chave privada (JWK) que identifica este site aos servidores de autorização ATProto. Gerada automaticamente no primeiro login via Bluesky; apague para gerar novamente."
 
-#: common/views_manage.py:983
+#: common/views_manage.py:1000
+#, fuzzy
+#| msgid "Cache Timeout (seconds)"
+msgid "Webhook Timeout (milliseconds)"
+msgstr "Tempo Limite de Cache (segundos)"
+
+#: common/views_manage.py:1001
+msgid "Timeout for delivering webhook requests to applications."
+msgstr ""
+
+#: common/views_manage.py:1006
 msgid "Domains"
 msgstr "Domínios"
 
-#: common/views_manage.py:986
+#: common/views_manage.py:1009
 msgid "Operational"
 msgstr "Operacional"
 
-#: common/views_manage.py:1002
+#: common/views_manage.py:1026
 msgid "Movie Genres"
 msgstr "Gêneros de Filmes"
 
-#: common/views_manage.py:1004
+#: common/views_manage.py:1028
 msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "Códigos de gênero oferecidos no menu suspenso de edição de Filme, um por linha. Deixe em branco para usar o padrão integrado."
 
-#: common/views_manage.py:1009
+#: common/views_manage.py:1033
 msgid "TV Genres"
 msgstr "Gêneros de TV"
 
-#: common/views_manage.py:1011
+#: common/views_manage.py:1035
 msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "Códigos de gênero oferecidos no menu suspenso de edição de TV, um por linha. Deixe em branco para usar o padrão integrado."
 
-#: common/views_manage.py:1016
+#: common/views_manage.py:1040
 msgid "Music Genres"
 msgstr "Gêneros Musicais"
 
-#: common/views_manage.py:1018
+#: common/views_manage.py:1042
 msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "Códigos de gênero oferecidos no menu suspenso de edição de Música, um por linha. Deixe em branco para usar o padrão integrado."
 
-#: common/views_manage.py:1023
+#: common/views_manage.py:1047
 msgid "Game Genres"
 msgstr "Gêneros de Jogos"
 
-#: common/views_manage.py:1025
+#: common/views_manage.py:1049
 msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "Códigos de gênero oferecidos no menu suspenso de edição de Jogo, um por linha. Deixe em branco para usar o padrão integrado."
 
-#: common/views_manage.py:1030
+#: common/views_manage.py:1054
 msgid "Podcast Genres"
 msgstr "Gêneros de Podcast"
 
-#: common/views_manage.py:1032
+#: common/views_manage.py:1056
 msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "Códigos de gênero oferecidos no menu suspenso de edição de Podcast, um por linha. Deixe em branco para usar o padrão integrado."
 
-#: common/views_manage.py:1037
+#: common/views_manage.py:1061
 msgid "Performance Genres"
 msgstr "Gêneros de Espetáculo"
 
-#: common/views_manage.py:1039
+#: common/views_manage.py:1063
 msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "Códigos de gênero oferecidos no menu suspenso de edição de Espetáculo, um por linha. Deixe em branco para usar o padrão integrado."
 
-#: common/views_manage.py:1045
+#: common/views_manage.py:1069
 msgid "Genres by Category"
 msgstr "Gêneros por Categoria"
 
-#: common/views_manage.py:1069
+#: common/views_manage.py:1093
 #, fuzzy
 #| msgid "Site Name"
 msgid "Site"
 msgstr "Nome do Site"
 
-#: common/views_manage.py:1079
+#: common/views_manage.py:1103
 #, fuzzy
 #| msgid "Database Admin"
 msgid "Database and Services"
 msgstr "Administração do Banco de Dados"
 
-#: common/views_manage.py:1089
+#: common/views_manage.py:1113
 msgid "Media and Files"
 msgstr ""
 
-#: common/views_manage.py:1098
+#: common/views_manage.py:1122
 msgid "Monitoring"
 msgstr ""
 
-#: common/views_manage.py:1102
+#: common/views_manage.py:1126
 msgid "Security"
 msgstr ""
 
-#: common/views_manage.py:1111
+#: common/views_manage.py:1135
 msgid "Other Environment Variables"
 msgstr ""
 
-#: common/views_manage.py:1113
+#: common/views_manage.py:1137
 msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
 msgstr ""
 
@@ -5040,7 +5074,8 @@ msgstr "Ao salvar, substituir espaços iniciais por espaços de largura total"
 #: users/templates/users/data.html:60 users/templates/users/data.html:113
 #: users/templates/users/data.html:170 users/templates/users/data.html:221
 #: users/templates/users/data.html:284 users/templates/users/data.html:346
-#: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
+#: users/templates/users/data.html:525 users/templates/users/data.html:578
+#: users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
 msgid "Visibility"
@@ -5070,8 +5105,8 @@ msgstr "somente proprietário"
 msgid "owner and their local mutuals"
 msgstr "proprietário e seus contatos mútuos locais"
 
-#: journal/forms.py:169 journal/templates/collection.html:193
-#: journal/templates/collection.html:202
+#: journal/forms.py:169 journal/templates/collection.html:194
+#: journal/templates/collection.html:203
 msgid "Collaborative editing"
 msgstr "Edição colaborativa"
 
@@ -5122,7 +5157,7 @@ msgstr "Arquivo correspondido ausente; não é possível importar."
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr "Importação concluída: {imported} importado(s), {skipped} ignorado(s), {failed} com falha"
 
-#: journal/models/article.py:215 journal/views/article.py:218
+#: journal/models/article.py:224 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr "(pode conter conteúdo sensível)"
 
@@ -5134,73 +5169,74 @@ msgstr "(pode conter conteúdo sensível)"
 msgid "note"
 msgstr "nota"
 
-#: journal/models/collection.py:115
+#: journal/models/collection.py:116
 msgid "search query for dynamic collection"
 msgstr "consulta de pesquisa para coleção dinâmica"
 
-#: journal/models/collection.py:566 journal/templatetags/collection.py:35
+#: journal/models/collection.py:575 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] "%(count)d livro"
 msgstr[1] "%(count)d livros"
 
-#: journal/models/collection.py:571 journal/templatetags/collection.py:43
+#: journal/models/collection.py:580 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] "%(count)d filme"
 msgstr[1] "%(count)d filmes"
 
-#: journal/models/collection.py:576 journal/templatetags/collection.py:51
+#: journal/models/collection.py:585 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] "%(count)d série"
 msgstr[1] "%(count)d séries"
 
-#: journal/models/collection.py:581 journal/templatetags/collection.py:59
+#: journal/models/collection.py:590 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] "%(count)d álbum"
 msgstr[1] "%(count)d álbuns"
 
-#: journal/models/collection.py:586 journal/templatetags/collection.py:67
+#: journal/models/collection.py:595 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] "%(count)d jogo"
 msgstr[1] "%(count)d jogos"
 
-#: journal/models/collection.py:591 journal/templatetags/collection.py:75
+#: journal/models/collection.py:600 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] "%(count)d podcast"
 msgstr[1] "%(count)d podcasts"
 
-#: journal/models/collection.py:597 journal/templatetags/collection.py:83
+#: journal/models/collection.py:606 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] "%(count)d apresentação"
 msgstr[1] "%(count)d apresentações"
 
-#: journal/models/collection.py:605 journal/templatetags/collection.py:91
+#: journal/models/collection.py:614 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] "%(count)d item"
 msgstr[1] "%(count)d itens"
 
-#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/models/common.py:59 journal/templates/action_open_post.html:15
 #: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
 #: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
 #: users/templates/users/data.html:122 users/templates/users/data.html:179
 #: users/templates/users/data.html:230 users/templates/users/data.html:292
 #: users/templates/users/data.html:355 users/templates/users/data.html:534
+#: users/templates/users/data.html:587
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5208,13 +5244,14 @@ msgstr[1] "%(count)d itens"
 msgid "Public"
 msgstr "Público"
 
-#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/models/common.py:60 journal/templates/action_open_post.html:9
 #: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
 #: users/templates/users/data.html:130 users/templates/users/data.html:187
 #: users/templates/users/data.html:238 users/templates/users/data.html:300
 #: users/templates/users/data.html:363 users/templates/users/data.html:542
+#: users/templates/users/data.html:595
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5222,12 +5259,13 @@ msgstr "Público"
 msgid "Followers Only"
 msgstr "Apenas Seguidores"
 
-#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/models/common.py:61 journal/templates/collection_share.html:57
 #: journal/templates/mark.html:102 journal/templates/post_compose.html:72
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
 #: users/templates/users/data.html:138 users/templates/users/data.html:195
 #: users/templates/users/data.html:246 users/templates/users/data.html:308
 #: users/templates/users/data.html:371 users/templates/users/data.html:550
+#: users/templates/users/data.html:603
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5235,27 +5273,27 @@ msgstr "Apenas Seguidores"
 msgid "Mentioned Only"
 msgstr "Apenas Mencionados"
 
-#: journal/models/common.py:806
+#: journal/models/common.py:851
 msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr "Uma publicação recente não foi enviada ao Bluesky. Por favor, faça login no NeoDB usando ATProto novamente para reautorizar."
 
-#: journal/models/common.py:1003
+#: journal/models/common.py:1048
 msgid "A recent post was not posted to Threads."
 msgstr "Uma publicação recente não foi enviada ao Threads."
 
-#: journal/models/common.py:1036
+#: journal/models/common.py:1081
 msgid "A recent post was not boosted on Mastodon."
 msgstr "Uma publicação recente não foi impulsionada no Mastodon."
 
-#: journal/models/common.py:1046
+#: journal/models/common.py:1091
 msgid "Original post no longer exists."
 msgstr "A publicação original não existe mais."
 
-#: journal/models/common.py:1060
+#: journal/models/common.py:1105
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr "Uma publicação recente não foi enviada ao Mastodon. Por favor, reautorize."
 
-#: journal/models/common.py:1069
+#: journal/models/common.py:1114
 msgid "A recent post was not posted to Mastodon."
 msgstr "Uma publicação recente não foi enviada ao Mastodon."
 
@@ -5271,81 +5309,81 @@ msgstr "Falhou"
 msgid "Retrying"
 msgstr "Repetindo"
 
-#: journal/models/mark.py:475
+#: journal/models/mark.py:477
 msgid "Please mark the item before setting progress."
 msgstr "Marque o item antes de definir o progresso."
 
-#: journal/models/mark.py:479
+#: journal/models/mark.py:481
 msgid "Progress must be 500 characters or fewer."
 msgstr "O progresso deve ter no máximo 500 caracteres."
 
-#: journal/models/mark.py:486
+#: journal/models/mark.py:488
 msgid "Invalid progress type."
 msgstr "Tipo de progresso inválido."
 
-#: journal/models/mark.py:488
+#: journal/models/mark.py:490
 msgid "Invalid progress type for this item."
 msgstr "Tipo de progresso inválido para este item."
 
-#: journal/models/note.py:47 users/templates/users/rym_import.html:73
+#: journal/models/note.py:48 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr "Página"
 
-#: journal/models/note.py:48
+#: journal/models/note.py:49
 msgid "Chapter"
 msgstr "Capítulo"
 
-#: journal/models/note.py:51
+#: journal/models/note.py:52
 msgid "Part"
 msgstr "Parte"
 
-#: journal/models/note.py:52
+#: journal/models/note.py:53
 msgid "Episode"
 msgstr "Episódio"
 
-#: journal/models/note.py:53
+#: journal/models/note.py:54
 msgid "Track"
 msgstr "Faixa"
 
-#: journal/models/note.py:54
+#: journal/models/note.py:55
 msgid "Cycle"
 msgstr "Ciclo"
 
-#: journal/models/note.py:55
+#: journal/models/note.py:56
 msgid "Timestamp"
 msgstr "Marcação de tempo"
 
-#: journal/models/note.py:56
+#: journal/models/note.py:57
 msgid "Percentage"
 msgstr "Porcentagem"
 
-#: journal/models/note.py:77
+#: journal/models/note.py:78
 #, python-brace-format
 msgid "Page {value}"
 msgstr "Página {value}"
 
-#: journal/models/note.py:78
+#: journal/models/note.py:79
 #, python-brace-format
 msgid "Chapter {value}"
 msgstr "Capítulo {value}"
 
-#: journal/models/note.py:81
+#: journal/models/note.py:82
 #, python-brace-format
 msgid "Part {value}"
 msgstr "Parte {value}"
 
-#: journal/models/note.py:82
+#: journal/models/note.py:83
 #, python-brace-format
 msgid "Episode {value}"
 msgstr "Episódio {value}"
 
-#: journal/models/note.py:83
+#: journal/models/note.py:84
 #, python-brace-format
 msgid "Track {value}"
 msgstr "Faixa {value}"
 
-#: journal/models/note.py:84
+#: journal/models/note.py:85
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr "Ciclo {value}"
@@ -5355,12 +5393,12 @@ msgstr "Ciclo {value}"
 msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr "sobre {item_title}, pode conter spoilers ou conteúdo sensível"
 
-#: journal/models/review.py:79
+#: journal/models/review.py:80
 #, python-brace-format
 msgid "a review of {title}"
 msgstr "uma análise de {title}"
 
-#: journal/models/review.py:81
+#: journal/models/review.py:82
 msgid "(may contain spoilers)"
 msgstr "(pode conter spoilers)"
 
@@ -5787,7 +5825,7 @@ msgstr "pessoas seguidas"
 msgid "started following {item}"
 msgstr "começou a seguir {item}"
 
-#: journal/models/shelf.py:923
+#: journal/models/shelf.py:925
 msgid "removed mark"
 msgstr "marcação removida"
 
@@ -5820,7 +5858,7 @@ msgstr "Remover da coleção"
 msgid "Update note"
 msgstr "Atualizar nota"
 
-#: journal/templates/_list_item.html:71 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:121
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
@@ -5970,7 +6008,7 @@ msgid "View post"
 msgstr "Ver publicação"
 
 #: journal/templates/action_quote_post.html:3
-#: journal/templates/article.html:190 journal/templates/collection.html:174
+#: journal/templates/article.html:188 journal/templates/collection.html:175
 msgid "Quote"
 msgstr "Citar"
 
@@ -5979,7 +6017,7 @@ msgid "reply"
 msgstr "responder"
 
 #: journal/templates/action_reply_post.html:3
-#: journal/templates/article.html:181 journal/templates/collection.html:165
+#: journal/templates/article.html:179 journal/templates/collection.html:166
 msgid "Reply"
 msgstr "Responder"
 
@@ -5996,19 +6034,19 @@ msgstr "Adicionar à coleção"
 msgid "Create a new collection"
 msgstr "Criar uma nova coleção"
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:76
+#: journal/templates/article.html:102 social/templates/_event_post.html:76
 msgid "wrote a review"
 msgstr "escreveu uma análise"
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:78
+#: journal/templates/article.html:104 social/templates/_event_post.html:78
 msgid "wrote an article"
 msgstr "escreveu um artigo"
 
-#: journal/templates/article.html:136
+#: journal/templates/article.html:134
 msgid "This article may contain sensitive content. Click to reveal."
 msgstr "Este artigo pode conter conteúdo sensível. Clique para revelar."
 
-#: journal/templates/article.html:155
+#: journal/templates/article.html:153
 msgid "The author has set it to be viewable only by logged-in users."
 msgstr "O autor definiu que só pode ser visualizado por usuários conectados."
 
@@ -6069,18 +6107,18 @@ msgstr "NOV"
 msgid "DEC"
 msgstr "DEZ"
 
-#: journal/templates/collection.html:71
+#: journal/templates/collection.html:72
 #: journal/templates/collection_share.html:12
 #: journal/templates/collection_share.html:66
 #: journal/templates/wrapped_share.html:59
 msgid "Share"
 msgstr "Compartilhar"
 
-#: journal/templates/collection.html:86
+#: journal/templates/collection.html:87
 msgid "created a collection"
 msgstr "criou uma coleção"
 
-#: journal/templates/collection.html:181
+#: journal/templates/collection.html:182
 msgid "Query"
 msgstr "Consulta"
 
@@ -6362,12 +6400,12 @@ msgid "Liked Collections"
 msgstr "Coleções Curtidas"
 
 #: journal/templates/user_follow_list.html:23 journal/views/profile.py:507
-#: users/templates/users/account.html:443
+#: users/templates/users/account.html:455
 msgid "Following"
 msgstr "Seguindo"
 
 #: journal/templates/user_follow_list.html:28 journal/views/profile.py:511
-#: users/templates/users/account.html:452
+#: users/templates/users/account.html:464
 msgid "Followers"
 msgstr "Seguidores"
 
@@ -6684,8 +6722,8 @@ msgstr "O login via Bluesky está desativado."
 #: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
 #: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
 #: mastodon/views/threads.py:57 mastodon/views/threads.py:65
-#: mastodon/views/threads.py:71 users/views/account.py:256
-#: users/views/account.py:375
+#: mastodon/views/threads.py:71 users/views/account.py:257
+#: users/views/account.py:376
 msgid "Authentication failed"
 msgstr "Falha na autenticação"
 
@@ -6723,7 +6761,7 @@ msgstr "Dados de conta inválidos do Bluesky."
 msgid "Invalid user."
 msgstr "Usuário inválido."
 
-#: mastodon/views/common.py:52 users/views/account.py:416
+#: mastodon/views/common.py:52 users/views/account.py:417
 msgid "Registration failed"
 msgstr "Falha no cadastro"
 
@@ -7644,120 +7682,137 @@ msgstr "Aplicativo"
 msgid "Scopes"
 msgstr "Escopos"
 
-#: users/templates/users/account.html:398
+#: users/templates/users/account.html:386
+#, fuzzy
+#| msgid "Discord Webhooks"
+msgid "Webhook"
+msgstr "Webhooks do Discord"
+
+#: users/templates/users/account.html:400
+msgid "disabled"
+msgstr ""
+
+#: users/templates/users/account.html:402
+#, fuzzy
+#| msgid "Activities"
+msgid "active"
+msgstr "Atividades"
+
+#: users/templates/users/account.html:410
 msgid "Revoke access for this application?"
 msgstr "Revogar o acesso deste aplicativo?"
 
-#: users/templates/users/account.html:401
+#: users/templates/users/account.html:413
 msgid "Revoke"
 msgstr "Revogar"
 
-#: users/templates/users/account.html:409
+#: users/templates/users/account.html:421
 msgid "No authorized applications."
 msgstr "Nenhum aplicativo autorizado."
 
-#: users/templates/users/account.html:412
+#: users/templates/users/account.html:424
 #: users/templates/users/authorized_app_create.html:9
 #: users/templates/users/authorized_app_create.html:19
 msgid "Create Personal Token"
 msgstr "Criar Token Pessoal"
 
-#: users/templates/users/account.html:418
+#: users/templates/users/account.html:430
 msgid "Import/Export Social Graph"
 msgstr "Importar/Exportar Grafo Social"
 
-#: users/templates/users/account.html:419
+#: users/templates/users/account.html:431
 msgid "Upload a CSV file exported from Mastodon or compatible services."
 msgstr "Envie um arquivo CSV exportado do Mastodon ou de serviços compatíveis."
 
-#: users/templates/users/account.html:425
+#: users/templates/users/account.html:437
 msgid "Import type"
 msgstr "Tipo de importação"
 
-#: users/templates/users/account.html:427
+#: users/templates/users/account.html:439
 msgid "Following list"
 msgstr "Lista de Seguindo"
 
-#: users/templates/users/account.html:428
+#: users/templates/users/account.html:440
 msgid "Block list"
 msgstr "Lista de Bloqueios"
 
-#: users/templates/users/account.html:429
+#: users/templates/users/account.html:441
 msgid "Mute list"
 msgstr "Lista de Silenciados"
 
-#: users/templates/users/account.html:433
+#: users/templates/users/account.html:445
 msgid "CSV file"
 msgstr "Arquivo CSV"
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/account.html:448 users/templates/users/data.html:89
 #: users/templates/users/data.html:141 users/templates/users/data.html:198
 #: users/templates/users/data.html:249 users/templates/users/data.html:313
 #: users/templates/users/data.html:376 users/templates/users/data.html:553
+#: users/templates/users/data.html:606 users/templates/users/data.html:631
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr "Importar"
 
-#: users/templates/users/account.html:447
-#: users/templates/users/account.html:456
-#: users/templates/users/account.html:465
-#: users/templates/users/account.html:474
+#: users/templates/users/account.html:459
+#: users/templates/users/account.html:468
+#: users/templates/users/account.html:477
+#: users/templates/users/account.html:486
 msgid "Download CSV"
 msgstr "Baixar CSV"
 
-#: users/templates/users/account.html:461
+#: users/templates/users/account.html:473
 msgid "Blocks"
 msgstr "Bloqueios"
 
-#: users/templates/users/account.html:470
+#: users/templates/users/account.html:482
 msgid "Mutes"
 msgstr "Silenciados"
 
-#: users/templates/users/account.html:484
+#: users/templates/users/account.html:496
 msgid "Migrate Account"
 msgstr "Migrar Conta"
 
-#: users/templates/users/account.html:488
+#: users/templates/users/account.html:500
 msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
 msgstr "É altamente recomendável vincular um e-mail à sua conta antes de migrar de outra instância do Fediverso."
 
-#: users/templates/users/account.html:491
+#: users/templates/users/account.html:503
 msgid "Migrate another account here"
 msgstr "Migrar outra conta para cá"
 
-#: users/templates/users/account.html:494
+#: users/templates/users/account.html:506
 msgid "Migrate to another account"
 msgstr "Migrar para outra conta"
 
-#: users/templates/users/account.html:501
+#: users/templates/users/account.html:513
 msgid "Delete Account"
 msgstr "Excluir Conta"
 
-#: users/templates/users/account.html:504
+#: users/templates/users/account.html:516
 msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
 msgstr "Uma vez excluídos, os dados da conta não poderão ser recuperados. Tem certeza de que deseja prosseguir?"
 
-#: users/templates/users/account.html:507
+#: users/templates/users/account.html:519
 msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
 msgstr "Insira o <code>nome_de_usuário@instância.social</code> ou <code>email@domínio.com</code> completo para confirmar a exclusão."
 
-#: users/templates/users/account.html:517
+#: users/templates/users/account.html:529
 msgid "Once deleted, account data cannot be recovered."
 msgstr "Uma vez excluídos, os dados da conta não poderão ser recuperados."
 
-#: users/templates/users/account.html:520
+#: users/templates/users/account.html:532
 msgid "Task in progress, can't delete now."
 msgstr "Tarefa em andamento, não é possível excluir agora."
 
-#: users/templates/users/account.html:524
+#: users/templates/users/account.html:536
 msgid "Permanently Delete"
 msgstr "Excluir Permanentemente"
 
-#: users/templates/users/account.html:565
+#: users/templates/users/account.html:577
 msgid "Delete this passkey?"
 msgstr "Excluir esta chave de acesso?"
 
-#: users/templates/users/account.html:585
+#: users/templates/users/account.html:597
 msgid "Rename passkey:"
 msgstr "Renomear chave de acesso:"
 
@@ -7779,10 +7834,10 @@ msgstr "Acesso completo"
 
 #: users/templates/users/authorized_app_create.html:48
 #: users/templates/users/authorized_app_created.html:39
-#: users/templates/users/migrate_in.html:70
-#: users/templates/users/migrate_out.html:67
-msgid "Back to Preferences"
-msgstr "Voltar às Preferências"
+#, fuzzy
+#| msgid "Migrate Account"
+msgid "Back to Account"
+msgstr "Migrar Conta"
 
 #: users/templates/users/authorized_app_created.html:9
 #: users/templates/users/authorized_app_created.html:19
@@ -7916,7 +7971,7 @@ msgstr "Substituir: atualizar todos os status importados."
 msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
 msgstr "Outra importação está em andamento. Iniciar uma nova importação pode causar problemas. Tem certeza de que deseja importar?"
 
-#: users/templates/users/data.html:89 users/views/data.py:1130
+#: users/templates/users/data.html:89 users/views/data.py:1194
 msgid "Import in progress, please wait"
 msgstr "Importação em andamento, aguarde"
 
@@ -8073,7 +8128,43 @@ msgstr "No WordPress, vá em <b>Ferramentas</b> - <b>Exportar</b> - <b>Publicaç
 msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr "Apenas publicações publicadas usam a visibilidade abaixo. Rascunhos, pendentes, privados e publicações protegidas por senha são sempre importados como somente mencionados, portanto nada não publicado se torna público."
 
-#: users/templates/users/data.html:560
+#: users/templates/users/data.html:561
+#, fuzzy
+#| msgid "Import NeoDB Archive"
+msgid "Import Twitter / X Archive"
+msgstr "Importar Arquivo do NeoDB"
+
+#: users/templates/users/data.html:567
+msgid "On X, go to <b>Settings</b> - <b>Your account</b> - <b>Download an archive of your data</b>. Upload the <code>.zip</code> you receive, or only the <code>data/tweets.js</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:570
+msgid "Each tweet becomes a post with its original date, text, links and photos. Replies to your own tweets are kept as a thread. A retweet becomes a short post that links to the original tweet. Videos are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:573
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Tweets that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:615
+#, fuzzy
+#| msgid "Import NeoDB Archive"
+msgid "Import Mastodon Archive"
+msgstr "Importar Arquivo do NeoDB"
+
+#: users/templates/users/data.html:621
+msgid "On your Mastodon server, go to <b>Preferences</b> - <b>Import and export</b> - <b>Request your archive</b>. Upload the <code>.zip</code> you receive, or only the <code>outbox.json</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:624
+msgid "Each post is imported with its original date, text, links, photos, content warning and visibility, so a followers-only post or a direct message stays that way. Replies to your own posts are kept as a thread. A boost becomes a short post that links to the original post. Videos, favourites and bookmarks are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:627
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Posts that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:639
 msgid "View Annual Summary"
 msgstr "Ver Resumo Anual"
 
@@ -8195,6 +8286,11 @@ msgstr "Alias Atuais"
 #: users/templates/users/migrate_in.html:64
 msgid "No aliases configured."
 msgstr "Nenhum alias configurado."
+
+#: users/templates/users/migrate_in.html:70
+#: users/templates/users/migrate_out.html:67
+msgid "Back to Preferences"
+msgstr "Voltar às Preferências"
 
 #: users/templates/users/migrate_out.html:9
 #: users/templates/users/migrate_out.html:43
@@ -8708,190 +8804,191 @@ msgstr "Talvez mais tarde"
 msgid "Passkey created"
 msgstr "Chave de acesso criada"
 
-#: users/views/account.py:126
+#: users/views/account.py:127
 msgid "This username is already in use."
 msgstr "Este nome de usuário já está em uso."
 
-#: users/views/account.py:137
+#: users/views/account.py:138
 msgid "This email address is already in use."
 msgstr "Este endereço de e-mail já está em uso."
 
-#: users/views/account.py:257 users/views/account.py:376
+#: users/views/account.py:258 users/views/account.py:377
 msgid "Registration is for invitation only"
 msgstr "O cadastro é apenas por convite"
 
-#: users/views/account.py:268 users/views/account.py:340
+#: users/views/account.py:269 users/views/account.py:341
 msgid "Time is up"
 msgstr "O tempo acabou"
 
-#: users/views/account.py:269 users/views/account.py:312
-#: users/views/account.py:341
+#: users/views/account.py:270 users/views/account.py:313
+#: users/views/account.py:342
 msgid "Please log in again to continue registration."
 msgstr "Por favor, faça login novamente para continuar o registro."
 
-#: users/views/account.py:315
+#: users/views/account.py:316
 msgid "That is not quite right. Here is a new set."
 msgstr "Isso não está exatamente certo. Aqui está um novo conjunto."
 
-#: users/views/account.py:327
+#: users/views/account.py:328
 msgid "Too many attempts"
 msgstr "Muitas tentativas"
 
-#: users/views/account.py:328
+#: users/views/account.py:329
 msgid "Please try again later."
 msgstr "Por favor, tente novamente mais tarde."
 
-#: users/views/account.py:417
+#: users/views/account.py:418
 msgid "Username already taken. Please try again."
 msgstr "Nome de usuário já está em uso. Tente novamente."
 
-#: users/views/account.py:447
+#: users/views/account.py:448
 msgid "Valid username required"
 msgstr "Nome de usuário válido obrigatório"
 
-#: users/views/account.py:518
+#: users/views/account.py:519
 msgid "Account is being deleted."
 msgstr "A conta está sendo excluída."
 
-#: users/views/account.py:521
+#: users/views/account.py:522
 msgid "Account mismatch."
 msgstr "Incompatibilidade de conta."
 
-#: users/views/data.py:264 users/views/data.py:296
+#: users/views/data.py:276 users/views/data.py:308
 msgid "Export file not available."
 msgstr "Arquivo de exportação não disponível."
 
-#: users/views/data.py:290
+#: users/views/data.py:302
 msgid "Generating exports."
 msgstr "Gerando exportações."
 
-#: users/views/data.py:308
+#: users/views/data.py:320
 msgid "Export file expired. Please export again."
 msgstr "Arquivo de exportação expirado. Por favor, exporte novamente."
 
-#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
+#: users/views/data.py:335 users/views/data.py:356 users/views/data.py:377
 msgid "Recent export still in progress."
 msgstr "Exportação recente ainda em andamento."
 
-#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
-#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
-#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
+#: users/views/data.py:393 users/views/data.py:419 users/views/data.py:447
+#: users/views/data.py:579 users/views/data.py:613 users/views/data.py:838
+#: users/views/data.py:1055 users/views/data.py:1081 users/views/data.py:1106
+#: users/views/data.py:1131 users/views/data.py:1201
 msgid "Invalid file."
 msgstr "Arquivo inválido."
 
-#: users/views/data.py:405
+#: users/views/data.py:469
 msgid "Sync in progress."
 msgstr "Sincronização em andamento."
 
-#: users/views/data.py:419
+#: users/views/data.py:483
 msgid "Settings saved."
 msgstr "Configurações salvas."
 
-#: users/views/data.py:474
+#: users/views/data.py:538
 msgid "Account no longer linked."
 msgstr "Conta não está mais vinculada."
 
-#: users/views/data.py:477
+#: users/views/data.py:541
 msgid "Content is no longer public."
 msgstr "O conteúdo não está mais público."
 
-#: users/views/data.py:505
+#: users/views/data.py:569
 msgid "Retry did not complete, please try again."
 msgstr "A repetição não foi concluída; tente novamente."
 
-#: users/views/data.py:585 users/views/data.py:810
+#: users/views/data.py:649 users/views/data.py:874
 msgid "Loaded from uploaded matched file."
 msgstr "Carregado a partir do arquivo correspondido enviado."
 
-#: users/views/data.py:610 users/views/data.py:839
+#: users/views/data.py:674 users/views/data.py:903
 msgid "Cancelled."
 msgstr "Cancelado."
 
-#: users/views/data.py:630
+#: users/views/data.py:694
 msgid "No RateYourMusic import to preview."
 msgstr "Nenhuma importação do RateYourMusic para pré-visualizar."
 
-#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
-#: users/views/data.py:974
+#: users/views/data.py:702 users/views/data.py:812 users/views/data.py:933
+#: users/views/data.py:1038
 msgid "Matched file missing."
 msgstr "Arquivo correspondido ausente."
 
-#: users/views/data.py:734 users/views/data.py:960
+#: users/views/data.py:798 users/views/data.py:1024
 msgid "Starting import..."
 msgstr "Iniciando importação..."
 
-#: users/views/data.py:744 users/views/data.py:970
+#: users/views/data.py:808 users/views/data.py:1034
 msgid "No matched file available."
 msgstr "Nenhum arquivo correspondido disponível."
 
-#: users/views/data.py:861
+#: users/views/data.py:925
 msgid "No StoryGraph import to preview."
 msgstr "Nenhuma importação do StoryGraph para pré-visualizar."
 
-#: users/views/data.py:1226
+#: users/views/data.py:1290
 msgid "Name is required."
 msgstr "O nome é obrigatório."
 
-#: users/views/data.py:1248
+#: users/views/data.py:1314
 msgid "Application access has been revoked."
 msgstr "O acesso do aplicativo foi revogado."
 
-#: users/views/data.py:1264
+#: users/views/data.py:1330
 msgid "Alias update not allowed for a moved account."
 msgstr "Não é permitido atualizar o alias de uma conta que já foi movida."
 
-#: users/views/data.py:1269
+#: users/views/data.py:1335
 msgid "No alias specified."
 msgstr "Nenhum alias especificado."
 
-#: users/views/data.py:1279 users/views/data.py:1330
+#: users/views/data.py:1345 users/views/data.py:1396
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr "Consultando a conta. Tente novamente em alguns segundos."
 
-#: users/views/data.py:1286
+#: users/views/data.py:1352
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr "Alias para {handle} removido."
 
-#: users/views/data.py:1291
+#: users/views/data.py:1357
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr "Alias para {handle} adicionado."
 
-#: users/views/data.py:1317
+#: users/views/data.py:1383
 msgid "Migration cancelled."
 msgstr "Migração cancelada."
 
-#: users/views/data.py:1322
+#: users/views/data.py:1388
 msgid "No target account specified."
 msgstr "Nenhuma conta de destino especificada."
 
-#: users/views/data.py:1335
+#: users/views/data.py:1401
 msgid "Cannot migrate to a local account."
 msgstr "Não é possível migrar para uma conta local."
 
-#: users/views/data.py:1346
+#: users/views/data.py:1412
 msgid "You must set up an alias in the target account first."
 msgstr "Você deve primeiro configurar um alias na conta de destino."
 
-#: users/views/data.py:1352
+#: users/views/data.py:1418
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr "Iniciando a mudança para {handle}."
 
-#: users/views/data.py:1410
+#: users/views/data.py:1476
 msgid "No file uploaded."
 msgstr "Nenhum arquivo enviado."
 
-#: users/views/data.py:1426
+#: users/views/data.py:1492
 msgid "The uploaded file is not a valid CSV."
 msgstr "O arquivo enviado não é um CSV válido."
 
-#: users/views/data.py:1430
+#: users/views/data.py:1496
 msgid "No valid entries found in the CSV file."
 msgstr "Nenhuma entrada válida encontrada no arquivo CSV."
 
-#: users/views/data.py:1440
+#: users/views/data.py:1506
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr "Recebidas {count} entradas para importação. Elas serão processadas em segundo plano."

--- a/neodb/locale/ru/LC_MESSAGES/django.po
+++ b/neodb/locale/ru/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 20:04-0400\n"
+"POT-Creation-Date: 2026-09-07 14:56-0400\n"
 "PO-Revision-Date: 2026-08-09 06:32+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/neodb/neodb/ru/>\n"
@@ -59,15 +59,15 @@ msgstr "Упрощенный китайский"
 msgid "Traditional Chinese"
 msgstr "Традиционный китайский"
 
-#: catalog/forms.py:35 catalog/models/item.py:307
+#: catalog/forms.py:35 catalog/models/item.py:412
 msgid "Primary ID Type"
 msgstr ""
 
-#: catalog/forms.py:40 catalog/models/item.py:310
+#: catalog/forms.py:40 catalog/models/item.py:415
 msgid "Primary ID Value"
 msgstr ""
 
-#: catalog/forms.py:176
+#: catalog/forms.py:177
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
@@ -120,11 +120,11 @@ msgid "other title"
 msgstr ""
 
 #: catalog/models/book.py:282 catalog/models/book.py:566
-#: catalog/models/item.py:119
+#: catalog/models/item.py:224
 msgid "author"
 msgstr ""
 
-#: catalog/models/book.py:289 catalog/models/item.py:120
+#: catalog/models/book.py:289 catalog/models/item.py:225
 msgid "translator"
 msgstr ""
 
@@ -133,7 +133,7 @@ msgid "book format"
 msgstr ""
 
 #: catalog/models/book.py:303 catalog/models/game.py:135
-#: catalog/models/item.py:134 catalog/models/music.py:142
+#: catalog/models/item.py:239 catalog/models/music.py:142
 msgid "publisher"
 msgstr ""
 
@@ -165,7 +165,7 @@ msgstr ""
 msgid "price"
 msgstr "цена"
 
-#: catalog/models/book.py:326 catalog/models/item.py:145
+#: catalog/models/book.py:326 catalog/models/item.py:250
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr ""
@@ -571,7 +571,7 @@ msgid "Exhibition"
 msgstr ""
 
 #: catalog/models/common.py:174 catalog/models/common.py:191
-#: journal/templates/collection.html:29 journal/templates/collection.html:40
+#: journal/templates/collection.html:30 journal/templates/collection.html:41
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
@@ -693,16 +693,16 @@ msgstr ""
 msgid "Special Edition"
 msgstr ""
 
-#: catalog/models/game.py:111 catalog/models/item.py:126
+#: catalog/models/game.py:111 catalog/models/item.py:231
 msgid "designer"
 msgstr ""
 
-#: catalog/models/game.py:119 catalog/models/item.py:125
+#: catalog/models/game.py:119 catalog/models/item.py:230
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr ""
 
-#: catalog/models/game.py:127 catalog/models/item.py:135
+#: catalog/models/game.py:127 catalog/models/item.py:240
 msgid "developer"
 msgstr ""
 
@@ -732,141 +732,141 @@ msgstr ""
 msgid "website"
 msgstr "вебсайт"
 
-#: catalog/models/item.py:121 catalog/models/movie.py:123
+#: catalog/models/item.py:226 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
 #: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr ""
 
-#: catalog/models/item.py:122 catalog/models/movie.py:130
+#: catalog/models/item.py:227 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
 #: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr ""
 
-#: catalog/models/item.py:123 catalog/models/movie.py:137
+#: catalog/models/item.py:228 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
 #: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr ""
 
-#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/item.py:229 catalog/models/movie.py:144
 #: catalog/models/tv.py:237 catalog/models/tv.py:463
 msgid "producer"
 msgstr ""
 
-#: catalog/models/item.py:127 catalog/models/performance.py:203
+#: catalog/models/item.py:232 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr "композитор"
 
-#: catalog/models/item.py:128 catalog/models/performance.py:210
+#: catalog/models/item.py:233 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr "хореограф"
 
-#: catalog/models/item.py:129 catalog/models/performance.py:224
+#: catalog/models/item.py:234 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr "исполнитель"
 
-#: catalog/models/item.py:130 catalog/models/podcast.py:80
+#: catalog/models/item.py:235 catalog/models/podcast.py:80
 msgid "host"
 msgstr ""
 
-#: catalog/models/item.py:131 catalog/models/performance.py:196
+#: catalog/models/item.py:236 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr ""
 
-#: catalog/models/item.py:132 catalog/models/performance.py:238
+#: catalog/models/item.py:237 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr ""
 
-#: catalog/models/item.py:136
+#: catalog/models/item.py:241
 msgid "production company"
 msgstr ""
 
-#: catalog/models/item.py:137
+#: catalog/models/item.py:242
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:138
+#: catalog/models/item.py:243
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:139
+#: catalog/models/item.py:244
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:140 catalog/models/performance.py:231
+#: catalog/models/item.py:245 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr ""
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:248
 msgid "voice actor"
 msgstr ""
 
-#: catalog/models/item.py:144 catalog/templates/edition.html:30
+#: catalog/models/item.py:249 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr ""
 
-#: catalog/models/item.py:169 catalog/models/people.py:476
+#: catalog/models/item.py:274 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr "роль"
 
-#: catalog/models/item.py:170 catalog/models/people.py:155
+#: catalog/models/item.py:275 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr ""
 
-#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:277 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:304 catalog/models/item.py:336
-#: journal/models/collection.py:100
+#: catalog/models/item.py:409 catalog/models/item.py:441
+#: journal/models/collection.py:101
 msgid "title"
 msgstr ""
 
-#: catalog/models/item.py:305 catalog/models/item.py:344
-#: journal/models/collection.py:101
+#: catalog/models/item.py:410 catalog/models/item.py:449
+#: journal/models/collection.py:102
 msgid "description"
 msgstr ""
 
-#: catalog/models/item.py:316 catalog/models/people.py:484
+#: catalog/models/item.py:421 catalog/models/people.py:484
 msgid "metadata"
 msgstr "метаданные"
 
-#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:423 catalog/templates/_item_card.html:28
 msgid "cover"
 msgstr "обложка"
 
-#: catalog/models/item.py:1526
+#: catalog/models/item.py:1612
 msgid "source site"
 msgstr ""
 
-#: catalog/models/item.py:1528
+#: catalog/models/item.py:1614
 msgid "ID on source site"
 msgstr ""
 
-#: catalog/models/item.py:1530
+#: catalog/models/item.py:1616
 msgid "source url"
 msgstr ""
 
-#: catalog/models/item.py:1546
+#: catalog/models/item.py:1632
 msgid "IdType of the source site"
 msgstr ""
 
-#: catalog/models/item.py:1552
+#: catalog/models/item.py:1638
 msgid "Primary Id on the source site"
 msgstr ""
 
-#: catalog/models/item.py:1555
+#: catalog/models/item.py:1641
 msgid "url to the resource"
 msgstr ""
 
@@ -1153,12 +1153,12 @@ msgstr ""
 #: catalog/templates/_item_card_metadata_tvseason.html:7
 #: catalog/templates/_item_card_metadata_tvshow.html:7
 #: catalog/templates/_item_card_metadata_work.html:7
-#: catalog/templates/item_base.html:201
+#: catalog/templates/item_base.html:186
 msgid "ratings"
 msgstr ""
 
-#: catalog/templates/_item_card_metadata_base.html:34
-#: catalog/templates/item_base.html:256
+#: catalog/templates/_item_card_metadata_base.html:28
+#: catalog/templates/item_base.html:241
 msgid "part of"
 msgstr ""
 
@@ -1176,14 +1176,14 @@ msgid "hide this tooltip"
 msgstr ""
 
 #: catalog/templates/_item_comments.html:58
-#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:83
+#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:81
 msgid "translate"
 msgstr ""
 
 #: catalog/templates/_item_comments.html:92
 #: catalog/templates/_item_comments_by_episode.html:80
 #: catalog/templates/_item_notes.html:88
-#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:284
+#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:269
 #: catalog/templates/podcast_episode_data.html:41
 msgid "show more"
 msgstr ""
@@ -1296,8 +1296,8 @@ msgstr "Синхронизация в процессе."
 #: catalog/templates/_item_user_pieces.html:101
 #: catalog/templates/catalog_edit.html:12
 #: journal/templates/action_edit_post.html:6
-#: journal/templates/action_edit_post.html:8 journal/templates/article.html:196
-#: journal/templates/collection.html:185 journal/templates/collection.html:193
+#: journal/templates/action_edit_post.html:8 journal/templates/article.html:194
+#: journal/templates/collection.html:186 journal/templates/collection.html:194
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_edit.html:26
 #: journal/templates/post_compose.html:16 journal/templates/tag_edit.html:16
@@ -1339,7 +1339,7 @@ msgstr ""
 #: catalog/templates/_sidebar_edit.html:20
 #: catalog/templates/catalog_verify.html:11
 #: catalog/templates/catalog_verify.html:17
-#: catalog/templates/item_base.html:182
+#: catalog/templates/item_base.html:167
 msgid "Creator verification"
 msgstr ""
 
@@ -1347,7 +1347,7 @@ msgstr ""
 msgid "Edit Options"
 msgstr "Изменить параметры"
 
-#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
+#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:163
 #: catalog/views/edit.py:160 catalog/views/edit.py:221
 #: catalog/views/edit.py:288 catalog/views/edit.py:309
 #: catalog/views/edit.py:364 catalog/views/edit.py:471
@@ -1507,7 +1507,7 @@ msgstr ""
 #: catalog/templates/_sidebar_edit.html:265
 #: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
-#: journal/templates/article.html:199 journal/templates/collection.html:188
+#: journal/templates/article.html:197 journal/templates/collection.html:189
 #: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
@@ -1692,7 +1692,7 @@ msgstr ""
 msgid "Remove my verification"
 msgstr ""
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:311
+#: catalog/templates/_verify_status.html:31 users/views/account.py:312
 msgid "Verification failed"
 msgstr ""
 
@@ -1882,7 +1882,7 @@ msgstr ""
 
 #: catalog/templates/discover.html:229
 #: catalog/templates/discover_original_podcasts.html:25
-#: catalog/templates/item_base.html:282
+#: catalog/templates/item_base.html:267
 #: catalog/templates/item_mark_list.html:71
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
@@ -1950,67 +1950,67 @@ msgstr ""
 msgid "System busy, please try again in a minute."
 msgstr ""
 
-#: catalog/templates/item_base.html:95
+#: catalog/templates/item_base.html:80
 msgid "select one of the seasons to comment"
 msgstr ""
 
-#: catalog/templates/item_base.html:129
+#: catalog/templates/item_base.html:114
 msgid "mark, comment and collect"
 msgstr ""
 
-#: catalog/templates/item_base.html:142
+#: catalog/templates/item_base.html:127
 msgid "Login or register to review or add this item to your collection."
 msgstr ""
 
-#: catalog/templates/item_base.html:151
+#: catalog/templates/item_base.html:136
 msgid "Related Collections"
 msgstr ""
 
-#: catalog/templates/item_base.html:166
+#: catalog/templates/item_base.html:151
 msgid "Unsupported item type."
 msgstr ""
 
-#: catalog/templates/item_base.html:176
+#: catalog/templates/item_base.html:161
 msgid "Edit this item"
 msgstr ""
 
-#: catalog/templates/item_base.html:187
+#: catalog/templates/item_base.html:172
 msgid "Last edited"
 msgstr ""
 
-#: catalog/templates/item_base.html:230
+#: catalog/templates/item_base.html:215
 msgid "No enough ratings"
 msgstr ""
 
-#: catalog/templates/item_base.html:274
+#: catalog/templates/item_base.html:259
 msgid "overview"
 msgstr ""
 
-#: catalog/templates/item_base.html:305
+#: catalog/templates/item_base.html:290
 msgid "comments"
 msgstr ""
 
-#: catalog/templates/item_base.html:308
+#: catalog/templates/item_base.html:293
 #: catalog/templates/item_mark_list.html:22
 #: catalog/templates/item_mark_list.html:25
 #: catalog/templates/item_review_list.html:21
 msgid "marks"
 msgstr ""
 
-#: catalog/templates/item_base.html:309
+#: catalog/templates/item_base.html:294
 #: catalog/templates/item_mark_list.html:23
 #: catalog/templates/item_mark_list.html:26
 #: catalog/templates/item_review_list.html:22
 msgid "marks from who you follow"
 msgstr ""
 
-#: catalog/templates/item_base.html:323
+#: catalog/templates/item_base.html:308
 #: catalog/templates/item_mark_list.html:28
 #: catalog/templates/item_review_list.html:23
 msgid "reviews"
 msgstr ""
 
-#: catalog/templates/item_base.html:333
+#: catalog/templates/item_base.html:318
 msgid "notes"
 msgstr ""
 
@@ -2395,7 +2395,7 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
+#: catalog/views/verify.py:164 common/utils.py:148 common/utils.py:189
 #: journal/views/article.py:186 journal/views/review.py:182
 #: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
@@ -4057,7 +4057,7 @@ msgstr ""
 msgid "Open Registration"
 msgstr ""
 
-#: common/templates/common/about.html:40 common/views_manage.py:657
+#: common/templates/common/about.html:40 common/views_manage.py:671
 msgid "Preferred Languages"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:738
+#: common/templates/common/scan.html:60 common/views_manage.py:756
 msgid "Search"
 msgstr ""
 
@@ -4193,16 +4193,16 @@ msgstr ""
 msgid "unavailable"
 msgstr ""
 
-#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
+#: common/utils.py:152 common/utils.py:193 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr ""
 
-#: common/utils.py:135 common/utils.py:137 common/utils.py:140
-#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
+#: common/utils.py:159 common/utils.py:161 common/utils.py:164
+#: common/utils.py:200 common/utils.py:204 journal/views/profile.py:499
 msgid "Access denied"
 msgstr ""
 
-#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
+#: common/utils.py:167 common/utils.py:169 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr ""
@@ -4221,7 +4221,7 @@ msgstr ""
 msgid "Access"
 msgstr "Принять"
 
-#: common/views_manage.py:39 common/views_manage.py:733
+#: common/views_manage.py:39 common/views_manage.py:751
 msgid "Federation"
 msgstr ""
 
@@ -4571,435 +4571,463 @@ msgid "Sender name and address for outgoing email."
 msgstr ""
 
 #: common/views_manage.py:649
+msgid "Enable Twitter / X Archive Import"
+msgstr ""
+
+#: common/views_manage.py:651
+msgid "Show the Twitter / X archive import on the data page. Imported tweets become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:656
+msgid "Enable Mastodon Archive Import"
+msgstr ""
+
+#: common/views_manage.py:658
+msgid "Show the Mastodon archive import on the data page. Imported posts become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:663
 #, fuzzy
 #| msgid "language"
 msgid "Default Language"
 msgstr "язык"
 
-#: common/views_manage.py:652
+#: common/views_manage.py:666
 msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:673
 msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:665
+#: common/views_manage.py:679
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:672
+#: common/views_manage.py:686
 msgid "Login Methods"
 msgstr ""
 
-#: common/views_manage.py:677 mastodon/models/common.py:30
+#: common/views_manage.py:691 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr ""
 
-#: common/views_manage.py:681
-msgid "Localization"
-msgstr ""
-
-#: common/views_manage.py:692
-msgid "Disable Default Relay"
-msgstr ""
-
-#: common/views_manage.py:694
-msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
+#: common/views_manage.py:695
+msgid "Data Import"
 msgstr ""
 
 #: common/views_manage.py:699
-msgid "Fanout Limit (days)"
+msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:700
-msgid "Posts older than this many days will not be fanned out."
-msgstr ""
-
-#: common/views_manage.py:704
-msgid "Remote Prune Horizon (days)"
-msgstr ""
-
-#: common/views_manage.py:706
-msgid "Remote profiles inactive for this many days will be pruned."
-msgstr ""
-
-#: common/views_manage.py:711
-msgid "Search Sites"
+#: common/views_manage.py:710
+msgid "Disable Default Relay"
 msgstr ""
 
 #: common/views_manage.py:712
+msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
+msgstr ""
+
+#: common/views_manage.py:717
+msgid "Fanout Limit (days)"
+msgstr ""
+
+#: common/views_manage.py:718
+msgid "Posts older than this many days will not be fanned out."
+msgstr ""
+
+#: common/views_manage.py:722
+msgid "Remote Prune Horizon (days)"
+msgstr ""
+
+#: common/views_manage.py:724
+msgid "Remote profiles inactive for this many days will be pruned."
+msgstr ""
+
+#: common/views_manage.py:729
+msgid "Search Sites"
+msgstr ""
+
+#: common/views_manage.py:730
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:715
+#: common/views_manage.py:733
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:716
+#: common/views_manage.py:734
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:719
+#: common/views_manage.py:737
 msgid "Hidden Categories"
 msgstr ""
 
-#: common/views_manage.py:720
+#: common/views_manage.py:738
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:723
+#: common/views_manage.py:741
 msgid "Guest Search Page Limit"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:743
 msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
 msgstr ""
 
-#: common/views_manage.py:751
+#: common/views_manage.py:769
 msgid "Spotify API Key"
 msgstr ""
 
-#: common/views_manage.py:752
+#: common/views_manage.py:770
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:773
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:756
+#: common/views_manage.py:774
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:759
+#: common/views_manage.py:777
 msgid "Google Books API Key"
 msgstr ""
 
-#: common/views_manage.py:760
+#: common/views_manage.py:778
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:763
+#: common/views_manage.py:781
 #, fuzzy
 #| msgid "Discogs"
 msgid "Discogs API Key"
 msgstr "Discogs"
 
-#: common/views_manage.py:765
+#: common/views_manage.py:783
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:769
+#: common/views_manage.py:787
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:770
+#: common/views_manage.py:788
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:773
+#: common/views_manage.py:791
 msgid "IGDB Client Secret"
 msgstr ""
 
-#: common/views_manage.py:776
+#: common/views_manage.py:794
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:778
+#: common/views_manage.py:796
 msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:783
+#: common/views_manage.py:801
 msgid "MyAnimeList Client ID"
 msgstr ""
 
-#: common/views_manage.py:785
+#: common/views_manage.py:803
 msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
 msgstr ""
 
-#: common/views_manage.py:790 users/templates/users/steam_import.html:26
+#: common/views_manage.py:808 users/templates/users/steam_import.html:26
 msgid "Steam API Key"
 msgstr ""
 
-#: common/views_manage.py:792
+#: common/views_manage.py:810
 msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:797
+#: common/views_manage.py:815
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:798
+#: common/views_manage.py:816
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:801
+#: common/views_manage.py:819
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:804
+#: common/views_manage.py:822
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:807
+#: common/views_manage.py:825
 msgid "Threads App ID"
 msgstr ""
 
-#: common/views_manage.py:808
+#: common/views_manage.py:826
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:811
+#: common/views_manage.py:829
 msgid "Threads App Secret"
 msgstr ""
 
-#: common/views_manage.py:814
+#: common/views_manage.py:832
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:834
 msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:833
+#: common/views_manage.py:851
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:844
+#: common/views_manage.py:862
 msgid "Translation"
 msgstr ""
 
-#: common/views_manage.py:849
+#: common/views_manage.py:867
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:853 social/templates/feed.html:27
+#: common/views_manage.py:871 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr ""
 
-#: common/views_manage.py:863
+#: common/views_manage.py:881
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:882
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:885
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:868
+#: common/views_manage.py:886
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:871
+#: common/views_manage.py:889
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:874
+#: common/views_manage.py:892
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:877
+#: common/views_manage.py:895
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:880
+#: common/views_manage.py:898
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:883
+#: common/views_manage.py:901
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:886
+#: common/views_manage.py:904
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:887
+#: common/views_manage.py:905
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:908
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:894
+#: common/views_manage.py:912
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:898
+#: common/views_manage.py:916
 msgid "Retries"
 msgstr ""
 
-#: common/views_manage.py:903
+#: common/views_manage.py:921
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:908
+#: common/views_manage.py:926
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:915
+#: common/views_manage.py:933
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:927
+#: common/views_manage.py:945
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:928
+#: common/views_manage.py:946
 msgid "One domain per line."
 msgstr ""
 
-#: common/views_manage.py:931
+#: common/views_manage.py:949
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:932
+#: common/views_manage.py:950
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:935
+#: common/views_manage.py:953
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:937
+#: common/views_manage.py:955
 msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:943
+#: common/views_manage.py:961
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:944
+#: common/views_manage.py:962
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:947
+#: common/views_manage.py:965
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:948
+#: common/views_manage.py:966
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:958
+#: common/views_manage.py:976
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:960
+#: common/views_manage.py:978
 msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:966
+#: common/views_manage.py:984
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:968
+#: common/views_manage.py:986
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:974
+#: common/views_manage.py:992
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:976
+#: common/views_manage.py:994
 msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:983
+#: common/views_manage.py:1000
+msgid "Webhook Timeout (milliseconds)"
+msgstr ""
+
+#: common/views_manage.py:1001
+msgid "Timeout for delivering webhook requests to applications."
+msgstr ""
+
+#: common/views_manage.py:1006
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:986
+#: common/views_manage.py:1009
 #, fuzzy
 #| msgid "optional"
 msgid "Operational"
 msgstr "опционально"
 
-#: common/views_manage.py:1002
+#: common/views_manage.py:1026
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:1004
+#: common/views_manage.py:1028
 msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1009
+#: common/views_manage.py:1033
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:1011
+#: common/views_manage.py:1035
 msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1016
+#: common/views_manage.py:1040
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:1018
+#: common/views_manage.py:1042
 msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1023
+#: common/views_manage.py:1047
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:1025
+#: common/views_manage.py:1049
 msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1030
+#: common/views_manage.py:1054
 msgid "Podcast Genres"
 msgstr ""
 
-#: common/views_manage.py:1032
+#: common/views_manage.py:1056
 msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1037
+#: common/views_manage.py:1061
 msgid "Performance Genres"
 msgstr ""
 
-#: common/views_manage.py:1039
+#: common/views_manage.py:1063
 msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1045
+#: common/views_manage.py:1069
 msgid "Genres by Category"
 msgstr ""
 
-#: common/views_manage.py:1069
+#: common/views_manage.py:1093
 msgid "Site"
 msgstr ""
 
-#: common/views_manage.py:1079
+#: common/views_manage.py:1103
 msgid "Database and Services"
 msgstr ""
 
-#: common/views_manage.py:1089
+#: common/views_manage.py:1113
 msgid "Media and Files"
 msgstr ""
 
-#: common/views_manage.py:1098
+#: common/views_manage.py:1122
 msgid "Monitoring"
 msgstr ""
 
-#: common/views_manage.py:1102
+#: common/views_manage.py:1126
 msgid "Security"
 msgstr ""
 
-#: common/views_manage.py:1111
+#: common/views_manage.py:1135
 msgid "Other Environment Variables"
 msgstr ""
 
-#: common/views_manage.py:1113
+#: common/views_manage.py:1137
 msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
 msgstr ""
 
@@ -5043,7 +5071,8 @@ msgstr ""
 #: users/templates/users/data.html:60 users/templates/users/data.html:113
 #: users/templates/users/data.html:170 users/templates/users/data.html:221
 #: users/templates/users/data.html:284 users/templates/users/data.html:346
-#: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
+#: users/templates/users/data.html:525 users/templates/users/data.html:578
+#: users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
 msgid "Visibility"
@@ -5075,8 +5104,8 @@ msgstr ""
 msgid "owner and their local mutuals"
 msgstr ""
 
-#: journal/forms.py:169 journal/templates/collection.html:193
-#: journal/templates/collection.html:202
+#: journal/forms.py:169 journal/templates/collection.html:194
+#: journal/templates/collection.html:203
 msgid "Collaborative editing"
 msgstr ""
 
@@ -5127,7 +5156,7 @@ msgstr ""
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:215 journal/views/article.py:218
+#: journal/models/article.py:224 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
@@ -5139,11 +5168,11 @@ msgstr ""
 msgid "note"
 msgstr ""
 
-#: journal/models/collection.py:115
+#: journal/models/collection.py:116
 msgid "search query for dynamic collection"
 msgstr ""
 
-#: journal/models/collection.py:566 journal/templatetags/collection.py:35
+#: journal/models/collection.py:575 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
@@ -5151,7 +5180,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: journal/models/collection.py:571 journal/templatetags/collection.py:43
+#: journal/models/collection.py:580 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
@@ -5159,7 +5188,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: journal/models/collection.py:576 journal/templatetags/collection.py:51
+#: journal/models/collection.py:585 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
@@ -5167,7 +5196,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: journal/models/collection.py:581 journal/templatetags/collection.py:59
+#: journal/models/collection.py:590 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
@@ -5175,7 +5204,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: journal/models/collection.py:586 journal/templatetags/collection.py:67
+#: journal/models/collection.py:595 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
@@ -5183,7 +5212,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: journal/models/collection.py:591 journal/templatetags/collection.py:75
+#: journal/models/collection.py:600 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
@@ -5191,7 +5220,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: journal/models/collection.py:597 journal/templatetags/collection.py:83
+#: journal/models/collection.py:606 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
@@ -5199,7 +5228,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: journal/models/collection.py:605 journal/templatetags/collection.py:91
+#: journal/models/collection.py:614 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
@@ -5207,13 +5236,14 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/models/common.py:59 journal/templates/action_open_post.html:15
 #: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
 #: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
 #: users/templates/users/data.html:122 users/templates/users/data.html:179
 #: users/templates/users/data.html:230 users/templates/users/data.html:292
 #: users/templates/users/data.html:355 users/templates/users/data.html:534
+#: users/templates/users/data.html:587
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5221,13 +5251,14 @@ msgstr[2] ""
 msgid "Public"
 msgstr ""
 
-#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/models/common.py:60 journal/templates/action_open_post.html:9
 #: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
 #: users/templates/users/data.html:130 users/templates/users/data.html:187
 #: users/templates/users/data.html:238 users/templates/users/data.html:300
 #: users/templates/users/data.html:363 users/templates/users/data.html:542
+#: users/templates/users/data.html:595
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5235,12 +5266,13 @@ msgstr ""
 msgid "Followers Only"
 msgstr ""
 
-#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/models/common.py:61 journal/templates/collection_share.html:57
 #: journal/templates/mark.html:102 journal/templates/post_compose.html:72
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
 #: users/templates/users/data.html:138 users/templates/users/data.html:195
 #: users/templates/users/data.html:246 users/templates/users/data.html:308
 #: users/templates/users/data.html:371 users/templates/users/data.html:550
+#: users/templates/users/data.html:603
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5248,27 +5280,27 @@ msgstr ""
 msgid "Mentioned Only"
 msgstr ""
 
-#: journal/models/common.py:806
+#: journal/models/common.py:851
 msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr ""
 
-#: journal/models/common.py:1003
+#: journal/models/common.py:1048
 msgid "A recent post was not posted to Threads."
 msgstr ""
 
-#: journal/models/common.py:1036
+#: journal/models/common.py:1081
 msgid "A recent post was not boosted on Mastodon."
 msgstr ""
 
-#: journal/models/common.py:1046
+#: journal/models/common.py:1091
 msgid "Original post no longer exists."
 msgstr ""
 
-#: journal/models/common.py:1060
+#: journal/models/common.py:1105
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr ""
 
-#: journal/models/common.py:1069
+#: journal/models/common.py:1114
 msgid "A recent post was not posted to Mastodon."
 msgstr ""
 
@@ -5284,83 +5316,83 @@ msgstr ""
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:475
+#: journal/models/mark.py:477
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:479
+#: journal/models/mark.py:481
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:486
+#: journal/models/mark.py:488
 #, fuzzy
 #| msgid "Sync in progress."
 msgid "Invalid progress type."
 msgstr "Синхронизация в процессе."
 
-#: journal/models/mark.py:488
+#: journal/models/mark.py:490
 msgid "Invalid progress type for this item."
 msgstr ""
 
-#: journal/models/note.py:47 users/templates/users/rym_import.html:73
+#: journal/models/note.py:48 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr ""
 
-#: journal/models/note.py:48
+#: journal/models/note.py:49
 msgid "Chapter"
 msgstr ""
 
-#: journal/models/note.py:51
+#: journal/models/note.py:52
 msgid "Part"
 msgstr ""
 
-#: journal/models/note.py:52
+#: journal/models/note.py:53
 msgid "Episode"
 msgstr ""
 
-#: journal/models/note.py:53
+#: journal/models/note.py:54
 msgid "Track"
 msgstr ""
 
-#: journal/models/note.py:54
+#: journal/models/note.py:55
 msgid "Cycle"
 msgstr ""
 
-#: journal/models/note.py:55
+#: journal/models/note.py:56
 msgid "Timestamp"
 msgstr ""
 
-#: journal/models/note.py:56
+#: journal/models/note.py:57
 msgid "Percentage"
-msgstr ""
-
-#: journal/models/note.py:77
-#, python-brace-format
-msgid "Page {value}"
 msgstr ""
 
 #: journal/models/note.py:78
 #, python-brace-format
-msgid "Chapter {value}"
+msgid "Page {value}"
 msgstr ""
 
-#: journal/models/note.py:81
+#: journal/models/note.py:79
 #, python-brace-format
-msgid "Part {value}"
+msgid "Chapter {value}"
 msgstr ""
 
 #: journal/models/note.py:82
 #, python-brace-format
-msgid "Episode {value}"
+msgid "Part {value}"
 msgstr ""
 
 #: journal/models/note.py:83
 #, python-brace-format
-msgid "Track {value}"
+msgid "Episode {value}"
 msgstr ""
 
 #: journal/models/note.py:84
+#, python-brace-format
+msgid "Track {value}"
+msgstr ""
+
+#: journal/models/note.py:85
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr ""
@@ -5370,12 +5402,12 @@ msgstr ""
 msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr ""
 
-#: journal/models/review.py:79
+#: journal/models/review.py:80
 #, python-brace-format
 msgid "a review of {title}"
 msgstr ""
 
-#: journal/models/review.py:81
+#: journal/models/review.py:82
 msgid "(may contain spoilers)"
 msgstr ""
 
@@ -5802,7 +5834,7 @@ msgstr ""
 msgid "started following {item}"
 msgstr ""
 
-#: journal/models/shelf.py:923
+#: journal/models/shelf.py:925
 msgid "removed mark"
 msgstr ""
 
@@ -5835,7 +5867,7 @@ msgstr ""
 msgid "Update note"
 msgstr ""
 
-#: journal/templates/_list_item.html:71 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:121
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
@@ -5985,7 +6017,7 @@ msgid "View post"
 msgstr ""
 
 #: journal/templates/action_quote_post.html:3
-#: journal/templates/article.html:190 journal/templates/collection.html:174
+#: journal/templates/article.html:188 journal/templates/collection.html:175
 msgid "Quote"
 msgstr ""
 
@@ -5994,7 +6026,7 @@ msgid "reply"
 msgstr ""
 
 #: journal/templates/action_reply_post.html:3
-#: journal/templates/article.html:181 journal/templates/collection.html:165
+#: journal/templates/article.html:179 journal/templates/collection.html:166
 msgid "Reply"
 msgstr ""
 
@@ -6011,23 +6043,23 @@ msgstr ""
 msgid "Create a new collection"
 msgstr ""
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:76
+#: journal/templates/article.html:102 social/templates/_event_post.html:76
 #, fuzzy
 #| msgid "write a review"
 msgid "wrote a review"
 msgstr "написать обзор"
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:78
+#: journal/templates/article.html:104 social/templates/_event_post.html:78
 #, fuzzy
 #| msgid "write a review"
 msgid "wrote an article"
 msgstr "написать обзор"
 
-#: journal/templates/article.html:136
+#: journal/templates/article.html:134
 msgid "This article may contain sensitive content. Click to reveal."
 msgstr ""
 
-#: journal/templates/article.html:155
+#: journal/templates/article.html:153
 msgid "The author has set it to be viewable only by logged-in users."
 msgstr ""
 
@@ -6090,20 +6122,20 @@ msgstr ""
 msgid "DEC"
 msgstr ""
 
-#: journal/templates/collection.html:71
+#: journal/templates/collection.html:72
 #: journal/templates/collection_share.html:12
 #: journal/templates/collection_share.html:66
 #: journal/templates/wrapped_share.html:59
 msgid "Share"
 msgstr ""
 
-#: journal/templates/collection.html:86
+#: journal/templates/collection.html:87
 #, fuzzy
 #| msgid "my collection"
 msgid "created a collection"
 msgstr "моя коллекция"
 
-#: journal/templates/collection.html:181
+#: journal/templates/collection.html:182
 msgid "Query"
 msgstr ""
 
@@ -6352,12 +6384,12 @@ msgid "Liked Collections"
 msgstr ""
 
 #: journal/templates/user_follow_list.html:23 journal/views/profile.py:507
-#: users/templates/users/account.html:443
+#: users/templates/users/account.html:455
 msgid "Following"
 msgstr ""
 
 #: journal/templates/user_follow_list.html:28 journal/views/profile.py:511
-#: users/templates/users/account.html:452
+#: users/templates/users/account.html:464
 msgid "Followers"
 msgstr ""
 
@@ -6662,8 +6694,8 @@ msgstr ""
 #: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
 #: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
 #: mastodon/views/threads.py:57 mastodon/views/threads.py:65
-#: mastodon/views/threads.py:71 users/views/account.py:256
-#: users/views/account.py:375
+#: mastodon/views/threads.py:71 users/views/account.py:257
+#: users/views/account.py:376
 msgid "Authentication failed"
 msgstr ""
 
@@ -6703,7 +6735,7 @@ msgstr ""
 msgid "Invalid user."
 msgstr ""
 
-#: mastodon/views/common.py:52 users/views/account.py:416
+#: mastodon/views/common.py:52 users/views/account.py:417
 msgid "Registration failed"
 msgstr ""
 
@@ -7580,120 +7612,133 @@ msgstr ""
 msgid "Scopes"
 msgstr ""
 
-#: users/templates/users/account.html:398
+#: users/templates/users/account.html:386
+msgid "Webhook"
+msgstr ""
+
+#: users/templates/users/account.html:400
+msgid "disabled"
+msgstr ""
+
+#: users/templates/users/account.html:402
+msgid "active"
+msgstr ""
+
+#: users/templates/users/account.html:410
 msgid "Revoke access for this application?"
 msgstr ""
 
-#: users/templates/users/account.html:401
+#: users/templates/users/account.html:413
 msgid "Revoke"
 msgstr ""
 
-#: users/templates/users/account.html:409
+#: users/templates/users/account.html:421
 msgid "No authorized applications."
 msgstr ""
 
-#: users/templates/users/account.html:412
+#: users/templates/users/account.html:424
 #: users/templates/users/authorized_app_create.html:9
 #: users/templates/users/authorized_app_create.html:19
 msgid "Create Personal Token"
 msgstr ""
 
-#: users/templates/users/account.html:418
+#: users/templates/users/account.html:430
 msgid "Import/Export Social Graph"
 msgstr ""
 
-#: users/templates/users/account.html:419
+#: users/templates/users/account.html:431
 msgid "Upload a CSV file exported from Mastodon or compatible services."
 msgstr ""
 
-#: users/templates/users/account.html:425
+#: users/templates/users/account.html:437
 msgid "Import type"
 msgstr ""
 
-#: users/templates/users/account.html:427
+#: users/templates/users/account.html:439
 msgid "Following list"
 msgstr ""
 
-#: users/templates/users/account.html:428
+#: users/templates/users/account.html:440
 msgid "Block list"
 msgstr ""
 
-#: users/templates/users/account.html:429
+#: users/templates/users/account.html:441
 msgid "Mute list"
 msgstr ""
 
-#: users/templates/users/account.html:433
+#: users/templates/users/account.html:445
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/account.html:448 users/templates/users/data.html:89
 #: users/templates/users/data.html:141 users/templates/users/data.html:198
 #: users/templates/users/data.html:249 users/templates/users/data.html:313
 #: users/templates/users/data.html:376 users/templates/users/data.html:553
+#: users/templates/users/data.html:606 users/templates/users/data.html:631
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr ""
 
-#: users/templates/users/account.html:447
-#: users/templates/users/account.html:456
-#: users/templates/users/account.html:465
-#: users/templates/users/account.html:474
+#: users/templates/users/account.html:459
+#: users/templates/users/account.html:468
+#: users/templates/users/account.html:477
+#: users/templates/users/account.html:486
 msgid "Download CSV"
 msgstr ""
 
-#: users/templates/users/account.html:461
+#: users/templates/users/account.html:473
 msgid "Blocks"
 msgstr ""
 
-#: users/templates/users/account.html:470
+#: users/templates/users/account.html:482
 msgid "Mutes"
 msgstr ""
 
-#: users/templates/users/account.html:484
+#: users/templates/users/account.html:496
 msgid "Migrate Account"
 msgstr ""
 
-#: users/templates/users/account.html:488
+#: users/templates/users/account.html:500
 msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
 msgstr ""
 
-#: users/templates/users/account.html:491
+#: users/templates/users/account.html:503
 msgid "Migrate another account here"
 msgstr ""
 
-#: users/templates/users/account.html:494
+#: users/templates/users/account.html:506
 msgid "Migrate to another account"
 msgstr ""
 
-#: users/templates/users/account.html:501
+#: users/templates/users/account.html:513
 msgid "Delete Account"
 msgstr ""
 
-#: users/templates/users/account.html:504
+#: users/templates/users/account.html:516
 msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
 msgstr ""
 
-#: users/templates/users/account.html:507
+#: users/templates/users/account.html:519
 msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
 msgstr ""
 
-#: users/templates/users/account.html:517
+#: users/templates/users/account.html:529
 msgid "Once deleted, account data cannot be recovered."
 msgstr ""
 
-#: users/templates/users/account.html:520
+#: users/templates/users/account.html:532
 msgid "Task in progress, can't delete now."
 msgstr ""
 
-#: users/templates/users/account.html:524
+#: users/templates/users/account.html:536
 msgid "Permanently Delete"
 msgstr ""
 
-#: users/templates/users/account.html:565
+#: users/templates/users/account.html:577
 msgid "Delete this passkey?"
 msgstr ""
 
-#: users/templates/users/account.html:585
+#: users/templates/users/account.html:597
 msgid "Rename passkey:"
 msgstr ""
 
@@ -7715,9 +7760,7 @@ msgstr ""
 
 #: users/templates/users/authorized_app_create.html:48
 #: users/templates/users/authorized_app_created.html:39
-#: users/templates/users/migrate_in.html:70
-#: users/templates/users/migrate_out.html:67
-msgid "Back to Preferences"
+msgid "Back to Account"
 msgstr ""
 
 #: users/templates/users/authorized_app_created.html:9
@@ -7857,7 +7900,7 @@ msgstr ""
 msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
 msgstr ""
 
-#: users/templates/users/data.html:89 users/views/data.py:1130
+#: users/templates/users/data.html:89 users/views/data.py:1194
 msgid "Import in progress, please wait"
 msgstr ""
 
@@ -8014,7 +8057,39 @@ msgstr ""
 msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
-#: users/templates/users/data.html:560
+#: users/templates/users/data.html:561
+msgid "Import Twitter / X Archive"
+msgstr ""
+
+#: users/templates/users/data.html:567
+msgid "On X, go to <b>Settings</b> - <b>Your account</b> - <b>Download an archive of your data</b>. Upload the <code>.zip</code> you receive, or only the <code>data/tweets.js</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:570
+msgid "Each tweet becomes a post with its original date, text, links and photos. Replies to your own tweets are kept as a thread. A retweet becomes a short post that links to the original tweet. Videos are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:573
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Tweets that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:615
+msgid "Import Mastodon Archive"
+msgstr ""
+
+#: users/templates/users/data.html:621
+msgid "On your Mastodon server, go to <b>Preferences</b> - <b>Import and export</b> - <b>Request your archive</b>. Upload the <code>.zip</code> you receive, or only the <code>outbox.json</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:624
+msgid "Each post is imported with its original date, text, links, photos, content warning and visibility, so a followers-only post or a direct message stays that way. Replies to your own posts are kept as a thread. A boost becomes a short post that links to the original post. Videos, favourites and bookmarks are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:627
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Posts that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:639
 msgid "View Annual Summary"
 msgstr ""
 
@@ -8137,6 +8212,11 @@ msgstr ""
 
 #: users/templates/users/migrate_in.html:64
 msgid "No aliases configured."
+msgstr ""
+
+#: users/templates/users/migrate_in.html:70
+#: users/templates/users/migrate_out.html:67
+msgid "Back to Preferences"
 msgstr ""
 
 #: users/templates/users/migrate_out.html:9
@@ -8649,196 +8729,197 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:126
+#: users/views/account.py:127
 msgid "This username is already in use."
 msgstr "Это имя пользователя уже используется."
 
-#: users/views/account.py:137
+#: users/views/account.py:138
 msgid "This email address is already in use."
 msgstr "Этот email-адрес уже используется."
 
-#: users/views/account.py:257 users/views/account.py:376
+#: users/views/account.py:258 users/views/account.py:377
 msgid "Registration is for invitation only"
 msgstr "Регистрация только по приглашению"
 
-#: users/views/account.py:268 users/views/account.py:340
+#: users/views/account.py:269 users/views/account.py:341
 msgid "Time is up"
 msgstr ""
 
-#: users/views/account.py:269 users/views/account.py:312
-#: users/views/account.py:341
+#: users/views/account.py:270 users/views/account.py:313
+#: users/views/account.py:342
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:315
+#: users/views/account.py:316
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:327
+#: users/views/account.py:328
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:328
+#: users/views/account.py:329
 msgid "Please try again later."
 msgstr ""
 
-#: users/views/account.py:417
+#: users/views/account.py:418
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:447
+#: users/views/account.py:448
 msgid "Valid username required"
 msgstr "Требуется корректное имя пользователя"
 
-#: users/views/account.py:518
+#: users/views/account.py:519
 msgid "Account is being deleted."
 msgstr "Аккаунт удаляется."
 
-#: users/views/account.py:521
+#: users/views/account.py:522
 msgid "Account mismatch."
 msgstr "Несоответствие аккаунта."
 
-#: users/views/data.py:264 users/views/data.py:296
+#: users/views/data.py:276 users/views/data.py:308
 msgid "Export file not available."
 msgstr "Экспортируемый файл недоступен."
 
-#: users/views/data.py:290
+#: users/views/data.py:302
 msgid "Generating exports."
 msgstr "Формирование экспорта."
 
-#: users/views/data.py:308
+#: users/views/data.py:320
 msgid "Export file expired. Please export again."
 msgstr "Экспорт файла истёк. Пожалуйста, экспортируйте снова."
 
-#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
+#: users/views/data.py:335 users/views/data.py:356 users/views/data.py:377
 msgid "Recent export still in progress."
 msgstr "Последний экспорт всё ещё в процессе."
 
-#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
-#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
-#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
+#: users/views/data.py:393 users/views/data.py:419 users/views/data.py:447
+#: users/views/data.py:579 users/views/data.py:613 users/views/data.py:838
+#: users/views/data.py:1055 users/views/data.py:1081 users/views/data.py:1106
+#: users/views/data.py:1131 users/views/data.py:1201
 msgid "Invalid file."
 msgstr "Некорректный файл."
 
-#: users/views/data.py:405
+#: users/views/data.py:469
 msgid "Sync in progress."
 msgstr "Синхронизация в процессе."
 
-#: users/views/data.py:419
+#: users/views/data.py:483
 msgid "Settings saved."
 msgstr "Настройки сохранены."
 
-#: users/views/data.py:474
+#: users/views/data.py:538
 #, fuzzy
 #| msgid "Account is being deleted."
 msgid "Account no longer linked."
 msgstr "Аккаунт удаляется."
 
-#: users/views/data.py:477
+#: users/views/data.py:541
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:505
+#: users/views/data.py:569
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:585 users/views/data.py:810
+#: users/views/data.py:649 users/views/data.py:874
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:610 users/views/data.py:839
+#: users/views/data.py:674 users/views/data.py:903
 msgid "Cancelled."
 msgstr ""
 
-#: users/views/data.py:630
+#: users/views/data.py:694
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
-#: users/views/data.py:974
+#: users/views/data.py:702 users/views/data.py:812 users/views/data.py:933
+#: users/views/data.py:1038
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:734 users/views/data.py:960
+#: users/views/data.py:798 users/views/data.py:1024
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:744 users/views/data.py:970
+#: users/views/data.py:808 users/views/data.py:1034
 #, fuzzy
 #| msgid "Export file not available."
 msgid "No matched file available."
 msgstr "Экспортируемый файл недоступен."
 
-#: users/views/data.py:861
+#: users/views/data.py:925
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1290
 #, fuzzy
 #| msgid "Valid username required"
 msgid "Name is required."
 msgstr "Требуется корректное имя пользователя"
 
-#: users/views/data.py:1248
+#: users/views/data.py:1314
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1264
+#: users/views/data.py:1330
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1269
+#: users/views/data.py:1335
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1279 users/views/data.py:1330
+#: users/views/data.py:1345 users/views/data.py:1396
 msgid "Looking up the account. Please try again in a few seconds."
-msgstr ""
-
-#: users/views/data.py:1286
-#, python-brace-format
-msgid "Alias to {handle} removed."
-msgstr ""
-
-#: users/views/data.py:1291
-#, python-brace-format
-msgid "Alias to {handle} added."
-msgstr ""
-
-#: users/views/data.py:1317
-msgid "Migration cancelled."
-msgstr ""
-
-#: users/views/data.py:1322
-msgid "No target account specified."
-msgstr ""
-
-#: users/views/data.py:1335
-msgid "Cannot migrate to a local account."
-msgstr ""
-
-#: users/views/data.py:1346
-msgid "You must set up an alias in the target account first."
 msgstr ""
 
 #: users/views/data.py:1352
 #, python-brace-format
+msgid "Alias to {handle} removed."
+msgstr ""
+
+#: users/views/data.py:1357
+#, python-brace-format
+msgid "Alias to {handle} added."
+msgstr ""
+
+#: users/views/data.py:1383
+msgid "Migration cancelled."
+msgstr ""
+
+#: users/views/data.py:1388
+msgid "No target account specified."
+msgstr ""
+
+#: users/views/data.py:1401
+msgid "Cannot migrate to a local account."
+msgstr ""
+
+#: users/views/data.py:1412
+msgid "You must set up an alias in the target account first."
+msgstr ""
+
+#: users/views/data.py:1418
+#, python-brace-format
 msgid "Start moving to {handle}."
 msgstr ""
 
-#: users/views/data.py:1410
+#: users/views/data.py:1476
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1426
+#: users/views/data.py:1492
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1430
+#: users/views/data.py:1496
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1440
+#: users/views/data.py:1506
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""

--- a/neodb/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hant/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 20:04-0400\n"
+"POT-Creation-Date: 2026-09-07 14:56-0400\n"
 "PO-Revision-Date: 2026-08-09 06:32+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hant/>\n"
@@ -60,15 +60,15 @@ msgstr "簡體中文"
 msgid "Traditional Chinese"
 msgstr "繁體中文"
 
-#: catalog/forms.py:35 catalog/models/item.py:307
+#: catalog/forms.py:35 catalog/models/item.py:412
 msgid "Primary ID Type"
 msgstr "主要標識類型"
 
-#: catalog/forms.py:40 catalog/models/item.py:310
+#: catalog/forms.py:40 catalog/models/item.py:415
 msgid "Primary ID Value"
 msgstr "主要標識數據"
 
-#: catalog/forms.py:176
+#: catalog/forms.py:177
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
@@ -121,11 +121,11 @@ msgid "other title"
 msgstr "其它標題"
 
 #: catalog/models/book.py:282 catalog/models/book.py:566
-#: catalog/models/item.py:119
+#: catalog/models/item.py:224
 msgid "author"
 msgstr "作者"
 
-#: catalog/models/book.py:289 catalog/models/item.py:120
+#: catalog/models/book.py:289 catalog/models/item.py:225
 msgid "translator"
 msgstr "譯者"
 
@@ -134,7 +134,7 @@ msgid "book format"
 msgstr "格式"
 
 #: catalog/models/book.py:303 catalog/models/game.py:135
-#: catalog/models/item.py:134 catalog/models/music.py:142
+#: catalog/models/item.py:239 catalog/models/music.py:142
 msgid "publisher"
 msgstr "出版發行"
 
@@ -166,7 +166,7 @@ msgstr "目錄"
 msgid "price"
 msgstr "價格"
 
-#: catalog/models/book.py:326 catalog/models/item.py:145
+#: catalog/models/book.py:326 catalog/models/item.py:250
 #: catalog/templates/edition.html:34
 msgid "imprint"
 msgstr "出品方"
@@ -591,7 +591,7 @@ msgid "Exhibition"
 msgstr "展覽"
 
 #: catalog/models/common.py:174 catalog/models/common.py:191
-#: journal/templates/collection.html:29 journal/templates/collection.html:40
+#: journal/templates/collection.html:30 journal/templates/collection.html:41
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
@@ -721,16 +721,16 @@ msgstr "重製"
 msgid "Special Edition"
 msgstr "特別版"
 
-#: catalog/models/game.py:111 catalog/models/item.py:126
+#: catalog/models/game.py:111 catalog/models/item.py:231
 msgid "designer"
 msgstr "設計者"
 
-#: catalog/models/game.py:119 catalog/models/item.py:125
+#: catalog/models/game.py:119 catalog/models/item.py:230
 #: catalog/models/music.py:134
 msgid "artist"
 msgstr "藝術家"
 
-#: catalog/models/game.py:127 catalog/models/item.py:135
+#: catalog/models/game.py:127 catalog/models/item.py:240
 msgid "developer"
 msgstr "開發者"
 
@@ -760,147 +760,147 @@ msgstr "發佈類型"
 msgid "website"
 msgstr "網站"
 
-#: catalog/models/item.py:121 catalog/models/movie.py:123
+#: catalog/models/item.py:226 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
 #: catalog/models/tv.py:216 catalog/models/tv.py:442
 msgid "director"
 msgstr "導演"
 
-#: catalog/models/item.py:122 catalog/models/movie.py:130
+#: catalog/models/item.py:227 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
 #: catalog/models/tv.py:223 catalog/models/tv.py:449
 msgid "playwright"
 msgstr "編劇"
 
-#: catalog/models/item.py:123 catalog/models/movie.py:137
+#: catalog/models/item.py:228 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
 #: catalog/models/tv.py:230 catalog/models/tv.py:456
 msgid "actor"
 msgstr "演員"
 
-#: catalog/models/item.py:124 catalog/models/movie.py:144
+#: catalog/models/item.py:229 catalog/models/movie.py:144
 #: catalog/models/tv.py:237 catalog/models/tv.py:463
 #, fuzzy
 #| msgid "production"
 msgid "producer"
 msgstr "上演"
 
-#: catalog/models/item.py:127 catalog/models/performance.py:203
+#: catalog/models/item.py:232 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr "作曲"
 
-#: catalog/models/item.py:128 catalog/models/performance.py:210
+#: catalog/models/item.py:233 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr "編舞"
 
-#: catalog/models/item.py:129 catalog/models/performance.py:224
+#: catalog/models/item.py:234 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr "表演者"
 
-#: catalog/models/item.py:130 catalog/models/podcast.py:80
+#: catalog/models/item.py:235 catalog/models/podcast.py:80
 msgid "host"
 msgstr "主播"
 
-#: catalog/models/item.py:131 catalog/models/performance.py:196
+#: catalog/models/item.py:236 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr "原始創作者"
 
-#: catalog/models/item.py:132 catalog/models/performance.py:238
+#: catalog/models/item.py:237 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr "工作人員"
 
-#: catalog/models/item.py:136
+#: catalog/models/item.py:241
 #, fuzzy
 #| msgid "production"
 msgid "production company"
 msgstr "上演"
 
-#: catalog/models/item.py:137
+#: catalog/models/item.py:242
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:138
+#: catalog/models/item.py:243
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:139
+#: catalog/models/item.py:244
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:140 catalog/models/performance.py:231
+#: catalog/models/item.py:245 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr "劇團"
 
-#: catalog/models/item.py:143
+#: catalog/models/item.py:248
 #, fuzzy
 #| msgid "director"
 msgid "voice actor"
 msgstr "導演"
 
-#: catalog/models/item.py:144 catalog/templates/edition.html:30
+#: catalog/models/item.py:249 catalog/templates/edition.html:30
 msgid "publishing house"
 msgstr "出版社"
 
-#: catalog/models/item.py:169 catalog/models/people.py:476
+#: catalog/models/item.py:274 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr "角色"
 
-#: catalog/models/item.py:170 catalog/models/people.py:155
+#: catalog/models/item.py:275 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr "名字"
 
-#: catalog/models/item.py:172 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:277 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:304 catalog/models/item.py:336
-#: journal/models/collection.py:100
+#: catalog/models/item.py:409 catalog/models/item.py:441
+#: journal/models/collection.py:101
 msgid "title"
 msgstr "標題"
 
-#: catalog/models/item.py:305 catalog/models/item.py:344
-#: journal/models/collection.py:101
+#: catalog/models/item.py:410 catalog/models/item.py:449
+#: journal/models/collection.py:102
 msgid "description"
 msgstr "描述"
 
-#: catalog/models/item.py:316 catalog/models/people.py:484
+#: catalog/models/item.py:421 catalog/models/people.py:484
 msgid "metadata"
 msgstr "元數據"
 
-#: catalog/models/item.py:318 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:423 catalog/templates/_item_card.html:28
 msgid "cover"
 msgstr "封面"
 
-#: catalog/models/item.py:1526
+#: catalog/models/item.py:1612
 msgid "source site"
 msgstr "來源站點"
 
-#: catalog/models/item.py:1528
+#: catalog/models/item.py:1614
 msgid "ID on source site"
 msgstr "來源站點標識"
 
-#: catalog/models/item.py:1530
+#: catalog/models/item.py:1616
 msgid "source url"
 msgstr "來源站點網址"
 
-#: catalog/models/item.py:1546
+#: catalog/models/item.py:1632
 msgid "IdType of the source site"
 msgstr "來源站點的主要標識類型"
 
-#: catalog/models/item.py:1552
+#: catalog/models/item.py:1638
 msgid "Primary Id on the source site"
 msgstr "來源站點的主要標識數據"
 
-#: catalog/models/item.py:1555
+#: catalog/models/item.py:1641
 msgid "url to the resource"
 msgstr "指向外部資源的網址"
 
@@ -1231,12 +1231,12 @@ msgstr "無法加載條目，請確認連結正確。部分網站可能刪除條
 #: catalog/templates/_item_card_metadata_tvseason.html:7
 #: catalog/templates/_item_card_metadata_tvshow.html:7
 #: catalog/templates/_item_card_metadata_work.html:7
-#: catalog/templates/item_base.html:201
+#: catalog/templates/item_base.html:186
 msgid "ratings"
 msgstr "個評分"
 
-#: catalog/templates/_item_card_metadata_base.html:34
-#: catalog/templates/item_base.html:256
+#: catalog/templates/_item_card_metadata_base.html:28
+#: catalog/templates/item_base.html:241
 msgid "part of"
 msgstr "所屬"
 
@@ -1254,7 +1254,7 @@ msgid "hide this tooltip"
 msgstr "不再提示"
 
 #: catalog/templates/_item_comments.html:58
-#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:83
+#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:81
 #, fuzzy
 #| msgid "translator"
 msgid "translate"
@@ -1263,7 +1263,7 @@ msgstr "譯者"
 #: catalog/templates/_item_comments.html:92
 #: catalog/templates/_item_comments_by_episode.html:80
 #: catalog/templates/_item_notes.html:88
-#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:284
+#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:269
 #: catalog/templates/podcast_episode_data.html:41
 msgid "show more"
 msgstr "顯示更多"
@@ -1384,8 +1384,8 @@ msgstr "正在同步。"
 #: catalog/templates/_item_user_pieces.html:101
 #: catalog/templates/catalog_edit.html:12
 #: journal/templates/action_edit_post.html:6
-#: journal/templates/action_edit_post.html:8 journal/templates/article.html:196
-#: journal/templates/collection.html:185 journal/templates/collection.html:193
+#: journal/templates/action_edit_post.html:8 journal/templates/article.html:194
+#: journal/templates/collection.html:186 journal/templates/collection.html:194
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_edit.html:26
 #: journal/templates/post_compose.html:16 journal/templates/tag_edit.html:16
@@ -1429,7 +1429,7 @@ msgstr "回到條目"
 #: catalog/templates/_sidebar_edit.html:20
 #: catalog/templates/catalog_verify.html:11
 #: catalog/templates/catalog_verify.html:17
-#: catalog/templates/item_base.html:182
+#: catalog/templates/item_base.html:167
 #, fuzzy
 #| msgid "Verification"
 msgid "Creator verification"
@@ -1439,7 +1439,7 @@ msgstr "驗證"
 msgid "Edit Options"
 msgstr "編輯選項"
 
-#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
+#: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:163
 #: catalog/views/edit.py:160 catalog/views/edit.py:221
 #: catalog/views/edit.py:288 catalog/views/edit.py:309
 #: catalog/views/edit.py:364 catalog/views/edit.py:471
@@ -1613,7 +1613,7 @@ msgstr "合併到另一條目"
 #: catalog/templates/_sidebar_edit.html:265
 #: catalog/templates/_sidebar_edit.html:269
 #: journal/templates/action_delete_post.html:10
-#: journal/templates/article.html:199 journal/templates/collection.html:188
+#: journal/templates/article.html:197 journal/templates/collection.html:189
 #: journal/templates/mark.html:157 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
@@ -1820,7 +1820,7 @@ msgstr ""
 msgid "Remove my verification"
 msgstr "從收藏單中移除"
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:311
+#: catalog/templates/_verify_status.html:31 users/views/account.py:312
 #, fuzzy
 #| msgid "Verification Code"
 msgid "Verification failed"
@@ -2014,7 +2014,7 @@ msgstr "熱門標籤"
 
 #: catalog/templates/discover.html:229
 #: catalog/templates/discover_original_podcasts.html:25
-#: catalog/templates/item_base.html:282
+#: catalog/templates/item_base.html:267
 #: catalog/templates/item_mark_list.html:71
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
@@ -2084,67 +2084,67 @@ msgstr "正在從%(site_label)s獲取"
 msgid "System busy, please try again in a minute."
 msgstr "系統繁忙，請稍等幾秒鐘再搜索。"
 
-#: catalog/templates/item_base.html:95
+#: catalog/templates/item_base.html:80
 msgid "select one of the seasons to comment"
 msgstr "這是全劇條目，以下是可標記的單季"
 
-#: catalog/templates/item_base.html:129
+#: catalog/templates/item_base.html:114
 msgid "mark, comment and collect"
 msgstr "標籤 · 短評 · 評論 · 收藏"
 
-#: catalog/templates/item_base.html:142
+#: catalog/templates/item_base.html:127
 msgid "Login or register to review or add this item to your collection."
 msgstr "登入後可管理標記收藏"
 
-#: catalog/templates/item_base.html:151
+#: catalog/templates/item_base.html:136
 msgid "Related Collections"
 msgstr "相關收藏單"
 
-#: catalog/templates/item_base.html:166
+#: catalog/templates/item_base.html:151
 msgid "Unsupported item type."
 msgstr "此類數據尚未支持"
 
-#: catalog/templates/item_base.html:176
+#: catalog/templates/item_base.html:161
 msgid "Edit this item"
 msgstr "編輯這個條目"
 
-#: catalog/templates/item_base.html:187
+#: catalog/templates/item_base.html:172
 msgid "Last edited"
 msgstr "最近編輯"
 
-#: catalog/templates/item_base.html:230
+#: catalog/templates/item_base.html:215
 msgid "No enough ratings"
 msgstr "評分人數不足"
 
-#: catalog/templates/item_base.html:274
+#: catalog/templates/item_base.html:259
 msgid "overview"
 msgstr "簡介"
 
-#: catalog/templates/item_base.html:305
+#: catalog/templates/item_base.html:290
 msgid "comments"
 msgstr "短評"
 
-#: catalog/templates/item_base.html:308
+#: catalog/templates/item_base.html:293
 #: catalog/templates/item_mark_list.html:22
 #: catalog/templates/item_mark_list.html:25
 #: catalog/templates/item_review_list.html:21
 msgid "marks"
 msgstr "標記"
 
-#: catalog/templates/item_base.html:309
+#: catalog/templates/item_base.html:294
 #: catalog/templates/item_mark_list.html:23
 #: catalog/templates/item_mark_list.html:26
 #: catalog/templates/item_review_list.html:22
 msgid "marks from who you follow"
 msgstr "好友標記"
 
-#: catalog/templates/item_base.html:323
+#: catalog/templates/item_base.html:308
 #: catalog/templates/item_mark_list.html:28
 #: catalog/templates/item_review_list.html:23
 msgid "reviews"
 msgstr "評論"
 
-#: catalog/templates/item_base.html:333
+#: catalog/templates/item_base.html:318
 #, fuzzy
 #| msgid "note"
 msgid "notes"
@@ -2553,7 +2553,7 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:124 common/utils.py:165
+#: catalog/views/verify.py:164 common/utils.py:148 common/utils.py:189
 #: journal/views/article.py:186 journal/views/review.py:182
 #: users/views/actions.py:44 users/views/actions.py:130
 msgid "User not found"
@@ -4325,7 +4325,7 @@ msgstr "自己和提到的人"
 msgid "Open Registration"
 msgstr "註冊失敗"
 
-#: common/templates/common/about.html:40 common/views_manage.py:657
+#: common/templates/common/about.html:40 common/views_manage.py:671
 #, fuzzy
 #| msgid "Preferences"
 msgid "Preferred Languages"
@@ -4391,7 +4391,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:738
+#: common/templates/common/scan.html:60 common/views_manage.py:756
 #, fuzzy
 #| msgid "Search results"
 msgid "Search"
@@ -4477,16 +4477,16 @@ msgstr ""
 msgid "unavailable"
 msgstr ""
 
-#: common/utils.py:128 common/utils.py:169 users/views/actions.py:133
+#: common/utils.py:152 common/utils.py:193 users/views/actions.py:133
 msgid "User no longer exists"
 msgstr "用戶不存在了"
 
-#: common/utils.py:135 common/utils.py:137 common/utils.py:140
-#: common/utils.py:176 common/utils.py:180 journal/views/profile.py:499
+#: common/utils.py:159 common/utils.py:161 common/utils.py:164
+#: common/utils.py:200 common/utils.py:204 journal/views/profile.py:499
 msgid "Access denied"
 msgstr "訪問被拒絕"
 
-#: common/utils.py:143 common/utils.py:145 journal/views/article.py:204
+#: common/utils.py:167 common/utils.py:169 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr "登入後訪問"
@@ -4509,7 +4509,7 @@ msgstr "短評"
 msgid "Access"
 msgstr "接受"
 
-#: common/views_manage.py:39 common/views_manage.py:733
+#: common/views_manage.py:39 common/views_manage.py:751
 #, fuzzy
 #| msgid "duration"
 msgid "Federation"
@@ -4893,465 +4893,495 @@ msgid "Sender name and address for outgoing email."
 msgstr ""
 
 #: common/views_manage.py:649
+msgid "Enable Twitter / X Archive Import"
+msgstr ""
+
+#: common/views_manage.py:651
+msgid "Show the Twitter / X archive import on the data page. Imported tweets become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:656
+msgid "Enable Mastodon Archive Import"
+msgstr ""
+
+#: common/views_manage.py:658
+msgid "Show the Mastodon archive import on the data page. Imported posts become local posts that are never federated."
+msgstr ""
+
+#: common/views_manage.py:663
 #, fuzzy
 #| msgid "Language"
 msgid "Default Language"
 msgstr "語言"
 
-#: common/views_manage.py:652
+#: common/views_manage.py:666
 msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:673
 msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:665
+#: common/views_manage.py:679
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:672
+#: common/views_manage.py:686
 #, fuzzy
 #| msgid "Import Method"
 msgid "Login Methods"
 msgstr "匯入方式"
 
-#: common/views_manage.py:677 mastodon/models/common.py:30
+#: common/views_manage.py:691 mastodon/models/common.py:30
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr "電子郵件"
 
-#: common/views_manage.py:681
+#: common/views_manage.py:695
+#, fuzzy
+#| msgid "Import"
+msgid "Data Import"
+msgstr "匯入"
+
+#: common/views_manage.py:699
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:692
+#: common/views_manage.py:710
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:694
+#: common/views_manage.py:712
 msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:699
+#: common/views_manage.py:717
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:700
+#: common/views_manage.py:718
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:704
+#: common/views_manage.py:722
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:706
+#: common/views_manage.py:724
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:711
+#: common/views_manage.py:729
 #, fuzzy
 #| msgid "Search results"
 msgid "Search Sites"
 msgstr "搜索結果"
 
-#: common/views_manage.py:712
+#: common/views_manage.py:730
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:715
+#: common/views_manage.py:733
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:716
+#: common/views_manage.py:734
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:719
+#: common/views_manage.py:737
 #, fuzzy
 #| msgid "Add tv series"
 msgid "Hidden Categories"
 msgstr "添加電視劇集"
 
-#: common/views_manage.py:720
+#: common/views_manage.py:738
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:723
+#: common/views_manage.py:741
 msgid "Guest Search Page Limit"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:743
 msgid "Visitors who are not logged in cannot open search result pages beyond this one. Lower it to keep crawlers out of deep pagination, which is expensive to serve."
 msgstr ""
 
-#: common/views_manage.py:751
+#: common/views_manage.py:769
 #, fuzzy
 #| msgid "Spotify Album"
 msgid "Spotify API Key"
 msgstr "Spotify專輯"
 
-#: common/views_manage.py:752
+#: common/views_manage.py:770
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:755
+#: common/views_manage.py:773
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:756
+#: common/views_manage.py:774
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:759
+#: common/views_manage.py:777
 #, fuzzy
 #| msgid "Google Books"
 msgid "Google Books API Key"
 msgstr "谷歌圖書"
 
-#: common/views_manage.py:760
+#: common/views_manage.py:778
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:763
+#: common/views_manage.py:781
 #, fuzzy
 #| msgid "Discogs"
 msgid "Discogs API Key"
 msgstr "Discogs"
 
-#: common/views_manage.py:765
+#: common/views_manage.py:783
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:769
+#: common/views_manage.py:787
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:770
+#: common/views_manage.py:788
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:773
+#: common/views_manage.py:791
 #, fuzzy
 #| msgid "client secret"
 msgid "IGDB Client Secret"
 msgstr "實例應用Client Secret"
 
-#: common/views_manage.py:776
+#: common/views_manage.py:794
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:778
+#: common/views_manage.py:796
 msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:783
+#: common/views_manage.py:801
 msgid "MyAnimeList Client ID"
 msgstr ""
 
-#: common/views_manage.py:785
+#: common/views_manage.py:803
 msgid "Client ID of an app registered at https://myanimelist.net/apiconfig. MyAnimeList is disabled when empty."
 msgstr ""
 
-#: common/views_manage.py:790 users/templates/users/steam_import.html:26
+#: common/views_manage.py:808 users/templates/users/steam_import.html:26
 #, fuzzy
 #| msgid "Steam Game"
 msgid "Steam API Key"
 msgstr "Steam遊戲"
 
-#: common/views_manage.py:792
+#: common/views_manage.py:810
 msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:797
+#: common/views_manage.py:815
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:798
+#: common/views_manage.py:816
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:801
+#: common/views_manage.py:819
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:804
+#: common/views_manage.py:822
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:807
+#: common/views_manage.py:825
 #, fuzzy
 #| msgid "Threads"
 msgid "Threads App ID"
 msgstr "Threads"
 
-#: common/views_manage.py:808
+#: common/views_manage.py:826
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:811
+#: common/views_manage.py:829
 #, fuzzy
 #| msgid "Threads.net"
 msgid "Threads App Secret"
 msgstr "Threads.net"
 
-#: common/views_manage.py:814
+#: common/views_manage.py:832
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:834
 msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:833
+#: common/views_manage.py:851
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:844
+#: common/views_manage.py:862
 #, fuzzy
 #| msgid "translator"
 msgid "Translation"
 msgstr "譯者"
 
-#: common/views_manage.py:849
+#: common/views_manage.py:867
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:853 social/templates/feed.html:27
+#: common/views_manage.py:871 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr "通知"
 
-#: common/views_manage.py:863
+#: common/views_manage.py:881
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:882
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:867
+#: common/views_manage.py:885
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:868
+#: common/views_manage.py:886
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:871
+#: common/views_manage.py:889
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:874
+#: common/views_manage.py:892
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:877
+#: common/views_manage.py:895
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:880
+#: common/views_manage.py:898
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:883
+#: common/views_manage.py:901
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:886
+#: common/views_manage.py:904
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:887
+#: common/views_manage.py:905
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:908
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:894
+#: common/views_manage.py:912
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:898
+#: common/views_manage.py:916
 #, fuzzy
 #| msgid "series"
 msgid "Retries"
 msgstr "叢書"
 
-#: common/views_manage.py:903
+#: common/views_manage.py:921
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:908
+#: common/views_manage.py:926
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:915
+#: common/views_manage.py:933
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:927
+#: common/views_manage.py:945
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:928
+#: common/views_manage.py:946
 #, fuzzy
 #| msgid "site domain name"
 msgid "One domain per line."
 msgstr "站點域名"
 
-#: common/views_manage.py:931
+#: common/views_manage.py:949
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:932
+#: common/views_manage.py:950
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:935
+#: common/views_manage.py:953
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:937
+#: common/views_manage.py:955
 msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:943
+#: common/views_manage.py:961
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:944
+#: common/views_manage.py:962
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:947
+#: common/views_manage.py:965
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:948
+#: common/views_manage.py:966
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:958
+#: common/views_manage.py:976
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:960
+#: common/views_manage.py:978
 msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:966
+#: common/views_manage.py:984
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:968
+#: common/views_manage.py:986
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:974
+#: common/views_manage.py:992
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:976
+#: common/views_manage.py:994
 msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:983
+#: common/views_manage.py:1000
+msgid "Webhook Timeout (milliseconds)"
+msgstr ""
+
+#: common/views_manage.py:1001
+msgid "Timeout for delivering webhook requests to applications."
+msgstr ""
+
+#: common/views_manage.py:1006
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:986
+#: common/views_manage.py:1009
 #, fuzzy
 #| msgid "optional"
 msgid "Operational"
 msgstr "可選"
 
-#: common/views_manage.py:1002
+#: common/views_manage.py:1026
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:1004
+#: common/views_manage.py:1028
 msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1009
+#: common/views_manage.py:1033
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:1011
+#: common/views_manage.py:1035
 msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1016
+#: common/views_manage.py:1040
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:1018
+#: common/views_manage.py:1042
 msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1023
+#: common/views_manage.py:1047
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:1025
+#: common/views_manage.py:1049
 msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1030
+#: common/views_manage.py:1054
 #, fuzzy
 #| msgid "Podcast"
 msgid "Podcast Genres"
 msgstr "播客"
 
-#: common/views_manage.py:1032
+#: common/views_manage.py:1056
 msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1037
+#: common/views_manage.py:1061
 #, fuzzy
 #| msgid "Performance"
 msgid "Performance Genres"
 msgstr "演出"
 
-#: common/views_manage.py:1039
+#: common/views_manage.py:1063
 msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:1045
+#: common/views_manage.py:1069
 msgid "Genres by Category"
 msgstr ""
 
-#: common/views_manage.py:1069
+#: common/views_manage.py:1093
 msgid "Site"
 msgstr ""
 
-#: common/views_manage.py:1079
+#: common/views_manage.py:1103
 #, fuzzy
 #| msgid "Database"
 msgid "Database and Services"
 msgstr "數據庫"
 
-#: common/views_manage.py:1089
+#: common/views_manage.py:1113
 msgid "Media and Files"
 msgstr ""
 
-#: common/views_manage.py:1098
+#: common/views_manage.py:1122
 msgid "Monitoring"
 msgstr ""
 
-#: common/views_manage.py:1102
+#: common/views_manage.py:1126
 msgid "Security"
 msgstr ""
 
-#: common/views_manage.py:1111
+#: common/views_manage.py:1135
 msgid "Other Environment Variables"
 msgstr ""
 
-#: common/views_manage.py:1113
+#: common/views_manage.py:1137
 msgid "Present in the environment of this process but not read by NeoDB settings. They are used by Docker Compose or by Takahe."
 msgstr ""
 
@@ -5399,7 +5429,8 @@ msgstr "保存時將行首空格替換爲全角"
 #: users/templates/users/data.html:60 users/templates/users/data.html:113
 #: users/templates/users/data.html:170 users/templates/users/data.html:221
 #: users/templates/users/data.html:284 users/templates/users/data.html:346
-#: users/templates/users/data.html:525 users/templates/users/rym_import.html:81
+#: users/templates/users/data.html:525 users/templates/users/data.html:578
+#: users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
 msgid "Visibility"
@@ -5439,8 +5470,8 @@ msgstr "僅創建者"
 msgid "owner and their local mutuals"
 msgstr "創建者和他們的互相關注"
 
-#: journal/forms.py:169 journal/templates/collection.html:193
-#: journal/templates/collection.html:202
+#: journal/forms.py:169 journal/templates/collection.html:194
+#: journal/templates/collection.html:203
 msgid "Collaborative editing"
 msgstr "協作編輯"
 
@@ -5493,7 +5524,7 @@ msgstr ""
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:215 journal/views/article.py:218
+#: journal/models/article.py:224 journal/views/article.py:218
 msgid "(may contain sensitive content)"
 msgstr ""
 
@@ -5505,67 +5536,68 @@ msgstr ""
 msgid "note"
 msgstr "備註"
 
-#: journal/models/collection.py:115
+#: journal/models/collection.py:116
 #, fuzzy
 #| msgid "shared {username}'s collection"
 msgid "search query for dynamic collection"
 msgstr "分享 {username} 的收藏單"
 
-#: journal/models/collection.py:566 journal/templatetags/collection.py:35
+#: journal/models/collection.py:575 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] "%(count)d 本書"
 
-#: journal/models/collection.py:571 journal/templatetags/collection.py:43
+#: journal/models/collection.py:580 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] "%(count)d 部電影"
 
-#: journal/models/collection.py:576 journal/templatetags/collection.py:51
+#: journal/models/collection.py:585 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] "%(count)d 部電視劇"
 
-#: journal/models/collection.py:581 journal/templatetags/collection.py:59
+#: journal/models/collection.py:590 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] "%(count)d 張專輯"
 
-#: journal/models/collection.py:586 journal/templatetags/collection.py:67
+#: journal/models/collection.py:595 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] "%(count)d 個遊戲"
 
-#: journal/models/collection.py:591 journal/templatetags/collection.py:75
+#: journal/models/collection.py:600 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] "%(count)d 個播客"
 
-#: journal/models/collection.py:597 journal/templatetags/collection.py:83
+#: journal/models/collection.py:606 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] "%(count)d 場演出"
 
-#: journal/models/collection.py:605 journal/templatetags/collection.py:91
+#: journal/models/collection.py:614 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] "%(count)d 個條目"
 
-#: journal/models/common.py:56 journal/templates/action_open_post.html:15
+#: journal/models/common.py:59 journal/templates/action_open_post.html:15
 #: journal/templates/collection_share.html:35 journal/templates/mark.html:88
 #: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
 #: journal/templates/wrapped_share.html:43 users/templates/users/data.html:69
 #: users/templates/users/data.html:122 users/templates/users/data.html:179
 #: users/templates/users/data.html:230 users/templates/users/data.html:292
 #: users/templates/users/data.html:355 users/templates/users/data.html:534
+#: users/templates/users/data.html:587
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -5573,13 +5605,14 @@ msgstr[0] "%(count)d 個條目"
 msgid "Public"
 msgstr "公開"
 
-#: journal/models/common.py:57 journal/templates/action_open_post.html:9
+#: journal/models/common.py:60 journal/templates/action_open_post.html:9
 #: journal/templates/collection_share.html:46 journal/templates/mark.html:95
 #: journal/templates/post_compose.html:65
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:77
 #: users/templates/users/data.html:130 users/templates/users/data.html:187
 #: users/templates/users/data.html:238 users/templates/users/data.html:300
 #: users/templates/users/data.html:363 users/templates/users/data.html:542
+#: users/templates/users/data.html:595
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -5587,12 +5620,13 @@ msgstr "公開"
 msgid "Followers Only"
 msgstr "僅關注者"
 
-#: journal/models/common.py:58 journal/templates/collection_share.html:57
+#: journal/models/common.py:61 journal/templates/collection_share.html:57
 #: journal/templates/mark.html:102 journal/templates/post_compose.html:72
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:85
 #: users/templates/users/data.html:138 users/templates/users/data.html:195
 #: users/templates/users/data.html:246 users/templates/users/data.html:308
 #: users/templates/users/data.html:371 users/templates/users/data.html:550
+#: users/templates/users/data.html:603
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -5600,31 +5634,31 @@ msgstr "僅關注者"
 msgid "Mentioned Only"
 msgstr "自己和提到的人"
 
-#: journal/models/common.py:806
+#: journal/models/common.py:851
 msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr "帖文未能發佈到Bluesky，請重新用Bluesky驗證登入。"
 
-#: journal/models/common.py:1003
+#: journal/models/common.py:1048
 msgid "A recent post was not posted to Threads."
 msgstr "帖文未能發佈到Threads。"
 
-#: journal/models/common.py:1036
+#: journal/models/common.py:1081
 #, fuzzy
 #| msgid "A recent post was not posted to Mastodon."
 msgid "A recent post was not boosted on Mastodon."
 msgstr "帖文未能發佈到聯邦實例。"
 
-#: journal/models/common.py:1046
+#: journal/models/common.py:1091
 #, fuzzy
 #| msgid "Item no longer exists"
 msgid "Original post no longer exists."
 msgstr "條目已不存在"
 
-#: journal/models/common.py:1060
+#: journal/models/common.py:1105
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr "帖文未能發佈到聯邦實例，請重新驗證登入。"
 
-#: journal/models/common.py:1069
+#: journal/models/common.py:1114
 msgid "A recent post was not posted to Mastodon."
 msgstr "帖文未能發佈到聯邦實例。"
 
@@ -5642,85 +5676,85 @@ msgstr "失敗"
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:475
+#: journal/models/mark.py:477
 msgid "Please mark the item before setting progress."
 msgstr ""
 
-#: journal/models/mark.py:479
+#: journal/models/mark.py:481
 msgid "Progress must be 500 characters or fewer."
 msgstr ""
 
-#: journal/models/mark.py:486
+#: journal/models/mark.py:488
 #, fuzzy
 #| msgid "Invalid parameter"
 msgid "Invalid progress type."
 msgstr "無效參數"
 
-#: journal/models/mark.py:488
+#: journal/models/mark.py:490
 #, fuzzy
 #| msgid "Invalid response from Fediverse instance."
 msgid "Invalid progress type for this item."
 msgstr "聯邦實例返回信息無效"
 
-#: journal/models/note.py:47 users/templates/users/rym_import.html:73
+#: journal/models/note.py:48 users/templates/users/rym_import.html:73
 #: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr "頁碼"
 
-#: journal/models/note.py:48
+#: journal/models/note.py:49
 msgid "Chapter"
 msgstr "章節"
 
-#: journal/models/note.py:51
+#: journal/models/note.py:52
 msgid "Part"
 msgstr "分部"
 
-#: journal/models/note.py:52
+#: journal/models/note.py:53
 msgid "Episode"
 msgstr "單集"
 
-#: journal/models/note.py:53
+#: journal/models/note.py:54
 msgid "Track"
 msgstr "曲目"
 
-#: journal/models/note.py:54
+#: journal/models/note.py:55
 msgid "Cycle"
 msgstr "周目"
 
-#: journal/models/note.py:55
+#: journal/models/note.py:56
 msgid "Timestamp"
 msgstr "時間戳"
 
-#: journal/models/note.py:56
+#: journal/models/note.py:57
 msgid "Percentage"
 msgstr "百分比"
 
-#: journal/models/note.py:77
+#: journal/models/note.py:78
 #, python-brace-format
 msgid "Page {value}"
 msgstr "第{value}頁"
 
-#: journal/models/note.py:78
+#: journal/models/note.py:79
 #, python-brace-format
 msgid "Chapter {value}"
 msgstr "第{value}章"
 
-#: journal/models/note.py:81
+#: journal/models/note.py:82
 #, python-brace-format
 msgid "Part {value}"
 msgstr "第{value}部"
 
-#: journal/models/note.py:82
+#: journal/models/note.py:83
 #, python-brace-format
 msgid "Episode {value}"
 msgstr "第{value}集"
 
-#: journal/models/note.py:83
+#: journal/models/note.py:84
 #, python-brace-format
 msgid "Track {value}"
 msgstr "第{value}首"
 
-#: journal/models/note.py:84
+#: journal/models/note.py:85
 #, python-brace-format
 msgid "Cycle {value}"
 msgstr "{value}周目"
@@ -5730,13 +5764,13 @@ msgstr "{value}周目"
 msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr "關於 {item_title}，可能包含劇透或敏感內容"
 
-#: journal/models/review.py:79
+#: journal/models/review.py:80
 #, fuzzy, python-brace-format
 #| msgid "a review of {item_title}"
 msgid "a review of {title}"
 msgstr "關於 {item_title} 的評論"
 
-#: journal/models/review.py:81
+#: journal/models/review.py:82
 #, fuzzy
 #| msgid "Item contains sub-items."
 msgid "(may contain spoilers)"
@@ -6168,7 +6202,7 @@ msgstr "正在關注的用戶"
 msgid "started following {item}"
 msgstr "在玩 {item}"
 
-#: journal/models/shelf.py:923
+#: journal/models/shelf.py:925
 msgid "removed mark"
 msgstr "移除標記"
 
@@ -6203,7 +6237,7 @@ msgstr "從收藏單中移除"
 msgid "Update note"
 msgstr "修改備註"
 
-#: journal/templates/_list_item.html:71 journal/templates/article.html:123
+#: journal/templates/_list_item.html:71 journal/templates/article.html:121
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
@@ -6372,7 +6406,7 @@ msgid "View post"
 msgstr ""
 
 #: journal/templates/action_quote_post.html:3
-#: journal/templates/article.html:190 journal/templates/collection.html:174
+#: journal/templates/article.html:188 journal/templates/collection.html:175
 msgid "Quote"
 msgstr ""
 
@@ -6381,7 +6415,7 @@ msgid "reply"
 msgstr "回應"
 
 #: journal/templates/action_reply_post.html:3
-#: journal/templates/article.html:181 journal/templates/collection.html:165
+#: journal/templates/article.html:179 journal/templates/collection.html:166
 msgid "Reply"
 msgstr "回應"
 
@@ -6400,23 +6434,23 @@ msgstr "添加到收藏單"
 msgid "Create a new collection"
 msgstr "創建新收藏單"
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:76
+#: journal/templates/article.html:102 social/templates/_event_post.html:76
 #, fuzzy
 #| msgid "wrote a review of {item}"
 msgid "wrote a review"
 msgstr "寫了關於 {item} 的評論"
 
-#: journal/templates/article.html:106 social/templates/_event_post.html:78
+#: journal/templates/article.html:104 social/templates/_event_post.html:78
 #, fuzzy
 #| msgid "wrote a note"
 msgid "wrote an article"
 msgstr "寫了筆記"
 
-#: journal/templates/article.html:136
+#: journal/templates/article.html:134
 msgid "This article may contain sensitive content. Click to reveal."
 msgstr ""
 
-#: journal/templates/article.html:155
+#: journal/templates/article.html:153
 msgid "The author has set it to be viewable only by logged-in users."
 msgstr "作者已設定僅限已登入用戶查看"
 
@@ -6481,20 +6515,20 @@ msgstr "十一月"
 msgid "DEC"
 msgstr "十二月"
 
-#: journal/templates/collection.html:71
+#: journal/templates/collection.html:72
 #: journal/templates/collection_share.html:12
 #: journal/templates/collection_share.html:66
 #: journal/templates/wrapped_share.html:59
 msgid "Share"
 msgstr "分享"
 
-#: journal/templates/collection.html:86
+#: journal/templates/collection.html:87
 #, fuzzy
 #| msgid "created collection"
 msgid "created a collection"
 msgstr "創建了收藏單"
 
-#: journal/templates/collection.html:181
+#: journal/templates/collection.html:182
 msgid "Query"
 msgstr ""
 
@@ -6851,14 +6885,14 @@ msgid "Liked Collections"
 msgstr "喜歡的收藏單"
 
 #: journal/templates/user_follow_list.html:23 journal/views/profile.py:507
-#: users/templates/users/account.html:443
+#: users/templates/users/account.html:455
 #, fuzzy
 #| msgid "following you"
 msgid "Following"
 msgstr "關注了你"
 
 #: journal/templates/user_follow_list.html:28 journal/views/profile.py:511
-#: users/templates/users/account.html:452
+#: users/templates/users/account.html:464
 #, fuzzy
 #| msgid "Followers Only"
 msgid "Followers"
@@ -7199,8 +7233,8 @@ msgstr "Bluesky 登入名"
 #: mastodon/views/mastodon.py:70 mastodon/views/mastodon.py:77
 #: mastodon/views/mastodon.py:87 mastodon/views/mastodon.py:94
 #: mastodon/views/threads.py:57 mastodon/views/threads.py:65
-#: mastodon/views/threads.py:71 users/views/account.py:256
-#: users/views/account.py:375
+#: mastodon/views/threads.py:71 users/views/account.py:257
+#: users/views/account.py:376
 msgid "Authentication failed"
 msgstr "認證失敗"
 
@@ -7248,7 +7282,7 @@ msgstr "Bluesky返回了無效的帳號數據。"
 msgid "Invalid user."
 msgstr "無效用戶。"
 
-#: mastodon/views/common.py:52 users/views/account.py:416
+#: mastodon/views/common.py:52 users/views/account.py:417
 msgid "Registration failed"
 msgstr "註冊失敗"
 
@@ -8232,144 +8266,159 @@ msgstr "發行年份"
 msgid "Scopes"
 msgstr ""
 
-#: users/templates/users/account.html:398
+#: users/templates/users/account.html:386
+msgid "Webhook"
+msgstr ""
+
+#: users/templates/users/account.html:400
+msgid "disabled"
+msgstr ""
+
+#: users/templates/users/account.html:402
+#, fuzzy
+#| msgid "Activities"
+msgid "active"
+msgstr "動態"
+
+#: users/templates/users/account.html:410
 msgid "Revoke access for this application?"
 msgstr ""
 
-#: users/templates/users/account.html:401
+#: users/templates/users/account.html:413
 msgid "Revoke"
 msgstr ""
 
-#: users/templates/users/account.html:409
+#: users/templates/users/account.html:421
 #, fuzzy
 #| msgid "View authorized applications"
 msgid "No authorized applications."
 msgstr "查看已授權的應用程序"
 
-#: users/templates/users/account.html:412
+#: users/templates/users/account.html:424
 #: users/templates/users/authorized_app_create.html:9
 #: users/templates/users/authorized_app_create.html:19
 msgid "Create Personal Token"
 msgstr ""
 
-#: users/templates/users/account.html:418
+#: users/templates/users/account.html:430
 msgid "Import/Export Social Graph"
 msgstr ""
 
-#: users/templates/users/account.html:419
+#: users/templates/users/account.html:431
 msgid "Upload a CSV file exported from Mastodon or compatible services."
 msgstr ""
 
-#: users/templates/users/account.html:425
+#: users/templates/users/account.html:437
 #, fuzzy
 #| msgid "Import"
 msgid "Import type"
 msgstr "匯入"
 
-#: users/templates/users/account.html:427
+#: users/templates/users/account.html:439
 #, fuzzy
 #| msgid "following you"
 msgid "Following list"
 msgstr "關注了你"
 
-#: users/templates/users/account.html:428
+#: users/templates/users/account.html:440
 #, fuzzy
 #| msgid "to listen"
 msgid "Block list"
 msgstr "想聽"
 
-#: users/templates/users/account.html:429
+#: users/templates/users/account.html:441
 #, fuzzy
 #| msgid "to listen"
 msgid "Mute list"
 msgstr "想聽"
 
-#: users/templates/users/account.html:433
+#: users/templates/users/account.html:445
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:436 users/templates/users/data.html:89
+#: users/templates/users/account.html:448 users/templates/users/data.html:89
 #: users/templates/users/data.html:141 users/templates/users/data.html:198
 #: users/templates/users/data.html:249 users/templates/users/data.html:313
 #: users/templates/users/data.html:376 users/templates/users/data.html:553
+#: users/templates/users/data.html:606 users/templates/users/data.html:631
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr "匯入"
 
-#: users/templates/users/account.html:447
-#: users/templates/users/account.html:456
-#: users/templates/users/account.html:465
-#: users/templates/users/account.html:474
+#: users/templates/users/account.html:459
+#: users/templates/users/account.html:468
+#: users/templates/users/account.html:477
+#: users/templates/users/account.html:486
 #, fuzzy
 #| msgid "Download"
 msgid "Download CSV"
 msgstr "下載"
 
-#: users/templates/users/account.html:461
+#: users/templates/users/account.html:473
 #, fuzzy
 #| msgid "blocked"
 msgid "Blocks"
 msgstr "已屏蔽"
 
-#: users/templates/users/account.html:470
+#: users/templates/users/account.html:482
 msgid "Mutes"
 msgstr ""
 
-#: users/templates/users/account.html:484
+#: users/templates/users/account.html:496
 msgid "Migrate Account"
 msgstr "遷移帳號"
 
-#: users/templates/users/account.html:488
+#: users/templates/users/account.html:500
 msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
 msgstr "建議關聯電子郵件後再從其他實例遷入。"
 
-#: users/templates/users/account.html:491
+#: users/templates/users/account.html:503
 #, fuzzy
 #| msgid "Migrate from anther instance to here"
 msgid "Migrate another account here"
 msgstr "從其他實例遷移到本站"
 
-#: users/templates/users/account.html:494
+#: users/templates/users/account.html:506
 #, fuzzy
 #| msgid "Migrate to another instance"
 msgid "Migrate to another account"
 msgstr "從本站遷移到其他實例"
 
-#: users/templates/users/account.html:501
+#: users/templates/users/account.html:513
 #, fuzzy
 #| msgid "Migrate Account"
 msgid "Delete Account"
 msgstr "遷移帳號"
 
-#: users/templates/users/account.html:504
+#: users/templates/users/account.html:516
 msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
 msgstr "帳號數據一旦刪除後將無法恢復，確定繼續嗎？"
 
-#: users/templates/users/account.html:507
+#: users/templates/users/account.html:519
 msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
 msgstr "輸入完整的登入用 <code>用戶名@實例名</code> 或 <code>電子郵件地址</code> 以確認刪除"
 
-#: users/templates/users/account.html:517
+#: users/templates/users/account.html:529
 msgid "Once deleted, account data cannot be recovered."
 msgstr "帳號數據一旦刪除後將無法恢復"
 
-#: users/templates/users/account.html:520
+#: users/templates/users/account.html:532
 #, fuzzy
 #| msgid "Importing in progress, can't delete now."
 msgid "Task in progress, can't delete now."
 msgstr "暫時無法刪除，因爲有匯入任務正在進行"
 
-#: users/templates/users/account.html:524
+#: users/templates/users/account.html:536
 msgid "Permanently Delete"
 msgstr "永久刪除"
 
-#: users/templates/users/account.html:565
+#: users/templates/users/account.html:577
 #, fuzzy
 #| msgid "Delete this tag"
 msgid "Delete this passkey?"
 msgstr "刪除這個標籤"
 
-#: users/templates/users/account.html:585
+#: users/templates/users/account.html:597
 msgid "Rename passkey:"
 msgstr ""
 
@@ -8393,12 +8442,10 @@ msgstr ""
 
 #: users/templates/users/authorized_app_create.html:48
 #: users/templates/users/authorized_app_created.html:39
-#: users/templates/users/migrate_in.html:70
-#: users/templates/users/migrate_out.html:67
 #, fuzzy
-#| msgid "Preferences"
-msgid "Back to Preferences"
-msgstr "設定"
+#| msgid "Migrate Account"
+msgid "Back to Account"
+msgstr "遷移帳號"
 
 #: users/templates/users/authorized_app_created.html:9
 #: users/templates/users/authorized_app_created.html:19
@@ -8541,7 +8588,7 @@ msgstr "強制覆蓋：覆蓋已存在的標記和評論，匯入文件中未涉
 msgid "Another import is in progress, starting a new import may cause issues, sure to import?"
 msgstr "短期重複上傳可能有無法預期的效果，確定現在上傳匯入嗎？"
 
-#: users/templates/users/data.html:89 users/views/data.py:1130
+#: users/templates/users/data.html:89 users/views/data.py:1194
 msgid "Import in progress, please wait"
 msgstr "備份文件已上傳，請等待匯入完成或刷新頁面查看最新進度"
 
@@ -8714,7 +8761,41 @@ msgstr ""
 msgid "Only published posts use the visibility below. Drafts, pending, private and password-protected posts are always imported as mentioned-only, so nothing unpublished becomes public."
 msgstr ""
 
-#: users/templates/users/data.html:560
+#: users/templates/users/data.html:561
+msgid "Import Twitter / X Archive"
+msgstr ""
+
+#: users/templates/users/data.html:567
+msgid "On X, go to <b>Settings</b> - <b>Your account</b> - <b>Download an archive of your data</b>. Upload the <code>.zip</code> you receive, or only the <code>data/tweets.js</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:570
+msgid "Each tweet becomes a post with its original date, text, links and photos. Replies to your own tweets are kept as a thread. A retweet becomes a short post that links to the original tweet. Videos are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:573
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Tweets that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:615
+#, fuzzy
+#| msgid "Import Method"
+msgid "Import Mastodon Archive"
+msgstr "匯入方式"
+
+#: users/templates/users/data.html:621
+msgid "On your Mastodon server, go to <b>Preferences</b> - <b>Import and export</b> - <b>Request your archive</b>. Upload the <code>.zip</code> you receive, or only the <code>outbox.json</code> file inside it if the archive is larger than 100 MB (photos are then not imported)."
+msgstr ""
+
+#: users/templates/users/data.html:624
+msgid "Each post is imported with its original date, text, links, photos, content warning and visibility, so a followers-only post or a direct message stays that way. Replies to your own posts are kept as a thread. A boost becomes a short post that links to the original post. Videos, favourites and bookmarks are skipped."
+msgstr ""
+
+#: users/templates/users/data.html:627
+msgid "Imported posts are only visible on this site and are never sent to other servers or to followers. Posts that were imported before are skipped, so the same archive can be uploaded again."
+msgstr ""
+
+#: users/templates/users/data.html:639
 msgid "View Annual Summary"
 msgstr "查看年度小結"
 
@@ -8844,6 +8925,13 @@ msgstr "當前目標"
 #: users/templates/users/migrate_in.html:64
 msgid "No aliases configured."
 msgstr ""
+
+#: users/templates/users/migrate_in.html:70
+#: users/templates/users/migrate_out.html:67
+#, fuzzy
+#| msgid "Preferences"
+msgid "Back to Preferences"
+msgstr "設定"
 
 #: users/templates/users/migrate_out.html:9
 #: users/templates/users/migrate_out.html:43
@@ -9392,205 +9480,206 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:126
+#: users/views/account.py:127
 msgid "This username is already in use."
 msgstr "用戶名已被使用"
 
-#: users/views/account.py:137
+#: users/views/account.py:138
 msgid "This email address is already in use."
 msgstr "此電子郵件地址已被使用"
 
-#: users/views/account.py:257 users/views/account.py:376
+#: users/views/account.py:258 users/views/account.py:377
 msgid "Registration is for invitation only"
 msgstr "本站僅限邀請註冊"
 
-#: users/views/account.py:268 users/views/account.py:340
+#: users/views/account.py:269 users/views/account.py:341
 #, fuzzy
 #| msgid "Timestamp"
 msgid "Time is up"
 msgstr "時間戳"
 
-#: users/views/account.py:269 users/views/account.py:312
-#: users/views/account.py:341
+#: users/views/account.py:270 users/views/account.py:313
+#: users/views/account.py:342
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:315
+#: users/views/account.py:316
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:327
+#: users/views/account.py:328
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:328
+#: users/views/account.py:329
 #, fuzzy
 #| msgid "System busy, please try again in a minute."
 msgid "Please try again later."
 msgstr "系統繁忙，請稍等幾秒鐘再搜索。"
 
-#: users/views/account.py:417
+#: users/views/account.py:418
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:447
+#: users/views/account.py:448
 msgid "Valid username required"
 msgstr "請輸入有效的用戶名"
 
-#: users/views/account.py:518
+#: users/views/account.py:519
 msgid "Account is being deleted."
 msgstr "帳號刪除進行中。"
 
-#: users/views/account.py:521
+#: users/views/account.py:522
 msgid "Account mismatch."
 msgstr "帳號資訊不符合。"
 
-#: users/views/data.py:264 users/views/data.py:296
+#: users/views/data.py:276 users/views/data.py:308
 msgid "Export file not available."
 msgstr "匯出檔案不可用"
 
-#: users/views/data.py:290
+#: users/views/data.py:302
 msgid "Generating exports."
 msgstr "正在產生匯出檔案文件。"
 
-#: users/views/data.py:308
+#: users/views/data.py:320
 msgid "Export file expired. Please export again."
 msgstr "匯出文件已失效，請重新匯出"
 
-#: users/views/data.py:323 users/views/data.py:344 users/views/data.py:365
+#: users/views/data.py:335 users/views/data.py:356 users/views/data.py:377
 msgid "Recent export still in progress."
 msgstr "正在匯入"
 
-#: users/views/data.py:381 users/views/data.py:515 users/views/data.py:549
-#: users/views/data.py:774 users/views/data.py:991 users/views/data.py:1017
-#: users/views/data.py:1042 users/views/data.py:1067 users/views/data.py:1137
+#: users/views/data.py:393 users/views/data.py:419 users/views/data.py:447
+#: users/views/data.py:579 users/views/data.py:613 users/views/data.py:838
+#: users/views/data.py:1055 users/views/data.py:1081 users/views/data.py:1106
+#: users/views/data.py:1131 users/views/data.py:1201
 msgid "Invalid file."
 msgstr "無效檔案。"
 
-#: users/views/data.py:405
+#: users/views/data.py:469
 msgid "Sync in progress."
 msgstr "正在同步。"
 
-#: users/views/data.py:419
+#: users/views/data.py:483
 msgid "Settings saved."
 msgstr "設定已儲存"
 
-#: users/views/data.py:474
+#: users/views/data.py:538
 #, fuzzy
 #| msgid "Account is being deleted."
 msgid "Account no longer linked."
 msgstr "帳號刪除進行中。"
 
-#: users/views/data.py:477
+#: users/views/data.py:541
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:505
+#: users/views/data.py:569
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:585 users/views/data.py:810
+#: users/views/data.py:649 users/views/data.py:874
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:610 users/views/data.py:839
+#: users/views/data.py:674 users/views/data.py:903
 #, fuzzy
 #| msgid "Cancel"
 msgid "Cancelled."
 msgstr "取消"
 
-#: users/views/data.py:630
+#: users/views/data.py:694
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:638 users/views/data.py:748 users/views/data.py:869
-#: users/views/data.py:974
+#: users/views/data.py:702 users/views/data.py:812 users/views/data.py:933
+#: users/views/data.py:1038
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:734 users/views/data.py:960
+#: users/views/data.py:798 users/views/data.py:1024
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:744 users/views/data.py:970
+#: users/views/data.py:808 users/views/data.py:1034
 #, fuzzy
 #| msgid "Export file not available."
 msgid "No matched file available."
 msgstr "匯出檔案不可用"
 
-#: users/views/data.py:861
+#: users/views/data.py:925
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1226
+#: users/views/data.py:1290
 #, fuzzy
 #| msgid "Login required"
 msgid "Name is required."
 msgstr "登入後訪問"
 
-#: users/views/data.py:1248
+#: users/views/data.py:1314
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1264
+#: users/views/data.py:1330
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1269
+#: users/views/data.py:1335
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1279 users/views/data.py:1330
+#: users/views/data.py:1345 users/views/data.py:1396
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:1286
+#: users/views/data.py:1352
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:1291
+#: users/views/data.py:1357
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:1317
+#: users/views/data.py:1383
 #, fuzzy
 #| msgid "Registration failed"
 msgid "Migration cancelled."
 msgstr "註冊失敗"
 
-#: users/views/data.py:1322
+#: users/views/data.py:1388
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:1335
+#: users/views/data.py:1401
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:1346
+#: users/views/data.py:1412
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:1352
+#: users/views/data.py:1418
 #, fuzzy, python-brace-format
 #| msgid "Continue login as {handle}."
 msgid "Start moving to {handle}."
 msgstr "繼續以 {handle} 登入。"
 
-#: users/views/data.py:1410
+#: users/views/data.py:1476
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1426
+#: users/views/data.py:1492
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1430
+#: users/views/data.py:1496
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1440
+#: users/views/data.py:1506
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""


### PR DESCRIPTION
Weblate msgmerge sync: brings the 14 non-zh_Hans locales up to the current POT (`neodb/locale/django.pot`, 2026-09-07), which main regenerated in 99d7164.

No existing translation is touched. Verified with polib keyed on `(msgctxt, msgid, msgid_plural)`, ignoring obsolete entries:

- **0 regressions** against main: no entry that was translated and non-fuzzy is dropped, altered, or turned fuzzy.
- Each locale gains exactly the same **19 new msgids**, 1981 -> 2000, matching the 2000 non-obsolete entries in the POT.
- msgmerge fuzzy-matched some of those new msgids (37 entries across all 14 locales, e.g. 8 in pt_BR, 0 in eu/fa/lmo/ru). All fuzzy growth is confined to the new keys, and `msgfmt` excludes fuzzy entries, so nothing ships to users until a translator confirms them.
- `msgfmt -c` passes on all 14 files.

The rest of the diff is `POT-Creation-Date` and `#:` source line numbers.

`zh_Hans` and `django.pot` are untouched here; main already carries them.

Please land this with "Create a merge commit". A squash or rebase merge leaves the Weblate commit out of the history and Weblate conflicts again on its next rebase.
