### PR TITLE
fix(takahe): render post content unescaped on takahe web pages

### DIFF
--- a/takahe/activities/models/post.py
+++ b/takahe/activities/models/post.py
@@ -7,7 +7,7 @@ import re
 import ssl
 from collections.abc import Iterable
 from typing import Optional
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 import httpx
 import urlman
@@ -39,6 +39,7 @@ from django.template import loader
 from django.template.defaultfilters import linebreaks_filter
 from django.utils import timezone
 from django.utils.html import strip_tags
+from django.utils.safestring import mark_safe
 from pyld.jsonld import JsonLdError
 from stator.exceptions import TryAgainLater
 from stator.models import State, StateField, StateGraph, StatorModel
@@ -815,13 +816,25 @@ class Post(StatorModel):
             return func(local=local)
         return self._safe_content_note(local=local)  # fallback
 
-    @staticmethod
-    def _rewrite_neodb_urls(content: str) -> str:
+    _neodb_url_regex = re.compile(r'href="(https?://[^/"]+)/~neodb~(/[^"]+)"')
+
+    @classmethod
+    def _rewrite_neodb_urls(cls, content: str) -> str:
         """Rewrite ~neodb~ placeholder URLs to local search URLs for display."""
-        return re.sub(
-            r'href="(https?://[^/"]+)/~neodb~(/[^"]+)"',
-            'href="https://' + settings.SETUP.MAIN_DOMAIN + r'/search?r=1&q=\1\2"',
-            content,
+        # mark_safe: input is render_post output (already sanitized), and the
+        # inserted href is quoted, so the rewrite introduces no unsafe markup.
+        # Without it re.sub returns a plain str and templates escape the HTML.
+        return mark_safe(
+            cls._neodb_url_regex.sub(
+                lambda m: (
+                    'href="https://'
+                    + settings.SETUP.MAIN_DOMAIN
+                    + "/search?r=1&q="
+                    + quote(m.group(1) + m.group(2), safe="")
+                    + '"'
+                ),
+                content,
+            )
         )
 
     def safe_content_local(self):

--- a/takahe/templates/base.html
+++ b/takahe/templates/base.html
@@ -6,7 +6,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         {% load static %}
         <link rel="stylesheet" href="{% static "css/style.css" %}" type="text/css" media="screen" />
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@7.2.0/css/fontawesome.min.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@7.3.1/css/all.min.css">
         <link rel="shortcut icon" href="{{ config.site_icon }}">
         <script src="{% static "js/hyperscript.min.js" %}"></script>
         <script src="{% static "js/htmx.min.js" %}"></script>


### PR DESCRIPTION
## Summary

- `Post._rewrite_neodb_urls` in takahe ran `re.sub` on the `SafeString` returned by `ContentRenderer.render_post` and returned a plain `str`. Django then autoescaped the post body, so the hashtag timeline (`/tags/<tag>/`, the only public HTML page still served by takahe) and the report / moderation / delete pages showed raw HTML. The result is now marked safe and the search query is percent-encoded, matching the mirror in `neodb/takahe/models.py` (af216c6e).
- `takahe/templates/base.html` loaded only Font Awesome `fontawesome.min.css`, which declares no `@font-face`, so icons never rendered on takahe pages. Switched to `all.min.css` on the same version NeoDB uses.

Example: https://eggplant.place/tags/aliceweidel/

## Test plan

- [x] `uv run pre-commit run --files` on both files
- [x] takahe `tests/activities/models/test_post.py`, `test_converted_post_types.py`, `tests/core/test_html.py` pass except the pre-existing `test_fetch_post` failure
- [x] Django shell: helper returns `SafeString`, template renders anchor unescaped, query percent-encoded
