### PR TITLE
fix(catalog): sniff image bytes when Content-Type is not an image type

### DIFF
--- a/neodb/catalog/common/downloaders.py
+++ b/neodb/catalog/common/downloaders.py
@@ -487,9 +487,12 @@ class ImageDownloaderMixin:
                     self.extention = "svg"
                     return RESPONSE_OK
                 file_type = filetype.get_type(mime=mime) if mime else None
-                if file_type is None:
+                if file_type is None or not (file_type.mime or "").startswith("image/"):
                     # Fall back to magic-byte sniffing -- some CDNs send empty
-                    # or non-standard Content-Type for valid images.
+                    # or non-standard Content-Type for valid images. The
+                    # declared type must not be trusted when it is not an
+                    # image: filetype maps application/octet-stream, which
+                    # proxies commonly return, to the EOT font type.
                     file_type = filetype.guess(response.content)
                 if file_type is None or not (file_type.mime or "").startswith("image/"):
                     logger.error(

--- a/neodb/tests/core/test_downloaders.py
+++ b/neodb/tests/core/test_downloaders.py
@@ -276,6 +276,37 @@ class TestImageDownloaderMimeNormalization:
         assert dl.validate_response(_img_response(_png_bytes(), "")) == RESPONSE_OK
         assert dl.extention == "png"
 
+    def test_octet_stream_sniffs_jpeg_body(self):
+        # filetype maps application/octet-stream to the EOT font type, so the
+        # declared type alone would reject a perfectly valid image.
+        dl = BasicImageDownloader("https://example.com/x.jpg")
+        assert (
+            dl.validate_response(
+                _img_response(_jpeg_bytes(), "application/octet-stream")
+            )
+            == RESPONSE_OK
+        )
+        assert dl.extention == "jpg"
+
+    def test_octet_stream_sniffs_png_body(self):
+        dl = BasicImageDownloader("https://example.com/x.png")
+        assert (
+            dl.validate_response(
+                _img_response(_png_bytes(), "application/octet-stream")
+            )
+            == RESPONSE_OK
+        )
+        assert dl.extention == "png"
+
+    def test_octet_stream_with_html_rejected(self):
+        dl = BasicImageDownloader("https://example.com/x.jpg")
+        assert (
+            dl.validate_response(
+                _img_response(b"<html></html>", "application/octet-stream")
+            )
+            == RESPONSE_NETWORK_ERROR
+        )
+
     def test_empty_content_type_with_html_rejected(self):
         dl = BasicImageDownloader("https://example.com/x.jpg")
         assert (


### PR DESCRIPTION
## Problem

Cover downloads fail with `Unsupported image type: application/octet-stream` (Sentry NEODB-SOCIAL-7Y2) whenever the upstream CDN or a scrape proxy serves a valid image under the generic `application/octet-stream` type.

`ImageDownloaderMixin.validate_response` already has a magic-byte sniffing fallback for CDNs that mislabel images, but it only runs when `filetype.get_type(mime=...)` returns `None`. The `filetype` library registers the EOT **font** type under `application/octet-stream`:

```python
>>> filetype.get_type(mime="application/octet-stream")
<filetype.types.archive.Eot object at ...>
```

So the lookup succeeds with a non-image type, the fallback is skipped, and the valid image is rejected. This makes the fallback dead for by far the most common generic Content-Type.

## Fix

Run the fallback whenever the declared type does not resolve to an `image/*` type, not only when it resolves to nothing. The SVG short-circuit above is untouched, since `filetype` cannot sniff SVG.

Content that is genuinely not an image is still rejected, because the sniff then returns `None` or a non-image type and the existing check fires.

## Tests

Three cases added to `TestImageDownloaderMimeNormalization`: `application/octet-stream` with JPEG bytes accepted as `jpg`, with PNG bytes as `png`, and with HTML bytes still rejected. The first two fail on `main` with the exact Sentry message.