### PR TITLE
fix(common): skip translation for blank text

### DIFF
--- a/neodb/common/models/lang.py
+++ b/neodb/common/models/lang.py
@@ -838,6 +838,8 @@ def translate(
     lang: str,
     src: str | None,
 ) -> str:
+    if not message.strip():
+        return message
     cache_key = f"trans_{lang}_{hashlib.sha1(message.encode()).hexdigest()}"
     r = cache.get(cache_key)
     if r is not None:

--- a/neodb/tests/core/test_lang_coverage.py
+++ b/neodb/tests/core/test_lang_coverage.py
@@ -12,7 +12,9 @@ from common.models.lang import (
     get_current_locales,
     localize_number,
     localized_label_text,
+    translate,
 )
+from common.models.site_config import SiteConfig
 
 
 class TestLocalizeNumber:
@@ -218,3 +220,26 @@ class TestLocalizedLabelText:
 
     def test_none_for_empty_list(self):
         assert localized_label_text([], ["en"]) is None
+
+
+class TestTranslateEmptyMessage:
+    """DeepL raises ValueError on an empty string, so a blank comment must
+    never reach either translation backend."""
+
+    @pytest.fixture(autouse=True)
+    def enable_backends(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        enabled = SiteConfig.system.model_copy(
+            update={"deepl_api_key": "key", "lt_api_url": "http://lt.example"}
+        )
+        monkeypatch.setattr(SiteConfig, "system", enabled)
+        monkeypatch.setattr(SiteConfig, "__forced__", True, raising=False)
+
+        def boom(*args: Any, **kwargs: Any) -> None:
+            raise AssertionError("translation backend must not be called")
+
+        monkeypatch.setattr(lang.deepl, "DeepLClient", boom)
+        monkeypatch.setattr(lang.httpx, "post", boom)
+
+    @pytest.mark.parametrize("message", ["", "   ", "\n\t"])
+    def test_blank_message_is_returned_unchanged(self, message: str) -> None:
+        assert translate(message, "zh-hans", "en") == message


### PR DESCRIPTION
Fixes NEODB-SOCIAL-7X3: `ValueError: text must not be empty` at `POST /comment/translate/<uuid>`.

A comment with empty text reached `translate()`, and the DeepL client rejects an empty string. `translate()` now returns blank input unchanged before touching the cache or either backend, which covers the comment, post, review and article translate views. Tests added.