### PR TITLE
feat(takahe): log inbound POST signatures that do not cover Digest

### DIFF
--- a/takahe/core/signatures.py
+++ b/takahe/core/signatures.py
@@ -211,6 +211,26 @@ class HttpSignature:
             raise VerificationFormatError(f"{label} is too far away")
 
     @classmethod
+    def check_digest_coverage(
+        cls, request: HttpRequest, signature_details: "HttpSignatureDetails"
+    ) -> bool:
+        """
+        Reports whether a POST signature covers the Digest header.
+
+        Mastodon and Misskey reject a POST whose signature does not cover Digest,
+        because the body is then unauthenticated. This only logs for now, so we
+        can measure which senders would break before making it a hard failure.
+        """
+        if request.method != "POST" or "digest" in signature_details["headers"]:
+            return True
+        logger.error(
+            "Inbox: POST signature from %s does not cover Digest (headers=%s)",
+            signature_details.get("keyid"),
+            " ".join(signature_details["headers"]),
+        )
+        return False
+
+    @classmethod
     def verify_request(cls, request, public_key, skip_date=False):
         """
         Verifies that the request has a valid signature for its body
@@ -241,6 +261,7 @@ class HttpSignature:
             and signature_details["algorithm"] != "hs2019"
         ):
             raise VerificationFormatError("Unknown signature algorithm")
+        cls.check_digest_coverage(request, signature_details)
         # Validate hs2019 (created) timestamp when used in place of Date header.
         # Note: (expires) is intentionally not enforced here — neither Mastodon nor
         # Pleroma enforce it, and doing so unilaterally would break interop with

--- a/takahe/core/signatures.py
+++ b/takahe/core/signatures.py
@@ -221,7 +221,9 @@ class HttpSignature:
         Call it only after the signature verified, so forged requests cannot
         flood the log.
         """
-        if "digest" in signed_headers:
+        # parse_signature keeps the sender's casing; the signed payload is
+        # built case-insensitively, so compare the same way.
+        if "digest" in (name.lower() for name in signed_headers):
             return True
         logger.error(
             "Inbox: POST signature from %s does not cover Digest (headers=%s)",

--- a/takahe/core/signatures.py
+++ b/takahe/core/signatures.py
@@ -211,22 +211,23 @@ class HttpSignature:
             raise VerificationFormatError(f"{label} is too far away")
 
     @classmethod
-    def check_digest_coverage(
-        cls, request: HttpRequest, signature_details: "HttpSignatureDetails"
-    ) -> bool:
+    def check_digest_coverage(cls, key_id: str, signed_headers: list[str]) -> bool:
         """
-        Reports whether a POST signature covers the Digest header.
+        Reports whether a verified POST signature covers the Digest header.
 
         Mastodon and Misskey reject a POST whose signature does not cover Digest,
         because the body is then unauthenticated. This only logs for now, so we
         can measure which senders would break before making it a hard failure.
+        Call it only after the signature verified, so forged requests cannot
+        flood the log.
         """
-        if request.method != "POST" or "digest" in signature_details["headers"]:
+        if "digest" in signed_headers:
             return True
         logger.error(
             "Inbox: POST signature from %s does not cover Digest (headers=%s)",
-            signature_details.get("keyid"),
-            " ".join(signature_details["headers"]),
+            key_id,
+            " ".join(signed_headers),
+            extra={"keyid": key_id, "signed_headers": signed_headers},
         )
         return False
 
@@ -261,7 +262,6 @@ class HttpSignature:
             and signature_details["algorithm"] != "hs2019"
         ):
             raise VerificationFormatError("Unknown signature algorithm")
-        cls.check_digest_coverage(request, signature_details)
         # Validate hs2019 (created) timestamp when used in place of Date header.
         # Note: (expires) is intentionally not enforced here — neither Mastodon nor
         # Pleroma enforce it, and doing so unilaterally would break interop with
@@ -282,6 +282,10 @@ class HttpSignature:
             headers_string,
             public_key,
         )
