### PR TITLE
fix(takahe): stop retrying follow imports for handles that do not resolve

### DIFF
--- a/takahe/tests/users/views/test_import_export.py
+++ b/takahe/tests/users/views/test_import_export.py
@@ -45,6 +45,35 @@ def test_import_following(
 
 
 @pytest.mark.django_db
+@pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
+def test_import_following_unresolvable_handle(
+    identity: Identity,
+    stator: StatorRunner,
+    httpx_mock: HTTPXMock,
+):
+    """
+    A handle that does not resolve must error the message rather than retry forever
+    """
+    httpx_mock.add_response(
+        url="https://gone.test/.well-known/webfinger?resource=acct:nobody@gone.test",
+        status_code=404,
+    )
+    InboxMessage.create_internal(
+        {
+            "type": "AddFollow",
+            "source": identity.pk,
+            "target_handle": "nobody@gone.test",
+            "boosts": True,
+        }
+    )
+
+    stator.run_single_cycle()
+
+    assert InboxMessage.objects.get().state == "errored"
+    assert identity.outbound_follows.count() == 0
+
+
+@pytest.mark.django_db
 def test_export_following(
     client_with_user: Client,
     identity: Identity,

--- a/takahe/users/services/identity.py
+++ b/takahe/users/services/identity.py
@@ -14,6 +14,7 @@ from activities.models import (
     PostInteraction,
     PostInteractionStates,
 )
+from core.exceptions import ActivityPubError
 from core.files import resize_image
 from core.html import FediverseHtmlParser
 from stator.exceptions import TryAgainLater
@@ -378,7 +379,11 @@ class IdentityService:
         username, domain = payload["target_handle"].split("@")
         target_identity = Identity.by_username_and_domain(username, domain, fetch=True)
         if target_identity is None:
-            raise ValueError(f"Cannot find identity to follow: {target_identity}")
+            # The handle does not resolve, so retrying cannot help; a remote that is
+            # only busy raises TryAgainLater from the webfinger fetch instead.
+            handle = payload["target_handle"]
+            logger.warning("Cannot find identity to follow: %s", handle)
+            raise ActivityPubError(f"Cannot find identity to follow: {handle}")
         # Follow!
         self.follow(target_identity=target_identity, boosts=payload.get("boosts", True))
 


### PR DESCRIPTION
Fixes Sentry NEODB-SOCIAL-7Y1 (`ValueError: Cannot find identity to follow: None`, 397 events in 17 hours).

An `AddFollow` inbox message whose target handle cannot be resolved raised a plain `ValueError`, which `InboxMessageStates.handle_received` does not catch. Stator logged the exception and retried the message every 300 s until it aged out three days later, so a single dead domain in an imported following list produced hundreds of identical errors. The two handles in the reported issue come from one CSV import: one domain no longer resolves, the other answers 502.

This raises `ActivityPubError` instead, which `handle_received` already catches and turns into the `errored` state, and names the handle in the message. The old text interpolated `target_identity`, which is always `None` at that point, which is why the Sentry title carries no information.

Genuinely transient failures are unaffected: `fetch_webfinger` still raises `TryAgainLater` for timeouts, 408, 429 and 504, which stator retries quietly.

The new test drives the full state machine, so it covers the retry loop rather than only the handler; it fails on the previous code.