### PR TITLE
fix(catalog): save an external search result in one click

### DIFF
--- a/neodb/catalog/templates/external_search_results.html
+++ b/neodb/catalog/templates/external_search_results.html
@@ -12,7 +12,23 @@
   {% endif %}
   {% for item in external_items %}
     <div class="item-card-list">
-      <article class="item-card external">{% include "_item_card.html" with item=item %}</article>
+      <article class="item-card external">
+        {% include "_item_card.html" with item=item %}
+        <form method="post" action="{% url 'catalog:fetch_url' %}" hidden>
+          {% csrf_token %}
+          <input type="hidden" name="url" value="{{ item.source_url }}">
+        </form>
+      </article>
     {% endfor %}
   </div>
 </details>
+<script>
+// Post the url and fetch right away; the confirmation only guards a GET.
+$('.item-card.external a[href^="/search?q="]').on('click', function (e) {
+  if (e.button || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+  var form = this.closest('article').querySelector('form');
+  if (!form) return;
+  e.preventDefault();
+  form.submit();
+});
+</script>

--- a/neodb/tests/catalog/test_url_fetch_confirm.py
+++ b/neodb/tests/catalog/test_url_fetch_confirm.py
@@ -1,22 +1,25 @@
 """A pasted URL must not make the server fetch on a GET.
 
-The header posts a url typed into the search box to `fetch_url`; every GET
+The search box and the external result cards post to `fetch_url`; every GET
 gets a confirmation form first, signed in or not.
 """
 
 from unittest.mock import patch
+from urllib.parse import quote_plus
 
 import pytest
 from django.conf import settings
 from django.test import Client
 from django.urls import reverse
 
-from catalog.models import Movie
+from catalog.models import ItemCategory, Movie, SiteName
+from catalog.search.external import ExternalSearchResultItem, ExternalSources
 from users.models import User
 
 from .test_fetch_lock import FakeCache, StubSite
 
 URL = "https://example.com/unknown-thing"
+SOURCE_URL = "https://www.themoviedb.org/movie/1"
 
 
 def _get(client, url, item=None):
@@ -123,3 +126,36 @@ class TestSignedInUrlFetch:
         assert response.status_code == 200
         assert "fetch_pending.html" in [t.name for t in response.templates]
         enqueue.assert_called_once()
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestExternalResultCard:
+    """Clicking a result posts, so saving it locally stays one click."""
+
+    def _html(self, monkeypatch):
+        results = [
+            ExternalSearchResultItem(
+                ItemCategory.Movie, SiteName.TMDB, SOURCE_URL, "Ext", "", "brief", ""
+            )
+        ]
+        monkeypatch.setattr(
+            ExternalSources, "search", classmethod(lambda cls, *a, **kw: results)
+        )
+        user = User.register(email="card@example.com", username="carduser")
+        client = Client()
+        client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+        response = client.get(reverse("catalog:external_search"), {"q": "movie"})
+        assert response.status_code == 200
+        return response.content.decode()
+
+    def test_card_carries_a_post_form_for_the_source_url(self, monkeypatch):
+        html = self._html(monkeypatch)
+        assert f'action="{reverse("catalog:fetch_url")}"' in html
+        assert 'name="csrfmiddlewaretoken"' in html
+        assert f'name="url" value="{SOURCE_URL}"' in html
+        assert "form.submit()" in html  # the click handler ships with the card
+
+    def test_card_keeps_the_search_link_as_a_fallback(self, monkeypatch):
+        """A modified click, or no JS at all, still reaches the confirmation."""
+        html = self._html(monkeypatch)
+        assert f'href="/search?q={quote_plus(SOURCE_URL)}"' in html


### PR DESCRIPTION
Follow-up to c9f4b33c.

That commit stopped a GET from making the server fetch a host the visitor chose, which is the right guard for a crawler or another site. But an external search result card is a plain link to `/search?q=<source url>`, so it started landing on `fetch_confirm.html` and saving a result took two clicks. The confirmation is there to keep a GET from fetching, not to add a step to an in-site click.

Each result card now carries a hidden POST form to `catalog:fetch_url`, and a plain left click on the card submits it, so the fetch starts right away. The `href` is unchanged, so a modified click (cmd/ctrl/shift/alt), a crawler, a shared link and a visitor without JS all still reach the confirmation. The shared `_item_card.html` is untouched.

Other `/search?q=<external url>` entry points, reviewed and left alone:

- the header search box already posts through the JS added in c9f4b33c
- `people_search` shares `resolve_url_query`, so it takes the same path
- the PWA share target `/share?url=` redirects into `/search?q=`, and it is reachable from a cross-site `<img>`, so the confirmation is exactly right there
- OpenSearch from the address bar, and the `/scan` manual box, stay on the confirmation
- `/api/catalog/fetch` is an OAuth GET and is untouched

Verified in a dev cluster: one click on a Bangumi result went straight to "Fetching from Bangumi" and on to the item page; opening the same `/search?q=<url>` directly still shows the confirmation. `tests/catalog` passes (925), and the new POST-form test fails without the template change.
