### PR TITLE
fix(mastodon): register a single redirect uri on Mitra and log app creation errors

### DIFF
--- a/neodb/mastodon/models/mastodon.py
+++ b/neodb/mastodon/models/mastodon.py
@@ -254,17 +254,33 @@ def post_toot2(
 
 def _get_redirect_uris(server_version: str) -> str:
     v = server_version or ""
+    # GoToSocial, Mitra and a few others reject more than one redirect uri
     allow_multiple_redir = not (
-        re.search(r"Pixelfed|Friendica", v) or v.startswith("0.")
-    )  # GoToSocial and a few don't support multiple redirect uris
+        re.search(r"Pixelfed|Friendica|Mitra", v) or v.startswith("0.")
+    )
     u = settings.SITE_INFO["site_url"] + "/account/login/oauth"
     if not allow_multiple_redir:
         return u
-    u2s = [
-        f"https://{d}/account/login/oauth"
-        for d in SiteConfig.system.alternative_domains
-    ]
-    return "\n".join([u] + u2s)
+    uris = [u]
+    for d in SiteConfig.system.alternative_domains:
+        d = d.strip().lower()
+        if not d:
+            continue
+        alt = f"https://{d}/account/login/oauth"
+        if alt not in uris:
+            uris.append(alt)
+    return "\n".join(uris)
+
+
+def _response_error(response: requests.Response) -> str:
+    """Server-side reason for a failed request, for logs and error messages."""
+    try:
+        data = response.json()
+    except ValueError:
+        return response.text[:200]
+    if isinstance(data, dict):
+        return str(data.get("error_description") or data.get("error") or "")[:200]
+    return ""
 
 
 def _get_scopes(server_version: str) -> str:
@@ -520,10 +536,12 @@ def get_or_create_fediverse_application(login_domain: str):
             return app
     response = create_app(api_domain, server_version)
     if response.status_code != 200:
+        detail = _response_error(response)
         logger.error(
-            f"Error creating app for {domain} on {api_domain}: {response.status_code}"
+            f"Error creating app for {domain} on {api_domain}: {response.status_code} {detail}"
         )
-        raise Exception("Error creating app, code: " + str(response.status_code))
+        msg = f"Error creating app, code: {response.status_code}"
+        raise Exception(f"{msg} ({detail})" if detail else msg)
     try:
         data = response.json()
     except Exception:
@@ -626,7 +644,7 @@ class MastodonApplication(models.Model):
         response = create_app(self.api_domain, self.server_version)
         if response.status_code != 200:
             logger.error(
-                f"Error creating app for {self.domain_name} on {self.api_domain}: {response.status_code}"
+                f"Error creating app for {self.domain_name} on {self.api_domain}: {response.status_code} {_response_error(response)}"
             )
             return False
         data = response.json()

--- a/neodb/tests/mastodon/test_models.py
+++ b/neodb/tests/mastodon/test_models.py
@@ -5,12 +5,14 @@ from django.conf import settings
 from django.db import IntegrityError
 from django.utils import timezone
 
+from common.models import SiteConfig
 from mastodon.models import MastodonAccount, MastodonApplication, Platform
 from mastodon.models.mastodon import (
     TootVisibilityEnum,
     _force_recreate_app,
     _get_redirect_uris,
     _get_scopes,
+    _response_error,
     get_toot_visibility,
 )
 from users.models import User
@@ -72,6 +74,46 @@ class TestGetRedirectUris:
         result = _get_redirect_uris("4.1.0")
         # At minimum, the primary site URL is included
         assert settings.SITE_INFO["site_url"] + "/account/login/oauth" in result
+
+    def test_mitra_returns_single_uri(self, monkeypatch):
+        monkeypatch.setattr(
+            SiteConfig.system, "alternative_domains", ["alt.example.org"]
+        )
+        result = _get_redirect_uris("4.0.0 (compatible; Mitra 5.10.0)")
+        assert result == settings.SITE_INFO["site_url"] + "/account/login/oauth"
+
+    def test_alternative_domains_are_cleaned(self, monkeypatch):
+        primary = settings.SITE_INFO["site_url"] + "/account/login/oauth"
+        monkeypatch.setattr(
+            SiteConfig.system,
+            "alternative_domains",
+            ["", "  ", settings.SITE_DOMAIN, "Alt.Example.org", "alt.example.org"],
+        )
+        result = _get_redirect_uris("4.1.0")
+        assert result.split("\n") == [
+            primary,
+            "https://alt.example.org/account/login/oauth",
+        ]
+
+
+class TestResponseError:
+    def test_json_error_description(self):
+        response = Mock(
+            json=Mock(return_value={"error": "x", "error_description": "invalid uri"})
+        )
+        assert _response_error(response) == "invalid uri"
+
+    def test_json_error_only(self):
+        response = Mock(json=Mock(return_value={"error": "bad"}))
+        assert _response_error(response) == "bad"
+
+    def test_non_json_body(self):
+        response = Mock(json=Mock(side_effect=ValueError), text="<html>oops</html>")
+        assert _response_error(response) == "<html>oops</html>"
+
+    def test_json_list(self):
+        response = Mock(json=Mock(return_value=[1]))
+        assert _response_error(response) == ""
 
 
 @pytest.mark.django_db(databases="__all__")


### PR DESCRIPTION
Fixes #1873

## Cause

Mitra validates the `redirect_uris` field of `POST /api/v1/apps` as one absolute URI. When a NeoDB instance has alternative domains configured, `_get_redirect_uris` joins several URIs with newlines, so Mitra rejects the registration:

```
{"error":"invalid redirect URI","error_description":"invalid redirect URI"}
HTTP 400
```

Mitra reports its version as `4.0.0 (compatible; Mitra 5.10.0)`, which the existing `Pixelfed|Friendica` single-URI exception did not match. Verified against a live Mitra instance: the newline-joined value fails, the single URI succeeds.

## Changes

- Add `Mitra` to the single-redirect-URI exception.
- Drop blank alternative domain entries and duplicates of the main domain when building the list.
- Include the server's `error_description` in the app creation error log and in the user-facing message, so the next such report carries the reason instead of only a status code.
- Tests for the Mitra case, the cleanup, and the error detail helper.

## Notes

- Mitra rejects `grant_type=client_credentials`, so the post-registration `verify_client` call logs one error on Mitra. Login still proceeds. Not changed here.
- Like Pixelfed and Friendica, only the primary domain is registered on Mitra, so logging in from an alternative NeoDB domain will not work on Mitra.