### PR TITLE
fix(api): batch-load items in the tag items API

### DIFF
--- a/neodb/journal/apis/collection.py
+++ b/neodb/journal/apis/collection.py
@@ -121,8 +121,8 @@ class CollectionItemSchema(Schema):
         return note if isinstance(note, str) else ""
 
 
-def _prefetch_collection_member_items(data: list) -> None:
-    """Batch-hydrate items for ``CollectionItemSchema`` (``item: ItemSchema``).
+def _prefetch_list_member_items(data: list) -> None:
+    """Batch-hydrate items for list member schemas (``item: ItemSchema``).
 
     Without this, each member serializes its item's ``external_resources`` and
     ``credits`` one row at a time. Dynamic collections carry the item in a
@@ -158,9 +158,11 @@ def _prefetch_collection_member_items(data: list) -> None:
     Rating.attach_to_items(items)
 
 
-class CollectionItemPageNumberPagination(PageNumberPagination):
-    """Hydrate the page's items so ``CollectionItemSchema`` serialization does
-    not fire per-item ``external_resources``/``credits`` queries (N+1)."""
+class ListMemberPageNumberPagination(PageNumberPagination):
+    """Hydrate the page's items so member serialization does not fire
+    per-item ``item``/``external_resources``/``credits`` queries (N+1).
+
+    Shared by the collection and tag item APIs."""
 
     def paginate_queryset(
         self,
@@ -172,7 +174,7 @@ class CollectionItemPageNumberPagination(PageNumberPagination):
         val = super().paginate_queryset(queryset, pagination, request, **params)
         data = val.get("data")
         if data:
-            _prefetch_collection_member_items(list(data))
+            _prefetch_list_member_items(list(data))
         return val
 
 
@@ -327,7 +329,7 @@ def get_collection(request, collection_uuid: str):
     tags=["collection"],
     auth=OptionalOAuthAccessTokenAuth(),
 )
-@paginate(CollectionItemPageNumberPagination)
+@paginate(ListMemberPageNumberPagination)
 def collection_list_items(request, collection_uuid: str):
     """
     Get items in a collection collections
@@ -504,7 +506,7 @@ def delete_collection(request, collection_uuid: str):
     response={200: list[CollectionItemSchema], 401: Result, 403: Result, 404: Result},
     tags=["collection"],
 )
-@paginate(CollectionItemPageNumberPagination)
+@paginate(ListMemberPageNumberPagination)
 def user_collection_list_items(request, collection_uuid: str):
     """
     Get items in a collection collections

--- a/neodb/journal/apis/tag.py
+++ b/neodb/journal/apis/tag.py
@@ -8,6 +8,7 @@ from catalog.models import Item, ItemSchema
 from common.api import PageNumberPagination, Result, api
 
 from ..models import Tag
+from .collection import ListMemberPageNumberPagination
 
 
 class TagSchema(Schema):
@@ -153,7 +154,7 @@ def delete_tag(request, tag_uuid: str):
     response={200: list[TagItemSchema], 401: Result, 403: Result, 404: Result},
     tags=["tag"],
 )
-@paginate(PageNumberPagination)
+@paginate(ListMemberPageNumberPagination)
 def tag_list_items(request, tag_uuid: str):
     """
     Get items in a tag tags

--- a/neodb/tests/journal/test_collection.py
+++ b/neodb/tests/journal/test_collection.py
@@ -9,7 +9,7 @@ from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 
 from catalog.models import Edition, ExternalResource, IdType, Item, ItemCredit, Movie
-from journal.apis.collection import _prefetch_collection_member_items
+from journal.apis.collection import _prefetch_list_member_items
 from journal.models import Mark, ShelfType
 from journal.models.collection import Collection
 from takahe.utils import Takahe
@@ -380,7 +380,7 @@ class TestCollectionItemsApiPrefetch:
     """The ``/collection/{uuid}/item/`` and ``/me/collection/{uuid}/item/``
     APIs serialize each member's item via ``ItemSchema``; without batch
     prefetch each item fired a per-row ``catalog_externalresource`` query.
-    ``CollectionItemPageNumberPagination`` hydrates the page post-slice
+    ``ListMemberPageNumberPagination`` hydrates the page post-slice
     (mirrors the shelf API).
     """
 
@@ -405,7 +405,7 @@ class TestCollectionItemsApiPrefetch:
     def test_member_items_external_resources_and_credits_prefetched(self):
         # Fresh member instances, as the paginator receives them post-slice.
         members = list(self.collection.ordered_members)
-        _prefetch_collection_member_items(members)
+        _prefetch_list_member_items(members)
         # Reading external_resources and credits (as ItemSchema does) must now
         # be served from the prefetch cache without per-item queries.
         with CaptureQueriesContext(connection) as ctx:

--- a/neodb/tests/journal/test_n_plus_one.py
+++ b/neodb/tests/journal/test_n_plus_one.py
@@ -1532,3 +1532,58 @@ class TestOwnerIdentityPrefetchOnApiLists:
         ]
         # one is the auth lookup; a per-row miss would add five more
         assert len(single_identity) <= 1, single_identity
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestTagItemsApiPrefetch:
+    """``GET /api/me/tag/{uuid}/item/`` serializes each member's item via
+    ``ItemSchema``; the item FK is polymorphic and cannot be select_related,
+    so the paginator must batch-load items (NEODB-SOCIAL-7XJ)."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="tagpf@example.com", username="tagpf")
+        self.tag = Tag.objects.create(
+            owner=self.user.identity, title="tagpf", visibility=0
+        )
+        for i in range(3):
+            book = Edition.objects.create(title=f"Tagpf Book {i}")
+            ExternalResource.objects.create(
+                item=book,
+                id_type=IdType.RSS,
+                id_value=f"tagpf-{i}",
+                url=f"https://example.com/tagpf-{i}",
+            )
+            self.tag.append_item(book)
+        app = Takahe.get_or_create_app(
+            "Tag Prefetch Tests",
+            "https://example.org",
+            "https://example.org/callback",
+            owner_pk=self.user.identity.pk,
+        )
+        self.token = Takahe.refresh_token(app, self.user.identity.pk, self.user.pk)
+
+    def test_tag_items_api_batches_item_queries(self):
+        client = Client()
+        with CaptureQueriesContext(connection) as ctx:
+            response = client.get(
+                f"/api/me/tag/{self.tag.uuid}/item/",
+                HTTP_AUTHORIZATION=f"Bearer {self.token}",
+            )
+        assert response.status_code == 200
+        assert response.json()["count"] == 3
+        item_individual = [
+            q
+            for q in ctx.captured_queries
+            if 'FROM "catalog_item"' in q["sql"]
+            and 'WHERE "catalog_item"."id" = ' in q["sql"]
+        ]
+        assert item_individual == [], (
+            f"tag items API loaded items one at a time: {len(item_individual)}"
+        )
+        extres = [
+            q
+            for q in ctx.captured_queries
+            if 'FROM "catalog_externalresource"' in q["sql"]
+        ]
+        assert len(extres) <= 1, "external_resources not batched"


### PR DESCRIPTION
Fixes NEODB-SOCIAL-7XJ: N+1 query on `GET /api/me/tag/{tag_uuid}/item/`.

The endpoint returned raw `TagMember` rows, so `ItemSchema` loaded each member's polymorphic item, and then its external resources and credits, one query at a time.

The collection items API already hydrates a page's items in batched queries through its paginator. That paginator is renamed `ListMemberPageNumberPagination` since it now serves both list types, and the tag endpoint uses it. A query-count test reproduces the per-item loads on the old code and passes with the fix.