### PR TITLE
fix(catalog): confirm before an anonymous url paste triggers a fetch

### DIFF
--- a/neodb/catalog/templates/fetch_confirm.html
+++ b/neodb/catalog/templates/fetch_confirm.html
@@ -1,0 +1,41 @@
+{% load static %}
+{% load i18n %}
+{% load l10n %}
+{% load humanize %}
+{% load mastodon %}
+{% load thumb %}
+{% get_current_language as LANGUAGE_CODE %}
+<!DOCTYPE html>
+<html lang="{{ LANGUAGE_CODE }}" class="classic-page">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ site_name }} - {% trans 'Search results' %}</title>
+    {% include "common_libs.html" %}
+  </head>
+  <body>
+    {% include '_header.html' %}
+    <main>
+      <div class="grid__main">
+        <article>
+          <h5>{% trans "This link is not in the catalog yet." %}</h5>
+          <p>
+            <code>{{ url }}</code>
+          </p>
+          <p>
+            {% blocktrans with site_label=source %}Get the data from {{ site_label }} and add it to the catalog?{% endblocktrans %}
+          </p>
+          <form method="post" action="{% url 'catalog:fetch_url' %}">
+            {% csrf_token %}
+            <input type="hidden" name="url" value="{{ url }}">
+            <input type="submit" value="{% trans 'Fetch' %}">
+          </form>
+        </article>
+      </div>
+      <aside class="grid__aside bottom">
+        {% include "_sidebar_search.html" %}
+      </aside>
+    </main>
+    {% include '_footer.html' %}
+  </body>
+</html>

