### PR TITLE
fix(journal): stop collection share crashing for users without a Fediverse account

### DIFF
--- a/neodb/journal/templates/collection.html
+++ b/neodb/journal/templates/collection.html
@@ -63,7 +63,7 @@
                 {% endif %}
                 {% include "action_like_post.html" with post=collection.latest_post %}
                 {% include "action_boost_post.html" with post=collection.latest_post %}
-                {% if request.user.is_authenticated and request.user.mastodon %}
+                {% if request.user.is_authenticated %}
                   <span>
                     <a href="#"
                        hx-get="{% url 'journal:collection_share' collection.uuid %}"

--- a/neodb/journal/templates/collection.html
+++ b/neodb/journal/templates/collection.html
@@ -63,7 +63,7 @@
                 {% endif %}
                 {% include "action_like_post.html" with post=collection.latest_post %}
                 {% include "action_boost_post.html" with post=collection.latest_post %}
-                {% if request.user.is_authenticated %}
+                {% if request.user.is_authenticated and request.user.mastodon %}
                   <span>
                     <a href="#"
                        hx-get="{% url 'journal:collection_share' collection.uuid %}"

--- a/neodb/journal/views/collection.py
+++ b/neodb/journal/views/collection.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.contrib.auth.decorators import login_required
-from django.core.exceptions import BadRequest, PermissionDenied
+from django.core.exceptions import BadRequest, PermissionDenied, RequestAborted
 from django.core.signing import b62_encode
 from django.http import Http404, HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -373,6 +373,16 @@ def collection_share(request: AuthedHttpRequest, collection_uuid):
     if request.method == "GET":
         return render(request, "collection_share.html", {"collection": collection})
     else:
+        if not user.mastodon:
+            return render(
+                request,
+                "common/error.html",
+                {
+                    "msg": _(
+                        "Link a Fediverse account in account settings to share this."
+                    ),
+                },
+            )
         comment = request.POST.get("comment", "")
         # boost if possible, otherwise quote
         if (
@@ -380,8 +390,7 @@ def collection_share(request: AuthedHttpRequest, collection_uuid):
             and user.preference.mastodon_repost_mode == 0
             and collection.latest_post
         ):
-            if user.mastodon:
-                user.mastodon.boost_later(collection.latest_post.url)
+            user.mastodon.boost_later(collection.latest_post.url)
         else:
             visibility = VisibilityType(int_(request.POST.get("visibility")))
             link = (
@@ -389,8 +398,18 @@ def collection_share(request: AuthedHttpRequest, collection_uuid):
                 if collection.latest_post
                 else collection.absolute_url
             ) or ""
-            if not share_collection(collection, comment, user, visibility, link):
+            try:
+                share_collection(collection, comment, user, visibility, link)
+            except PermissionDenied:
+                logger.warning(f"post to mastodon error 401 {user}")
                 return render_relogin(request)
+            except Exception as e:
+                logger.warning(f"post to mastodon error {e} {user}")
+                return render(
+                    request,
+                    "common/error.html",
+                    {"msg": _("Unable to crosspost to Fediverse instance.")},
+                )
         referer = get_safe_referer_url(request)
         return HttpResponseRedirect(referer)
 
@@ -401,9 +420,14 @@ def share_collection(
     user: User,
     visibility: VisibilityType,
     link: str,
-):
-    if not user or not user.mastodon:
-        return
+) -> None:
+    """Post the collection to the user's Mastodon account.
+
+    Raises PermissionDenied when the instance rejects the token, and
+    RequestAborted on any other failure.
+    """
+    if not user.mastodon:
+        raise RequestAborted()
     tags = (
         "\n"
         + user.preference.mastodon_append_tag.replace("[category]", _("collection"))
@@ -424,11 +448,7 @@ def share_collection(
         )
     )
     content = f"{user_str}:{collection.title}\n{link}\n{comment}{tags}"
-    try:
-        user.mastodon.post(content, visibility)
-        return True
-    except Exception:
-        return False
+    user.mastodon.post(content, visibility)
 
 
 @login_required

--- a/neodb/journal/views/collection.py
+++ b/neodb/journal/views/collection.py
@@ -429,7 +429,7 @@ def _collection_share_text(
             else " @" + owner.handle + " "
         )
         user_str = _("shared {username}'s collection").format(username=owner_str)