+        if request.method == "POST":
+            cls.check_digest_coverage(
+                signature_details["keyid"], signature_details["headers"]
+            )
 
     @classmethod
     def signed_request(

--- a/takahe/tests/core/test_signatures.py
+++ b/takahe/tests/core/test_signatures.py
@@ -257,7 +257,9 @@ def _signed_request(keypair, method: str, signed_headers: list[str], tamper=Fals
         "date": date,
         "digest": digest,
     }
-    signed_string = "\n".join(f"{name}: {values[name]}" for name in signed_headers)
+    signed_string = "\n".join(
+        f"{name.lower()}: {values[name.lower()]}" for name in signed_headers
+    )
     private_key = serialization.load_pem_private_key(
         keypair["private_key"].encode(), password=None
     )
@@ -327,8 +329,21 @@ def test_verify_request_bad_signature_without_digest_not_logged(keypair, caplog)
     assert caplog.records == []
 
 
+def test_verify_request_mixed_case_digest_not_logged(keypair, caplog):
+    """
+    Senders may list header names in any case; a signed `Digest` covers the body.
+    """
+    request = _signed_request(
+        keypair, "POST", ["(request-target)", "Host", "Date", "Digest"]
+    )
+    with caplog.at_level("ERROR", logger="core.signatures"):
+        HttpSignature.verify_request(request, keypair["public_key"])
+    assert caplog.records == []
+
+
 def test_check_digest_coverage():
     assert HttpSignature.check_digest_coverage("k", ["host", "date", "digest"])
+    assert HttpSignature.check_digest_coverage("k", ["Host", "Date", "DIGEST"])
     assert not HttpSignature.check_digest_coverage("k", ["host", "date"])
 
 

--- a/takahe/tests/core/test_signatures.py
+++ b/takahe/tests/core/test_signatures.py
@@ -9,6 +9,7 @@ from pytest_httpx import HTTPXMock
 from core.files import check_url_safety
 from core.signatures import (
     HttpSignature,
+    HttpSignatureDetails,
     LDSignature,
     VerificationError,
     VerificationFormatError,
@@ -237,6 +238,80 @@ def test_verify_request_hs2019_with_created(keypair):
     )
     # Should verify without raising
     HttpSignature.verify_request(request, keypair["public_key"])
+
+
+def _signed_post(keypair, signed_headers: list[str]):
+    """
+    Builds a POST to /inbox whose signature covers exactly signed_headers.
+    Digest and Date headers are always sent; only their coverage varies.
+    """
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import padding
+    from django.utils.http import http_date
+
+    body = b'{"type": "Note"}'
+    digest = HttpSignature.calculate_digest(body)
+    date = http_date()
+    values = {
+        "(request-target)": "post /inbox",
+        "host": "example.com",
+        "date": date,
+        "digest": digest,
+    }
+    signed_string = "\n".join(f"{name}: {values[name]}" for name in signed_headers)
+    private_key = serialization.load_pem_private_key(
+        keypair["private_key"].encode(), password=None
+    )
+    sig_b64 = base64.b64encode(
+        private_key.sign(signed_string.encode(), padding.PKCS1v15(), hashes.SHA256())
+    ).decode()
+    return RequestFactory().post(
+        path="/inbox",
+        data=body,
+        content_type="application/json",
+        HTTP_HOST="example.com",
+        HTTP_DATE=date,
+        HTTP_DIGEST=digest,
+        HTTP_SIGNATURE=(
+            f'keyId="{keypair["public_key_id"]}",'
+            f'algorithm="rsa-sha256",'
+            f'headers="{" ".join(signed_headers)}",'
+            f'signature="{sig_b64}"'
+        ),
+    )
+
+
+def test_verify_request_logs_unsigned_digest(keypair, caplog):
+    """
+    A POST whose signature does not cover Digest still verifies for now, but
+    is logged at error level so affected senders can be found before enforcing.
+    """
+    request = _signed_post(keypair, ["(request-target)", "host", "date"])
+    with caplog.at_level("ERROR", logger="core.signatures"):
+        HttpSignature.verify_request(request, keypair["public_key"])
+    assert len(caplog.records) == 1
+    assert "does not cover Digest" in caplog.records[0].getMessage()
+    assert keypair["public_key_id"] in caplog.records[0].getMessage()
+
+
+def test_verify_request_signed_digest_not_logged(keypair, caplog):
+    request = _signed_post(keypair, ["(request-target)", "host", "date", "digest"])
+    with caplog.at_level("ERROR", logger="core.signatures"):
+        HttpSignature.verify_request(request, keypair["public_key"])
+    assert caplog.records == []
+
+
+def test_check_digest_coverage_ignores_get(caplog):
+    request = RequestFactory().get("/actor")
+    details: HttpSignatureDetails = {
+        "algorithm": "rsa-sha256",
+        "headers": ["(request-target)", "host", "date"],
+        "signature": b"",
+        "keyid": "https://example.com/a#main-key",
+    }
+    with caplog.at_level("ERROR", logger="core.signatures"):
+        assert HttpSignature.check_digest_coverage(request, details)
+    assert caplog.records == []
 
 
 def test_verify_request_created_timestamp_too_old(keypair):

--- a/takahe/tests/core/test_signatures.py
+++ b/takahe/tests/core/test_signatures.py
@@ -9,7 +9,6 @@ from pytest_httpx import HTTPXMock
 from core.files import check_url_safety
 from core.signatures import (
     HttpSignature,
-    HttpSignatureDetails,
     LDSignature,
     VerificationError,
     VerificationFormatError,
@@ -240,9 +239,9 @@ def test_verify_request_hs2019_with_created(keypair):
     HttpSignature.verify_request(request, keypair["public_key"])
 
 
-def _signed_post(keypair, signed_headers: list[str]):
+def _signed_request(keypair, method: str, signed_headers: list[str], tamper=False):
     """
-    Builds a POST to /inbox whose signature covers exactly signed_headers.
+    Builds a request to /inbox whose signature covers exactly signed_headers.
     Digest and Date headers are always sent; only their coverage varies.
     """
     from cryptography.hazmat.primitives import hashes, serialization
@@ -253,7 +252,7 @@ def _signed_post(keypair, signed_headers: list[str]):
     digest = HttpSignature.calculate_digest(body)
     date = http_date()
     values = {
-        "(request-target)": "post /inbox",
+        "(request-target)": f"{method.lower()} /inbox",
         "host": "example.com",
         "date": date,
         "digest": digest,
@@ -262,11 +261,15 @@ def _signed_post(keypair, signed_headers: list[str]):
     private_key = serialization.load_pem_private_key(
         keypair["private_key"].encode(), password=None
     )
-    sig_b64 = base64.b64encode(
-        private_key.sign(signed_string.encode(), padding.PKCS1v15(), hashes.SHA256())
-    ).decode()
-    return RequestFactory().post(
-        path="/inbox",
+    sig_bytes = private_key.sign(
+        signed_string.encode(), padding.PKCS1v15(), hashes.SHA256()
+    )
+    if tamper:
+        sig_bytes = bytes([sig_bytes[0] ^ 0xFF]) + sig_bytes[1:]
+    sig_b64 = base64.b64encode(sig_bytes).decode()
+    return RequestFactory().generic(
+        method,
+        "/inbox",
         data=body,
         content_type="application/json",
         HTTP_HOST="example.com",
@@ -286,32 +289,47 @@ def test_verify_request_logs_unsigned_digest(keypair, caplog):
     A POST whose signature does not cover Digest still verifies for now, but
     is logged at error level so affected senders can be found before enforcing.
     """
-    request = _signed_post(keypair, ["(request-target)", "host", "date"])
+    request = _signed_request(keypair, "POST", ["(request-target)", "host", "date"])
     with caplog.at_level("ERROR", logger="core.signatures"):
         HttpSignature.verify_request(request, keypair["public_key"])
     assert len(caplog.records) == 1
     assert "does not cover Digest" in caplog.records[0].getMessage()
-    assert keypair["public_key_id"] in caplog.records[0].getMessage()
+    assert caplog.records[0].keyid == keypair["public_key_id"]
 
 
 def test_verify_request_signed_digest_not_logged(keypair, caplog):
-    request = _signed_post(keypair, ["(request-target)", "host", "date", "digest"])
+    request = _signed_request(
+        keypair, "POST", ["(request-target)", "host", "date", "digest"]
+    )
     with caplog.at_level("ERROR", logger="core.signatures"):
         HttpSignature.verify_request(request, keypair["public_key"])
     assert caplog.records == []
 
 
-def test_check_digest_coverage_ignores_get(caplog):
-    request = RequestFactory().get("/actor")
-    details: HttpSignatureDetails = {
-        "algorithm": "rsa-sha256",
-        "headers": ["(request-target)", "host", "date"],
-        "signature": b"",
-        "keyid": "https://example.com/a#main-key",
-    }
+def test_verify_request_get_without_digest_not_logged(keypair, caplog):
+    request = _signed_request(keypair, "GET", ["(request-target)", "host", "date"])
     with caplog.at_level("ERROR", logger="core.signatures"):
-        assert HttpSignature.check_digest_coverage(request, details)
+        HttpSignature.verify_request(request, keypair["public_key"])
     assert caplog.records == []
+
+
+def test_verify_request_bad_signature_without_digest_not_logged(keypair, caplog):
+    """
+    The coverage log runs only after verification, so forged requests cannot
+    flood it.
+    """
+    request = _signed_request(
+        keypair, "POST", ["(request-target)", "host", "date"], tamper=True
+    )
+    with caplog.at_level("ERROR", logger="core.signatures"):
+        with pytest.raises(VerificationError):
+            HttpSignature.verify_request(request, keypair["public_key"])
+    assert caplog.records == []
+
+
+def test_check_digest_coverage():
+    assert HttpSignature.check_digest_coverage("k", ["host", "date", "digest"])
+    assert not HttpSignature.check_digest_coverage("k", ["host", "date"])
 
 
 def test_verify_request_created_timestamp_too_old(keypair):

--- a/takahe/users/models/inbox_message.py
+++ b/takahe/users/models/inbox_message.py
@@ -108,6 +108,11 @@ class InboxMessageStates(StateGraph):
                         sig_data["headers_string"],
                         identity.public_key,
                     )
+                    # Entries stored before this field existed skip the check.
+                    if "signed_headers" in sig_data:
+                        HttpSignature.check_digest_coverage(
+                            actor_uri, sig_data["signed_headers"]
+                        )
                 logger.debug(
                     "Inbox: Deferred %s verification succeeded for %s",
                     sig_type,

--- a/takahe/users/views/activitypub.py
+++ b/takahe/users/views/activitypub.py
@@ -370,6 +370,7 @@ class Inbox(FederatedView):
                 else:
                     logger.info("Inbox: No key available for %s", key_id_actor)
                     # Pre-compute signed cleartext for deferred verification.
+                    HttpSignature.check_digest_coverage(request, signature_details)
                     if "digest" in request.headers:
                         expected_digest = HttpSignature.calculate_digest(request.body)
                         if request.headers["digest"] != expected_digest:

--- a/takahe/users/views/activitypub.py
+++ b/takahe/users/views/activitypub.py
@@ -370,7 +370,6 @@ class Inbox(FederatedView):
                 else:
                     logger.info("Inbox: No key available for %s", key_id_actor)
                     # Pre-compute signed cleartext for deferred verification.
-                    HttpSignature.check_digest_coverage(request, signature_details)
                     if "digest" in request.headers:
                         expected_digest = HttpSignature.calculate_digest(request.body)
                         if request.headers["digest"] != expected_digest:
@@ -384,12 +383,14 @@ class Inbox(FederatedView):
                             "relay_uri": key_id_actor,
                             "signature": sig_b64,
                             "headers_string": headers_string,
+                            "signed_headers": signature_details["headers"],
                         }
                     else:
                         metadata["http_sig"] = {
                             "actor_uri": document["actor"],
                             "signature": sig_b64,
                             "headers_string": headers_string,
+                            "signed_headers": signature_details["headers"],
                         }
             except VerificationFormatError as e:
                 logger.warning("Inbox error: Bad HTTP signature format: %s", e.args[0])


### PR DESCRIPTION
## Summary

Mastodon and Misskey reject an inbound POST whose HTTP signature does not cover the `Digest` header, since the body is then unauthenticated. Takahe checks a Digest only when one is present and never requires it to be signed.

This is a conservative first step: `HttpSignature.check_digest_coverage` logs at error level (so Sentry surfaces it, with `keyid` and `signed_headers` as extra data) when a **verified** POST signature omits `digest`. Nothing is rejected yet. Once the logs show no legitimate senders are affected, the check can become a hard failure.

The log runs only after the signature verifies, so forged requests cannot flood it:
- cached-key path: at the end of `HttpSignature.verify_request`
- deferred path: the inbox view stores the signed header list in the `http_sig` / `relay_http_sig` metadata, and `InboxMessage._verify_deferred` logs once the stored signature verifies. Entries stored before this field existed skip the check.

Verified that our own senders already sign `(request-target) host date digest content-type`: takahe outbound, neodb-relay (go-fed httpsig) and neodb-bridge.

## Test plan

- [x] `takahe/tests/core/test_signatures.py`: log on unsigned digest, no log when signed, no log for GET, no log for a bad signature
- [x] `uv run pre-commit run --files ...` passes
- [ ] CI on fork