--- a/neodb/catalog/urls.py
+++ b/neodb/catalog/urls.py
@@ -291,6 +291,7 @@ urlpatterns = [
     path("search/", RedirectView.as_view(url="/search", query_string=True)),
     path("search/external", external_search, name="external_search"),
     path("fetch_refresh/<str:job_id>", fetch_refresh, name="fetch_refresh"),
+    path("fetch", fetch_url, name="fetch_url"),
     path("refetch", refetch, name="refetch"),
     path("unlink", unlink, name="unlink"),
     path(

--- a/neodb/catalog/views/search.py
+++ b/neodb/catalog/views/search.py
@@ -187,16 +187,10 @@ def _fetch_or_confirm(
 ) -> HttpResponse:
     """Start the fetch, or ask the visitor to confirm it first.
 
-    Fetching makes the server issue an outbound request to a host the
-    visitor chose, so a GET must not trigger it: a crawler following
-    ``/search?q=<url>`` links would spend the shared throttle budget
-    (``get_actor_fetch_lock``) for everyone. What the gate asks is how
-    the request arrived, not who sent it. Submitting the search box is
-    already deliberate, and the header posts such a query straight to
-    ``fetch_url``; every GET is someone opening a link, a bookmark or an
-    address-bar search, and is confirmed first whether or not they are
-    signed in. A url already in the catalog still redirects with nothing
-    to confirm.
+    A GET must not make the server fetch a host the visitor chose: a
+    crawler following ``/search?q=<url>`` would spend the shared throttle
+    budget for everyone. Only a POST is deliberate, from the search box
+    or from the confirmation form.
     """
     if confirmed:
         return fetch(request, url, site, False)
@@ -219,8 +213,7 @@ def resolve_url_query(request, keywords, confirmed: bool = False):
     response and return it; otherwise return None.
 
     Shared by the generic and people/org search views so paste-URL
-    behavior stays consistent. `confirmed` is set by the POST view that
-    the anonymous confirmation form submits to.
+    behavior stays consistent. `confirmed` is set by `fetch_url`.
     """
     if keywords.find("://") <= 0:
         return None
@@ -438,14 +431,12 @@ def external_search(request):
 @user_identity_required
 @require_http_methods(["POST"])
 def fetch_url(request):
-    """Start a fetch the visitor asked for: the header search box posts a
-    url query here, and so does the confirmation form.
+    """Start a fetch the visitor asked for, from the search box or the
+    confirmation form.
 
     Open to anonymous callers by design, hence `user_identity_required`
-    rather than `login_required`; the POST and its CSRF token are what
-    make the fetch a deliberate act. The url goes back through
-    `resolve_url_query` so a hand-crafted POST still takes the local and
-    remote-mirror redirects instead of fetching.
+    rather than `login_required`. Goes back through `resolve_url_query`
+    so a hand-crafted POST still takes the redirect branches.
     """
     url = request.POST.get("url", "").strip()
     response = resolve_url_query(request, url, confirmed=True) if url else None

--- a/neodb/catalog/views/search.py
+++ b/neodb/catalog/views/search.py
@@ -185,17 +185,20 @@ def _list_sync_args_from_post(piece):
 def _fetch_or_confirm(
     request, url: str, site: AbstractSite | None, confirmed: bool
 ) -> HttpResponse:
-    """Start the fetch, or ask an anonymous visitor to confirm it first.
+    """Start the fetch, or ask the visitor to confirm it first.
 
     Fetching makes the server issue an outbound request to a host the
-    visitor chose, and every anonymous caller shares one throttle slot
-    (``get_actor_fetch_lock``), so a GET must not trigger it: a crawler
-    following ``/search?q=<url>`` links would spend that budget for
-    everyone. Signed-in traffic is attributable and keeps the one-step
-    behavior, and a url already in the catalog still redirects for
-    everyone with nothing to confirm.
+    visitor chose, so a GET must not trigger it: a crawler following
+    ``/search?q=<url>`` links would spend the shared throttle budget
+    (``get_actor_fetch_lock``) for everyone. What the gate asks is how
+    the request arrived, not who sent it. Submitting the search box is
+    already deliberate, and the header posts such a query straight to
+    ``fetch_url``; every GET is someone opening a link, a bookmark or an
+    address-bar search, and is confirmed first whether or not they are
+    signed in. A url already in the catalog still redirects with nothing
+    to confirm.
     """
-    if confirmed or request.user.is_authenticated:
+    if confirmed:
         return fetch(request, url, site, False)
     item = site.get_item(allow_rematch=False) if site else None
     if item:
@@ -435,7 +438,8 @@ def external_search(request):
 @user_identity_required
 @require_http_methods(["POST"])
 def fetch_url(request):
-    """Target of the confirmation form shown to anonymous visitors.
+    """Start a fetch the visitor asked for: the header search box posts a
+    url query here, and so does the confirmation form.
 
     Open to anonymous callers by design, hence `user_identity_required`
     rather than `login_required`; the POST and its CSRF token are what

--- a/neodb/catalog/views/search.py
+++ b/neodb/catalog/views/search.py
@@ -182,12 +182,42 @@ def _list_sync_args_from_post(piece):
     return items_url, inline_items
 
 
-def resolve_url_query(request, keywords):
+def _fetch_or_confirm(
+    request, url: str, site: AbstractSite | None, confirmed: bool
+) -> HttpResponse:
+    """Start the fetch, or ask an anonymous visitor to confirm it first.
+
+    Fetching makes the server issue an outbound request to a host the
+    visitor chose, and every anonymous caller shares one throttle slot
+    (``get_actor_fetch_lock``), so a GET must not trigger it: a crawler
+    following ``/search?q=<url>`` links would spend that budget for
+    everyone. Signed-in traffic is attributable and keeps the one-step
+    behavior, and a url already in the catalog still redirects for
+    everyone with nothing to confirm.
+    """
+    if confirmed or request.user.is_authenticated:
+        return fetch(request, url, site, False)
+    item = site.get_item(allow_rematch=False) if site else None
+    if item:
+        return redirect(item.url)
+    return render(
+        request,
+        "fetch_confirm.html",
+        {
+            "url": url,
+            "source": site.SITE_NAME.label if site else _("the internet"),
+            "sites": SiteName.labels,
+        },
+    )
+
+
+def resolve_url_query(request, keywords, confirmed: bool = False):
     """If `keywords` looks like a URL, resolve it to a redirect or fetch
     response and return it; otherwise return None.
 
     Shared by the generic and people/org search views so paste-URL
-    behavior stays consistent.
+    behavior stays consistent. `confirmed` is set by the POST view that
+    the anonymous confirmation form submits to.
     """
     if keywords.find("://") <= 0:
         return None
@@ -210,12 +240,12 @@ def resolve_url_query(request, keywords):
         keywords, detect_redirection=False, detect_fallback=False
     )
     if site:
-        return fetch(request, keywords, site, False)
+        return _fetch_or_confirm(request, keywords, site, confirmed)
     if request.GET.get("r") and url_has_allowed_host_and_scheme(
         keywords, allowed_hosts=allowed_hosts, require_https=settings.SSL_ONLY
     ):
         return redirect(keywords)
-    return fetch(request, keywords, None, False)
+    return _fetch_or_confirm(request, keywords, None, confirmed)
 
 
 def visible_categories(request):
@@ -400,6 +430,24 @@ def external_search(request):
         else []
     )
     return render(request, "external_search_results.html", {"external_items": items})
+
+
+@user_identity_required
+@require_http_methods(["POST"])
+def fetch_url(request):
+    """Target of the confirmation form shown to anonymous visitors.
+
+    Open to anonymous callers by design, hence `user_identity_required`
+    rather than `login_required`; the POST and its CSRF token are what
+    make the fetch a deliberate act. The url goes back through
+    `resolve_url_query` so a hand-crafted POST still takes the local and
+    remote-mirror redirects instead of fetching.
+    """
+    url = request.POST.get("url", "").strip()
+    response = resolve_url_query(request, url, confirmed=True) if url else None
+    if response is None:
+        raise BadRequest(_("Invalid URL"))
+    return response
 
 
 @login_required

--- a/neodb/common/templates/_header.html
+++ b/neodb/common/templates/_header.html
@@ -200,3 +200,24 @@ _search_cat_change();
 <form id="logout" action="{% url 'users:logout' %}" method="post">
   {% csrf_token %}
 </form>
+{# Submitting the search box is a deliberate act, so a url typed there posts straight to the fetch endpoint and skips the confirmation page. A GET of /search?q=<url> is a link, a bookmark or an address-bar search, and is confirmed first. #}
+<form id="fetch-url-form"
+      action="{% url 'catalog:fetch_url' %}"
+      method="post"
+      hidden>
+  {% csrf_token %}
+  <input type="hidden" name="url">
+</form>
+<script>
+$('.nav-search form[role=search]').on('submit', function (e) {
+  var q = ($('#q').val() || '').trim();
+  var c = $('.nav-search select[name=c]').val();
+  // journal and timeline never resolve a query as a url, so a link stays a text search there
+  if (c === 'journal' || c === 'timeline') return;
+  if (!/^https?:\/\//i.test(q)) return;
+  e.preventDefault();
+  var form = document.getElementById('fetch-url-form');
+  form.querySelector('input[name=url]').value = q;
+  form.submit();
+});
+</script>

--- a/neodb/common/templates/_header.html
+++ b/neodb/common/templates/_header.html
@@ -200,7 +200,6 @@ _search_cat_change();
 <form id="logout" action="{% url 'users:logout' %}" method="post">
   {% csrf_token %}
 </form>
-{# Submitting the search box is a deliberate act, so a url typed there posts straight to the fetch endpoint and skips the confirmation page. A GET of /search?q=<url> is a link, a bookmark or an address-bar search, and is confirmed first. #}
 <form id="fetch-url-form"
       action="{% url 'catalog:fetch_url' %}"
       method="post"
@@ -212,7 +211,6 @@ _search_cat_change();
 $('.nav-search form[role=search]').on('submit', function (e) {
   var q = ($('#q').val() || '').trim();
   var c = $('.nav-search select[name=c]').val();
-  // journal and timeline never resolve a query as a url, so a link stays a text search there
   if (c === 'journal' || c === 'timeline') return;
   if (!/^https?:\/\//i.test(q)) return;
   e.preventDefault();

--- a/neodb/locale/django.pot
+++ b/neodb/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-08 21:25-0400\n"
+"POT-Creation-Date: 2026-09-10 22:57-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1335,7 +1335,7 @@ msgstr ""
 #: catalog/views/edit.py:624 catalog/views/edit.py:664
 #: catalog/views/edit.py:674 catalog/views/edit.py:703
 #: catalog/views/edit.py:782 catalog/views/edit.py:837
-#: catalog/views/edit.py:859 catalog/views/search.py:418
+#: catalog/views/edit.py:859 catalog/views/search.py:466
 msgid "Editing this item is restricted."
 msgstr ""
 
@@ -1909,8 +1909,22 @@ msgstr ""
 msgid "Some items were found from other websites and instances, click their title to save them locally."
 msgstr ""
 
+#: catalog/templates/fetch_confirm.html:13
 #: catalog/templates/fetch_pending.html:13
 msgid "Search results"
+msgstr ""
+
+#: catalog/templates/fetch_confirm.html:21
+msgid "This link is not in the catalog yet."
+msgstr ""
+
+#: catalog/templates/fetch_confirm.html:26
+#, python-format
+msgid "Get the data from %(site_label)s and add it to the catalog?"
+msgstr ""
+
+#: catalog/templates/fetch_confirm.html:31
+msgid "Fetch"
 msgstr ""
 
 #: catalog/templates/fetch_pending.html:22
@@ -2174,8 +2188,8 @@ msgstr ""
 #: catalog/views/edit.py:293 catalog/views/edit.py:296
 #: catalog/views/edit.py:440 catalog/views/edit.py:443
 #: catalog/views/verify.py:197 journal/views/collection.py:79
-#: journal/views/collection.py:104 journal/views/collection.py:607
-#: journal/views/collection.py:703 journal/views/common.py:235
+#: journal/views/collection.py:104 journal/views/collection.py:609
+#: journal/views/collection.py:705 journal/views/common.py:235
 #: journal/views/mark.py:244 journal/views/post.py:119
 #: journal/views/post.py:121 journal/views/post.py:168
 #: journal/views/post.py:187 journal/views/post.py:189
@@ -2209,9 +2223,9 @@ msgstr ""
 #: journal/views/article.py:133 journal/views/article.py:153
 #: journal/views/collection.py:252 journal/views/collection.py:345
 #: journal/views/collection.py:358 journal/views/collection.py:376
-#: journal/views/collection.py:508 journal/views/collection.py:551
-#: journal/views/collection.py:590 journal/views/collection.py:602
-#: journal/views/collection.py:627 journal/views/collection.py:664
+#: journal/views/collection.py:510 journal/views/collection.py:553
+#: journal/views/collection.py:592 journal/views/collection.py:604
+#: journal/views/collection.py:629 journal/views/collection.py:666
 #: journal/views/common.py:308 journal/views/mark.py:317
 #: journal/views/post.py:60 journal/views/post.py:80 journal/views/post.py:102
 #: journal/views/post.py:172 journal/views/post.py:201
@@ -2326,15 +2340,15 @@ msgstr ""
 msgid "This edition will be unlinked from the following work"
 msgstr ""
 
-#: catalog/views/search.py:113
+#: catalog/views/search.py:113 catalog/views/search.py:208
 msgid "the internet"
 msgstr ""
 
-#: catalog/views/search.py:410
+#: catalog/views/search.py:449 catalog/views/search.py:458
 msgid "Invalid URL"
 msgstr ""
 
-#: catalog/views/search.py:413
+#: catalog/views/search.py:461
 msgid "Unsupported URL"
 msgstr ""
 
@@ -5866,7 +5880,7 @@ msgstr ""
 msgid "Boost this post?"
 msgstr ""
 
-#: journal/templates/action_boost_post.html:10 mastodon/models/mastodon.py:706
+#: journal/templates/action_boost_post.html:10 mastodon/models/mastodon.py:724
 msgid "Boost"
 msgstr ""
 
@@ -6364,20 +6378,20 @@ msgstr ""
 msgid "shared {username}'s collection"
 msgstr ""
 
-#: journal/views/collection.py:553 journal/views/collection.py:592
-#: journal/views/collection.py:604 journal/views/collection.py:630
+#: journal/views/collection.py:555 journal/views/collection.py:594
+#: journal/views/collection.py:606 journal/views/collection.py:632
 msgid "Dynamic collection is not editable"
 msgstr ""
 
-#: journal/views/collection.py:569
+#: journal/views/collection.py:571
 msgid "The item is already in the collection."
 msgstr ""
 
-#: journal/views/collection.py:571
+#: journal/views/collection.py:573
 msgid "Unable to find the item, please use item url from this site."
 msgstr ""
 
-#: journal/views/collection.py:617
+#: journal/views/collection.py:619
 msgid "Saved."
 msgstr ""
 
@@ -6555,43 +6569,43 @@ msgid ""
 "If you prefer to register a new account with this email, please use this verification code: {code}"
 msgstr ""
 
-#: mastodon/models/mastodon.py:570
+#: mastodon/models/mastodon.py:588
 msgid "site domain name"
 msgstr ""
 
-#: mastodon/models/mastodon.py:571
+#: mastodon/models/mastodon.py:589
 msgid "domain for api call"
 msgstr ""
 
-#: mastodon/models/mastodon.py:572
+#: mastodon/models/mastodon.py:590
 msgid "type and verion"
 msgstr ""
 
-#: mastodon/models/mastodon.py:573
+#: mastodon/models/mastodon.py:591
 msgid "in-site app id"
 msgstr ""
 
-#: mastodon/models/mastodon.py:574
+#: mastodon/models/mastodon.py:592
 msgid "client id"
 msgstr ""
 
-#: mastodon/models/mastodon.py:575
+#: mastodon/models/mastodon.py:593
 msgid "client secret"
 msgstr ""
 
-#: mastodon/models/mastodon.py:576
+#: mastodon/models/mastodon.py:594
 msgid "vapid key"
 msgstr ""
 
-#: mastodon/models/mastodon.py:578
+#: mastodon/models/mastodon.py:596
 msgid "0: unicode moon; 1: custom emoji"
 msgstr ""
 
-#: mastodon/models/mastodon.py:581
+#: mastodon/models/mastodon.py:599
 msgid "max toot len"
 msgstr ""
 
-#: mastodon/models/mastodon.py:707
+#: mastodon/models/mastodon.py:725
 msgid "New Post"
 msgstr ""
 

--- a/neodb/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-08 21:25-0400\n"
+"POT-Creation-Date: 2026-09-10 22:57-0400\n"
 "PO-Revision-Date: 2026-08-08 21:19+0000\n"
 "Last-Translator: reducedradius <137701630+flytothehighest@users.noreply.github.com>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -1334,7 +1334,7 @@ msgstr "编辑选项"
 #: catalog/views/edit.py:624 catalog/views/edit.py:664
 #: catalog/views/edit.py:674 catalog/views/edit.py:703
 #: catalog/views/edit.py:782 catalog/views/edit.py:837
-#: catalog/views/edit.py:859 catalog/views/search.py:418
+#: catalog/views/edit.py:859 catalog/views/search.py:466
 msgid "Editing this item is restricted."
 msgstr "这个条目仅管理员可编辑。"
 
@@ -1908,9 +1908,23 @@ msgstr "借阅或购买"
 msgid "Some items were found from other websites and instances, click their title to save them locally."
 msgstr "找到了一些来自其它网站可能相关的条目，点击标题可添加到本站。"
 
+#: catalog/templates/fetch_confirm.html:13
 #: catalog/templates/fetch_pending.html:13
 msgid "Search results"
 msgstr "搜索结果"
+
+#: catalog/templates/fetch_confirm.html:21
+msgid "This link is not in the catalog yet."
+msgstr "这个链接还不在目录中。"
+
+#: catalog/templates/fetch_confirm.html:26
+#, python-format
+msgid "Get the data from %(site_label)s and add it to the catalog?"
+msgstr "从%(site_label)s获取数据并添加到目录？"
+
+#: catalog/templates/fetch_confirm.html:31
+msgid "Fetch"
+msgstr "获取"
 
 #: catalog/templates/fetch_pending.html:22
 #, python-format
@@ -2173,8 +2187,8 @@ msgstr "版本"
 #: catalog/views/edit.py:293 catalog/views/edit.py:296
 #: catalog/views/edit.py:440 catalog/views/edit.py:443
 #: catalog/views/verify.py:197 journal/views/collection.py:79
-#: journal/views/collection.py:104 journal/views/collection.py:607
-#: journal/views/collection.py:703 journal/views/common.py:235
+#: journal/views/collection.py:104 journal/views/collection.py:609
+#: journal/views/collection.py:705 journal/views/common.py:235
 #: journal/views/mark.py:244 journal/views/post.py:119
 #: journal/views/post.py:121 journal/views/post.py:168
 #: journal/views/post.py:187 journal/views/post.py:189
@@ -2208,9 +2222,9 @@ msgstr "本操作不可撤销。"
 #: journal/views/article.py:133 journal/views/article.py:153
 #: journal/views/collection.py:252 journal/views/collection.py:345
 #: journal/views/collection.py:358 journal/views/collection.py:376
-#: journal/views/collection.py:508 journal/views/collection.py:551
-#: journal/views/collection.py:590 journal/views/collection.py:602
-#: journal/views/collection.py:627 journal/views/collection.py:664
+#: journal/views/collection.py:510 journal/views/collection.py:553
+#: journal/views/collection.py:592 journal/views/collection.py:604
+#: journal/views/collection.py:629 journal/views/collection.py:666
 #: journal/views/common.py:308 journal/views/mark.py:317
 #: journal/views/post.py:60 journal/views/post.py:80 journal/views/post.py:102
 #: journal/views/post.py:172 journal/views/post.py:201
@@ -2325,15 +2339,15 @@ msgstr "确定取消关联吗？"
 msgid "This edition will be unlinked from the following work"
 msgstr "这个图书版本将与以下作品取消关联"
 
-#: catalog/views/search.py:113
+#: catalog/views/search.py:113 catalog/views/search.py:208
 msgid "the internet"
 msgstr "互联网"
 
-#: catalog/views/search.py:410
+#: catalog/views/search.py:449 catalog/views/search.py:458
 msgid "Invalid URL"
 msgstr "无效网址"
 
-#: catalog/views/search.py:413
+#: catalog/views/search.py:461
 msgid "Unsupported URL"
 msgstr "尚未支持的网址"
 
@@ -5878,7 +5892,7 @@ msgstr "全部分类"
 msgid "Boost this post?"
 msgstr "转播这则帖文吗？"
 
-#: journal/templates/action_boost_post.html:10 mastodon/models/mastodon.py:706
+#: journal/templates/action_boost_post.html:10 mastodon/models/mastodon.py:724
 msgid "Boost"
 msgstr "转播"
 
@@ -6421,20 +6435,20 @@ msgstr "分享我的收藏单"
 msgid "shared {username}'s collection"
 msgstr "分享 {username} 的收藏单"
 
-#: journal/views/collection.py:553 journal/views/collection.py:592
-#: journal/views/collection.py:604 journal/views/collection.py:630
+#: journal/views/collection.py:555 journal/views/collection.py:594
+#: journal/views/collection.py:606 journal/views/collection.py:632
 msgid "Dynamic collection is not editable"
 msgstr "不能修改动态收藏单中的条目"
 
-#: journal/views/collection.py:569
+#: journal/views/collection.py:571
 msgid "The item is already in the collection."
 msgstr "条目已在收藏单中。"
 
-#: journal/views/collection.py:571
+#: journal/views/collection.py:573
 msgid "Unable to find the item, please use item url from this site."
 msgstr "找不到条目，请使用本站条目网址。"
 
-#: journal/views/collection.py:617
+#: journal/views/collection.py:619
 msgid "Saved."
 msgstr "已保存"
 
@@ -6629,43 +6643,43 @@ msgstr ""
 "\n"
 "如果你确认要使用电子邮件新注册账号，请输入如下验证码： {code}"
 
-#: mastodon/models/mastodon.py:570
+#: mastodon/models/mastodon.py:588
 msgid "site domain name"
 msgstr "站点域名"
 
-#: mastodon/models/mastodon.py:571
+#: mastodon/models/mastodon.py:589
 msgid "domain for api call"
 msgstr "站点API域名"
 
-#: mastodon/models/mastodon.py:572
+#: mastodon/models/mastodon.py:590
 msgid "type and verion"
 msgstr "站点类型和版本"
 
-#: mastodon/models/mastodon.py:573
+#: mastodon/models/mastodon.py:591
 msgid "in-site app id"
 msgstr "实例应用id"
 
-#: mastodon/models/mastodon.py:574
+#: mastodon/models/mastodon.py:592
 msgid "client id"
 msgstr "实例应用Client ID"
 
-#: mastodon/models/mastodon.py:575
+#: mastodon/models/mastodon.py:593
 msgid "client secret"
 msgstr "实例应用Client Secret"
 
-#: mastodon/models/mastodon.py:576
+#: mastodon/models/mastodon.py:594
 msgid "vapid key"
 msgstr "实例应用VAPID Key"
 
-#: mastodon/models/mastodon.py:578
+#: mastodon/models/mastodon.py:596
 msgid "0: unicode moon; 1: custom emoji"
 msgstr "0: 月亮表情; 1: 定制表情"
 
-#: mastodon/models/mastodon.py:581
+#: mastodon/models/mastodon.py:599
 msgid "max toot len"
 msgstr "帖文长度限制"
 
-#: mastodon/models/mastodon.py:707
+#: mastodon/models/mastodon.py:725
 msgid "New Post"
 msgstr "新帖文"
 

--- a/neodb/tests/catalog/test_url_fetch_confirm.py
+++ b/neodb/tests/catalog/test_url_fetch_confirm.py
@@ -1,0 +1,118 @@
+"""An anonymous URL paste must not make the server fetch on a GET.
+
+`/search?q=<url>` used to queue an outbound fetch straight from the GET.
+Anonymous callers share one throttle slot, so a crawler following such a
+link spent that budget for everyone. Now they get a confirmation form and
+the fetch starts on the POST.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from django.conf import settings
+from django.test import Client
+from django.urls import reverse
+
+from catalog.models import Movie
+from users.models import User
+
+from .test_fetch_lock import FakeCache, StubSite
+
+URL = "https://example.com/unknown-thing"
+
+
+def _get(client, url, item=None):
+    fake_cache = FakeCache()
+    with (
+        patch(
+            "catalog.views.search.SiteManager.get_site_by_url",
+            return_value=StubSite(item),
+        ),
+        patch("catalog.search.utils.cache", fake_cache),
+        patch("catalog.views.search.enqueue_fetch") as enqueue,
+    ):
+        return client.get(url), enqueue
+
+
+def _post(client, data, item=None):
+    fake_cache = FakeCache()
+    with (
+        patch(
+            "catalog.views.search.SiteManager.get_site_by_url",
+            return_value=StubSite(item),
+        ),
+        patch("catalog.search.utils.cache", fake_cache),
+        patch("catalog.views.search.enqueue_fetch") as enqueue,
+    ):
+        return client.post(reverse("catalog:fetch_url"), data), enqueue
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestAnonymousUrlFetchConfirm:
+    def test_guest_gets_a_form_instead_of_a_fetch(self):
+        response, enqueue = _get(Client(), f"/search?q={URL}")
+        assert response.status_code == 200
+        assert "fetch_confirm.html" in [t.name for t in response.templates]
+        enqueue.assert_not_called()
+
+    def test_confirm_form_posts_the_url_back(self):
+        response, __ = _get(Client(), f"/search?q={URL}")
+        content = response.content.decode()
+        assert f'action="{reverse("catalog:fetch_url")}"' in content
+        assert 'name="csrfmiddlewaretoken"' in content
+        assert f'name="url" value="{URL}"' in content
+
+    def test_existing_item_still_redirects_without_confirming(self):
+        movie = Movie.objects.create(title="Already Here")
+        response, enqueue = _get(Client(), f"/search?q={URL}", item=movie)
+        assert response.status_code == 302
+        assert response["Location"] == movie.url
+        enqueue.assert_not_called()
+
+    def test_people_search_confirms_too(self):
+        """``people_search`` shares ``resolve_url_query``."""
+        response, enqueue = _get(Client(), f"/search?c=people&q={URL}")
+        assert "fetch_confirm.html" in [t.name for t in response.templates]
+        enqueue.assert_not_called()
+
+    def test_guest_post_starts_the_fetch(self):
+        response, enqueue = _post(Client(), {"url": URL})
+        assert response.status_code == 200
+        assert "fetch_pending.html" in [t.name for t in response.templates]
+        enqueue.assert_called_once()
+
+    def test_post_without_a_url_is_rejected(self):
+        response, enqueue = _post(Client(), {})
+        assert response.status_code == 400
+        enqueue.assert_not_called()
+
+    def test_post_of_a_non_url_is_rejected(self):
+        """``resolve_url_query`` returns None for anything without a scheme,
+        which must not fall through as a successful fetch."""
+        response, enqueue = _post(Client(), {"url": "not a url"})
+        assert response.status_code == 400
+        enqueue.assert_not_called()
+
+    def test_post_of_a_local_url_redirects_without_fetching(self):
+        """A hand-crafted POST still takes the local-host branch of
+        ``resolve_url_query`` rather than fetching our own site."""
+        local = f"https://{settings.SITE_DOMAINS[0]}/movie/abc"
+        response, enqueue = _post(Client(), {"url": local})
+        assert response.status_code == 302
+        assert response["Location"] == local
+        enqueue.assert_not_called()
+
+    def test_get_on_the_fetch_route_is_not_allowed(self):
+        assert Client().get(reverse("catalog:fetch_url")).status_code == 405
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestSignedInUrlFetch:
+    def test_user_still_fetches_in_one_step(self):
+        user = User.register(email="fetcher@example.com", username="fetcher")
+        client = Client()
+        client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+        response, enqueue = _get(client, f"/search?q={URL}")
+        assert response.status_code == 200
+        assert "fetch_pending.html" in [t.name for t in response.templates]
+        enqueue.assert_called_once()

--- a/neodb/tests/catalog/test_url_fetch_confirm.py
+++ b/neodb/tests/catalog/test_url_fetch_confirm.py
@@ -1,10 +1,7 @@
 """A pasted URL must not make the server fetch on a GET.
 
-`/search?q=<url>` used to queue an outbound fetch straight from the GET, so
-a crawler following such a link spent the shared throttle budget for
-everyone. The gate asks how the request arrived, not who sent it: the
-header posts a url typed into the search box straight to `fetch_url`, while
-every GET gets a confirmation form first, signed in or not.
+The header posts a url typed into the search box to `fetch_url`; every GET
+gets a confirmation form first, signed in or not.
 """
 
 from unittest.mock import patch
@@ -88,15 +85,13 @@ class TestAnonymousUrlFetchConfirm:
         enqueue.assert_not_called()
 
     def test_post_of_a_non_url_is_rejected(self):
-        """``resolve_url_query`` returns None for anything without a scheme,
-        which must not fall through as a successful fetch."""
+        """``resolve_url_query`` returns None without a scheme."""
         response, enqueue = _post(Client(), {"url": "not a url"})
         assert response.status_code == 400
         enqueue.assert_not_called()
 
     def test_post_of_a_local_url_redirects_without_fetching(self):
-        """A hand-crafted POST still takes the local-host branch of
-        ``resolve_url_query`` rather than fetching our own site."""
+        """A POST still takes the local-host branch."""
         local = f"https://{settings.SITE_DOMAINS[0]}/movie/abc"
         response, enqueue = _post(Client(), {"url": local})
         assert response.status_code == 302
@@ -109,8 +104,7 @@ class TestAnonymousUrlFetchConfirm:
 
 @pytest.mark.django_db(databases="__all__")
 class TestSignedInUrlFetch:
-    """Signing in does not skip the confirmation: a link opened from
-    elsewhere is no more deliberate for a user than for a guest."""
+    """Signing in does not skip the confirmation."""
 
     def _client(self, username="fetcher"):
         user = User.register(email=f"{username}@example.com", username=username)

--- a/neodb/tests/catalog/test_url_fetch_confirm.py
+++ b/neodb/tests/catalog/test_url_fetch_confirm.py
@@ -1,9 +1,10 @@
-"""An anonymous URL paste must not make the server fetch on a GET.
+"""A pasted URL must not make the server fetch on a GET.
 
-`/search?q=<url>` used to queue an outbound fetch straight from the GET.
-Anonymous callers share one throttle slot, so a crawler following such a
-link spent that budget for everyone. Now they get a confirmation form and
-the fetch starts on the POST.
+`/search?q=<url>` used to queue an outbound fetch straight from the GET, so
+a crawler following such a link spent the shared throttle budget for
+everyone. The gate asks how the request arrived, not who sent it: the
+header posts a url typed into the search box straight to `fetch_url`, while
+every GET gets a confirmation form first, signed in or not.
 """
 
 from unittest.mock import patch
@@ -108,11 +109,23 @@ class TestAnonymousUrlFetchConfirm:
 
 @pytest.mark.django_db(databases="__all__")
 class TestSignedInUrlFetch:
-    def test_user_still_fetches_in_one_step(self):
-        user = User.register(email="fetcher@example.com", username="fetcher")
+    """Signing in does not skip the confirmation: a link opened from
+    elsewhere is no more deliberate for a user than for a guest."""
+
+    def _client(self, username="fetcher"):
+        user = User.register(email=f"{username}@example.com", username=username)
         client = Client()
         client.force_login(user, backend="mastodon.auth.OAuth2Backend")
-        response, enqueue = _get(client, f"/search?q={URL}")
+        return client
+
+    def test_user_get_is_confirmed_too(self):
+        response, enqueue = _get(self._client(), f"/search?q={URL}")
+        assert response.status_code == 200
+        assert "fetch_confirm.html" in [t.name for t in response.templates]
+        enqueue.assert_not_called()
+
+    def test_user_post_starts_the_fetch(self):
+        response, enqueue = _post(self._client("poster"), {"url": URL})
         assert response.status_code == 200
         assert "fetch_pending.html" in [t.name for t in response.templates]
         enqueue.assert_called_once()

--- a/neodb/tests/journal/test_collection_federation.py
+++ b/neodb/tests/journal/test_collection_federation.py
@@ -403,15 +403,17 @@ class TestRemoteCollectionUrlPaste:
         intruder = User.register(email="intruder@test.com", username="intruder")
         rf = RequestFactory().get("/search?q=" + remote_url)
         rf.user = intruder
-        # Stub the catalog fall-through fetcher: when the mirror is hidden
-        # ``resolve_url_query`` continues into the regular catalog
-        # ``fetch`` helper, which would render a template that needs
-        # session middleware. We only care that no 302 to the local
-        # mirror was emitted and that no resync was enqueued.
+        # Stub the catalog fall-through: when the mirror is hidden
+        # ``resolve_url_query`` continues into ``_fetch_or_confirm``,
+        # which would render a template that needs session middleware.
+        # We only care that no 302 to the local mirror was emitted and
+        # that no resync was enqueued.
         sentinel = object()
         with (
             patch("django_rq.get_queue") as gq,
-            patch("catalog.views.search.fetch", return_value=sentinel) as fetch_mock,
+            patch(
+                "catalog.views.search._fetch_or_confirm", return_value=sentinel
+            ) as fetch_mock,
         ):
             response = resolve_url_query(rf, remote_url)
         assert not gq.return_value.enqueue.called

--- a/neodb/tests/journal/test_collection_federation.py
+++ b/neodb/tests/journal/test_collection_federation.py
@@ -403,11 +403,8 @@ class TestRemoteCollectionUrlPaste:
         intruder = User.register(email="intruder@test.com", username="intruder")
         rf = RequestFactory().get("/search?q=" + remote_url)
         rf.user = intruder
-        # Stub the catalog fall-through: when the mirror is hidden
-        # ``resolve_url_query`` continues into ``_fetch_or_confirm``,
-        # which would render a template that needs session middleware.
-        # We only care that no 302 to the local mirror was emitted and
-        # that no resync was enqueued.
+        # Stub the fall-through: ``_fetch_or_confirm`` would render a
+        # template that needs session middleware.
         sentinel = object()
         with (
             patch("django_rq.get_queue") as gq,


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] You, as a human, have fully reviewed every single line of this PR
- [ ] You, as a human, have fully tested this PR


* **What kind of change does this PR introduce?**
- [x] bug fix, including security or performance improvements
- [ ] feature
- [ ] docs
- [ ] other


* **What is the current behavior?** (Link to an open issue if applicable)

Pasting a URL into search resolves it straight to a fetch job. A plain `GET /search?q=<url>` therefore makes the server issue an outbound request to a host the visitor chose.

Nothing about that GET says a person asked for it. A crawler that follows `/search?q=...` links, or anyone who posts such links, makes the server fetch arbitrary hosts and spends the shared throttle budget (`get_actor_fetch_lock`) for everyone.


* **What is the new behavior?**

Whether a fetch was asked for now depends on how the request arrived, not on who sent it.

- Typing a URL into the search box and submitting is deliberate, so the header posts it straight to a new `/fetch` endpoint. That path never sees a confirmation page, for guests and signed-in users alike.
- Every `GET /search?q=<url>` is someone opening a link, a bookmark or an address-bar search, so it renders a confirmation page with a POST form instead of fetching. Signed in or not.
- A URL that already resolves locally still redirects, with nothing to confirm.

Implementation:

- `_fetch_or_confirm()` sits between `resolve_url_query()` and `fetch()`. It fetches only when `confirmed`, which the POST view sets. Otherwise it does a DB-only `site.get_item(allow_rematch=False)` check and redirects when the item exists, and renders the confirmation page when it does not.
- New POST-only view `fetch_url()` (route `/fetch`) re-enters `resolve_url_query(..., confirmed=True)`, so a hand-crafted POST still takes the local-host and remote-mirror redirect branches instead of fetching. It is deliberately open to anonymous callers, hence `user_identity_required` rather than `login_required`; the POST and its CSRF token are what make the fetch a deliberate act.
- `_header.html` intercepts the search form submit when the query matches `^https?://` and posts it to `/fetch`. Categories `journal` and `timeline` are excluded, because those views never resolve a query as a URL and a link is a legitimate text query there.
- Throttling and the SSRF gate are untouched: `fetch()` still gates on `get_fetch_lock`, and `enqueue_fetch` still runs `is_valid_url`.


* **Does this PR introduce a breaking change?**

Not for the REST API, and not for anyone who uses the search box.

Anyone who reaches `/search?q=<url>` another way now needs one extra click: a shared link, a bookmark, an address-bar or opensearch search, and any client without JavaScript. Crawlers get a page with a form instead of a queued fetch, which is the point of the change.


* **Other information**:

Tests: `neodb/tests/catalog/test_url_fetch_confirm.py` covers the guest and signed-in GET both reaching the confirmation page, the redirect when the item already exists, people search (it shares `resolve_url_query`), the guest and signed-in POST, empty / non-URL / local-URL POSTs, and the 405 on `GET /fetch`.

Verified on a local dev instance, logged out: typing a Douban URL into the search box lands directly on "Fetching from Douban"; opening `/search?q=<same url>` renders the confirmation page, and its button starts the fetch; a URL searched under category `journal` still does a plain GET text search; no console errors.

Two neighbouring surfaces left alone, both outside "URL not in the catalog":

- `GET /api/catalog/fetch?url=...` has `auth=None` and still queues a fetch on a GET. Its documented contract is GET plus a 202, so gating it would break API clients and needs its own decision.
- `_maybe_remote_piece()` still enqueues a member resync on an anonymous GET, but only for a mirror that already exists locally.

The `.po` / `.pot` diff carries location churn in `journal/views/collection.py` and `mastodon/models/mastodon.py`, files this PR does not touch. The committed catalog was already stale against the code on `main`; that part is not a behaviour change.