-    return f"{user_str}:{title}\n{link}\n{comment}".rstrip()
+    return "\n".join(p for p in (f"{user_str}:{title}", link, comment) if p)
 
 
 def share_collection_to_mastodon(
@@ -453,7 +453,9 @@ def share_collection_to_mastodon(
     user.mastodon.post(content + tags, visibility)
 
 
-def share_collection_to_bluesky(collection: Collection, comment: str, user: User):
+def share_collection_to_bluesky(
+    collection: Collection, comment: str, user: User
+) -> None:
     """Public-only. The title becomes a link and the collection is attached
     as an external card, so the URL is left out of the text."""
     if not user.bluesky:

--- a/neodb/journal/views/collection.py
+++ b/neodb/journal/views/collection.py
@@ -11,6 +11,7 @@ from django.views.decorators.http import require_http_methods
 
 from catalog.models import Item, ItemCategory, item_categories
 from common.models import int_
+from common.models.misc import MISSING_COVER
 from common.sentry import record_activity
 from common.utils import (
     AuthedHttpRequest,
@@ -19,7 +20,9 @@ from common.utils import (
     get_uuid_or_404,
 )
 from common.validators import get_safe_referer_url
+from mastodon.models.bluesky import EmbedObj
 from takahe.auth import _SigError, verify_http_signature
+from takahe.utils import Takahe
 from users.models import User
 
 from ..forms import *
@@ -34,6 +37,7 @@ from .common import (
     require_piece_handle,
     target_identity_required,
 )
+from .post import _allowed_quote_visibilities
 
 logger = logging.getLogger(__name__)
 
@@ -372,34 +376,19 @@ def collection_share(request: AuthedHttpRequest, collection_uuid):
         raise PermissionDenied(_("Insufficient permission"))
     if request.method == "GET":
         return render(request, "collection_share.html", {"collection": collection})
-    else:
-        if not user.mastodon:
-            return render(
-                request,
-                "common/error.html",
-                {
-                    "msg": _(
-                        "Link a Fediverse account in account settings to share this."
-                    ),
-                },
-            )
-        comment = request.POST.get("comment", "")
+    comment = request.POST.get("comment", "").strip()
+    visibility = VisibilityType(int_(request.POST.get("visibility")))
+    post = collection.latest_post
+    link = (post.url if post else collection.absolute_url) or ""
+    if user.mastodon:
         # boost if possible, otherwise quote
-        if (
-            not comment
-            and user.preference.mastodon_repost_mode == 0
-            and collection.latest_post
-        ):
-            user.mastodon.boost_later(collection.latest_post.url)
+        if not comment and user.preference.mastodon_repost_mode == 0 and post:
+            user.mastodon.boost_later(post.url)
         else:
-            visibility = VisibilityType(int_(request.POST.get("visibility")))
-            link = (
-                collection.latest_post.url
-                if collection.latest_post
-                else collection.absolute_url
-            ) or ""
             try:
-                share_collection(collection, comment, user, visibility, link)
+                share_collection_to_mastodon(
+                    collection, comment, user, visibility, link
+                )
             except PermissionDenied:
                 logger.warning(f"post to mastodon error 401 {user}")
                 return render_relogin(request)
@@ -410,22 +399,48 @@ def collection_share(request: AuthedHttpRequest, collection_uuid):
                     "common/error.html",
                     {"msg": _("Unable to crosspost to Fediverse instance.")},
                 )
-        referer = get_safe_referer_url(request)
-        return HttpResponseRedirect(referer)
+    elif user.bluesky and visibility == VisibilityType.Public:
+        # Bluesky has no visibility; a non-public share stays on NeoDB
+        try:
+            share_collection_to_bluesky(collection, comment, user)
+        except Exception as e:
+            logger.warning(f"post to bluesky error {e} {user}")
+            return render(
+                request,
+                "common/error.html",
+                {"msg": _("Unable to share to Bluesky.")},
+            )
+    else:
+        share_collection_locally(collection, comment, user, visibility, link)
+    referer = get_safe_referer_url(request)
+    return HttpResponseRedirect(referer)
 
 
-def share_collection(
+def _collection_share_text(
+    collection: Collection, user: User, title: str, link: str, comment: str
+) -> str:
+    if user == collection.owner.user:
+        user_str = _("shared my collection")
+    else:
+        owner = collection.owner
+        owner_str = (
+            " @" + owner.user.mastodon.handle + " "
+            if user.mastodon and owner.user and owner.user.mastodon
+            else " @" + owner.handle + " "
+        )
+        user_str = _("shared {username}'s collection").format(username=owner_str)
+    return f"{user_str}:{title}\n{link}\n{comment}".rstrip()
+
+
+def share_collection_to_mastodon(
     collection: Collection,
     comment: str,
     user: User,
     visibility: VisibilityType,
     link: str,
 ) -> None:
-    """Post the collection to the user's Mastodon account.
-
-    Raises PermissionDenied when the instance rejects the token, and
-    RequestAborted on any other failure.
-    """
+    """Raises PermissionDenied when the instance rejects the token, and
+    RequestAborted on any other failure."""
     if not user.mastodon:
         raise RequestAborted()
     tags = (
@@ -434,21 +449,55 @@ def share_collection(
         if user.preference.mastodon_append_tag
         else ""
     )
-    user_str = (
-        _("shared my collection")
-        if user == collection.owner.user
-        else (
-            _("shared {username}'s collection").format(
-                username=(
-                    " @" + collection.owner.user.mastodon.handle + " "
-                    if collection.owner.user.mastodon
-                    else " " + collection.owner.username + " "
-                )
-            )
-        )
+    content = _collection_share_text(collection, user, collection.title, link, comment)
+    user.mastodon.post(content + tags, visibility)
+
+
+def share_collection_to_bluesky(collection: Collection, comment: str, user: User):
+    """Public-only. The title becomes a link and the collection is attached
+    as an external card, so the URL is left out of the text."""
+    if not user.bluesky:
+        raise RequestAborted()
+    has_cover = bool(collection.cover) and str(collection.cover) != MISSING_COVER
+    embed = EmbedObj(
+        collection.title,
+        collection.brief,
+        collection.absolute_url,
+        image=collection.cover.read() if has_cover else None,
     )
-    content = f"{user_str}:{collection.title}\n{link}\n{comment}{tags}"
-    user.mastodon.post(content, visibility)
+    content = _collection_share_text(collection, user, "##obj##", "", comment)
+    user.bluesky.post(content, obj=embed)
+
+
+def share_collection_locally(
+    collection: Collection,
+    comment: str,
+    user: User,
+    visibility: VisibilityType,
+    link: str,
+) -> None:
+    """Share from the user's own NeoDB identity: boost the collection's post
+    when there is nothing to add, otherwise quote it (or post a plain link when
+    the collection has no post)."""
+    post = collection.latest_post
+    v = Takahe.visibility_n2t(visibility, user.preference.post_public_mode)
+    boostable = post and post.visibility in (
+        Takahe.Visibilities.public,
+        Takahe.Visibilities.unlisted,
+        Takahe.Visibilities.local_only,
+    )
+    if post and boostable and not comment:
+        # not Takahe.boost_post: that flips, so a second share would undo it
+        Takahe.interact_post(post.pk, user.identity.pk, "boost")
+        return
+    quote_url = None
+    if post:
+        allowed = _allowed_quote_visibilities(post.visibility)
+        if v not in allowed:
+            v = Takahe.Visibilities(allowed[0])
+        quote_url = post.object_uri
+    content = _collection_share_text(collection, user, collection.title, link, comment)
+    Takahe.post(user.identity.pk, content, v, quote_url=quote_url)
 
 
 @login_required
@@ -657,7 +706,6 @@ def collection_edit(request: AuthedHttpRequest, collection_uuid=None):
 @target_identity_required
 def user_collection_list(request: AuthedHttpRequest, user_name):
     from journal.models.common import prefetch_latest_posts
-    from takahe.utils import Takahe
 
     target = request.target_identity
     collections = list(
@@ -683,7 +731,6 @@ def user_collection_list(request: AuthedHttpRequest, user_name):
 @target_identity_required
 def user_liked_collection_list(request: AuthedHttpRequest, user_name):
     from journal.models.common import prefetch_latest_posts
-    from takahe.utils import Takahe
 
     target = request.target_identity
     collections = Collection.objects.filter(

--- a/neodb/journal/views/common.py
+++ b/neodb/journal/views/common.py
@@ -170,8 +170,12 @@ def conditional_get_for_anonymous(get_timestamp):
     return decorator
 
 
-def render_relogin(request):
-    login_url = reverse("mastodon:login") + "?domain=" + request.user.mastodon.domain
+def render_relogin(request: AuthedHttpRequest) -> HttpResponse:
+    msg = _("Data saved but unable to crosspost to Fediverse instance.")
+    mastodon = request.user.mastodon
+    if not mastodon:
+        return render(request, "common/error.html", {"msg": msg})
+    login_url = reverse("mastodon:login") + "?domain=" + mastodon.domain
     if request.headers.get("HX-Request"):
         # the error page relies on a meta refresh, which an htmx swap cannot
         # run, so send the browser straight to the re-authentication step
@@ -181,7 +185,7 @@ def render_relogin(request):
         "common/error.html",
         {
             "url": login_url,
-            "msg": _("Data saved but unable to crosspost to Fediverse instance."),
+            "msg": msg,
             "secondary_msg": _(
                 "Redirecting to your Fediverse instance now to re-authenticate."
             ),

--- a/neodb/locale/django.pot
+++ b/neodb/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-07 14:56-0400\n"
+"POT-Creation-Date: 2026-09-08 19:24-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -534,7 +534,7 @@ msgid "Album"
 msgstr ""
 
 #: catalog/models/common.py:168 catalog/models/common.py:185
-#: catalog/models/common.py:199 common/templates/_header.html:53
+#: catalog/models/common.py:199 common/templates/_header.html:54
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
@@ -549,7 +549,7 @@ msgid "Podcast Episode"
 msgstr ""
 
 #: catalog/models/common.py:171 catalog/models/common.py:187
-#: catalog/models/common.py:201 common/templates/_header.html:57
+#: catalog/models/common.py:201 common/templates/_header.html:58
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
@@ -575,7 +575,7 @@ msgid "Person / Organization"
 msgstr ""
 
 #: catalog/models/common.py:181 catalog/models/common.py:195
-#: common/templates/_header.html:37
+#: common/templates/_header.html:38
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
@@ -588,14 +588,14 @@ msgid "TV"
 msgstr ""
 
 #: catalog/models/common.py:184 catalog/models/common.py:198
-#: common/templates/_header.html:49
+#: common/templates/_header.html:50
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr ""
 
 #: catalog/models/common.py:186 catalog/models/common.py:200
-#: catalog/templates/_sidebar_edit.html:213 common/templates/_header.html:45
+#: catalog/templates/_sidebar_edit.html:213 common/templates/_header.html:46
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
@@ -2174,8 +2174,8 @@ msgstr ""
 #: catalog/views/edit.py:293 catalog/views/edit.py:296
 #: catalog/views/edit.py:440 catalog/views/edit.py:443
 #: catalog/views/verify.py:197 journal/views/collection.py:75
-#: journal/views/collection.py:100 journal/views/collection.py:538
-#: journal/views/collection.py:634 journal/views/common.py:231
+#: journal/views/collection.py:100 journal/views/collection.py:558
+#: journal/views/collection.py:654 journal/views/common.py:235
 #: journal/views/mark.py:244 journal/views/post.py:119
 #: journal/views/post.py:121 journal/views/post.py:168
 #: journal/views/post.py:187 journal/views/post.py:189
@@ -2209,10 +2209,10 @@ msgstr ""
 #: journal/views/article.py:133 journal/views/article.py:153
 #: journal/views/collection.py:248 journal/views/collection.py:341
 #: journal/views/collection.py:354 journal/views/collection.py:372
-#: journal/views/collection.py:439 journal/views/collection.py:482
-#: journal/views/collection.py:521 journal/views/collection.py:533
-#: journal/views/collection.py:558 journal/views/collection.py:595
-#: journal/views/common.py:304 journal/views/mark.py:317
+#: journal/views/collection.py:459 journal/views/collection.py:502
+#: journal/views/collection.py:541 journal/views/collection.py:553
+#: journal/views/collection.py:578 journal/views/collection.py:615
+#: journal/views/common.py:308 journal/views/mark.py:317
 #: journal/views/post.py:60 journal/views/post.py:80 journal/views/post.py:102
 #: journal/views/post.py:172 journal/views/post.py:201
 #: journal/views/post.py:274 journal/views/post.py:289
@@ -3795,96 +3795,96 @@ msgstr ""
 msgid "You are visiting an alternative domain for %(site_name)s, please always use <a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if possible."
 msgstr ""
 
-#: common/templates/_header.html:19 common/templates/_header.html:177
+#: common/templates/_header.html:20 common/templates/_header.html:178
 msgid "title, creator, ISBN, item url, @user, @user@instance"
 msgstr ""
 
-#: common/templates/_header.html:34
+#: common/templates/_header.html:35
 msgid "All Items"
 msgstr ""
 
-#: common/templates/_header.html:41
+#: common/templates/_header.html:42
 msgid "Movie & TV"
 msgstr ""
 
-#: common/templates/_header.html:60
+#: common/templates/_header.html:61
 msgid "People & Organizations"
 msgstr ""
 
-#: common/templates/_header.html:62
+#: common/templates/_header.html:63
 msgid "Journal"
 msgstr ""
 
-#: common/templates/_header.html:64 journal/templates/user_post_list.html:10
+#: common/templates/_header.html:65 journal/templates/user_post_list.html:10
 #: journal/templates/user_post_list.html:23
 msgid "Posts"
 msgstr ""
 
-#: common/templates/_header.html:102
+#: common/templates/_header.html:103
 msgid "Explore"
 msgstr ""
 
-#: common/templates/_header.html:106 common/views_manage.py:36
+#: common/templates/_header.html:107 common/views_manage.py:36
 msgid "Feed"
 msgstr ""
 
-#: common/templates/_header.html:111 journal/templates/profile.html:13
+#: common/templates/_header.html:112 journal/templates/profile.html:13
 #: users/templates/users/preferences.html:46
 msgid "Home"
 msgstr ""
 
-#: common/templates/_header.html:127 common/templates/common/scan.html:9
+#: common/templates/_header.html:128 common/templates/common/scan.html:9
 #: common/templates/common/scan.html:42
 msgid "Scan Barcode"
 msgstr ""
 
-#: common/templates/_header.html:131 social/templates/notification.html:12
+#: common/templates/_header.html:132 social/templates/notification.html:12
 #: social/templates/notification.html:53
 msgid "Notification"
 msgstr ""
 
-#: common/templates/_header.html:135 users/models/task.py:23
+#: common/templates/_header.html:136 users/models/task.py:23
 #: users/templates/users/account.html:219
 #: users/templates/users/crossposts.html:9
 msgid "Pending"
 msgstr ""
 
-#: common/templates/_header.html:138
+#: common/templates/_header.html:139
 msgid "Data"
 msgstr ""
 
-#: common/templates/_header.html:141 common/templates/_header.html:159
+#: common/templates/_header.html:142 common/templates/_header.html:160
 #: users/templates/users/preferences.html:12
 #: users/templates/users/preferences.html:23
 #: users/templates/users/preferences_anonymous.html:13
 msgid "Preferences"
 msgstr ""
 
-#: common/templates/_header.html:144
+#: common/templates/_header.html:145
 msgid "Account"
 msgstr ""
 
-#: common/templates/_header.html:148
+#: common/templates/_header.html:149
 msgid "Manage"
 msgstr ""
 
-#: common/templates/_header.html:152
+#: common/templates/_header.html:153
 msgid "Logout"
 msgstr ""
 
-#: common/templates/_header.html:156
+#: common/templates/_header.html:157
 msgid "Sign up or Login"
 msgstr ""
 
-#: common/templates/_header.html:173
+#: common/templates/_header.html:174
 msgid "title or content  category:tv  status:complete  rating:8..10  date:2021-09-11..2022-02"
 msgstr ""
 
-#: common/templates/_header.html:175
+#: common/templates/_header.html:176
 msgid "name of a person or company"
 msgstr ""
 
-#: common/templates/_header.html:192
+#: common/templates/_header.html:193
 msgid "Open"
 msgstr ""
 
@@ -6239,7 +6239,7 @@ msgstr ""
 msgid "Articles"
 msgstr ""
 
-#: journal/templates/profile.html:166 journal/views/collection.py:409
+#: journal/templates/profile.html:166 journal/views/collection.py:433
 #: journal/views/profile.py:401
 msgid "collection"
 msgstr ""
@@ -6347,29 +6347,37 @@ msgstr ""
 msgid "Collection by {0}"
 msgstr ""
 
-#: journal/views/collection.py:414
+#: journal/views/collection.py:382
+msgid "Link a Fediverse account in account settings to share this."
+msgstr ""
+
+#: journal/views/collection.py:411
+msgid "Unable to crosspost to Fediverse instance."
+msgstr ""
+
+#: journal/views/collection.py:438
 msgid "shared my collection"
 msgstr ""
 
-#: journal/views/collection.py:417
+#: journal/views/collection.py:441
 #, python-brace-format
 msgid "shared {username}'s collection"
 msgstr ""
 
-#: journal/views/collection.py:484 journal/views/collection.py:523
-#: journal/views/collection.py:535 journal/views/collection.py:561
+#: journal/views/collection.py:504 journal/views/collection.py:543
+#: journal/views/collection.py:555 journal/views/collection.py:581
 msgid "Dynamic collection is not editable"
 msgstr ""
 
-#: journal/views/collection.py:500
+#: journal/views/collection.py:520
 msgid "The item is already in the collection."
 msgstr ""
 
-#: journal/views/collection.py:502
+#: journal/views/collection.py:522
 msgid "Unable to find the item, please use item url from this site."
 msgstr ""
 
-#: journal/views/collection.py:548
+#: journal/views/collection.py:568
 msgid "Saved."
 msgstr ""
 
@@ -6380,15 +6388,15 @@ msgstr ""
 msgid "Content not found"
 msgstr ""
 
-#: journal/views/common.py:184 journal/views/mark.py:210
+#: journal/views/common.py:174 journal/views/mark.py:210
 msgid "Data saved but unable to crosspost to Fediverse instance."
 msgstr ""
 
-#: journal/views/common.py:186
+#: journal/views/common.py:190
 msgid "Redirecting to your Fediverse instance now to re-authenticate."
 msgstr ""
 
-#: journal/views/common.py:193
+#: journal/views/common.py:197
 msgid "List not found."
 msgstr ""
 

--- a/neodb/locale/django.pot
+++ b/neodb/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-08 19:24-0400\n"
+"POT-Creation-Date: 2026-09-08 21:25-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2173,9 +2173,9 @@ msgstr ""
 
 #: catalog/views/edit.py:293 catalog/views/edit.py:296
 #: catalog/views/edit.py:440 catalog/views/edit.py:443
-#: catalog/views/verify.py:197 journal/views/collection.py:75
-#: journal/views/collection.py:100 journal/views/collection.py:558
-#: journal/views/collection.py:654 journal/views/common.py:235
+#: catalog/views/verify.py:197 journal/views/collection.py:79
+#: journal/views/collection.py:104 journal/views/collection.py:607
+#: journal/views/collection.py:703 journal/views/common.py:235
 #: journal/views/mark.py:244 journal/views/post.py:119
 #: journal/views/post.py:121 journal/views/post.py:168
 #: journal/views/post.py:187 journal/views/post.py:189
@@ -2207,11 +2207,11 @@ msgstr ""
 #: catalog/views/edit.py:752 catalog/views/verify.py:158
 #: catalog/views/verify.py:206 journal/views/article.py:44
 #: journal/views/article.py:133 journal/views/article.py:153
-#: journal/views/collection.py:248 journal/views/collection.py:341
-#: journal/views/collection.py:354 journal/views/collection.py:372
-#: journal/views/collection.py:459 journal/views/collection.py:502
-#: journal/views/collection.py:541 journal/views/collection.py:553
-#: journal/views/collection.py:578 journal/views/collection.py:615
+#: journal/views/collection.py:252 journal/views/collection.py:345
+#: journal/views/collection.py:358 journal/views/collection.py:376
+#: journal/views/collection.py:508 journal/views/collection.py:551
+#: journal/views/collection.py:590 journal/views/collection.py:602
+#: journal/views/collection.py:627 journal/views/collection.py:664
 #: journal/views/common.py:308 journal/views/mark.py:317
 #: journal/views/post.py:60 journal/views/post.py:80 journal/views/post.py:102
 #: journal/views/post.py:172 journal/views/post.py:201
@@ -6239,7 +6239,7 @@ msgstr ""
 msgid "Articles"
 msgstr ""
 
-#: journal/templates/profile.html:166 journal/views/collection.py:433
+#: journal/templates/profile.html:166 journal/views/collection.py:448
 #: journal/views/profile.py:401
 msgid "collection"
 msgstr ""
@@ -6342,42 +6342,42 @@ msgstr ""
 msgid "Link invalid"
 msgstr ""
 
-#: journal/views/collection.py:62 journal/views/collection.py:94
+#: journal/views/collection.py:66 journal/views/collection.py:98
 #, python-brace-format
 msgid "Collection by {0}"
 msgstr ""
 
-#: journal/views/collection.py:382
-msgid "Link a Fediverse account in account settings to share this."
-msgstr ""
-
-#: journal/views/collection.py:411
+#: journal/views/collection.py:400
 msgid "Unable to crosspost to Fediverse instance."
 msgstr ""
 
-#: journal/views/collection.py:438
+#: journal/views/collection.py:411
+msgid "Unable to share to Bluesky."
+msgstr ""
+
+#: journal/views/collection.py:423
 msgid "shared my collection"
 msgstr ""
 
-#: journal/views/collection.py:441
+#: journal/views/collection.py:431
 #, python-brace-format
 msgid "shared {username}'s collection"
 msgstr ""
 
-#: journal/views/collection.py:504 journal/views/collection.py:543
-#: journal/views/collection.py:555 journal/views/collection.py:581
+#: journal/views/collection.py:553 journal/views/collection.py:592
+#: journal/views/collection.py:604 journal/views/collection.py:630
 msgid "Dynamic collection is not editable"
 msgstr ""
 
-#: journal/views/collection.py:520
+#: journal/views/collection.py:569
 msgid "The item is already in the collection."
 msgstr ""
 
-#: journal/views/collection.py:522
+#: journal/views/collection.py:571
 msgid "Unable to find the item, please use item url from this site."
 msgstr ""
 
-#: journal/views/collection.py:568
+#: journal/views/collection.py:617
 msgid "Saved."
 msgstr ""
 

--- a/neodb/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-08 19:24-0400\n"
+"POT-Creation-Date: 2026-09-08 21:25-0400\n"
 "PO-Revision-Date: 2026-08-08 21:19+0000\n"
 "Last-Translator: reducedradius <137701630+flytothehighest@users.noreply.github.com>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -2172,9 +2172,9 @@ msgstr "版本"
 
 #: catalog/views/edit.py:293 catalog/views/edit.py:296
 #: catalog/views/edit.py:440 catalog/views/edit.py:443
-#: catalog/views/verify.py:197 journal/views/collection.py:75
-#: journal/views/collection.py:100 journal/views/collection.py:558
-#: journal/views/collection.py:654 journal/views/common.py:235
+#: catalog/views/verify.py:197 journal/views/collection.py:79
+#: journal/views/collection.py:104 journal/views/collection.py:607
+#: journal/views/collection.py:703 journal/views/common.py:235
 #: journal/views/mark.py:244 journal/views/post.py:119
 #: journal/views/post.py:121 journal/views/post.py:168
 #: journal/views/post.py:187 journal/views/post.py:189
@@ -2206,11 +2206,11 @@ msgstr "本操作不可撤销。"
 #: catalog/views/edit.py:752 catalog/views/verify.py:158
 #: catalog/views/verify.py:206 journal/views/article.py:44
 #: journal/views/article.py:133 journal/views/article.py:153
-#: journal/views/collection.py:248 journal/views/collection.py:341
-#: journal/views/collection.py:354 journal/views/collection.py:372
-#: journal/views/collection.py:459 journal/views/collection.py:502
-#: journal/views/collection.py:541 journal/views/collection.py:553
-#: journal/views/collection.py:578 journal/views/collection.py:615
+#: journal/views/collection.py:252 journal/views/collection.py:345
+#: journal/views/collection.py:358 journal/views/collection.py:376
+#: journal/views/collection.py:508 journal/views/collection.py:551
+#: journal/views/collection.py:590 journal/views/collection.py:602
+#: journal/views/collection.py:627 journal/views/collection.py:664
 #: journal/views/common.py:308 journal/views/mark.py:317
 #: journal/views/post.py:60 journal/views/post.py:80 journal/views/post.py:102
 #: journal/views/post.py:172 journal/views/post.py:201
@@ -6296,7 +6296,7 @@ msgstr "年度小结"
 msgid "Articles"
 msgstr "文章"
 
-#: journal/templates/profile.html:166 journal/views/collection.py:433
+#: journal/templates/profile.html:166 journal/views/collection.py:448
 #: journal/views/profile.py:401
 msgid "collection"
 msgstr "收藏单"
@@ -6399,42 +6399,42 @@ msgstr "{0} 的文章"
 msgid "Link invalid"
 msgstr "链接无效"
 
-#: journal/views/collection.py:62 journal/views/collection.py:94
+#: journal/views/collection.py:66 journal/views/collection.py:98
 #, python-brace-format
 msgid "Collection by {0}"
 msgstr "{0} 的收藏单"
 
-#: journal/views/collection.py:382
-msgid "Link a Fediverse account in account settings to share this."
-msgstr "请先在账号设置中关联联邦宇宙账号，然后再分享。"
-
-#: journal/views/collection.py:411
+#: journal/views/collection.py:400
 msgid "Unable to crosspost to Fediverse instance."
 msgstr "未能转发到联邦实例。"
 
-#: journal/views/collection.py:438
+#: journal/views/collection.py:411
+msgid "Unable to share to Bluesky."
+msgstr "未能分享到 Bluesky。"
+
+#: journal/views/collection.py:423
 msgid "shared my collection"
 msgstr "分享我的收藏单"
 
-#: journal/views/collection.py:441
+#: journal/views/collection.py:431
 #, python-brace-format
 msgid "shared {username}'s collection"
 msgstr "分享 {username} 的收藏单"
 
-#: journal/views/collection.py:504 journal/views/collection.py:543
-#: journal/views/collection.py:555 journal/views/collection.py:581
+#: journal/views/collection.py:553 journal/views/collection.py:592
+#: journal/views/collection.py:604 journal/views/collection.py:630
 msgid "Dynamic collection is not editable"
 msgstr "不能修改动态收藏单中的条目"
 
-#: journal/views/collection.py:520
+#: journal/views/collection.py:569
 msgid "The item is already in the collection."
 msgstr "条目已在收藏单中。"
 
-#: journal/views/collection.py:522
+#: journal/views/collection.py:571
 msgid "Unable to find the item, please use item url from this site."
 msgstr "找不到条目，请使用本站条目网址。"
 
-#: journal/views/collection.py:568
+#: journal/views/collection.py:617
 msgid "Saved."
 msgstr "已保存"
 

--- a/neodb/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-07 14:56-0400\n"
+"POT-Creation-Date: 2026-09-08 19:24-0400\n"
 "PO-Revision-Date: 2026-08-08 21:19+0000\n"
 "Last-Translator: reducedradius <137701630+flytothehighest@users.noreply.github.com>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -533,7 +533,7 @@ msgid "Album"
 msgstr "专辑"
 
 #: catalog/models/common.py:168 catalog/models/common.py:185
-#: catalog/models/common.py:199 common/templates/_header.html:53
+#: catalog/models/common.py:199 common/templates/_header.html:54
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
@@ -548,7 +548,7 @@ msgid "Podcast Episode"
 msgstr "播客单集"
 
 #: catalog/models/common.py:171 catalog/models/common.py:187
-#: catalog/models/common.py:201 common/templates/_header.html:57
+#: catalog/models/common.py:201 common/templates/_header.html:58
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
@@ -574,7 +574,7 @@ msgid "Person / Organization"
 msgstr "人物 / 团体"
 
 #: catalog/models/common.py:181 catalog/models/common.py:195
-#: common/templates/_header.html:37
+#: common/templates/_header.html:38
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
@@ -587,14 +587,14 @@ msgid "TV"
 msgstr "剧集"
 
 #: catalog/models/common.py:184 catalog/models/common.py:198
-#: common/templates/_header.html:49
+#: common/templates/_header.html:50
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr "音乐"
 
 #: catalog/models/common.py:186 catalog/models/common.py:200
-#: catalog/templates/_sidebar_edit.html:213 common/templates/_header.html:45
+#: catalog/templates/_sidebar_edit.html:213 common/templates/_header.html:46
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
@@ -2173,8 +2173,8 @@ msgstr "版本"
 #: catalog/views/edit.py:293 catalog/views/edit.py:296
 #: catalog/views/edit.py:440 catalog/views/edit.py:443
 #: catalog/views/verify.py:197 journal/views/collection.py:75
-#: journal/views/collection.py:100 journal/views/collection.py:538
-#: journal/views/collection.py:634 journal/views/common.py:231
+#: journal/views/collection.py:100 journal/views/collection.py:558
+#: journal/views/collection.py:654 journal/views/common.py:235
 #: journal/views/mark.py:244 journal/views/post.py:119
 #: journal/views/post.py:121 journal/views/post.py:168
 #: journal/views/post.py:187 journal/views/post.py:189
@@ -2208,10 +2208,10 @@ msgstr "本操作不可撤销。"
 #: journal/views/article.py:133 journal/views/article.py:153
 #: journal/views/collection.py:248 journal/views/collection.py:341
 #: journal/views/collection.py:354 journal/views/collection.py:372
-#: journal/views/collection.py:439 journal/views/collection.py:482
-#: journal/views/collection.py:521 journal/views/collection.py:533
-#: journal/views/collection.py:558 journal/views/collection.py:595
-#: journal/views/common.py:304 journal/views/mark.py:317
+#: journal/views/collection.py:459 journal/views/collection.py:502
+#: journal/views/collection.py:541 journal/views/collection.py:553
+#: journal/views/collection.py:578 journal/views/collection.py:615
+#: journal/views/common.py:308 journal/views/mark.py:317
 #: journal/views/post.py:60 journal/views/post.py:80 journal/views/post.py:102
 #: journal/views/post.py:172 journal/views/post.py:201
 #: journal/views/post.py:274 journal/views/post.py:289
@@ -3794,96 +3794,96 @@ msgstr "关于"
 msgid "You are visiting an alternative domain for %(site_name)s, please always use <a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if possible."
 msgstr "这是%(site_name)s的临时镜像，请尽可能使用<a href=\"%(site_url)s%(request.get_full_path)s\">原始站点</a>。"
 
-#: common/templates/_header.html:19 common/templates/_header.html:177
+#: common/templates/_header.html:20 common/templates/_header.html:178
 msgid "title, creator, ISBN, item url, @user, @user@instance"
 msgstr "标题、创作者、ISBN、站外条目链接、@用户名、@用户名@实例"
 
-#: common/templates/_header.html:34
+#: common/templates/_header.html:35
 msgid "All Items"
 msgstr "全部"
 
-#: common/templates/_header.html:41
+#: common/templates/_header.html:42
 msgid "Movie & TV"
 msgstr "影视"
 
-#: common/templates/_header.html:60
+#: common/templates/_header.html:61
 msgid "People & Organizations"
 msgstr "人物与团体"
 
-#: common/templates/_header.html:62
+#: common/templates/_header.html:63
 msgid "Journal"
 msgstr "记录"
 
-#: common/templates/_header.html:64 journal/templates/user_post_list.html:10
+#: common/templates/_header.html:65 journal/templates/user_post_list.html:10
 #: journal/templates/user_post_list.html:23
 msgid "Posts"
 msgstr "帖文"
 
-#: common/templates/_header.html:102
+#: common/templates/_header.html:103
 msgid "Explore"
 msgstr "发现"
 
-#: common/templates/_header.html:106 common/views_manage.py:36
+#: common/templates/_header.html:107 common/views_manage.py:36
 msgid "Feed"
 msgstr "动态"
 
-#: common/templates/_header.html:111 journal/templates/profile.html:13
+#: common/templates/_header.html:112 journal/templates/profile.html:13
 #: users/templates/users/preferences.html:46
 msgid "Home"
 msgstr "主页"
 
-#: common/templates/_header.html:127 common/templates/common/scan.html:9
+#: common/templates/_header.html:128 common/templates/common/scan.html:9
 #: common/templates/common/scan.html:42
 msgid "Scan Barcode"
 msgstr "扫描条形码"
 
-#: common/templates/_header.html:131 social/templates/notification.html:12
+#: common/templates/_header.html:132 social/templates/notification.html:12
 #: social/templates/notification.html:53
 msgid "Notification"
 msgstr "通知"
 
-#: common/templates/_header.html:135 users/models/task.py:23
+#: common/templates/_header.html:136 users/models/task.py:23
 #: users/templates/users/account.html:219
 #: users/templates/users/crossposts.html:9
 msgid "Pending"
 msgstr "等待"
 
-#: common/templates/_header.html:138
+#: common/templates/_header.html:139
 msgid "Data"
 msgstr "数据"
 
-#: common/templates/_header.html:141 common/templates/_header.html:159
+#: common/templates/_header.html:142 common/templates/_header.html:160
 #: users/templates/users/preferences.html:12
 #: users/templates/users/preferences.html:23
 #: users/templates/users/preferences_anonymous.html:13
 msgid "Preferences"
 msgstr "设置"
 
-#: common/templates/_header.html:144
+#: common/templates/_header.html:145
 msgid "Account"
 msgstr "账号"
 
-#: common/templates/_header.html:148
+#: common/templates/_header.html:149
 msgid "Manage"
 msgstr "管理"
 
-#: common/templates/_header.html:152
+#: common/templates/_header.html:153
 msgid "Logout"
 msgstr "登出"
 
-#: common/templates/_header.html:156
+#: common/templates/_header.html:157
 msgid "Sign up or Login"
 msgstr "注册或登录"
 
-#: common/templates/_header.html:173
+#: common/templates/_header.html:174
 msgid "title or content  category:tv  status:complete  rating:8..10  date:2021-09-11..2022-02"
 msgstr "搜索你的评论或条目，可加过滤条件如 category:tv status:complete rating:8..10 date:2021-09-11..2022-02"
 
-#: common/templates/_header.html:175
+#: common/templates/_header.html:176
 msgid "name of a person or company"
 msgstr "人物或公司名称"
 
-#: common/templates/_header.html:192
+#: common/templates/_header.html:193
 msgid "Open"
 msgstr "打开"
 
@@ -6296,7 +6296,7 @@ msgstr "年度小结"
 msgid "Articles"
 msgstr "文章"
 
-#: journal/templates/profile.html:166 journal/views/collection.py:409
+#: journal/templates/profile.html:166 journal/views/collection.py:433
 #: journal/views/profile.py:401
 msgid "collection"
 msgstr "收藏单"
@@ -6404,29 +6404,37 @@ msgstr "链接无效"
 msgid "Collection by {0}"
 msgstr "{0} 的收藏单"
 
-#: journal/views/collection.py:414
+#: journal/views/collection.py:382
+msgid "Link a Fediverse account in account settings to share this."
+msgstr "请先在账号设置中关联联邦宇宙账号，然后再分享。"
+
+#: journal/views/collection.py:411
+msgid "Unable to crosspost to Fediverse instance."
+msgstr "未能转发到联邦实例。"
+
+#: journal/views/collection.py:438
 msgid "shared my collection"
 msgstr "分享我的收藏单"
 
-#: journal/views/collection.py:417
+#: journal/views/collection.py:441
 #, python-brace-format
 msgid "shared {username}'s collection"
 msgstr "分享 {username} 的收藏单"
 
-#: journal/views/collection.py:484 journal/views/collection.py:523
-#: journal/views/collection.py:535 journal/views/collection.py:561
+#: journal/views/collection.py:504 journal/views/collection.py:543
+#: journal/views/collection.py:555 journal/views/collection.py:581
 msgid "Dynamic collection is not editable"
 msgstr "不能修改动态收藏单中的条目"
 
-#: journal/views/collection.py:500
+#: journal/views/collection.py:520
 msgid "The item is already in the collection."
 msgstr "条目已在收藏单中。"
 
-#: journal/views/collection.py:502
+#: journal/views/collection.py:522
 msgid "Unable to find the item, please use item url from this site."
 msgstr "找不到条目，请使用本站条目网址。"
 
-#: journal/views/collection.py:548
+#: journal/views/collection.py:568
 msgid "Saved."
 msgstr "已保存"
 
@@ -6437,15 +6445,15 @@ msgstr "已保存"
 msgid "Content not found"
 msgstr "内容未找到"
 
-#: journal/views/common.py:184 journal/views/mark.py:210
+#: journal/views/common.py:174 journal/views/mark.py:210
 msgid "Data saved but unable to crosspost to Fediverse instance."
 msgstr "数据已保存但未能转发到联邦实例。"
 
-#: journal/views/common.py:186
+#: journal/views/common.py:190
 msgid "Redirecting to your Fediverse instance now to re-authenticate."
 msgstr "正在重定向到你的联邦实例以重新认证。"
 
-#: journal/views/common.py:193
+#: journal/views/common.py:197
 msgid "List not found."
 msgstr "列表未找到。"
 

--- a/neodb/tests/journal/test_collection_share.py
+++ b/neodb/tests/journal/test_collection_share.py
@@ -4,14 +4,25 @@ from django.test import Client
 from django.urls import reverse
 
 from journal.models.collection import Collection
+from mastodon.models.bluesky import BlueskyAccount
 from mastodon.models.mastodon import MastodonAccount
+from takahe.models import Post
+from takahe.utils import Takahe
 from users.models import User
 
 
 def _collection(user: User) -> Collection:
-    return Collection.objects.create(
+    c = Collection.objects.create(
         owner=user.identity, title="shared list", visibility=0
     )
+    # refetch so latest_post is not a stale cached_property
+    return Collection.objects.get(pk=c.pk)
+
+
+def _latest_post(collection: Collection) -> Post:
+    post = collection.latest_post
+    assert post is not None
+    return post
 
 
 def _link_mastodon(user: User) -> MastodonAccount:
@@ -20,40 +31,28 @@ def _link_mastodon(user: User) -> MastodonAccount:
     )
 
 
-def _share(client: Client, collection: Collection, **extra):
+def _link_bluesky(user: User) -> BlueskyAccount:
+    return BlueskyAccount.objects.create(
+        handle="share.bsky.social", user=user, domain="bsky.social", uid="3"
+    )
+
+
+def _share(client: Client, collection: Collection, comment: str = "note", **extra):
     url = reverse("journal:collection_share", args=[collection.uuid])
-    return client.post(url, {"comment": "note", "visibility": "2"}, **extra)
+    data = {"comment": comment, "visibility": extra.pop("visibility", "0")}
+    return client.post(url, data, HTTP_REFERER="/", **extra)
 
 
 @pytest.mark.django_db(databases="__all__")
-class TestCollectionShare:
+class TestCollectionShareViaMastodon:
     def setup_method(self):
         self.user = User.register(email="share@example.com", username="shareuser")
         self.collection = _collection(self.user)
         self.client = Client()
         self.client.force_login(self.user, backend="mastodon.auth.OAuth2Backend")
-
-    def test_without_mastodon_account_shows_error(self):
-        response = _share(self.client, self.collection)
-        assert response.status_code == 200
-        assert "Link a Fediverse account" in response.content.decode()
-
-    def test_without_mastodon_account_hides_share_link(self):
-        response = self.client.get(self.collection.url)
-        assert response.status_code == 200
-        share_url = reverse("journal:collection_share", args=[self.collection.uuid])
-        assert share_url not in response.content.decode()
-
-    def test_with_mastodon_account_shows_share_link(self):
         _link_mastodon(self.user)
-        response = self.client.get(self.collection.url)
-        assert response.status_code == 200
-        share_url = reverse("journal:collection_share", args=[self.collection.uuid])
-        assert share_url in response.content.decode()
 
     def test_expired_token_redirects_to_relogin(self, monkeypatch):
-        _link_mastodon(self.user)
-
         def denied(*args, **kwargs):
             raise PermissionDenied()
 
@@ -65,8 +64,6 @@ class TestCollectionShare:
         assert reverse("mastodon:login") + "?domain=mast.social" in body
 
     def test_expired_token_htmx_redirects_to_relogin(self, monkeypatch):
-        _link_mastodon(self.user)
-
         def denied(*args, **kwargs):
             raise PermissionDenied()
 
@@ -75,8 +72,6 @@ class TestCollectionShare:
         assert response.headers["HX-Redirect"].endswith("?domain=mast.social")
 
     def test_instance_failure_shows_error_without_relogin(self, monkeypatch):
-        _link_mastodon(self.user)
-
         def aborted(*args, **kwargs):
             raise RequestAborted()
 
@@ -88,7 +83,6 @@ class TestCollectionShare:
         assert "re-authenticate" not in body
 
     def test_success_redirects(self, monkeypatch):
-        _link_mastodon(self.user)
         posted = {}
 
         def ok(self, content, visibility, *args, **kwargs):
@@ -96,6 +90,104 @@ class TestCollectionShare:
             return {"id": "1", "url": "https://mast.social/@share/1"}
 
         monkeypatch.setattr(MastodonAccount, "post", ok)
-        response = _share(self.client, self.collection, HTTP_REFERER="/")
+        response = _share(self.client, self.collection)
         assert response.status_code == 302
         assert "shared list" in posted["content"]
+        assert "note" in posted["content"]
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestCollectionShareViaBluesky:
+    def setup_method(self):
+        self.user = User.register(email="bsky@example.com", username="bskyuser")
+        self.collection = _collection(self.user)
+        self.client = Client()
+        self.client.force_login(self.user, backend="mastodon.auth.OAuth2Backend")
+        _link_bluesky(self.user)
+
+    def test_public_share_posts_to_bluesky(self, monkeypatch):
+        posted = {}
+
+        def ok(self, content, *args, **kwargs):
+            posted["content"] = content
+            posted["obj"] = kwargs.get("obj")
+            return {"id": "at://x", "url": "https://bsky.app/x"}
+
+        monkeypatch.setattr(BlueskyAccount, "post", ok)
+        response = _share(self.client, self.collection)
+        assert response.status_code == 302
+        assert "##obj##" in posted["content"]
+        assert "note" in posted["content"]
+        assert posted["obj"].display_title == "shared list"
+        assert posted["obj"].absolute_url == self.collection.absolute_url
+
+    def test_failure_shows_error(self, monkeypatch):
+        def boom(*args, **kwargs):
+            raise RuntimeError("pds down")
+
+        monkeypatch.setattr(BlueskyAccount, "post", boom)
+        response = _share(self.client, self.collection)
+        assert response.status_code == 200
+        assert "Unable to share to Bluesky" in response.content.decode()
+
+    def test_non_public_share_stays_on_neodb(self, monkeypatch):
+        def boom(*args, **kwargs):
+            raise AssertionError("bluesky must not be used for non-public shares")
+
+        monkeypatch.setattr(BlueskyAccount, "post", boom)
+        response = _share(self.client, self.collection, visibility="1")
+        assert response.status_code == 302
+        quote = Post.objects.filter(
+            author_id=self.user.identity.pk,
+            quote_url=_latest_post(self.collection).object_uri,
+        ).first()
+        assert quote is not None
+        assert quote.visibility == Takahe.Visibilities.followers
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestCollectionShareLocally:
+    def setup_method(self):
+        self.user = User.register(email="local@example.com", username="localuser")
+        self.owner = User.register(email="owner@example.com", username="listowner")
+        self.collection = _collection(self.owner)
+        self.client = Client()
+        self.client.force_login(self.user, backend="mastodon.auth.OAuth2Backend")
+
+    def test_share_link_shown_without_any_social_account(self):
+        response = self.client.get(self.collection.url)
+        assert response.status_code == 200
+        share_url = reverse("journal:collection_share", args=[self.collection.uuid])
+        assert share_url in response.content.decode()
+
+    def test_share_without_comment_boosts(self):
+        post = _latest_post(self.collection)
+        response = _share(self.client, self.collection, comment="")
+        assert response.status_code == 302
+        assert Takahe.post_boosted_by(post.pk, self.user.identity.pk)
+        # a second share must not undo the boost
+        _share(self.client, self.collection, comment="")
+        assert Takahe.post_boosted_by(post.pk, self.user.identity.pk)
+
+    def test_share_with_comment_quotes(self):
+        post = _latest_post(self.collection)
+        response = _share(self.client, self.collection, comment="great list")
+        assert response.status_code == 302
+        quote = Post.objects.filter(
+            author_id=self.user.identity.pk, quote_url=post.object_uri
+        ).first()
+        assert quote is not None
+        assert "great list" in quote.content
+        assert "shared list" in quote.content
+        assert "@listowner" in quote.content
+        assert not Takahe.post_boosted_by(post.pk, self.user.identity.pk)
+
+    def test_share_own_collection_with_comment(self):
+        own = _collection(self.user)
+        response = _share(self.client, own, comment="mine")
+        assert response.status_code == 302
+        quote = Post.objects.filter(
+            author_id=self.user.identity.pk, quote_url=_latest_post(own).object_uri
+        ).first()
+        assert quote is not None
+        assert "shared my collection" in quote.content

--- a/neodb/tests/journal/test_collection_share.py
+++ b/neodb/tests/journal/test_collection_share.py
@@ -1,0 +1,101 @@
+import pytest
+from django.core.exceptions import PermissionDenied, RequestAborted
+from django.test import Client
+from django.urls import reverse
+
+from journal.models.collection import Collection
+from mastodon.models.mastodon import MastodonAccount
+from users.models import User
+
+
+def _collection(user: User) -> Collection:
+    return Collection.objects.create(
+        owner=user.identity, title="shared list", visibility=0
+    )
+
+
+def _link_mastodon(user: User) -> MastodonAccount:
+    return MastodonAccount.objects.create(
+        handle="share@mast.social", user=user, domain="mast.social", uid="1"
+    )
+
+
+def _share(client: Client, collection: Collection, **extra):
+    url = reverse("journal:collection_share", args=[collection.uuid])
+    return client.post(url, {"comment": "note", "visibility": "2"}, **extra)
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestCollectionShare:
+    def setup_method(self):
+        self.user = User.register(email="share@example.com", username="shareuser")
+        self.collection = _collection(self.user)
+        self.client = Client()
+        self.client.force_login(self.user, backend="mastodon.auth.OAuth2Backend")
+
+    def test_without_mastodon_account_shows_error(self):
+        response = _share(self.client, self.collection)
+        assert response.status_code == 200
+        assert "Link a Fediverse account" in response.content.decode()
+
+    def test_without_mastodon_account_hides_share_link(self):
+        response = self.client.get(self.collection.url)
+        assert response.status_code == 200
+        share_url = reverse("journal:collection_share", args=[self.collection.uuid])
+        assert share_url not in response.content.decode()
+
+    def test_with_mastodon_account_shows_share_link(self):
+        _link_mastodon(self.user)
+        response = self.client.get(self.collection.url)
+        assert response.status_code == 200
+        share_url = reverse("journal:collection_share", args=[self.collection.uuid])
+        assert share_url in response.content.decode()
+
+    def test_expired_token_redirects_to_relogin(self, monkeypatch):
+        _link_mastodon(self.user)
+
+        def denied(*args, **kwargs):
+            raise PermissionDenied()
+
+        monkeypatch.setattr(MastodonAccount, "post", denied)
+        response = _share(self.client, self.collection)
+        assert response.status_code == 200
+        body = response.content.decode()
+        assert "re-authenticate" in body
+        assert reverse("mastodon:login") + "?domain=mast.social" in body
+
+    def test_expired_token_htmx_redirects_to_relogin(self, monkeypatch):
+        _link_mastodon(self.user)
+
+        def denied(*args, **kwargs):
+            raise PermissionDenied()
+
+        monkeypatch.setattr(MastodonAccount, "post", denied)
+        response = _share(self.client, self.collection, HTTP_HX_REQUEST="true")
+        assert response.headers["HX-Redirect"].endswith("?domain=mast.social")
+
+    def test_instance_failure_shows_error_without_relogin(self, monkeypatch):
+        _link_mastodon(self.user)
+
+        def aborted(*args, **kwargs):
+            raise RequestAborted()
+
+        monkeypatch.setattr(MastodonAccount, "post", aborted)
+        response = _share(self.client, self.collection)
+        assert response.status_code == 200
+        body = response.content.decode()
+        assert "Unable to crosspost" in body
+        assert "re-authenticate" not in body
+
+    def test_success_redirects(self, monkeypatch):
+        _link_mastodon(self.user)
+        posted = {}
+
+        def ok(self, content, visibility, *args, **kwargs):
+            posted["content"] = content
+            return {"id": "1", "url": "https://mast.social/@share/1"}
+
+        monkeypatch.setattr(MastodonAccount, "post", ok)
+        response = _share(self.client, self.collection, HTTP_REFERER="/")
+        assert response.status_code == 302
+        assert "shared list" in posted["content"]


### PR DESCRIPTION
Fixes NEODB-SOCIAL-7X5: `AttributeError: 'NoneType' object has no attribute 'domain'` at `POST /collection/share/<uuid>`.

## Cause

`share_collection` returned `None` both when the user had no Mastodon account and when the post to the instance failed. The view treated any falsy result as an expired token and called `render_relogin`, which reads `request.user.mastodon.domain` on a `None` account.

## Changes

Sharing now works for every signed-in user, with this fallback order:

1. **Mastodon linked**: as before. Boost when there is no comment and repost mode is on, otherwise post. A 401 goes to the relogin page; any other failure shows an error page without a relogin redirect.
2. **Bluesky linked**: post to Bluesky with the collection as an external card. Bluesky is public-only, so a non-public share from a Bluesky-only user falls through to step 3, which honors the chosen visibility.
3. **Neither**: share from the user's own NeoDB identity. With no comment the collection's post is boosted (idempotent, a second share does not undo it). With a comment the post is quoted, clamped to the visibilities allowed for quoting it. A collection with no post gets a plain post with the link.

`render_relogin` tolerates a missing Mastodon account. Tests cover each path, and zh_Hans has the one new string.